### PR TITLE
docs: add benchmark harness guide

### DIFF
--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -1,0 +1,353 @@
+# Benchmarking Rustinel
+
+Rustinel includes lightweight benchmark scripts for collecting agent overhead,
+workload timing, alert latency, and drop-counter evidence on Windows and Linux.
+The benchmark is intended to compare baseline host behavior against Rustinel on
+the same machine with a fixed rule corpus.
+
+Do not use a single run as a product claim. Run each mode at least three times,
+report medians, and keep the rule corpus, allowlists, cargo profile, and machine
+fixed across baseline and with-agent runs.
+
+## What To Report
+
+Report these fields for every benchmark set:
+
+- Git commit or diff summary.
+- Corpus metadata from `rules-bench/sources/metadata.json`.
+- Platform and machine info from `summary.json`.
+- Idle CPU average and p95.
+- Idle memory average and max.
+- Workload durations and slowdown percentages.
+- Detection latency from trigger action to alert output.
+- Queue or sensor drop counters.
+- `valid` and `validation_errors` from with-agent summaries.
+- Any warnings or errors in Rustinel operational logs.
+
+Calculate slowdown as:
+
+```text
+((rustinel_duration_ms - baseline_duration_ms) / baseline_duration_ms) * 100
+```
+
+## Run Validity
+
+With-agent runs write `valid` and `validation_errors` in `summary.json`.
+
+A with-agent run is invalid when:
+
+- the agent process is not observable after startup;
+- idle samples never observe `pid_count > 0`;
+- alert latency is null;
+- one or more workload steps fail;
+- on Windows, ETW drops are observed.
+
+Invalid runs are still useful for investigation, but they should not be used for
+slowdown or production-readiness claims.
+
+## Queue And Drop Signals
+
+Search operational logs for these messages:
+
+```text
+Sensor event channel full; dropping ETW event
+YARA queue full; dropping scan job
+IOC hash queue full; dropping job
+Active response queue full, dropping task
+```
+
+Windows benchmark summaries also include:
+
+```json
+"etw_drops": {
+  "warning_count": 0,
+  "final_counter": 0
+}
+```
+
+`warning_count` is the number of ETW drop warnings appended during that run.
+`final_counter` is the last `dropped_events=N` value seen during that run. A
+nonzero value marks the Windows with-agent run invalid.
+
+## Build
+
+Build the release binary before running benchmarks:
+
+```powershell
+cargo build --locked --release
+```
+
+On Linux or WSL:
+
+```bash
+cargo build --locked --release
+```
+
+## Rule Corpus
+
+The bundled rules are enough for a quick smoke benchmark. For a realistic
+benchmark, use a fixed `rules-bench` directory:
+
+```text
+rules-bench/
+├── sigma/
+├── yara/
+├── ioc/
+└── sources/
+```
+
+Fetch a corpus:
+
+```bash
+python scripts/rules/fetch_corpus.py --output rules-bench --force
+```
+
+The default fetch includes:
+
+- SigmaHQ community rules from the current `master` branch, excluding
+  deprecated, unsupported, test, and documentation directories.
+- YARA Forge `core`.
+- Feodo Tracker recommended C2 IP blocklist.
+
+Optional authenticated feeds:
+
+```bash
+THREATFOX_AUTH_KEY=... python scripts/rules/fetch_corpus.py \
+  --output rules-bench \
+  --force \
+  --threatfox-days 7 \
+  --threatfox-min-confidence 70
+```
+
+```bash
+URLHAUS_AUTH_KEY=... python scripts/rules/fetch_corpus.py \
+  --output rules-bench \
+  --force \
+  --include-urlhaus
+```
+
+For a heavier YARA profile:
+
+```bash
+python scripts/rules/fetch_corpus.py \
+  --output rules-bench \
+  --force \
+  --yara-forge-set extended
+```
+
+The fetcher writes source metadata to
+`rules-bench/sources/metadata.json`. Include that metadata when reporting
+benchmark results. YARA files are flattened into `rules-bench/yara/` because
+Rustinel loads YARA rules from the top-level configured directory.
+
+## Windows Full Matrix
+
+Run from an Administrator shell so Windows ETW providers can be collected.
+
+Run baseline three times:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\bench\windows.ps1 `
+  -Mode baseline `
+  -SigmaRulesPath .\rules-bench\sigma `
+  -YaraRulesPath .\rules-bench\yara `
+  -IocRulesPath .\rules-bench\ioc
+```
+
+Run with-agent three times:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\bench\windows.ps1 `
+  -Mode with-agent `
+  -SigmaRulesPath .\rules-bench\sigma `
+  -YaraRulesPath .\rules-bench\yara `
+  -IocRulesPath .\rules-bench\ioc
+```
+
+If Rustinel is not already running, the script starts
+`.\target\release\rustinel.exe run --console` and stops that process when the
+benchmark ends. When the script starts the agent, it creates a benchmark Sigma
+trigger rule and passes matching `EDR__` environment overrides so the agent uses
+the requested corpus.
+
+If Rustinel is already running, the script reuses it. In that case, restart the
+agent with the same corpus before benchmarking, or pass `-NoBenchmarkTriggerRule`
+only when the existing configuration already contains the alert trigger rule you
+want to measure.
+
+## Windows Isolated Workloads
+
+Use isolated workloads when ETW drops or workload regressions need root-cause
+work. Each selector runs only one workload:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\bench\windows.ps1 `
+  -Mode with-agent `
+  -ProcessOnly `
+  -SigmaRulesPath .\rules-bench\sigma `
+  -YaraRulesPath .\rules-bench\yara `
+  -IocRulesPath .\rules-bench\ioc `
+  -AlertRuleName "Local Accounts Discovery" `
+  -NoBenchmarkTriggerRule
+```
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\bench\windows.ps1 `
+  -Mode with-agent `
+  -FileOnly `
+  -SigmaRulesPath .\rules-bench\sigma `
+  -YaraRulesPath .\rules-bench\yara `
+  -IocRulesPath .\rules-bench\ioc `
+  -AlertRuleName "Local Accounts Discovery" `
+  -NoBenchmarkTriggerRule
+```
+
+For cargo-only isolation, avoid launching the agent from
+`target\release\rustinel.exe`, because Windows can lock the executable while the
+benchmark's cargo workload tries to rebuild it. Copy the agent first:
+
+```powershell
+New-Item -ItemType Directory -Force .\target\rustinel-bench-agent | Out-Null
+Copy-Item .\target\release\rustinel.exe .\target\rustinel-bench-agent\rustinel.exe -Force
+
+powershell -ExecutionPolicy Bypass -File .\scripts\bench\windows.ps1 `
+  -Mode with-agent `
+  -CargoOnly `
+  -AgentPath .\target\rustinel-bench-agent\rustinel.exe `
+  -SigmaRulesPath .\rules-bench\sigma `
+  -YaraRulesPath .\rules-bench\yara `
+  -IocRulesPath .\rules-bench\ioc `
+  -AlertRuleName "Local Accounts Discovery" `
+  -NoBenchmarkTriggerRule
+```
+
+Interpretation:
+
+- Process-only drops point at process ETW callback, queueing, normalization, or
+  rule-evaluation pressure.
+- File-only drops point at file ETW callback, queueing, normalization, or
+  rule-evaluation pressure.
+- Cargo-only drops usually indicate common ingestion or build-time host noise,
+  not cargo itself.
+
+## Linux Full Matrix
+
+Run Linux benchmarks as the normal user. The script elevates only Rustinel agent
+startup through sudo so cargo still uses the user's Rust toolchain.
+
+Run baseline three times:
+
+```bash
+bash scripts/bench/linux.sh \
+  --mode baseline \
+  --sigma-rules-path ./rules-bench/sigma \
+  --yara-rules-path ./rules-bench/yara \
+  --ioc-rules-path ./rules-bench/ioc
+```
+
+Run with-agent three times:
+
+```bash
+bash scripts/bench/linux.sh \
+  --mode with-agent \
+  --sigma-rules-path ./rules-bench/sigma \
+  --yara-rules-path ./rules-bench/yara \
+  --ioc-rules-path ./rules-bench/ioc
+```
+
+When prompted, enter sudo credentials so the agent can attach eBPF programs.
+The script calls `sudo -v` before starting the background agent, then starts the
+agent through sudo while keeping the benchmark workloads under the normal user.
+
+For noninteractive lab runs, set `SUDO_ASKPASS` to an executable askpass helper
+and run the same command. Do not commit askpass helpers or passwords.
+
+If Rustinel is already running, the script reuses it. Restart Rustinel with the
+same corpus before benchmarking, or pass `--no-benchmark-trigger-rule` only when
+the existing configuration already contains the alert trigger rule you want to
+measure.
+
+## Linux Isolated Workloads
+
+Linux supports the same workload selectors:
+
+```bash
+bash scripts/bench/linux.sh \
+  --mode with-agent \
+  --process-only \
+  --sigma-rules-path ./rules-bench/sigma \
+  --yara-rules-path ./rules-bench/yara \
+  --ioc-rules-path ./rules-bench/ioc
+```
+
+```bash
+bash scripts/bench/linux.sh \
+  --mode with-agent \
+  --file-only \
+  --sigma-rules-path ./rules-bench/sigma \
+  --yara-rules-path ./rules-bench/yara \
+  --ioc-rules-path ./rules-bench/ioc
+```
+
+```bash
+bash scripts/bench/linux.sh \
+  --mode with-agent \
+  --cargo-only \
+  --sigma-rules-path ./rules-bench/sigma \
+  --yara-rules-path ./rules-bench/yara \
+  --ioc-rules-path ./rules-bench/ioc
+```
+
+Use isolated Linux workloads when investigating idle CPU, alert latency, or a
+specific workload regression. For the current 2026-05-16 investigation, the
+clean Linux full matrix was valid and below the idle CPU acceptance threshold.
+
+## Output Files
+
+Each run writes a timestamped directory under `target/rustinel-bench/`:
+
+- `summary.json`: machine info, rule inventory, parameters, resource summaries,
+  workload steps, alert latency, `valid`, and `validation_errors`.
+- `resource-samples.csv`: per-second CPU, memory, process count, and thread
+  samples.
+- `workload-steps.jsonl`: raw workload timings and statuses.
+- `agent.stdout.log`: Linux-only stdout and stderr for an agent started by the
+  benchmark script.
+- `sigma-benchmark/`: generated benchmark trigger rule corpus when the script
+  starts the agent and trigger-rule injection is enabled.
+
+Do not commit generated benchmark output directories, logs, copied binaries, or
+temporary scripts.
+
+## Current Acceptance Targets
+
+Linux:
+
+- Idle CPU median below `3%`.
+- Idle CPU p95 below `8%`.
+- Alert latency non-null in three consecutive with-agent runs.
+- Median alert latency below `1,000 ms`.
+- Every workload status is `ok`.
+
+Windows:
+
+- Zero ETW drops in the default workload, or a documented bounded drop policy
+  for low-value event classes only.
+- Alert latency below `500 ms` median.
+- Process and file IO slowdown should not regress by more than `5%` relative to
+  the current with-agent baseline.
+- Every workload status is `ok`.
+
+## Reading The Current Results
+
+As of the 2026-05-16 investigation:
+
+- Linux full with-agent matrix is valid: median idle CPU avg `0.847%`, median
+  idle CPU p95 `0.875%`, and median alert latency `155 ms`.
+- Windows isolated process-only and file-only runs are invalid because ETW drops
+  were observed.
+- Windows cargo-only with the copied agent executable had zero ETW drops.
+
+The benchmark harness is suitable for tracking progress, but Rustinel should not
+be presented as production-ready EDR telemetry under Windows stress until the
+process/file ETW drop source is instrumented and mitigated.

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,7 @@ Rustinel is designed for blue teams, detection engineers, researchers, and anyon
 - [Configuration](configuration.md) — configure telemetry, rules, alerts, and response
 - [Detection](detection.md) — understand Sigma, YARA, and IOC matching
 - [Architecture](architecture.md) — understand how Rustinel works internally
+- [Benchmarking](benchmarking.md) — collect repeatable performance and latency evidence
 - [Troubleshooting](troubleshooting.md) — fix common issues
 
 ## Project background

--- a/scripts/bench/linux.sh
+++ b/scripts/bench/linux.sh
@@ -1,0 +1,570 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE="with-agent"
+AGENT_PATH="./target/release/rustinel"
+AGENT_ARGS="run"
+PROCESS_NAME="rustinel"
+OUTPUT_DIR="./target/rustinel-bench"
+IDLE_SECONDS=60
+PROCESS_LAUNCHES=500
+FILE_COUNT=2000
+FILE_SIZE_BYTES=1024
+ALERT_GLOB="./logs/alerts.json*"
+ALERT_RULE_NAME="Rustinel Benchmark Whoami Linux"
+SIGMA_RULES_PATH="./rules/sigma"
+YARA_RULES_PATH="./rules/yara"
+IOC_RULES_PATH="./rules/ioc"
+SKIP_CARGO=0
+NO_ALERT_LATENCY=0
+NO_BENCHMARK_TRIGGER_RULE=0
+PROCESS_ONLY=0
+FILE_ONLY=0
+CARGO_ONLY=0
+KEEP_AGENT=0
+EFFECTIVE_SIGMA_RULES_PATH="$SIGMA_RULES_PATH"
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/bench/linux.sh [options]
+
+Options:
+  --mode baseline|with-agent
+  --agent PATH
+  --agent-args ARGS
+  --process-name NAME
+  --output-dir DIR
+  --idle-seconds N
+  --process-launches N
+  --file-count N
+  --file-size-bytes N
+  --alert-glob GLOB
+  --alert-rule-name NAME
+  --sigma-rules-path DIR
+  --yara-rules-path DIR
+  --ioc-rules-path DIR
+  --skip-cargo
+  --no-alert-latency
+  --no-benchmark-trigger-rule
+  --process-only
+  --file-only
+  --cargo-only
+  --keep-agent
+  -h, --help
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mode) MODE="$2"; shift 2 ;;
+    --agent) AGENT_PATH="$2"; shift 2 ;;
+    --agent-args) AGENT_ARGS="$2"; shift 2 ;;
+    --process-name) PROCESS_NAME="$2"; shift 2 ;;
+    --output-dir) OUTPUT_DIR="$2"; shift 2 ;;
+    --idle-seconds) IDLE_SECONDS="$2"; shift 2 ;;
+    --process-launches) PROCESS_LAUNCHES="$2"; shift 2 ;;
+    --file-count) FILE_COUNT="$2"; shift 2 ;;
+    --file-size-bytes) FILE_SIZE_BYTES="$2"; shift 2 ;;
+    --alert-glob) ALERT_GLOB="$2"; shift 2 ;;
+    --alert-rule-name) ALERT_RULE_NAME="$2"; shift 2 ;;
+    --sigma-rules-path) SIGMA_RULES_PATH="$2"; shift 2 ;;
+    --yara-rules-path) YARA_RULES_PATH="$2"; shift 2 ;;
+    --ioc-rules-path) IOC_RULES_PATH="$2"; shift 2 ;;
+    --skip-cargo) SKIP_CARGO=1; shift ;;
+    --no-alert-latency) NO_ALERT_LATENCY=1; shift ;;
+    --no-benchmark-trigger-rule) NO_BENCHMARK_TRIGGER_RULE=1; shift ;;
+    --process-only) PROCESS_ONLY=1; shift ;;
+    --file-only) FILE_ONLY=1; shift ;;
+    --cargo-only) CARGO_ONLY=1; shift ;;
+    --keep-agent) KEEP_AGENT=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage; exit 2 ;;
+  esac
+done
+
+if [[ "$MODE" != "baseline" && "$MODE" != "with-agent" ]]; then
+  echo "--mode must be baseline or with-agent" >&2
+  exit 2
+fi
+
+selector_count=$((PROCESS_ONLY + FILE_ONLY + CARGO_ONLY))
+if [[ "$selector_count" -gt 1 ]]; then
+  echo "Use only one of --process-only, --file-only, or --cargo-only." >&2
+  exit 2
+fi
+RUN_PROCESS_WORKLOAD=1
+RUN_FILE_WORKLOAD=1
+RUN_CARGO_WORKLOAD=1
+WORKLOAD_MODE="all"
+if [[ "$PROCESS_ONLY" -eq 1 ]]; then
+  RUN_FILE_WORKLOAD=0
+  RUN_CARGO_WORKLOAD=0
+  WORKLOAD_MODE="process-only"
+elif [[ "$FILE_ONLY" -eq 1 ]]; then
+  RUN_PROCESS_WORKLOAD=0
+  RUN_CARGO_WORKLOAD=0
+  WORKLOAD_MODE="file-only"
+elif [[ "$CARGO_ONLY" -eq 1 ]]; then
+  RUN_PROCESS_WORKLOAD=0
+  RUN_FILE_WORKLOAD=0
+  WORKLOAD_MODE="cargo-only"
+fi
+if [[ "$SKIP_CARGO" -eq 1 ]]; then
+  RUN_CARGO_WORKLOAD=0
+fi
+
+EFFECTIVE_SIGMA_RULES_PATH="$SIGMA_RULES_PATH"
+timestamp="$(date -u +%Y%m%d-%H%M%S)"
+RUN_DIR="$OUTPUT_DIR/$MODE-linux-$timestamp"
+mkdir -p "$RUN_DIR"
+SAMPLES_PATH="$RUN_DIR/resource-samples.csv"
+STEPS_PATH="$RUN_DIR/workload-steps.jsonl"
+SUMMARY_PATH="$RUN_DIR/summary.json"
+AGENT_STDOUT="$RUN_DIR/agent.stdout.log"
+STARTED_AGENT_PID=""
+VALIDATION_ERRORS=()
+
+now_iso() {
+  date -u +"%Y-%m-%dT%H:%M:%S.%3NZ"
+}
+
+now_ms() {
+  local ns
+  ns="$(date +%s%N)"
+  echo $((ns / 1000000))
+}
+
+find_pids() {
+  pgrep -x "$PROCESS_NAME" 2>/dev/null || true
+}
+
+json_escape() {
+  printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
+add_validation_error() {
+  VALIDATION_ERRORS+=("$1")
+}
+
+validation_errors_json() {
+  local first=1 error
+  for error in "${VALIDATION_ERRORS[@]}"; do
+    if [[ "$first" -eq 0 ]]; then
+      printf ','
+    fi
+    printf '"%s"' "$(json_escape "$error")"
+    first=0
+  done
+}
+
+idle_has_agent_samples() {
+  awk -F, 'NR > 1 && $2 == "idle" && ($3 + 0) > 0 { found = 1 } END { exit found ? 0 : 1 }' "$SAMPLES_PATH"
+}
+
+alert_line_count() {
+  shopt -s nullglob
+  local total=0
+  local file
+  for file in $ALERT_GLOB; do
+    if [[ -f "$file" ]]; then
+      if [[ -n "$ALERT_RULE_NAME" ]]; then
+        total=$((total + $(grep -F -c "\"rule.name\":\"$ALERT_RULE_NAME\"" "$file" 2>/dev/null || true)))
+      else
+        total=$((total + $(wc -l < "$file")))
+      fi
+    fi
+  done
+  shopt -u nullglob
+  echo "$total"
+}
+
+prepare_benchmark_sigma_corpus() {
+  local source_path="$1"
+  local dest="$RUN_DIR/sigma-benchmark"
+  mkdir -p "$dest"
+  if [[ -d "$source_path" ]]; then
+    cp -a "$source_path"/. "$dest"/
+  fi
+  cat > "$dest/rustinel_benchmark_whoami_linux.yml" <<YAML
+title: $ALERT_RULE_NAME
+id: 5223d875-9423-45a6-9645-a2db3ac7b83d
+status: test
+description: Stable Linux whoami trigger used by Rustinel benchmark latency checks.
+author: Rustinel
+logsource:
+  category: process_creation
+  product: linux
+detection:
+  selection:
+    Image|endswith: '/whoami'
+  condition: selection
+level: low
+YAML
+  EFFECTIVE_SIGMA_RULES_PATH="$dest"
+}
+
+count_rule_files() {
+  local path="$1"
+  shift
+  if [[ ! -d "$path" ]]; then
+    echo 0
+    return
+  fi
+  find "$path" -type f "$@" | wc -l | tr -d ' '
+}
+
+count_ioc_lines() {
+  local path="$1"
+  if [[ ! -d "$path" ]]; then
+    echo 0
+    return
+  fi
+  awk '{
+    line = $0
+    sub(/^[ \t]+/, "", line)
+    sub(/[ \t]+$/, "", line)
+    if (line != "" && substr(line, 1, 1) != "#") count++
+  } END { print count + 0 }' "$path"/* 2>/dev/null
+}
+
+percentile_index() {
+  local count="$1"
+  if [[ "$count" -le 1 ]]; then
+    echo 1
+  else
+    awk -v n="$count" 'BEGIN { i = int(n * 0.95); if (i < 1) i = 1; if (i > n) i = n; print i }'
+  fi
+}
+
+summarize_samples() {
+  local label="$1"
+  local temp_file="$2"
+  local seconds="$3"
+  local count avg p95 rss_avg rss_max threads_max
+  count="$(wc -l < "$temp_file" | tr -d ' ')"
+  if [[ "$count" -eq 0 ]]; then
+    printf '{"label":"%s","seconds":%s,"cpu_avg_percent":0,"cpu_p95_percent":0,"rss_avg_mb":0,"rss_max_mb":0,"threads_max":0}' "$label" "$seconds"
+    return
+  fi
+  avg="$(awk '{ sum += $1 } END { printf "%.3f", sum / NR }' "$temp_file")"
+  local pidx
+  pidx="$(percentile_index "$count")"
+  p95="$(sort -n "$temp_file" | awk -v i="$pidx" 'NR == i { printf "%.3f", $1 }')"
+  rss_avg="$(awk '{ sum += $2 } END { printf "%.3f", sum / NR }' "$temp_file")"
+  rss_max="$(awk 'BEGIN { max = 0 } { if ($2 > max) max = $2 } END { printf "%.3f", max }' "$temp_file")"
+  threads_max="$(awk 'BEGIN { max = 0 } { if ($3 > max) max = $3 } END { print max }' "$temp_file")"
+  printf '{"label":"%s","seconds":%s,"cpu_avg_percent":%s,"cpu_p95_percent":%s,"rss_avg_mb":%s,"rss_max_mb":%s,"threads_max":%s}' "$label" "$seconds" "$avg" "$p95" "$rss_avg" "$rss_max" "$threads_max"
+}
+
+RESOURCE_SUMMARIES=()
+
+sample_agent_resources() {
+  local label="$1"
+  local seconds="$2"
+  local temp_file="$RUN_DIR/$label.samples.tmp"
+  local pids
+  pids="$(find_pids | tr '\n' ' ')"
+  local logical_cpus
+  logical_cpus="$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 1)"
+  local clk_tck
+  clk_tck="$(getconf CLK_TCK 2>/dev/null || echo 100)"
+  local page_size
+  page_size="$(getconf PAGESIZE 2>/dev/null || echo 4096)"
+  local previous_ticks=""
+  local previous_time_cs=""
+  : > "$temp_file"
+
+  for ((i = 0; i <= seconds; i++)); do
+    local pid_count cpu rss_kb rss_mb threads total_ticks uptime uptime_int uptime_frac now_cs
+    pid_count=0
+    cpu="0.000"
+    rss_kb=0
+    threads=0
+    total_ticks=0
+    read -r uptime _ < /proc/uptime || uptime="0.00"
+    uptime_int="${uptime%%.*}"
+    uptime_frac="${uptime#*.}"
+    uptime_frac="${uptime_frac:0:2}"
+    while [[ ${#uptime_frac} -lt 2 ]]; do
+      uptime_frac="${uptime_frac}0"
+    done
+    now_cs=$((10#$uptime_int * 100 + 10#$uptime_frac))
+
+    if [[ -n "${pids// }" ]]; then
+      local pid stat rest fields proc_ticks proc_threads proc_rss_pages
+      for pid in $pids; do
+        [[ -r "/proc/$pid/stat" ]] || continue
+        pid_count=$((pid_count + 1))
+        read -r stat < "/proc/$pid/stat" || continue
+        rest="${stat#*) }"
+        read -r -a fields <<< "$rest"
+        proc_ticks=$((fields[11] + fields[12]))
+        proc_threads="${fields[17]:-0}"
+        proc_rss_pages="${fields[21]:-0}"
+        total_ticks=$((total_ticks + proc_ticks))
+        threads=$((threads + proc_threads))
+        rss_kb=$((rss_kb + (proc_rss_pages * page_size / 1024)))
+      done
+      if [[ -n "$previous_ticks" && -n "$previous_time_cs" ]]; then
+        local delta_ticks delta_cs cpu_milli whole frac
+        delta_ticks=$((total_ticks - previous_ticks))
+        delta_cs=$((now_cs - previous_time_cs))
+        if [[ "$delta_ticks" -gt 0 && "$delta_cs" -gt 0 && "$logical_cpus" -gt 0 ]]; then
+          cpu_milli=$((delta_ticks * 100000 / clk_tck * 100 / delta_cs / logical_cpus))
+          whole=$((cpu_milli / 1000))
+          frac=$((cpu_milli % 1000))
+          printf -v cpu '%d.%03d' "$whole" "$frac"
+        fi
+      fi
+    fi
+
+    printf -v rss_mb '%d.%03d' $((rss_kb / 1024)) $(((rss_kb % 1024) * 1000 / 1024))
+    local sample_time
+    printf -v sample_time '%(%Y-%m-%dT%H:%M:%SZ)T' -1
+    printf '%s,%s,%s,%s,%s,%s\n' "$sample_time" "$label" "$pid_count" "$cpu" "$rss_mb" "$threads" >> "$SAMPLES_PATH"
+    if [[ "$i" -gt 0 ]]; then
+      printf '%s %s %s\n' "$cpu" "$rss_mb" "$threads" >> "$temp_file"
+    fi
+    previous_ticks="$total_ticks"
+    previous_time_cs="$now_cs"
+    if [[ "$i" -lt "$seconds" ]]; then
+      sleep 1
+    fi
+  done
+
+  RESOURCE_SUMMARIES+=("$(summarize_samples "$label" "$temp_file" "$seconds")")
+  rm -f "$temp_file"
+}
+
+run_step() {
+  local name="$1"
+  shift
+  echo "Running $name..."
+  local start end status error
+  start="$(now_ms)"
+  status="ok"
+  error=""
+  if ! "$@"; then
+    status="error"
+    error="command failed"
+  fi
+  end="$(now_ms)"
+  printf '{"name":"%s","status":"%s","duration_ms":%s,"error":"%s"}\n' \
+    "$(json_escape "$name")" "$status" "$((end - start))" "$(json_escape "$error")" >> "$STEPS_PATH"
+}
+
+workload_process_launch() {
+  for ((i = 0; i < PROCESS_LAUNCHES; i++)); do
+    /bin/sh -c ':' >/dev/null
+  done
+}
+
+workload_file_io() {
+  local work_dir="$RUN_DIR/file-io"
+  rm -rf "$work_dir"
+  mkdir -p "$work_dir"
+  for ((i = 0; i < FILE_COUNT; i++)); do
+    dd if=/dev/zero of="$work_dir/sample-$i.bin" bs="$FILE_SIZE_BYTES" count=1 status=none
+  done
+  find "$work_dir" -type f -print0 | xargs -0 cat >/dev/null
+  rm -rf "$work_dir"
+}
+
+workload_cargo_build() {
+  if [[ "$SKIP_CARGO" -eq 1 ]]; then
+    return 0
+  fi
+  command -v cargo >/dev/null 2>&1 || return 1
+  cargo build --locked --release
+}
+
+measure_alert_latency() {
+  if [[ "$NO_ALERT_LATENCY" -eq 1 ]]; then
+    echo "null"
+    return
+  fi
+
+  local before start after elapsed
+  before="$(alert_line_count)"
+  start="$(now_ms)"
+  whoami >/dev/null || true
+  while [[ $(( $(now_ms) - start )) -lt 15000 ]]; do
+    sleep 0.1
+    after="$(alert_line_count)"
+    if [[ "$after" -gt "$before" ]]; then
+      elapsed=$(( $(now_ms) - start ))
+      echo "$elapsed"
+      return
+    fi
+  done
+  echo "null"
+}
+
+cleanup() {
+  if [[ -n "$STARTED_AGENT_PID" && "$KEEP_AGENT" -eq 0 ]]; then
+    echo "Stopping Rustinel process $STARTED_AGENT_PID"
+    kill "$STARTED_AGENT_PID" 2>/dev/null || true
+    sleep 2
+    kill -9 "$STARTED_AGENT_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+sudo_refresh() {
+  if [[ -n "${SUDO_ASKPASS:-}" ]]; then
+    sudo -A -v
+  else
+    sudo -v
+  fi
+}
+
+echo "timestamp,label,pid_count,cpu_percent,rss_mb,threads" > "$SAMPLES_PATH"
+: > "$STEPS_PATH"
+
+echo "Writing benchmark output to $RUN_DIR"
+
+if [[ "$MODE" == "with-agent" ]]; then
+  if [[ -z "$(find_pids)" ]]; then
+    if [[ ! -x "$AGENT_PATH" ]]; then
+      echo "Agent not found or not executable: $AGENT_PATH" >&2
+      echo "Build first with cargo build --release or pass --agent PATH." >&2
+      exit 1
+    fi
+    if [[ "$NO_BENCHMARK_TRIGGER_RULE" -eq 0 ]]; then
+      prepare_benchmark_sigma_corpus "$SIGMA_RULES_PATH"
+      echo "Using benchmark Sigma corpus: $EFFECTIVE_SIGMA_RULES_PATH"
+    fi
+    echo "Starting Rustinel: $AGENT_PATH $AGENT_ARGS"
+    if [[ "$EUID" -eq 0 ]]; then
+      setsid env \
+        EDR__SCANNER__SIGMA_RULES_PATH="$EFFECTIVE_SIGMA_RULES_PATH" \
+        EDR__SCANNER__YARA_RULES_PATH="$YARA_RULES_PATH" \
+        EDR__IOC__HASHES_PATH="$IOC_RULES_PATH/hashes.txt" \
+        EDR__IOC__IPS_PATH="$IOC_RULES_PATH/ips.txt" \
+        EDR__IOC__DOMAINS_PATH="$IOC_RULES_PATH/domains.txt" \
+        EDR__IOC__PATHS_REGEX_PATH="$IOC_RULES_PATH/paths_regex.txt" \
+        "$AGENT_PATH" $AGENT_ARGS > "$AGENT_STDOUT" 2>&1 &
+    else
+      sudo_refresh
+      if [[ -n "${SUDO_ASKPASS:-}" ]]; then
+        setsid sudo -A -E env \
+          EDR__SCANNER__SIGMA_RULES_PATH="$EFFECTIVE_SIGMA_RULES_PATH" \
+          EDR__SCANNER__YARA_RULES_PATH="$YARA_RULES_PATH" \
+          EDR__IOC__HASHES_PATH="$IOC_RULES_PATH/hashes.txt" \
+          EDR__IOC__IPS_PATH="$IOC_RULES_PATH/ips.txt" \
+          EDR__IOC__DOMAINS_PATH="$IOC_RULES_PATH/domains.txt" \
+          EDR__IOC__PATHS_REGEX_PATH="$IOC_RULES_PATH/paths_regex.txt" \
+          "$AGENT_PATH" $AGENT_ARGS > "$AGENT_STDOUT" 2>&1 &
+      else
+        setsid sudo -E env \
+          EDR__SCANNER__SIGMA_RULES_PATH="$EFFECTIVE_SIGMA_RULES_PATH" \
+          EDR__SCANNER__YARA_RULES_PATH="$YARA_RULES_PATH" \
+          EDR__IOC__HASHES_PATH="$IOC_RULES_PATH/hashes.txt" \
+          EDR__IOC__IPS_PATH="$IOC_RULES_PATH/ips.txt" \
+          EDR__IOC__DOMAINS_PATH="$IOC_RULES_PATH/domains.txt" \
+          EDR__IOC__PATHS_REGEX_PATH="$IOC_RULES_PATH/paths_regex.txt" \
+          "$AGENT_PATH" $AGENT_ARGS > "$AGENT_STDOUT" 2>&1 &
+      fi
+    fi
+    STARTED_AGENT_PID="$!"
+    sleep 5
+    if [[ -z "$(find_pids)" ]]; then
+      add_validation_error "with-agent mode did not observe an agent process after startup"
+    fi
+  else
+    echo "Using existing $PROCESS_NAME process: $(find_pids | tr '\n' ' ')"
+    if [[ "$NO_BENCHMARK_TRIGGER_RULE" -eq 0 ]]; then
+      echo "Warning: benchmark trigger rule cannot be injected into an already-running agent. Restart Rustinel or pass --no-benchmark-trigger-rule if the existing config already contains the trigger rule." >&2
+    fi
+  fi
+fi
+
+sample_agent_resources "idle" "$IDLE_SECONDS"
+if [[ "$MODE" == "with-agent" ]] && ! idle_has_agent_samples; then
+  add_validation_error "with-agent idle samples did not observe pid_count > 0"
+fi
+if [[ "$RUN_PROCESS_WORKLOAD" -eq 1 ]]; then
+  run_step "process_launch_$PROCESS_LAUNCHES" workload_process_launch
+  sample_agent_resources "post_process_launch_idle" 10
+fi
+if [[ "$RUN_FILE_WORKLOAD" -eq 1 ]]; then
+  run_step "file_io_${FILE_COUNT}x${FILE_SIZE_BYTES}" workload_file_io
+fi
+if [[ "$RUN_CARGO_WORKLOAD" -eq 1 ]]; then
+  run_step "cargo_build_release" workload_cargo_build
+fi
+ALERT_LATENCY_MS="$(measure_alert_latency)"
+if [[ "$MODE" == "with-agent" && "$NO_ALERT_LATENCY" -eq 0 && "$ALERT_LATENCY_MS" == "null" ]]; then
+  add_validation_error "with-agent alert latency was null"
+fi
+if grep -q '"status":"error"' "$STEPS_PATH"; then
+  add_validation_error "one or more workload steps failed"
+fi
+
+RUN_VALID="true"
+if [[ "${#VALIDATION_ERRORS[@]}" -gt 0 ]]; then
+  RUN_VALID="false"
+fi
+
+steps_json="$(paste -sd, "$STEPS_PATH")"
+resources_json="$(IFS=,; echo "${RESOURCE_SUMMARIES[*]}")"
+validation_errors="$(validation_errors_json)"
+os_name="$(uname -srvmo | sed 's/"/\\"/g')"
+cpu_name="$(awk -F: '/model name|Hardware/ { gsub(/^[ \t]+/, "", $2); print $2; exit }' /proc/cpuinfo 2>/dev/null | sed 's/"/\\"/g')"
+logical_cpus="$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 1)"
+total_memory_mb="$(awk '/MemTotal/ { printf "%.0f", $2 / 1024 }' /proc/meminfo 2>/dev/null || echo 0)"
+sigma_rule_files="$(count_rule_files "$EFFECTIVE_SIGMA_RULES_PATH" \( -name '*.yml' -o -name '*.yaml' \))"
+yara_rule_files="$(count_rule_files "$YARA_RULES_PATH" \( -name '*.yar' -o -name '*.yara' \))"
+ioc_non_comment_lines="$(count_ioc_lines "$IOC_RULES_PATH")"
+
+cat > "$SUMMARY_PATH" <<JSON
+{
+  "generated_at": "$(now_iso)",
+  "platform": "linux",
+  "mode": "$(json_escape "$MODE")",
+  "agent_path": "$(json_escape "$AGENT_PATH")",
+  "process_name": "$(json_escape "$PROCESS_NAME")",
+  "machine": {
+    "os": "$os_name",
+    "cpu": "$cpu_name",
+    "logical_cpus": $logical_cpus,
+    "total_memory_mb": $total_memory_mb
+  },
+  "rule_inventory": {
+    "sigma_rules_path": "$(json_escape "$SIGMA_RULES_PATH")",
+    "effective_sigma_rules_path": "$(json_escape "$EFFECTIVE_SIGMA_RULES_PATH")",
+    "sigma_rule_files": $sigma_rule_files,
+    "yara_rules_path": "$(json_escape "$YARA_RULES_PATH")",
+    "yara_rule_files": $yara_rule_files,
+    "ioc_rules_path": "$(json_escape "$IOC_RULES_PATH")",
+    "ioc_non_comment_lines": $ioc_non_comment_lines,
+    "note": "Counts describe the configured rule corpus on disk. Runtime logs contain parser skips and loaded-rule details."
+  },
+  "parameters": {
+    "idle_seconds": $IDLE_SECONDS,
+    "process_launches": $PROCESS_LAUNCHES,
+    "file_count": $FILE_COUNT,
+    "file_size_bytes": $FILE_SIZE_BYTES,
+    "alert_rule_name": "$(json_escape "$ALERT_RULE_NAME")",
+    "benchmark_trigger_rule": $([[ "$NO_BENCHMARK_TRIGGER_RULE" -eq 0 ]] && echo true || echo false),
+    "workload_mode": "$(json_escape "$WORKLOAD_MODE")"
+  },
+  "resource_summaries": [$resources_json],
+  "workload_steps": [$steps_json],
+  "alert_latency_ms": $ALERT_LATENCY_MS,
+  "valid": $RUN_VALID,
+  "validation_errors": [$validation_errors],
+  "samples_csv": "$(json_escape "$SAMPLES_PATH")",
+  "notes": [
+    "Run once with --mode baseline and once with --mode with-agent on the same machine.",
+    "Alert latency is null when no new alert line appears within 15 seconds."
+  ]
+}
+JSON
+
+echo "Summary: $SUMMARY_PATH"
+echo "Samples: $SAMPLES_PATH"
+if [[ "$RUN_VALID" != "true" ]]; then
+  echo "Invalid benchmark run: ${VALIDATION_ERRORS[*]}" >&2
+  exit 1
+fi

--- a/scripts/bench/windows.ps1
+++ b/scripts/bench/windows.ps1
@@ -1,0 +1,562 @@
+param(
+    [ValidateSet("baseline", "with-agent")]
+    [string]$Mode = "with-agent",
+    [string]$AgentPath = ".\target\release\rustinel.exe",
+    [string]$AgentArgs = "run --console",
+    [string]$ProcessName = "rustinel",
+    [string]$OutputDir = ".\target\rustinel-bench",
+    [int]$IdleSeconds = 60,
+    [int]$ProcessLaunches = 500,
+    [int]$FileCount = 2000,
+    [int]$FileSizeBytes = 1024,
+    [string]$AlertGlob = ".\logs\alerts.json*",
+    [string]$AlertRuleName = "Rustinel Benchmark Whoami Windows",
+    [string]$SigmaRulesPath = ".\rules\sigma",
+    [string]$YaraRulesPath = ".\rules\yara",
+    [string]$IocRulesPath = ".\rules\ioc",
+    [switch]$SkipCargo,
+    [switch]$NoAlertLatency,
+    [switch]$NoBenchmarkTriggerRule,
+    [switch]$ProcessOnly,
+    [switch]$FileOnly,
+    [switch]$CargoOnly,
+    [switch]$KeepAgent
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$workloadSelectorCount = 0
+foreach ($selector in @($ProcessOnly, $FileOnly, $CargoOnly)) {
+    if ($selector) {
+        $workloadSelectorCount++
+    }
+}
+if ($workloadSelectorCount -gt 1) {
+    throw "Use only one of -ProcessOnly, -FileOnly, or -CargoOnly."
+}
+$runProcessWorkload = -not ($FileOnly -or $CargoOnly)
+$runFileWorkload = -not ($ProcessOnly -or $CargoOnly)
+$runCargoWorkload = -not ($ProcessOnly -or $FileOnly -or $SkipCargo)
+$workloadMode = if ($ProcessOnly) { "process-only" } elseif ($FileOnly) { "file-only" } elseif ($CargoOnly) { "cargo-only" } else { "all" }
+
+function Get-NowIso {
+    (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffZ")
+}
+
+function New-BenchDirectory {
+    $timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
+    $dir = Join-Path $OutputDir "$Mode-windows-$timestamp"
+    New-Item -ItemType Directory -Force -Path $dir | Out-Null
+    return (Resolve-Path $dir).Path
+}
+
+function Get-AgentProcesses {
+    @(Get-Process -Name $ProcessName -ErrorAction SilentlyContinue)
+}
+
+function Get-AlertLineCount {
+    param([string]$RuleName = "")
+
+    $total = 0
+    $needle = if ($RuleName.Length -gt 0) { '"rule.name":"' + $RuleName + '"' } else { "" }
+    foreach ($file in @(Get-ChildItem -Path $AlertGlob -ErrorAction SilentlyContinue)) {
+        try {
+            if ($needle.Length -gt 0) {
+                $total += @(Select-String -Path $file.FullName -SimpleMatch $needle -ErrorAction Stop).Count
+            } else {
+                $total += @(Get-Content -Path $file.FullName -ErrorAction Stop).Count
+            }
+        } catch {
+            Write-Warning "Unable to read alert file $($file.FullName): $_"
+        }
+    }
+    return $total
+}
+
+function Get-OperationalLogOffsets {
+    $offsets = @{}
+    foreach ($file in @(Get-ChildItem -Path ".\logs\rustinel.log.*" -File -ErrorAction SilentlyContinue)) {
+        $offsets[$file.FullName] = $file.Length
+    }
+    return $offsets
+}
+
+function Get-AppendedLogText {
+    param([hashtable]$Offsets)
+
+    $builder = [System.Text.StringBuilder]::new()
+    foreach ($file in @(Get-ChildItem -Path ".\logs\rustinel.log.*" -File -ErrorAction SilentlyContinue)) {
+        $offset = if ($Offsets.ContainsKey($file.FullName)) { [int64]$Offsets[$file.FullName] } else { [int64]0 }
+        if ($file.Length -le $offset) {
+            continue
+        }
+
+        $stream = [System.IO.File]::Open($file.FullName, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::ReadWrite)
+        try {
+            [void]$stream.Seek($offset, [System.IO.SeekOrigin]::Begin)
+            $reader = [System.IO.StreamReader]::new($stream, [System.Text.Encoding]::UTF8, $true, 4096, $true)
+            try {
+                [void]$builder.Append($reader.ReadToEnd())
+            } finally {
+                $reader.Dispose()
+            }
+        } finally {
+            $stream.Dispose()
+        }
+    }
+    return $builder.ToString()
+}
+
+function Get-EtwDropSummary {
+    param([hashtable]$Offsets)
+
+    $text = Get-AppendedLogText -Offsets $Offsets
+    $dropWarnings = [regex]::Matches($text, "Sensor event channel full; dropping ETW event").Count
+    $counterMatches = [regex]::Matches($text, "dropped_events=(\d+)")
+    $finalCounter = [int64]0
+    foreach ($match in $counterMatches) {
+        $finalCounter = [int64]$match.Groups[1].Value
+    }
+
+    return [pscustomobject]@{
+        warning_count = $dropWarnings
+        final_counter = $finalCounter
+    }
+}
+
+function Test-IdleHasAgentSamples {
+    param([string]$SamplesPath)
+
+    if (-not (Test-Path $SamplesPath)) {
+        return $false
+    }
+
+    foreach ($sample in @(Import-Csv -Path $SamplesPath)) {
+        if ($sample.label -eq "idle" -and [int]$sample.pid_count -gt 0) {
+            return $true
+        }
+    }
+    return $false
+}
+
+function New-BenchmarkSigmaCorpus {
+    param(
+        [string]$SourcePath,
+        [string]$RuleName
+    )
+
+    $dest = Join-Path $script:RunDir "sigma-benchmark"
+    New-Item -ItemType Directory -Force -Path $dest | Out-Null
+
+    if (Test-Path $SourcePath) {
+        foreach ($item in @(Get-ChildItem -Path $SourcePath -Force -ErrorAction SilentlyContinue)) {
+            Copy-Item -LiteralPath $item.FullName -Destination $dest -Recurse -Force
+        }
+    }
+
+    $rulePath = Join-Path $dest "rustinel_benchmark_whoami_windows.yml"
+    $rule = @"
+title: $RuleName
+id: 9a782d5f-37f8-4f1d-9f64-e41881f5d3b7
+status: test
+description: Stable Windows whoami trigger used by Rustinel benchmark latency checks.
+author: Rustinel
+logsource:
+  category: process_creation
+  product: windows
+detection:
+  selection_img:
+    Image|endswith: '\whoami.exe'
+  selection_cmd:
+    CommandLine|contains: ' /all'
+  condition: selection_img and selection_cmd
+level: low
+"@
+    $utf8NoBom = New-Object System.Text.UTF8Encoding $false
+    [System.IO.File]::WriteAllText($rulePath, $rule, $utf8NoBom)
+    return (Resolve-Path $dest).Path
+}
+
+function Measure-AgentResources {
+    param(
+        [string]$Label,
+        [int]$DurationSeconds,
+        [string]$SamplesPath
+    )
+
+    $logicalCpus = [Math]::Max([Environment]::ProcessorCount, 1)
+    $samples = New-Object System.Collections.Generic.List[object]
+    $previousCpu = $null
+    $previousTime = $null
+
+    for ($i = 0; $i -le $DurationSeconds; $i++) {
+        $now = Get-Date
+        $procs = @(Get-AgentProcesses)
+        $cpuSeconds = ($procs | ForEach-Object { if ($null -ne $_.CPU) { $_.CPU } else { 0 } } | Measure-Object -Sum).Sum
+        if ($null -eq $cpuSeconds) {
+            $cpuSeconds = 0
+        }
+        $workingSetBytes = ($procs | ForEach-Object { $_.WorkingSet64 } | Measure-Object -Sum).Sum
+        if ($null -eq $workingSetBytes) {
+            $workingSetBytes = 0
+        }
+        $threadCount = ($procs | ForEach-Object { $_.Threads.Count } | Measure-Object -Sum).Sum
+        if ($null -eq $threadCount) {
+            $threadCount = 0
+        }
+
+        $cpuPercent = 0.0
+        if ($null -ne $previousCpu -and $null -ne $previousTime) {
+            $elapsed = [Math]::Max(($now - $previousTime).TotalSeconds, 0.001)
+            $cpuPercent = [Math]::Max(0.0, (($cpuSeconds - $previousCpu) / $elapsed / $logicalCpus) * 100.0)
+        }
+
+        $sample = [pscustomobject]@{
+            timestamp = (Get-NowIso)
+            label = $Label
+            pid_count = $procs.Count
+            cpu_percent = [Math]::Round($cpuPercent, 3)
+            working_set_mb = [Math]::Round($workingSetBytes / 1MB, 3)
+            threads = [int]$threadCount
+        }
+        $samples.Add($sample)
+
+        $previousCpu = $cpuSeconds
+        $previousTime = $now
+
+        if ($i -lt $DurationSeconds) {
+            Start-Sleep -Seconds 1
+        }
+    }
+
+    $samples | Export-Csv -Path $SamplesPath -NoTypeInformation -Append
+    $cpuValues = @($samples | Select-Object -Skip 1 | ForEach-Object { $_.cpu_percent } | Sort-Object)
+    $rssValues = @($samples | ForEach-Object { $_.working_set_mb } | Sort-Object)
+    $p95Index = if ($cpuValues.Count -gt 0) { [Math]::Min($cpuValues.Count - 1, [Math]::Ceiling($cpuValues.Count * 0.95) - 1) } else { 0 }
+
+    return [pscustomobject]@{
+        label = $Label
+        seconds = $DurationSeconds
+        cpu_avg_percent = if ($cpuValues.Count -gt 0) { [Math]::Round((($cpuValues | Measure-Object -Average).Average), 3) } else { 0.0 }
+        cpu_p95_percent = if ($cpuValues.Count -gt 0) { [Math]::Round($cpuValues[$p95Index], 3) } else { 0.0 }
+        working_set_avg_mb = if ($rssValues.Count -gt 0) { [Math]::Round((($rssValues | Measure-Object -Average).Average), 3) } else { 0.0 }
+        working_set_max_mb = if ($rssValues.Count -gt 0) { [Math]::Round((($rssValues | Measure-Object -Maximum).Maximum), 3) } else { 0.0 }
+        threads_max = if ($samples.Count -gt 0) { (($samples | ForEach-Object { $_.threads }) | Measure-Object -Maximum).Maximum } else { 0 }
+    }
+}
+
+function Measure-Step {
+    param(
+        [string]$Name,
+        [scriptblock]$Action
+    )
+
+    Write-Host "Running $Name..."
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    $status = "ok"
+    $errorMessage = $null
+    try {
+        & $Action
+    } catch {
+        $status = "error"
+        $errorMessage = $_.Exception.Message
+        Write-Warning "$Name failed: $errorMessage"
+    } finally {
+        $sw.Stop()
+    }
+
+    return [pscustomobject]@{
+        name = $Name
+        status = $status
+        duration_ms = [int64]$sw.ElapsedMilliseconds
+        error = $errorMessage
+    }
+}
+
+function Invoke-ProcessLaunchWorkload {
+    for ($i = 0; $i -lt $ProcessLaunches; $i++) {
+        $proc = Start-Process -FilePath $env:ComSpec -ArgumentList "/c", "exit", "0" -WindowStyle Hidden -PassThru
+        $proc.WaitForExit()
+    }
+}
+
+function Invoke-FileIoWorkload {
+    $workDir = Join-Path $script:RunDir "file-io"
+    if (Test-Path $workDir) {
+        Remove-Item -LiteralPath $workDir -Recurse -Force
+    }
+    New-Item -ItemType Directory -Force -Path $workDir | Out-Null
+
+    $buffer = New-Object byte[] $FileSizeBytes
+    for ($i = 0; $i -lt $FileCount; $i++) {
+        [System.IO.File]::WriteAllBytes((Join-Path $workDir "sample-$i.bin"), $buffer)
+    }
+    foreach ($file in Get-ChildItem -Path $workDir -File) {
+        $stream = [System.IO.File]::OpenRead($file.FullName)
+        try {
+            [void]$stream.ReadByte()
+        } finally {
+            $stream.Dispose()
+        }
+    }
+    Remove-Item -LiteralPath $workDir -Recurse -Force
+}
+
+function Invoke-CargoBuildWorkload {
+    if ($SkipCargo) {
+        return "skipped"
+    }
+    if ($null -eq (Get-Command cargo -ErrorAction SilentlyContinue)) {
+        throw "cargo not found"
+    }
+    & cargo build --locked --release
+    if ($LASTEXITCODE -ne 0) {
+        throw "cargo build failed with exit code $LASTEXITCODE"
+    }
+}
+
+function Measure-AlertLatency {
+    if ($NoAlertLatency) {
+        return $null
+    }
+
+    $before = Get-AlertLineCount -RuleName $AlertRuleName
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    & whoami /all | Out-Null
+    while ($sw.Elapsed.TotalSeconds -lt 15) {
+        Start-Sleep -Milliseconds 100
+        $after = Get-AlertLineCount -RuleName $AlertRuleName
+        if ($after -gt $before) {
+            $sw.Stop()
+            return [int64]$sw.ElapsedMilliseconds
+        }
+    }
+    $sw.Stop()
+    return $null
+}
+
+function Get-MachineInfo {
+    $os = [Environment]::OSVersion.VersionString
+    $cpu = "unknown"
+    $totalMemoryMb = 0
+
+    try {
+        $osInfo = Get-CimInstance Win32_OperatingSystem -ErrorAction Stop
+        if ($null -ne $osInfo.Caption) {
+            $os = $osInfo.Caption
+        }
+    } catch {
+        Write-Warning "Unable to query operating system metadata through CIM: $($_.Exception.Message)"
+    }
+
+    try {
+        $cpuInfo = Get-CimInstance Win32_Processor -ErrorAction Stop | Select-Object -First 1
+        if ($null -ne $cpuInfo.Name) {
+            $cpu = $cpuInfo.Name
+        }
+    } catch {
+        Write-Warning "Unable to query CPU metadata through CIM: $($_.Exception.Message)"
+    }
+
+    try {
+        $computerInfo = Get-CimInstance Win32_ComputerSystem -ErrorAction Stop
+        if ($null -ne $computerInfo.TotalPhysicalMemory) {
+            $totalMemoryMb = [Math]::Round($computerInfo.TotalPhysicalMemory / 1MB, 0)
+        }
+    } catch {
+        Write-Warning "Unable to query memory metadata through CIM: $($_.Exception.Message)"
+    }
+
+    return [pscustomobject]@{
+        os = $os
+        cpu = $cpu
+        logical_cpus = [Environment]::ProcessorCount
+        total_memory_mb = $totalMemoryMb
+    }
+}
+
+function Count-RuleFiles {
+    param(
+        [string]$Path,
+        [string[]]$Extensions
+    )
+
+    if (-not (Test-Path $Path)) {
+        return 0
+    }
+
+    $count = 0
+    foreach ($ext in $Extensions) {
+        $count += @(Get-ChildItem -Path $Path -Recurse -File -Filter "*.$ext" -ErrorAction SilentlyContinue).Count
+    }
+    return $count
+}
+
+function Count-NonCommentLines {
+    param([string]$Path)
+
+    if (-not (Test-Path $Path)) {
+        return 0
+    }
+
+    $count = 0
+    foreach ($file in @(Get-ChildItem -Path $Path -File -ErrorAction SilentlyContinue)) {
+        try {
+            foreach ($line in Get-Content -Path $file.FullName -ErrorAction Stop) {
+                $trimmed = $line.Trim()
+                if ($trimmed.Length -gt 0 -and -not $trimmed.StartsWith("#")) {
+                    $count++
+                }
+            }
+        } catch {
+            Write-Warning "Unable to read IOC file $($file.FullName): $_"
+        }
+    }
+    return $count
+}
+
+function Get-RuleInventory {
+    return [pscustomobject]@{
+        sigma_rules_path = $effectiveSigmaRulesPath
+        sigma_rule_files = Count-RuleFiles -Path $effectiveSigmaRulesPath -Extensions @("yml", "yaml")
+        yara_rules_path = $YaraRulesPath
+        yara_rule_files = Count-RuleFiles -Path $YaraRulesPath -Extensions @("yar", "yara")
+        ioc_rules_path = $IocRulesPath
+        ioc_non_comment_lines = Count-NonCommentLines -Path $IocRulesPath
+        note = "Counts describe the configured rule corpus on disk. Runtime logs contain parser skips and loaded-rule details."
+    }
+}
+
+$script:RunDir = New-BenchDirectory
+$samplesPath = Join-Path $script:RunDir "resource-samples.csv"
+$summaryPath = Join-Path $script:RunDir "summary.json"
+$startedAgent = $null
+$effectiveSigmaRulesPath = $SigmaRulesPath
+$validationErrors = New-Object System.Collections.Generic.List[string]
+$operationalLogOffsets = Get-OperationalLogOffsets
+$previousEnv = @{
+    sigma = $env:EDR__SCANNER__SIGMA_RULES_PATH
+    yara = $env:EDR__SCANNER__YARA_RULES_PATH
+    ioc_hashes = $env:EDR__IOC__HASHES_PATH
+    ioc_ips = $env:EDR__IOC__IPS_PATH
+    ioc_domains = $env:EDR__IOC__DOMAINS_PATH
+    ioc_paths = $env:EDR__IOC__PATHS_REGEX_PATH
+}
+
+try {
+    Write-Host "Writing benchmark output to $script:RunDir"
+
+    if ($Mode -eq "with-agent") {
+        $existing = @(Get-AgentProcesses)
+        if ($existing.Count -eq 0) {
+            if (-not (Test-Path $AgentPath)) {
+                throw "AgentPath not found: $AgentPath. Build first with cargo build --release or pass -AgentPath."
+            }
+            if (-not $NoBenchmarkTriggerRule) {
+                $effectiveSigmaRulesPath = New-BenchmarkSigmaCorpus -SourcePath $SigmaRulesPath -RuleName $AlertRuleName
+                Write-Host "Using benchmark Sigma corpus: $effectiveSigmaRulesPath"
+            }
+            $env:EDR__SCANNER__SIGMA_RULES_PATH = $effectiveSigmaRulesPath
+            $env:EDR__SCANNER__YARA_RULES_PATH = $YaraRulesPath
+            $env:EDR__IOC__HASHES_PATH = Join-Path $IocRulesPath "hashes.txt"
+            $env:EDR__IOC__IPS_PATH = Join-Path $IocRulesPath "ips.txt"
+            $env:EDR__IOC__DOMAINS_PATH = Join-Path $IocRulesPath "domains.txt"
+            $env:EDR__IOC__PATHS_REGEX_PATH = Join-Path $IocRulesPath "paths_regex.txt"
+            Write-Host "Starting Rustinel: $AgentPath $AgentArgs"
+            $startedAgent = Start-Process -FilePath (Resolve-Path $AgentPath).Path -ArgumentList $AgentArgs -WindowStyle Hidden -PassThru
+            Start-Sleep -Seconds 5
+            if (@(Get-AgentProcesses).Count -eq 0) {
+                [void]$validationErrors.Add("with-agent mode did not observe an agent process after startup")
+            }
+        } else {
+            Write-Host "Using existing $ProcessName process: $($existing.Id -join ', ')"
+            if (-not $NoBenchmarkTriggerRule) {
+                Write-Warning "Benchmark trigger rule cannot be injected into an already-running agent. Restart Rustinel or pass -NoBenchmarkTriggerRule if the existing config already contains the trigger rule."
+            }
+        }
+    }
+
+    $resourceSummaries = New-Object System.Collections.Generic.List[object]
+    $steps = New-Object System.Collections.Generic.List[object]
+
+    $resourceSummaries.Add((Measure-AgentResources -Label "idle" -DurationSeconds $IdleSeconds -SamplesPath $samplesPath))
+    if ($Mode -eq "with-agent" -and -not (Test-IdleHasAgentSamples -SamplesPath $samplesPath)) {
+        [void]$validationErrors.Add("with-agent idle samples did not observe pid_count > 0")
+    }
+    if ($runProcessWorkload) {
+        $steps.Add((Measure-Step -Name "process_launch_$ProcessLaunches" -Action { Invoke-ProcessLaunchWorkload }))
+        $resourceSummaries.Add((Measure-AgentResources -Label "post_process_launch_idle" -DurationSeconds 10 -SamplesPath $samplesPath))
+    }
+    if ($runFileWorkload) {
+        $steps.Add((Measure-Step -Name "file_io_${FileCount}x${FileSizeBytes}" -Action { Invoke-FileIoWorkload }))
+    }
+
+    if ($runCargoWorkload) {
+        $steps.Add((Measure-Step -Name "cargo_build_release" -Action { Invoke-CargoBuildWorkload }))
+    }
+
+    $alertLatency = Measure-AlertLatency
+    if ($Mode -eq "with-agent" -and -not $NoAlertLatency -and $null -eq $alertLatency) {
+        [void]$validationErrors.Add("with-agent alert latency was null")
+    }
+    if (@($steps | Where-Object { $_.status -eq "error" }).Count -gt 0) {
+        [void]$validationErrors.Add("one or more workload steps failed")
+    }
+    $etwDrops = Get-EtwDropSummary -Offsets $operationalLogOffsets
+    if ($Mode -eq "with-agent" -and $null -ne $etwDrops.final_counter -and $etwDrops.final_counter -gt 0) {
+        [void]$validationErrors.Add("ETW drops were observed")
+    }
+
+    $machineInfo = Get-MachineInfo
+    $ruleInventory = Get-RuleInventory
+
+    $summary = [pscustomobject]@{
+        generated_at = Get-NowIso
+        platform = "windows"
+        mode = $Mode
+        agent_path = $AgentPath
+        process_name = $ProcessName
+        machine = $machineInfo
+        rule_inventory = $ruleInventory
+        parameters = [pscustomobject]@{
+            idle_seconds = $IdleSeconds
+            process_launches = $ProcessLaunches
+            file_count = $FileCount
+            file_size_bytes = $FileSizeBytes
+            alert_rule_name = $AlertRuleName
+            benchmark_trigger_rule = -not $NoBenchmarkTriggerRule
+            effective_sigma_rules_path = $effectiveSigmaRulesPath
+            workload_mode = $workloadMode
+        }
+        resource_summaries = $resourceSummaries
+        workload_steps = $steps
+        alert_latency_ms = $alertLatency
+        etw_drops = $etwDrops
+        valid = $validationErrors.Count -eq 0
+        validation_errors = @($validationErrors)
+        samples_csv = $samplesPath
+        notes = @(
+            "Run once with -Mode baseline and once with -Mode with-agent on the same machine.",
+            "Alert latency is null when no new alert line appears within 15 seconds."
+        )
+    }
+
+    $summary | ConvertTo-Json -Depth 8 | Set-Content -Path $summaryPath -Encoding UTF8
+    Write-Host "Summary: $summaryPath"
+    Write-Host "Samples: $samplesPath"
+    if ($validationErrors.Count -gt 0) {
+        throw "Invalid benchmark run: $($validationErrors -join '; ')"
+    }
+} finally {
+    if ($null -ne $startedAgent -and -not $KeepAgent) {
+        Write-Host "Stopping Rustinel process $($startedAgent.Id)"
+        Stop-Process -Id $startedAgent.Id -Force -ErrorAction SilentlyContinue
+    }
+    $env:EDR__SCANNER__SIGMA_RULES_PATH = $previousEnv.sigma
+    $env:EDR__SCANNER__YARA_RULES_PATH = $previousEnv.yara
+    $env:EDR__IOC__HASHES_PATH = $previousEnv.ioc_hashes
+    $env:EDR__IOC__IPS_PATH = $previousEnv.ioc_ips
+    $env:EDR__IOC__DOMAINS_PATH = $previousEnv.ioc_domains
+    $env:EDR__IOC__PATHS_REGEX_PATH = $previousEnv.ioc_paths
+}

--- a/scripts/rules/fetch_corpus.py
+++ b/scripts/rules/fetch_corpus.py
@@ -1,0 +1,413 @@
+#!/usr/bin/env python3
+"""
+Build a Rustinel benchmark rule corpus from public community sources.
+
+The script intentionally uses only the Python standard library so it can run on
+Windows and Linux without a virtualenv.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import ipaddress
+import json
+import os
+import re
+import shutil
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import zipfile
+from pathlib import Path
+
+
+SIGMA_ZIP_URL = "https://github.com/SigmaHQ/sigma/archive/refs/heads/master.zip"
+YARA_FORGE_RELEASE_API = "https://api.github.com/repos/YARAHQ/yara-forge/releases/latest"
+FEODO_RECOMMENDED_URL = "https://feodotracker.abuse.ch/downloads/ipblocklist_recommended.txt"
+FEODO_30D_URL = "https://feodotracker.abuse.ch/downloads/ipblocklist.txt"
+THREATFOX_API_URL = "https://threatfox-api.abuse.ch/api/v1/"
+URLHAUS_RECENT_CSV_URL = "https://urlhaus-api.abuse.ch/v2/files/exports/{auth_key}/recent.csv"
+
+USER_AGENT = "rustinel-bench-corpus/1.0"
+
+
+def log(message: str) -> None:
+    print(message, flush=True)
+
+
+def request(url: str, *, data: bytes | None = None, headers: dict[str, str] | None = None) -> bytes:
+    req_headers = {"User-Agent": USER_AGENT}
+    if headers:
+        req_headers.update(headers)
+    req = urllib.request.Request(url, data=data, headers=req_headers)
+    try:
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            return resp.read()
+    except urllib.error.HTTPError as err:
+        body = err.read().decode("utf-8", "replace")[:500]
+        raise RuntimeError(f"HTTP {err.code} while fetching {url}: {body}") from err
+    except urllib.error.URLError as err:
+        raise RuntimeError(f"Failed to fetch {url}: {err}") from err
+
+
+def write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8", newline="\n")
+
+
+def append_unique(path: Path, values: set[str], header: str) -> None:
+    lines = [header]
+    for value in sorted(values):
+        lines.append(value)
+    write_text(path, "\n".join(lines) + "\n")
+
+
+def clean_output_dir(output: Path, force: bool) -> None:
+    if output.exists():
+        if not force:
+            raise SystemExit(f"{output} already exists. Pass --force to replace it.")
+        shutil.rmtree(output)
+    (output / "sigma").mkdir(parents=True)
+    (output / "yara").mkdir(parents=True)
+    (output / "ioc").mkdir(parents=True)
+    (output / "sources").mkdir(parents=True)
+
+
+def is_sigma_candidate(member_name: str) -> bool:
+    parts = member_name.split("/")
+    if len(parts) < 3:
+        return False
+    top_level = parts[1]
+    filename = parts[-1].lower()
+    if not filename.endswith((".yml", ".yaml")):
+        return False
+    if top_level in {"deprecated", "unsupported", "tests", "documentation"}:
+        return False
+    return top_level == "rules" or top_level.startswith("rules-")
+
+
+def fetch_sigma(output: Path, metadata: dict[str, object]) -> int:
+    log("Fetching SigmaHQ community rules...")
+    data = request(SIGMA_ZIP_URL)
+    count = 0
+    with zipfile.ZipFile(io.BytesIO(data)) as zf:
+        for info in zf.infolist():
+            if info.is_dir() or not is_sigma_candidate(info.filename):
+                continue
+            parts = info.filename.split("/")
+            relative = Path(*parts[1:])
+            target = output / "sigma" / relative
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(zf.read(info))
+            count += 1
+    metadata["sigma"] = {
+        "source": SIGMA_ZIP_URL,
+        "files": count,
+        "included": "rules* directories, excluding deprecated/unsupported/tests/documentation",
+    }
+    log(f"Sigma files: {count}")
+    return count
+
+
+def latest_yara_forge_asset(ruleset: str) -> tuple[str, str, str]:
+    release = json.loads(request(YARA_FORGE_RELEASE_API).decode("utf-8"))
+    assets = release.get("assets", [])
+    candidates = []
+    for asset in assets:
+        name = str(asset.get("name", ""))
+        download = asset.get("browser_download_url")
+        lower = name.lower()
+        if download and lower.endswith(".zip") and ruleset.lower() in lower:
+            candidates.append((name, download))
+    if not candidates:
+        asset_names = ", ".join(str(asset.get("name", "")) for asset in assets)
+        raise RuntimeError(
+            f"Could not find a YARA Forge {ruleset!r} zip asset in latest release. Assets: {asset_names}"
+        )
+    name, download = sorted(candidates, key=lambda item: len(item[0]))[0]
+    return str(release.get("tag_name", "")), name, str(download)
+
+
+def fetch_yara_forge(output: Path, ruleset: str, metadata: dict[str, object]) -> int:
+    log(f"Fetching YARA Forge {ruleset} rules...")
+    tag, asset_name, url = latest_yara_forge_asset(ruleset)
+    data = request(url)
+    count = 0
+    with zipfile.ZipFile(io.BytesIO(data)) as zf:
+        for info in zf.infolist():
+            if info.is_dir() or not info.filename.lower().endswith((".yar", ".yara")):
+                continue
+            # Rustinel's YARA loader currently reads only the top-level rules
+            # directory, so flatten package files into unique filenames.
+            safe_name = re.sub(r"[^A-Za-z0-9_.-]+", "_", info.filename).strip("_")
+            target = output / "yara" / safe_name
+            target.write_bytes(zf.read(info))
+            count += 1
+    metadata["yara_forge"] = {
+        "source": YARA_FORGE_RELEASE_API,
+        "release": tag,
+        "asset": asset_name,
+        "ruleset": ruleset,
+        "files": count,
+    }
+    log(f"YARA files: {count}")
+    return count
+
+
+def parse_feodo_ips(text: str, source_name: str) -> set[str]:
+    ips = set()
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or line.upper() == "END":
+            continue
+        token = line.split()[0].strip()
+        try:
+            ipaddress.ip_address(token)
+        except ValueError:
+            continue
+        ips.add(f"{token};{source_name}")
+    return ips
+
+
+def fetch_feodo(output: Path, mode: str, metadata: dict[str, object]) -> set[str]:
+    if mode == "off":
+        metadata["feodo"] = {"enabled": False}
+        return set()
+    url = FEODO_RECOMMENDED_URL if mode == "recommended" else FEODO_30D_URL
+    log(f"Fetching Feodo Tracker IP IOCs ({mode})...")
+    ips = parse_feodo_ips(request(url).decode("utf-8", "replace"), f"feodo:{mode}")
+    metadata["feodo"] = {"source": url, "mode": mode, "ips": len(ips)}
+    log(f"Feodo IP IOCs: {len(ips)}")
+    return ips
+
+
+def clean_domain(value: str) -> str | None:
+    value = value.strip().lower().strip(".")
+    if not value or "/" in value or " " in value:
+        return None
+    if "." not in value:
+        return None
+    return value
+
+
+def clean_hash(value: str) -> str | None:
+    value = value.strip().lower()
+    if re.fullmatch(r"[0-9a-f]{32}|[0-9a-f]{40}|[0-9a-f]{64}", value):
+        return value
+    return None
+
+
+def parse_ioc_value(ioc: str, ioc_type: str, comment: str) -> tuple[str, str] | None:
+    ioc = ioc.strip()
+    ioc_type = ioc_type.lower()
+    if ioc_type in {"ip:port", "ipv4:port", "ipv6:port"}:
+        ioc = ioc.rsplit(":", 1)[0]
+        ioc_type = "ip"
+    if ioc_type in {"ip", "ipv4", "ipv6"}:
+        try:
+            return "ip", f"{ipaddress.ip_address(ioc)};{comment}"
+        except ValueError:
+            return None
+    if ioc_type in {"domain", "hostname"}:
+        domain = clean_domain(ioc)
+        return ("domain", f"{domain};{comment}") if domain else None
+    if ioc_type in {"url"}:
+        host = urllib.parse.urlparse(ioc).hostname
+        domain = clean_domain(host or "")
+        return ("domain", f"{domain};{comment}") if domain else None
+    if ioc_type in {"md5_hash", "sha1_hash", "sha256_hash", "hash"}:
+        digest = clean_hash(ioc)
+        return ("hash", f"{digest};{comment}") if digest else None
+    return None
+
+
+def fetch_threatfox(
+    auth_key: str | None,
+    days: int,
+    min_confidence: int,
+    metadata: dict[str, object],
+) -> tuple[set[str], set[str], set[str]]:
+    if not auth_key:
+        metadata["threatfox"] = {"enabled": False, "reason": "missing auth key"}
+        return set(), set(), set()
+    log(f"Fetching ThreatFox recent IOCs ({days} days, confidence >= {min_confidence})...")
+    payload = json.dumps({"query": "get_iocs", "days": days}).encode("utf-8")
+    body = request(
+        THREATFOX_API_URL,
+        data=payload,
+        headers={"Auth-Key": auth_key, "Content-Type": "application/json"},
+    )
+    parsed = json.loads(body.decode("utf-8"))
+    ips: set[str] = set()
+    domains: set[str] = set()
+    hashes: set[str] = set()
+    for item in parsed.get("data", []) or []:
+        confidence = int(item.get("confidence_level") or 0)
+        if confidence < min_confidence:
+            continue
+        malware = str(item.get("malware_printable") or item.get("malware") or "unknown")
+        comment = f"threatfox:{malware}:confidence={confidence}"
+        converted = parse_ioc_value(str(item.get("ioc", "")), str(item.get("ioc_type", "")), comment)
+        if converted is None:
+            continue
+        kind, value = converted
+        if kind == "ip":
+            ips.add(value)
+        elif kind == "domain":
+            domains.add(value)
+        elif kind == "hash":
+            hashes.add(value)
+    metadata["threatfox"] = {
+        "source": THREATFOX_API_URL,
+        "days": days,
+        "min_confidence": min_confidence,
+        "ips": len(ips),
+        "domains": len(domains),
+        "hashes": len(hashes),
+    }
+    log(f"ThreatFox IOCs: {len(ips)} IPs, {len(domains)} domains, {len(hashes)} hashes")
+    return ips, domains, hashes
+
+
+def maybe_unzip(data: bytes) -> bytes:
+    if zipfile.is_zipfile(io.BytesIO(data)):
+        with zipfile.ZipFile(io.BytesIO(data)) as zf:
+            names = [name for name in zf.namelist() if not name.endswith("/")]
+            if not names:
+                return b""
+            return zf.read(names[0])
+    return data
+
+
+def fetch_urlhaus(auth_key: str | None, metadata: dict[str, object]) -> set[str]:
+    if not auth_key:
+        metadata["urlhaus"] = {"enabled": False, "reason": "missing auth key"}
+        return set()
+    log("Fetching URLhaus recent URL dataset...")
+    url = URLHAUS_RECENT_CSV_URL.format(auth_key=urllib.parse.quote(auth_key, safe=""))
+    data = maybe_unzip(request(url))
+    text = data.decode("utf-8", "replace")
+    domains: set[str] = set()
+    reader = csv.DictReader(line for line in text.splitlines() if not line.startswith("#"))
+    for row in reader:
+        raw_url = row.get("url") or row.get("URL") or row.get("urlhaus_reference") or ""
+        host = urllib.parse.urlparse(raw_url).hostname
+        domain = clean_domain(host or "")
+        if domain:
+            domains.add(f"{domain};urlhaus:recent")
+    metadata["urlhaus"] = {"source": URLHAUS_RECENT_CSV_URL.replace(auth_key, "<auth-key>"), "domains": len(domains)}
+    log(f"URLhaus domains: {len(domains)}")
+    return domains
+
+
+def count_files(path: Path, suffixes: tuple[str, ...]) -> int:
+    return sum(1 for child in path.rglob("*") if child.is_file() and child.name.lower().endswith(suffixes))
+
+
+def write_empty_ioc_files(output: Path) -> None:
+    headers = {
+        "hashes.txt": "# IOC Type: Hashes\n# Format: VALUE;COMMENT\n",
+        "ips.txt": "# IOC Type: IPs\n# Format: VALUE;COMMENT\n",
+        "domains.txt": "# IOC Type: Domains\n# Format: VALUE;COMMENT\n",
+        "paths_regex.txt": "# IOC Type: Path Regex\n# Format: VALUE;COMMENT\n",
+    }
+    for name, header in headers.items():
+        path = output / "ioc" / name
+        if not path.exists():
+            write_text(path, header)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Fetch community rules for Rustinel benchmark corpora.")
+    parser.add_argument("--output", default="rules-bench", help="Output corpus directory.")
+    parser.add_argument("--force", action="store_true", help="Replace the output directory if it already exists.")
+    parser.add_argument("--skip-sigma", action="store_true", help="Do not fetch SigmaHQ rules.")
+    parser.add_argument("--skip-yara-forge", action="store_true", help="Do not fetch YARA Forge.")
+    parser.add_argument("--yara-forge-set", choices=["core", "extended", "full"], default="core")
+    parser.add_argument("--feodo", choices=["off", "recommended", "30d"], default="recommended")
+    parser.add_argument("--threatfox-auth-key", default=os.getenv("THREATFOX_AUTH_KEY"))
+    parser.add_argument("--threatfox-days", type=int, default=7)
+    parser.add_argument("--threatfox-min-confidence", type=int, default=70)
+    parser.add_argument("--urlhaus-auth-key", default=os.getenv("URLHAUS_AUTH_KEY"))
+    parser.add_argument("--include-urlhaus", action="store_true", help="Fetch URLhaus recent URLs and extract domains.")
+    args = parser.parse_args()
+
+    if not 1 <= args.threatfox_days <= 7:
+        raise SystemExit("--threatfox-days must be between 1 and 7")
+    if not 0 <= args.threatfox_min_confidence <= 100:
+        raise SystemExit("--threatfox-min-confidence must be between 0 and 100")
+
+    output = Path(args.output)
+    clean_output_dir(output, args.force)
+
+    metadata: dict[str, object] = {
+        "generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "output": str(output),
+    }
+
+    if not args.skip_sigma:
+        fetch_sigma(output, metadata)
+    else:
+        metadata["sigma"] = {"enabled": False}
+
+    if not args.skip_yara_forge:
+        fetch_yara_forge(output, args.yara_forge_set, metadata)
+    else:
+        metadata["yara_forge"] = {"enabled": False}
+
+    ips: set[str] = set()
+    domains: set[str] = set()
+    hashes: set[str] = set()
+
+    ips |= fetch_feodo(output, args.feodo, metadata)
+    threatfox_ips, threatfox_domains, threatfox_hashes = fetch_threatfox(
+        args.threatfox_auth_key,
+        args.threatfox_days,
+        args.threatfox_min_confidence,
+        metadata,
+    )
+    ips |= threatfox_ips
+    domains |= threatfox_domains
+    hashes |= threatfox_hashes
+
+    if args.include_urlhaus:
+        domains |= fetch_urlhaus(args.urlhaus_auth_key, metadata)
+    else:
+        metadata["urlhaus"] = {"enabled": False}
+
+    append_unique(output / "ioc" / "ips.txt", ips, "# IOC Type: IPs\n# Format: VALUE;COMMENT")
+    append_unique(output / "ioc" / "domains.txt", domains, "# IOC Type: Domains\n# Format: VALUE;COMMENT")
+    append_unique(output / "ioc" / "hashes.txt", hashes, "# IOC Type: Hashes\n# Format: VALUE;COMMENT")
+    write_empty_ioc_files(output)
+
+    summary = {
+        "sigma_files": count_files(output / "sigma", (".yml", ".yaml")),
+        "yara_files": count_files(output / "yara", (".yar", ".yara")),
+        "ioc_ips": len(ips),
+        "ioc_domains": len(domains),
+        "ioc_hashes": len(hashes),
+    }
+    metadata["summary"] = summary
+    write_text(output / "sources" / "metadata.json", json.dumps(metadata, indent=2, sort_keys=True) + "\n")
+
+    log("")
+    log("Corpus ready:")
+    log(f"  Sigma files: {summary['sigma_files']}")
+    log(f"  YARA files:  {summary['yara_files']}")
+    log(f"  IOC IPs:     {summary['ioc_ips']}")
+    log(f"  IOC domains: {summary['ioc_domains']}")
+    log(f"  IOC hashes:  {summary['ioc_hashes']}")
+    log(f"  Output:      {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except KeyboardInterrupt:
+        raise SystemExit(130)


### PR DESCRIPTION
## Summary
- Add repeatable Windows and Linux benchmark harness scripts
- Add a public benchmarking guide with validity criteria, output files, and acceptance targets
- Add a standard-library corpus fetcher for reproducible benchmark rule sets
- Link the benchmarking guide from the docs index

## Validation
- `python -m py_compile scripts\rules\fetch_corpus.py`
- PowerShell parser check for `scripts\bench\windows.ps1`
- `bash -n scripts/bench/linux.sh` via `wsl.exe -d Ubuntu-26.04`