### PR TITLE
feat(linux): parse DNS QueryName from raw eBPF payload in userspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Examples include:
 - Service creation
 - Scheduled task creation
 - Suspicious process execution
-- Linux process and network activity
+- Linux process, network, file, and DNS query activity
 
 Sigma support makes Rustinel practical for detection engineers because existing community rules can be reused and adapted instead of being rewritten into a proprietary format.
 
@@ -127,7 +127,7 @@ IOC matching provides fast deterministic checks against:
 - Domains
 - Path regexes
 
-IOC matching is useful for threat intelligence and incident response, but it is strongest when combined with behavioral detections and YARA scanning.
+IOC matching is useful for threat intelligence and incident response, but it is strongest when combined with behavioral detections and YARA scanning. Domain IOCs can match DNS `QueryName` on both Windows and Linux; Linux support covers outbound plaintext DNS queries observed by eBPF.
 
 ---
 
@@ -138,7 +138,7 @@ IOC matching is useful for threat intelligence and incident response, but it is 
 | Windows 10/11, Server 2016+ | ETW | Process, image load, network, file, registry, DNS, PowerShell, WMI, service, task | Foreground run or built-in Windows service commands |
 | Linux 5.8+ with BTF | eBPF | Process, network, file, DNS | Foreground run under root or your supervisor of choice |
 
-Windows telemetry coverage is broader today. Linux support currently focuses on process, network, file, and DNS telemetry through eBPF.
+Windows telemetry coverage is broader today. Linux support currently focuses on process, network, file, and DNS telemetry through eBPF. Linux DNS events include outbound plaintext DNS `QueryName`; DNS response answers (`QueryResults`) are not parsed yet.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -106,7 +106,7 @@ The Linux sensor loads eBPF programs with Aya and currently covers:
 - Process execution and exit
 - Network connect activity
 - File create, delete, change, and rename flows
-- DNS queries observed from userspace sends; `QueryName` is not extracted in the eBPF program due to BPF verifier complexity limits, so Linux DNS events currently preserve `record_type` and process context but may not have the query name
+- DNS queries observed from userspace sends. The eBPF program emits a bounded raw DNS payload and userspace parses `QueryName`, keeping string parsing out of the verifier-sensitive in-kernel path. Linux DNS response answers are not parsed yet, so `QueryResults` remains unavailable on Linux.
 
 The current loader attaches a mix of tracepoints and kprobes, including:
 

--- a/docs/detection.md
+++ b/docs/detection.md
@@ -60,14 +60,14 @@ DNS field availability differs by platform:
 
 | Field | Windows ETW | Linux eBPF |
 | --- | --- | --- |
-| `QueryName` | Yes | No |
+| `QueryName` | Yes | Yes |
 | `QueryResults` | Yes | No |
 | `QueryStatus` | Yes | No |
 | `RecordType` | Yes | Yes |
 | `Image` | Yes | Yes |
 | `ProcessId` | Yes | Yes |
 
-On Linux, the current eBPF DNS path does not extract `QueryName` or `QueryResults`, so generic DNS rules that depend on domain names or resolved answers are much more effective on Windows today.
+On Linux, `QueryName` is extracted in userspace from the bounded raw DNS payload emitted by the eBPF `sendto` path. This covers outbound plaintext DNS queries observed on port 53. It does not cover DNS-over-HTTPS, DNS-over-TLS, cached resolver answers that do not send a packet, or DNS response answers. `QueryResults` and `QueryStatus` remain Windows-only today.
 
 After a Sigma hit, Rustinel enriches non-process alerts with `process_context` from the process cache when that context is available.
 
@@ -171,7 +171,7 @@ The IOC engine hot reloads indicator files and splits work between inline event 
 - Hash results are cached by file identity with a 10,000-entry cap and a 6-hour TTL.
 - Inline IOC matching can emit multiple alerts from a single event.
 
-Windows currently has much better IOC coverage for domains and DNS-answer IPs because its DNS events carry `QueryName` and `QueryResults`. Linux eBPF DNS events do not currently populate those fields.
+Domain IOC matching works on both Windows DNS events and Linux outbound DNS query events through `QueryName`. IOC matching on DNS answer IPs still depends on `QueryResults`, so it is effectively Windows-only today.
 
 ### IOC File Format
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -163,13 +163,22 @@ See [Detection](detection.md).
 
 ### Why are my Linux DNS or domain-based detections not matching?
 
-Because Linux DNS coverage is currently more limited than Windows.
+Linux DNS coverage is still narrower than Windows, but outbound query names are supported.
 
-The current eBPF DNS path preserves `record_type`, `Image`, and `ProcessId`, but it does not currently populate `QueryName` or `QueryResults`. That means:
+The eBPF DNS path observes userspace `sendto` calls for plaintext DNS traffic and parses the queried domain name in userspace. Linux DNS events can populate:
 
-- Sigma DNS rules that depend on the queried domain name are much more effective on Windows
-- IOC domain matching is also much stronger on Windows today
+- `QueryName`
+- `RecordType`
+- `Image`
+- `ProcessId`
+
+Linux DNS events do not currently populate `QueryResults` or `QueryStatus`. That means:
+
+- Sigma DNS rules that depend on `QueryName` can match on Linux
+- IOC domain matching from DNS `QueryName` works on Linux
 - IOC IP matching from DNS answers is effectively Windows-only right now
+
+Linux DNS query-name extraction covers outbound plaintext DNS queries observed on port 53. It does not cover DNS-over-HTTPS, DNS-over-TLS, cached resolver answers that do not send a packet, or response-answer parsing.
 
 See [Detection](detection.md).
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -8,7 +8,7 @@ It is not a strict release commitment.
 
 ### Linux
 
-- **DNS domain name extraction** — `QueryName` is currently absent from Linux DNS events because BPF verifier complexity prevents in-kernel string parsing of DNS payloads. The plan is to move extraction to a userspace eBPF ring-buffer consumer or a `perf_event` uprobe on resolver libraries.
+- **DNS response enrichment** — Linux DNS query names are extracted in userspace from raw eBPF payload events. Future work should parse DNS responses for `QueryResults` and DNS answer-to-network correlation.
 - **Expanded file telemetry** — cover `chmod`, `chown`, `truncate`, and `link` syscalls to close gaps in file-integrity coverage.
 - **Container context** — enrich process events with cgroup, namespace, and container runtime metadata so rules can scope to specific workloads.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -133,26 +133,35 @@ The most common reasons are:
 Examples:
 
 - registry, image load, PowerShell, WMI, service, and task detections are Windows-only today
-- Linux DNS events currently do not populate `QueryName` or `QueryResults`
+- Linux DNS events populate `QueryName` for outbound plaintext DNS queries, but not `QueryResults`
 - repeated network connections may be suppressed when aggregation is enabled
 
 ### Linux DNS or IOC domain rules do not match
 
-This is a current platform limitation, not just a rule problem.
+Linux DNS query-name extraction is available, but it has narrower coverage than Windows DNS ETW.
 
-Linux eBPF DNS events currently preserve `record_type`, `Image`, and `ProcessId`, but they do not currently populate:
+Linux eBPF DNS events can populate:
 
 - `QueryName`
+- `RecordType`
+- `Image`
+- `ProcessId`
+
+Linux eBPF DNS events do not currently populate:
+
 - `QueryResults`
 - `QueryStatus`
 
-That means:
+If a DNS or domain IOC rule does not match, check these first:
 
-- Sigma DNS rules that depend on the queried domain name are much stronger on Windows
-- IOC domain matching is much stronger on Windows
-- IOC IP matching from DNS answers is effectively Windows-only right now
+- the lookup must send plaintext DNS on port 53; DNS-over-HTTPS and DNS-over-TLS are not visible to the DNS parser
+- cached resolver answers may not send a DNS packet
+- the rule should match `QueryName` or the generic `query` alias, not `QueryResults`
+- DNS answer IP IOC matching requires `QueryResults`, so it is effectively Windows-only today
 
-See [Detection](detection.md) and [Roadmap](roadmap.md).
+Sigma DNS rules that depend on queried domain names and IOC domain matching can work on Linux when the query is visible to the eBPF `sendto` path.
+
+See [Detection](detection.md).
 
 ### YARA did not scan the process I expected
 

--- a/ebpf/src/dns.rs
+++ b/ebpf/src/dns.rs
@@ -54,11 +54,6 @@ struct SockAddrIn6 {
 #[map]
 pub static DNS_RING: RingBuf = RingBuf::with_byte_size(256 * 1024, 0);
 
-/// Per-CPU buffer: receives the raw DNS packet bytes in a single probe read.
-#[map]
-static DNS_PAYLOAD_BUF: PerCpuArray<[u8; MAX_DNS_PAYLOAD]> =
-    PerCpuArray::with_max_entries(1, 0);
-
 /// Per-CPU buffer: staging area for the outgoing `DnsEvent`.
 #[map]
 static DNS_SCRATCH: PerCpuArray<DnsEvent> = PerCpuArray::with_max_entries(1, 0);
@@ -86,13 +81,14 @@ unsafe fn try_handle_sendto(ctx: &TracePointContext) -> Result<u32, i64> {
 
     // ── Stage 1: one probe read ──────────────────────────────────────────────
 
-    let payload_buf = match DNS_PAYLOAD_BUF.get_ptr_mut(0) {
+    let scratch = match DNS_SCRATCH.get_ptr_mut(0) {
         Some(p) => p,
         None => return Ok(0),
     };
     let read_len = len.min(MAX_DNS_PAYLOAD);
+    (*scratch).payload = [0u8; MAX_DNS_PAYLOAD];
     let ret = aya_ebpf::helpers::gen::bpf_probe_read_user(
-        (*payload_buf).as_mut_ptr() as *mut core::ffi::c_void,
+        (*scratch).payload.as_mut_ptr() as *mut core::ffi::c_void,
         read_len as u32,
         buf_ptr as *const core::ffi::c_void,
     );
@@ -102,14 +98,9 @@ unsafe fn try_handle_sendto(ctx: &TracePointContext) -> Result<u32, i64> {
 
     // ── Stage 2: parse (kernel memory only) ─────────────────────────────────
 
-    let scratch = match DNS_SCRATCH.get_ptr_mut(0) {
-        Some(p) => p,
-        None => return Ok(0),
-    };
-
     // Validate DNS header: must be a query (QR=0) with at least one question.
-    let flags = (((*payload_buf)[2] as u16) << 8) | ((*payload_buf)[3] as u16);
-    let qdcount = (((*payload_buf)[4] as u16) << 8) | ((*payload_buf)[5] as u16);
+    let flags = (((*scratch).payload[2] as u16) << 8) | ((*scratch).payload[3] as u16);
+    let qdcount = (((*scratch).payload[4] as u16) << 8) | ((*scratch).payload[5] as u16);
     if flags & 0x8000 != 0 || qdcount == 0 {
         return Ok(0);
     }
@@ -124,7 +115,7 @@ unsafe fn try_handle_sendto(ctx: &TracePointContext) -> Result<u32, i64> {
         if pos >= read_len {
             return Ok(0);
         }
-        let b = (*payload_buf)[pos & (MAX_DNS_PAYLOAD - 1)];
+        let b = (*scratch).payload[pos & (MAX_DNS_PAYLOAD - 1)];
         if b == 0 {
             // Found end of name.
             break;
@@ -136,13 +127,15 @@ unsafe fn try_handle_sendto(ctx: &TracePointContext) -> Result<u32, i64> {
     if pos + 3 > read_len {
         return Ok(0);
     }
-    let qtype = (((*payload_buf)[(pos + 1) & (MAX_DNS_PAYLOAD - 1)] as u16) << 8)
-        | ((*payload_buf)[(pos + 2) & (MAX_DNS_PAYLOAD - 1)] as u16);
+    let qtype = (((*scratch).payload[(pos + 1) & (MAX_DNS_PAYLOAD - 1)] as u16) << 8)
+        | ((*scratch).payload[(pos + 2) & (MAX_DNS_PAYLOAD - 1)] as u16);
 
     (*scratch).kind = DNS_EVENT_QUERY;
     (*scratch).pid = pid;
     (*scratch).uid = uid;
     (*scratch).fd = fd;
+    (*scratch).payload_len = read_len as u16;
+    (*scratch)._pad0 = 0;
     (*scratch).query_name = [0u8; 96];
     (*scratch).query_results = [0u8; 96];
     (*scratch).record_type = [0u8; 16];

--- a/ebpf/src/events.rs
+++ b/ebpf/src/events.rs
@@ -97,10 +97,15 @@ pub struct DnsEvent {
     pub uid: u32,
     /// Socket file descriptor.
     pub fd: i32,
+    /// Number of valid bytes in `payload`.
+    pub payload_len: u16,
+    pub _pad0: u16,
     /// Null-terminated DNS query name (up to 95 chars).
     pub query_name: [u8; 96],
     /// Null-terminated DNS answer/result summary (up to 95 chars).
     pub query_results: [u8; 96],
     /// Null-terminated query type string (up to 15 chars).
     pub record_type: [u8; 16],
+    /// Raw DNS payload copied from userspace for userspace parsing.
+    pub payload: [u8; 256],
 }

--- a/src/sensor/linux/ebpf.rs
+++ b/src/sensor/linux/ebpf.rs
@@ -49,6 +49,9 @@ const EVENT_ID_DNS_QUERY: u16 = 22;
 
 const PROCESS_EVENT_EXEC: u32 = 1;
 const PROCESS_EVENT_EXIT: u32 = 2;
+const DNS_HEADER_LEN: usize = 12;
+const DNS_LABEL_POINTER_MASK: u8 = 0xc0;
+const DNS_LABEL_MAX_LEN: usize = 63;
 
 /// Linux eBPF sensor. Implements [`Sensor`]; call `start()` from within a
 /// tokio runtime context.
@@ -532,6 +535,15 @@ fn build_dns_event(ev: &DnsEvent) -> Option<SensorEvent> {
         return None;
     }
 
+    let query_name = parse_dns_query_name(ev).or_else(|| {
+        let value = bytes_to_string(&ev.query_name);
+        (!value.is_empty()).then_some(value)
+    });
+    let query_results = {
+        let value = bytes_to_string(&ev.query_results);
+        (!value.is_empty()).then_some(value)
+    };
+
     Some(SensorEvent {
         platform: Platform::Linux,
         provider: "ebpf",
@@ -544,16 +556,57 @@ fn build_dns_event(ev: &DnsEvent) -> Option<SensorEvent> {
         timestamp: SystemTime::now(),
         process_start_key: None,
         payload: SensorPayload::Dns(DnsQueryFields {
-            // Domain name is not extracted in eBPF (verifier complexity limit).
-            // Enrich in userspace via /proc/<pid>/net/ or application tracing.
-            query_name: None,
-            query_results: None,
+            query_name,
+            query_results,
             record_type: Some(record_type),
             query_status: None,
             process_id: Some(ev.pid.to_string()),
             image: None,
         }),
     })
+}
+
+fn parse_dns_query_name(ev: &DnsEvent) -> Option<String> {
+    let payload_len = usize::from(ev.payload_len).min(ev.payload.len());
+    let payload = ev.payload.get(..payload_len)?;
+    if payload.len() < DNS_HEADER_LEN {
+        return None;
+    }
+
+    let flags = u16::from_be_bytes([payload[2], payload[3]]);
+    let qdcount = u16::from_be_bytes([payload[4], payload[5]]);
+    if flags & 0x8000 != 0 || qdcount == 0 {
+        return None;
+    }
+
+    let mut pos = DNS_HEADER_LEN;
+    let mut labels: Vec<String> = Vec::new();
+    while pos < payload.len() {
+        let label_len = payload[pos];
+        pos += 1;
+
+        if label_len == 0 {
+            return if labels.is_empty() {
+                Some(".".to_string())
+            } else {
+                Some(labels.join("."))
+            };
+        }
+
+        if label_len & DNS_LABEL_POINTER_MASK != 0 {
+            return None;
+        }
+
+        let label_len = usize::from(label_len);
+        if label_len > DNS_LABEL_MAX_LEN || pos + label_len > payload.len() {
+            return None;
+        }
+
+        labels.push(String::from_utf8_lossy(&payload[pos..pos + label_len]).into_owned());
+        pos += label_len;
+    }
+
+    None
 }
 
 // ── Utilities ────────────────────────────────────────────────────────────────
@@ -625,7 +678,13 @@ fn attach_kprobe(bpf: &mut Ebpf, program: &str, function: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::IocConfig;
+    use crate::engine::Engine;
+    use crate::ioc::{IocEngine, IocKind};
     use crate::models::EventFields;
+    use crate::normalizer::Normalizer;
+    use crate::state::{ConnectionAggregator, DnsCache, ProcessCache, SidCache};
+    use std::sync::Arc;
 
     fn fixed<const N: usize>(value: &str) -> [u8; N] {
         let mut buf = [0u8; N];
@@ -633,6 +692,70 @@ mod tests {
         let len = bytes.len().min(N.saturating_sub(1));
         buf[..len].copy_from_slice(&bytes[..len]);
         buf
+    }
+
+    fn dns_query_payload(name: &str, qtype: u16) -> ([u8; 256], u16) {
+        let mut payload = [0u8; 256];
+        payload[4] = 0;
+        payload[5] = 1;
+
+        let mut pos = DNS_HEADER_LEN;
+        for label in name.split('.') {
+            let bytes = label.as_bytes();
+            payload[pos] = bytes.len() as u8;
+            pos += 1;
+            payload[pos..pos + bytes.len()].copy_from_slice(bytes);
+            pos += bytes.len();
+        }
+        payload[pos] = 0;
+        pos += 1;
+        payload[pos..pos + 2].copy_from_slice(&qtype.to_be_bytes());
+        pos += 2;
+        payload[pos..pos + 2].copy_from_slice(&1u16.to_be_bytes());
+        pos += 2;
+
+        (payload, pos as u16)
+    }
+
+    fn raw_dns_query(name: &str, record_type: &str) -> DnsEvent {
+        let qtype = match record_type {
+            "AAAA" => 28,
+            "CNAME" => 5,
+            "PTR" => 12,
+            "TXT" => 16,
+            _ => 1,
+        };
+        let (payload, payload_len) = dns_query_payload(name, qtype);
+        DnsEvent {
+            kind: 1,
+            pid: 4242,
+            uid: 1000,
+            fd: 5,
+            payload_len,
+            _pad0: 0,
+            query_name: [0u8; 96],
+            query_results: [0u8; 96],
+            record_type: fixed(record_type),
+            payload,
+        }
+    }
+
+    fn test_normalizer() -> Normalizer {
+        Normalizer::new(
+            Arc::new(ProcessCache::new()),
+            Arc::new(SidCache::new()),
+            Arc::new(DnsCache::new()),
+            Arc::new(ConnectionAggregator::new()),
+            false,
+        )
+    }
+
+    fn normalized_raw_dns_query(name: &str) -> crate::models::NormalizedEvent {
+        let raw = raw_dns_query(name, "A");
+        let event = build_dns_event(&raw).expect("raw dns event should build");
+        test_normalizer()
+            .normalize(&event)
+            .expect("raw dns event should normalize")
     }
 
     #[test]
@@ -870,16 +993,18 @@ mod tests {
 
     #[test]
     fn build_dns_event_maps_linux_dns_payload() {
+        let (payload, payload_len) = dns_query_payload("example.test", 1);
         let raw = DnsEvent {
             kind: 1,
             pid: 4242,
             uid: 1000,
             fd: 5,
-            // query_name is zeroed — name extraction was moved out of eBPF to
-            // avoid the BPF verifier complexity limit.
+            payload_len,
+            _pad0: 0,
             query_name: [0u8; 96],
             query_results: [0u8; 96],
             record_type: fixed("A"),
+            payload,
         };
 
         let event = build_dns_event(&raw).expect("dns event should build");
@@ -888,12 +1013,128 @@ mod tests {
 
         match event.payload {
             SensorPayload::Dns(fields) => {
-                assert_eq!(fields.query_name, None);
+                assert_eq!(fields.query_name.as_deref(), Some("example.test"));
                 assert_eq!(fields.query_results, None);
                 assert_eq!(fields.record_type.as_deref(), Some("A"));
             }
             other => panic!("unexpected payload: {:?}", other),
         }
+    }
+
+    #[test]
+    fn build_dns_event_falls_back_to_query_name_field() {
+        let raw = DnsEvent {
+            kind: 1,
+            pid: 4242,
+            uid: 1000,
+            fd: 5,
+            payload_len: 0,
+            _pad0: 0,
+            query_name: fixed("fallback.test"),
+            query_results: [0u8; 96],
+            record_type: fixed("AAAA"),
+            payload: [0u8; 256],
+        };
+
+        let event = build_dns_event(&raw).expect("dns event should build");
+
+        match event.payload {
+            SensorPayload::Dns(fields) => {
+                assert_eq!(fields.query_name.as_deref(), Some("fallback.test"));
+                assert_eq!(fields.record_type.as_deref(), Some("AAAA"));
+            }
+            other => panic!("unexpected payload: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_dns_query_name_rejects_truncated_payload() {
+        let (payload, payload_len) = dns_query_payload("example.test", 1);
+        let raw = DnsEvent {
+            kind: 1,
+            pid: 4242,
+            uid: 1000,
+            fd: 5,
+            payload_len: payload_len.min((DNS_HEADER_LEN + 4) as u16),
+            _pad0: 0,
+            query_name: [0u8; 96],
+            query_results: [0u8; 96],
+            record_type: fixed("A"),
+            payload,
+        };
+
+        assert_eq!(parse_dns_query_name(&raw), None);
+    }
+
+    #[test]
+    fn raw_dns_payload_query_name_matches_real_sigma_dns_rule() {
+        let tempdir = tempfile::tempdir().expect("create sigma tempdir");
+        let rules_dir = tempdir.path().join("sigma");
+        std::fs::create_dir_all(&rules_dir).expect("create sigma rules dir");
+        std::fs::write(
+            rules_dir.join("dns.yml"),
+            r#"title: Raw Linux DNS QueryName
+logsource:
+  product: linux
+  category: dns_query
+detection:
+  selection:
+    QueryName|endswith: ".example.test"
+    RecordType: "A"
+  condition: selection
+level: high
+"#,
+        )
+        .expect("write sigma rule");
+
+        let mut engine = Engine::new_for_platform(Platform::Linux);
+        engine.load_rules(&rules_dir).expect("load sigma rule");
+        assert_eq!(engine.stats().failed_rules, Vec::<(String, String)>::new());
+
+        let event = normalized_raw_dns_query("sub.example.test");
+        assert_eq!(event.get_field("QueryName"), Some("sub.example.test"));
+        assert_eq!(event.get_field("query"), Some("sub.example.test"));
+        assert_eq!(event.get_field("RecordType"), Some("A"));
+
+        let alert = engine
+            .check_event(&event)
+            .expect("dns Sigma rule should match raw eBPF QueryName");
+        assert_eq!(alert.rule_name, "Raw Linux DNS QueryName");
+    }
+
+    #[test]
+    fn raw_dns_payload_query_name_matches_domain_ioc() {
+        let tempdir = tempfile::tempdir().expect("create ioc tempdir");
+        let root = tempdir.path().join("ioc");
+        std::fs::create_dir_all(&root).expect("create ioc dir");
+        let hashes_path = root.join("hashes.txt");
+        let ips_path = root.join("ips.txt");
+        let domains_path = root.join("domains.txt");
+        let paths_regex_path = root.join("paths_regex.txt");
+        std::fs::write(&hashes_path, "").expect("write hashes");
+        std::fs::write(&ips_path, "").expect("write ips");
+        std::fs::write(&domains_path, ".example.test; raw dns suffix").expect("write domains");
+        std::fs::write(&paths_regex_path, "").expect("write path regexes");
+
+        let engine = IocEngine::load(&IocConfig {
+            enabled: true,
+            hashes_path,
+            ips_path,
+            domains_path,
+            paths_regex_path,
+            default_severity: "high".to_string(),
+            max_file_size_mb: 16,
+            hash_allowlist_paths: Vec::new(),
+        });
+        let event = normalized_raw_dns_query("sub.example.test");
+
+        let matches = engine.check_event(&event);
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].kind, IocKind::Domain);
+        assert_eq!(matches[0].observed, "sub.example.test");
+
+        let alert = engine.build_alert_for_match(&matches[0], &event);
+        assert_eq!(alert.rule_name, "ioc:domain:.example.test");
     }
 
     #[test]
@@ -903,9 +1144,12 @@ mod tests {
             pid: 1,
             uid: 0,
             fd: 3,
+            payload_len: 0,
+            _pad0: 0,
             query_name: [0u8; 96],
             query_results: [0u8; 96],
             record_type: [0u8; 16],
+            payload: [0u8; 256],
         };
         assert!(build_dns_event(&raw).is_none());
     }

--- a/src/sensor/linux/events.rs
+++ b/src/sensor/linux/events.rs
@@ -69,9 +69,12 @@ pub struct DnsEvent {
     pub pid: u32,
     pub uid: u32,
     pub fd: i32,
+    pub payload_len: u16,
+    pub _pad0: u16,
     pub query_name: [u8; 96],
     pub query_results: [u8; 96],
     pub record_type: [u8; 16],
+    pub payload: [u8; 256],
 }
 
 // ── Size assertions ──────────────────────────────────────────────────────────
@@ -90,7 +93,7 @@ const _: () = assert!(
     "FileEvent layout changed — update ebpf/src/events.rs to match"
 );
 const _: () = assert!(
-    core::mem::size_of::<DnsEvent>() == 224,
+    core::mem::size_of::<DnsEvent>() == 484,
     "DnsEvent layout changed — update ebpf/src/events.rs to match"
 );
 

--- a/tests/platform_mapping.rs
+++ b/tests/platform_mapping.rs
@@ -88,9 +88,12 @@ fn linux_ebpf_raw_events_map_to_sensor_events() {
         pid: 42,
         uid: 1000,
         fd: 3,
+        payload_len: 0,
+        _pad0: 0,
         query_name: [0; 96],
         query_results: [0; 96],
         record_type: [0; 16],
+        payload: [0; 256],
     };
     write_cstr(&mut dns.query_name, "example.test");
     write_cstr(&mut dns.query_results, "198.51.100.10");


### PR DESCRIPTION
## Summary

- Remove the dedicated `DNS_PAYLOAD_BUF` per-CPU map; embed the raw DNS payload (up to 256 bytes) directly in `DnsEvent` as a new `payload` field alongside a `payload_len` field
- Userspace parses `QueryName` from the wire-format DNS payload, keeping label parsing out of the verifier-sensitive in-kernel path
- Fall back to the existing `query_name` string field when `payload_len` is zero, preserving compatibility

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --locked --all-targets -- -D clippy::all` (WSL/Linux) — clean
- [x] `cargo test --locked` (WSL/Linux) — 108 unit tests + 38 integration tests, 0 failures
- [x] New unit tests: `build_dns_event_maps_linux_dns_payload`, `build_dns_event_falls_back_to_query_name_field`, `parse_dns_query_name_rejects_truncated_payload`
- [x] New integration tests: `raw_dns_payload_query_name_matches_real_sigma_dns_rule`, `raw_dns_payload_query_name_matches_domain_ioc`
- [x] `DnsEvent` size assertion updated (224 → 484 bytes); struct layout is consistent between `ebpf/src/events.rs` and `src/sensor/linux/events.rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)