### PR TITLE
fix: load YARA rules recursively from subdirectories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ tests/**/*
 
 .codex
 *.zip
+
+rules-bench/
+*.pyc
+__pycache__/

--- a/docs/detection.md
+++ b/docs/detection.md
@@ -118,8 +118,7 @@ YARA scanning is shared across both supported platforms.
 
 ### Behavior
 
-- Rules compile from top-level `.yar` and `.yara` files in `scanner.yara_rules_path`.
-- Rule loading is not recursive.
+- Rules compile recursively from `.yar` and `.yara` files in `scanner.yara_rules_path` and all subdirectories.
 - Only process-start events queue YARA scans.
 - On Windows, raw ETW paths are normalized before scanning so the worker can open the file.
 - Trusted path prefixes are skipped before queueing and checked again in the worker.

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -3,7 +3,7 @@
 //! Handles compiling rules, listening for process events, and scanning files.
 
 use anyhow::{Context, Result};
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::fs;
 use std::path::Path;
 use std::sync::Mutex;
@@ -224,26 +224,33 @@ impl Scanner {
         let mut files_found = 0;
         let mut files_compiled = 0;
 
-        info!("Loading YARA rules from: {:?}", rules_dir);
+        info!("Loading YARA rules from: {:?} (recursive)", rules_dir);
 
         if rules_dir.exists() && rules_dir.is_dir() {
-            for entry in fs::read_dir(rules_dir)? {
-                let entry = entry?;
-                let path = entry.path();
-                if let Some(ext) = path.extension() {
-                    if ext == "yar" || ext == "yara" {
-                        files_found += 1;
-                        debug!("Found YARA rule file: {:?}", path);
-                        let src = fs::read_to_string(&path)
-                            .with_context(|| format!("Failed to read {:?}", path))?;
+            let mut queue = VecDeque::from([rules_dir.to_path_buf()]);
+            while let Some(dir) = queue.pop_front() {
+                for entry in fs::read_dir(&dir)? {
+                    let entry = entry?;
+                    let path = entry.path();
+                    if path.is_dir() {
+                        queue.push_back(path);
+                        continue;
+                    }
+                    if let Some(ext) = path.extension() {
+                        if ext == "yar" || ext == "yara" {
+                            files_found += 1;
+                            debug!("Found YARA rule file: {:?}", path);
+                            let src = fs::read_to_string(&path)
+                                .with_context(|| format!("Failed to read {:?}", path))?;
 
-                        match compiler.add_source(src.as_str()) {
-                            Ok(_) => {
-                                files_compiled += 1;
-                                debug!("✓ Compiled YARA rule: {:?}", path);
-                            }
-                            Err(e) => {
-                                warn!("✗ Failed to compile {:?}: {}", path, e);
+                            match compiler.add_source(src.as_str()) {
+                                Ok(_) => {
+                                    files_compiled += 1;
+                                    debug!("✓ Compiled YARA rule: {:?}", path);
+                                }
+                                Err(e) => {
+                                    warn!("✗ Failed to compile {:?}: {}", path, e);
+                                }
                             }
                         }
                     }

--- a/tests/yara_disk.rs
+++ b/tests/yara_disk.rs
@@ -103,6 +103,25 @@ fn build_yara_alert(
 }
 
 #[test]
+fn yara_disk_scanner_loads_rules_from_subdirectories() {
+    let fixture = YaraFixture::new();
+    fixture.write_rule("subdir/nested.yar", "NestedSubdirRule", TEST_YARA_MARKER);
+    let scanner = Scanner::new(fixture.rules_dir()).expect("Scanner::new failed");
+    assert_eq!(
+        scanner.compiled_files(),
+        1,
+        "expected rule from subdirectory to be compiled"
+    );
+
+    let marker_sample = fixture.write_marker_sample();
+    let matches = scanner
+        .scan_file(&marker_sample.to_string_lossy(), MatchDebugLevel::Off)
+        .expect("scan failed");
+    assert_eq!(matches.len(), 1);
+    assert_eq!(matches[0].rule, "NestedSubdirRule");
+}
+
+#[test]
 fn yara_disk_scan_matches_marker_and_rejects_clean_temp_file() {
     let fixture = YaraFixture::new();
     let scanner = load_scanner(&fixture);


### PR DESCRIPTION
## Summary

- `Scanner::new` previously called `fs::read_dir` only on the top-level rules directory, silently ignoring any subdirectories
- Replaced the flat loop with a BFS queue (same pattern already used by `fingerprint_dir` in the hot-reload poller), so all `.yar`/`.yara` files nested at any depth are now compiled
- Updated `docs/detection.md` to reflect the new recursive behaviour
- Added a regression test (`yara_disk_scanner_loads_rules_from_subdirectories`) that writes a rule into a subdirectory and asserts it is compiled and matches

Fixes #22.

## Test plan

- [ ] `cargo test --test yara_disk` — all 4 tests pass, including the new subdirectory test
- [ ] Manual: place `.yar` files in a subdirectory of `rules/yara/` and confirm they are loaded on startup and after a hot-reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)