### PR TITLE
feat(macos): add macOS as a supported platform

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -26,8 +26,9 @@ jobs:
         run: cargo fmt --all -- --check
 
   # ── Clippy ──────────────────────────────────────────────────────────────────
-  # Run on both platforms so Linux-specific code (aya, libc) and
-  # Windows-specific code (ferrisetw, windows-rs) are each linted natively.
+  # Run on all platforms so Linux-specific code (aya, libc), Windows-specific
+  # code (ferrisetw, windows-rs), and macOS-specific code are each linted
+  # natively.
   clippy-linux:
     name: Clippy (Linux)
     runs-on: ubuntu-latest
@@ -48,6 +49,17 @@ jobs:
   clippy-windows:
     name: Clippy (Windows)
     runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy --locked --all-targets -- -D clippy::all
+
+  clippy-macos:
+    name: Clippy (macOS)
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -118,6 +130,15 @@ jobs:
   test-windows:
     name: Tests (Windows)
     runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test --locked --verbose
+
+  test-macos:
+    name: Tests (macOS)
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -223,8 +244,10 @@ jobs:
       - fmt
       - clippy-linux
       - clippy-windows
+      - clippy-macos
       - test-linux
       - test-windows
+      - test-macos
       - build-linux-x86_64
       - build-linux-arm64
       - build-windows

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,10 @@ config = "0.15.23"
 aya = { version = "0.13", default-features = false }
 libc = "0.2"
 
+# macOS-specific
+[target.'cfg(target_os = "macos")'.dependencies]
+libc = "0.2"
+
 # Windows-specific
 [target.'cfg(windows)'.dependencies]
 # PE parsing and memory-mapped I/O (Windows-only; PE metadata is not used on Linux)

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,14 +29,16 @@ fn default_allowlist_paths() -> Vec<String> {
     }
     #[cfg(target_os = "macos")]
     {
+        // OS-shipped directories only. /Applications is intentionally excluded:
+        // it holds user-installed software and is a common location for macOS
+        // malware, so allowlisting it would blind scanning and response there.
         vec![
             "/usr/bin/".to_string(),
             "/usr/sbin/".to_string(),
             "/usr/libexec/".to_string(), // system helper executables
             "/bin/".to_string(),
             "/sbin/".to_string(),
-            "/System/".to_string(),      // OS-shipped frameworks and binaries
-            "/Applications/".to_string(), // installed applications
+            "/System/".to_string(), // OS-shipped frameworks and binaries
         ]
     }
     #[cfg(not(any(windows, target_os = "macos")))]

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,7 +27,19 @@ fn default_allowlist_paths() -> Vec<String> {
             "C:\\Program Files (x86)\\".to_string(),
         ]
     }
-    #[cfg(not(windows))]
+    #[cfg(target_os = "macos")]
+    {
+        vec![
+            "/usr/bin/".to_string(),
+            "/usr/sbin/".to_string(),
+            "/usr/libexec/".to_string(), // system helper executables
+            "/bin/".to_string(),
+            "/sbin/".to_string(),
+            "/System/".to_string(),      // OS-shipped frameworks and binaries
+            "/Applications/".to_string(), // installed applications
+        ]
+    }
+    #[cfg(not(any(windows, target_os = "macos")))]
     {
         vec![
             "/usr/bin/".to_string(),

--- a/src/engine/alert.rs
+++ b/src/engine/alert.rs
@@ -520,6 +520,13 @@ impl Engine {
                             Some("dns_query"),
                         ));
                     }
+                    Platform::MacOS => {
+                        aliases.push(LogSourceKey::from_parts(
+                            Some("macos"),
+                            Some("sysmon"),
+                            Some("dns_query"),
+                        ));
+                    }
                 }
 
                 aliases.push(LogSourceKey::from_parts(None, None, Some("dns")));

--- a/src/engine/logsource.rs
+++ b/src/engine/logsource.rs
@@ -132,7 +132,12 @@ pub(crate) fn current_platform() -> Platform {
         Platform::Linux
     }
 
-    #[cfg(not(any(windows, target_os = "linux")))]
+    #[cfg(target_os = "macos")]
+    {
+        Platform::MacOS
+    }
+
+    #[cfg(not(any(windows, target_os = "linux", target_os = "macos")))]
     {
         Platform::Windows
     }
@@ -142,6 +147,7 @@ pub(crate) fn platform_product(platform: Platform) -> &'static str {
     match platform {
         Platform::Windows => "windows",
         Platform::Linux => "linux",
+        Platform::MacOS => "macos",
     }
 }
 
@@ -220,6 +226,18 @@ impl Engine {
                 LogSourceKey::from_parts(Some("linux"), Some("sysmon"), Some("file_rename")),
                 LogSourceKey::from_parts(Some("linux"), Some("sysmon"), Some("dns_query")),
             ],
+            // macOS telemetry comes from ESF (process, file) and /dev/bpf
+            // (network, DNS); mirror the Linux collector coverage.
+            Platform::MacOS => vec![
+                LogSourceKey::from_parts(Some("macos"), Some("sysmon"), Some("process_creation")),
+                LogSourceKey::from_parts(Some("macos"), Some("sysmon"), Some("network_connection")),
+                LogSourceKey::from_parts(Some("macos"), Some("sysmon"), Some("file_event")),
+                LogSourceKey::from_parts(Some("macos"), Some("sysmon"), Some("file_create")),
+                LogSourceKey::from_parts(Some("macos"), Some("sysmon"), Some("file_delete")),
+                LogSourceKey::from_parts(Some("macos"), Some("sysmon"), Some("file_change")),
+                LogSourceKey::from_parts(Some("macos"), Some("sysmon"), Some("file_rename")),
+                LogSourceKey::from_parts(Some("macos"), Some("sysmon"), Some("dns_query")),
+            ],
             Platform::Windows => vec![
                 LogSourceKey::from_parts(Some("windows"), Some("sysmon"), Some("process_creation")),
                 LogSourceKey::from_parts(
@@ -287,13 +305,15 @@ impl Engine {
         let service = logsource.service.as_deref();
 
         match self.platform {
-            Platform::Linux => {
+            // macOS shares the Linux collector model: only the generic DNS
+            // network logsource is known-but-inactive.
+            Platform::Linux | Platform::MacOS => {
                 matches!(service, Some("dns"))
                     && matches!(category, None | Some("network"))
                     && logsource
                         .product
                         .as_deref()
-                        .map(|product| product == "linux")
+                        .map(|product| product == platform_product(self.platform))
                         .unwrap_or(true)
             }
             Platform::Windows => {
@@ -416,5 +436,18 @@ impl Engine {
                 collector_active: true,
             } => {}
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::platform_product;
+    use crate::sensor::Platform;
+
+    #[test]
+    fn platform_product_maps_macos() {
+        assert_eq!(platform_product(Platform::MacOS), "macos");
+        assert_eq!(platform_product(Platform::Linux), "linux");
+        assert_eq!(platform_product(Platform::Windows), "windows");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,35 +5,35 @@
 //! YARA, and IOC detection, with alerts written as ECS NDJSON.
 
 // ── Platform-shared imports ───────────────────────────────────────────────────
-#[cfg(any(windows, target_os = "linux"))]
+#[cfg(any(windows, target_os = "linux", target_os = "macos"))]
 use rustinel::engine::{Engine, SigmaDetectionHandler};
-#[cfg(any(windows, target_os = "linux"))]
+#[cfg(any(windows, target_os = "linux", target_os = "macos"))]
 use rustinel::ioc::IocEngine;
-#[cfg(any(windows, target_os = "linux"))]
+#[cfg(any(windows, target_os = "linux", target_os = "macos"))]
 use rustinel::memory::MemoryScanConfig;
-#[cfg(any(windows, target_os = "linux"))]
+#[cfg(any(windows, target_os = "linux", target_os = "macos"))]
 use rustinel::normalizer::Normalizer;
-#[cfg(any(windows, target_os = "linux"))]
+#[cfg(any(windows, target_os = "linux", target_os = "macos"))]
 use rustinel::reload::DetectorStore;
-#[cfg(any(windows, target_os = "linux"))]
+#[cfg(any(windows, target_os = "linux", target_os = "macos"))]
 use rustinel::response::ResponseEngine;
-#[cfg(any(windows, target_os = "linux"))]
+#[cfg(any(windows, target_os = "linux", target_os = "macos"))]
 use rustinel::runtime::logging::{init_logging, log_startup_banner};
-#[cfg(any(windows, target_os = "linux"))]
+#[cfg(any(windows, target_os = "linux", target_os = "macos"))]
 use rustinel::runtime::{ioc as runtime_ioc, yara as runtime_yara};
-#[cfg(any(windows, target_os = "linux"))]
+#[cfg(any(windows, target_os = "linux", target_os = "macos"))]
 use rustinel::scanner::{YaraEventHandler, YaraMemoryJob};
-#[cfg(any(windows, target_os = "linux"))]
+#[cfg(any(windows, target_os = "linux", target_os = "macos"))]
 use rustinel::sensor::{Platform, Sensor, SensorEvent, SensorEventRouter};
-#[cfg(any(windows, target_os = "linux"))]
+#[cfg(any(windows, target_os = "linux", target_os = "macos"))]
 use rustinel::state::{ConnectionAggregator, DnsCache, ProcessCache, SidCache};
-#[cfg(any(windows, target_os = "linux"))]
+#[cfg(any(windows, target_os = "linux", target_os = "macos"))]
 use rustinel::{config, reload, scanner};
-#[cfg(any(windows, target_os = "linux"))]
+#[cfg(any(windows, target_os = "linux", target_os = "macos"))]
 use std::path::Path;
-#[cfg(any(windows, target_os = "linux"))]
+#[cfg(any(windows, target_os = "linux", target_os = "macos"))]
 use std::sync::Arc;
-#[cfg(any(windows, target_os = "linux"))]
+#[cfg(any(windows, target_os = "linux", target_os = "macos"))]
 use tracing::{error, info, warn};
 
 // ── Platform-specific imports ─────────────────────────────────────────────────
@@ -47,6 +47,11 @@ use tokio::sync::{mpsc, watch};
 #[cfg(target_os = "linux")]
 use rustinel::sensor::linux::EbpfSensor;
 #[cfg(target_os = "linux")]
+use tokio::sync::mpsc;
+
+#[cfg(target_os = "macos")]
+use rustinel::sensor::macos::PlaceholderSensor;
+#[cfg(target_os = "macos")]
 use tokio::sync::mpsc;
 
 #[cfg(windows)]
@@ -131,11 +136,29 @@ fn run_linux() -> anyhow::Result<()> {
     runtime.block_on(run_linux_edr())
 }
 
-// Catch-all for non-Windows, non-Linux platforms.
-#[cfg(not(any(windows, target_os = "linux")))]
+#[cfg(target_os = "macos")]
+fn main() -> anyhow::Result<()> {
+    use clap::Parser;
+    let cli = Cli::parse();
+
+    match cli.command {
+        Some(Commands::Service { action }) => handle_service_command(action),
+        Some(Commands::Run { .. }) | None => run_macos(),
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn run_macos() -> anyhow::Result<()> {
+    use tokio::runtime::Builder;
+    let runtime = Builder::new_multi_thread().enable_all().build()?;
+    runtime.block_on(run_macos_edr())
+}
+
+// Catch-all for unsupported platforms.
+#[cfg(not(any(windows, target_os = "linux", target_os = "macos")))]
 fn main() -> anyhow::Result<()> {
     Err(anyhow::anyhow!(
-        "This platform is not supported. Rustinel runs on Windows (ETW) and Linux (eBPF)."
+        "This platform is not supported. Rustinel runs on Windows (ETW), Linux (eBPF), and macOS (ESF)."
     ))
 }
 
@@ -1281,6 +1304,262 @@ async fn run_linux_edr() -> anyhow::Result<()> {
     let sensor_clone = Arc::clone(&sensor);
     if let Err(e) = sensor_clone.start(sensor_tx) {
         error!("eBPF sensor failed to start: {:#}", e);
+        return Err(e);
+    }
+
+    // 14. Wait for Ctrl+C
+    match tokio::signal::ctrl_c().await {
+        Ok(()) => info!("Received Ctrl+C, shutting down"),
+        Err(e) => error!("Failed to listen for Ctrl+C: {}", e),
+    }
+    sensor.shutdown();
+
+    // Drain workers
+    drop(router);
+    drop(response_engine);
+    let _ = sensor_worker_handle.await;
+    let _ = yara_worker_handle.await;
+    if let Some(h) = yara_memory_worker_handle {
+        let _ = h.await;
+    }
+    if let Some(h) = ioc_hash_worker_handle.take() {
+        let _ = h.await;
+    }
+    if let Some(h) = reload_poller_handle.take() {
+        h.abort();
+        let _ = h.await;
+    }
+    drop(reload_tx.take());
+    if let Some(h) = reload_worker_handle.take() {
+        let _ = h.await;
+    }
+    let _ = response_worker_handle.await;
+
+    info!("Shutdown complete");
+    Ok(())
+}
+
+// ── macOS EDR entry point ─────────────────────────────────────────────────────
+
+/// macOS EDR main loop. Mirrors `run_linux_edr` but replaces the eBPF sensor
+/// with the macOS sensor. In Phase 0 this is a no-op placeholder sensor so the
+/// shared pipeline can be exercised end to end; the Endpoint Security and
+/// /dev/bpf sources land in later phases.
+#[cfg(target_os = "macos")]
+async fn run_macos_edr() -> anyhow::Result<()> {
+    // 1. Configuration
+    let cfg = match config::AppConfig::new() {
+        Ok(cfg) => cfg,
+        Err(err) => {
+            eprintln!("Failed to load configuration: {}", err);
+            return Err(anyhow::anyhow!("configuration error: {}", err));
+        }
+    };
+
+    // 2. Logging
+    let (app_guard, alert_guard, alert_sink) = init_logging(&cfg);
+    let _guards = (app_guard, alert_guard);
+
+    log_startup_banner("macOS ESF");
+
+    // 3. Shared state
+    let process_cache = Arc::new(ProcessCache::new());
+    let sid_cache = Arc::new(SidCache::new()); // no-op on macOS; kept for Normalizer compat
+    let dns_cache = Arc::new(DnsCache::new());
+    let connection_aggregator = Arc::new(ConnectionAggregator::with_limits(
+        cfg.network.aggregation_max_entries,
+        cfg.network.aggregation_interval_buffer_size,
+    ));
+
+    // 4. Active response engine
+    let (response_engine, response_worker_handle) = ResponseEngine::new(&cfg.response);
+
+    // 5. Sigma engine
+    let mut sigma_engine = Engine::new_for_platform_with_logging_level_and_match_debug(
+        Platform::MacOS,
+        &cfg.logging.level,
+        cfg.alerts.match_debug,
+    );
+
+    if cfg.scanner.sigma_enabled {
+        info!(rules_path = ?cfg.scanner.sigma_rules_path, "Loading Sigma rules");
+        if let Err(e) = sigma_engine.load_rules(&cfg.scanner.sigma_rules_path) {
+            warn!(error = %e, "Failed to load Sigma rules");
+        } else {
+            let stats = sigma_engine.stats();
+            info!(
+                total_rules = stats.total_rules,
+                skipped_deferred_rules = stats.skipped_deferred_rules,
+                skipped_unknown_logsource_rules = stats.skipped_unknown_logsource_rules,
+                skipped_product_rules = stats.skipped_product_rules,
+                inactive_collector_rules = stats.inactive_collector_rules,
+                "Sigma engine initialized"
+            );
+            for (logsource, count) in stats.rules_by_logsource {
+                info!(logsource = %logsource, count, "Sigma rules loaded");
+            }
+        }
+    }
+    let sigma_engine = Arc::new(sigma_engine);
+
+    // 6. YARA scanner
+    let yara_scanner = if cfg.scanner.yara_enabled {
+        match scanner::Scanner::new(&cfg.scanner.yara_rules_path) {
+            Ok(s) => {
+                info!("YARA scanner initialized");
+                Arc::new(s)
+            }
+            Err(e) => {
+                warn!(error = %e, "Failed to load YARA rules; YARA scanning disabled");
+                Arc::new(scanner::Scanner::new(Path::new(".")).expect("empty YARA scanner"))
+            }
+        }
+    } else {
+        Arc::new(scanner::Scanner::new(Path::new(".")).expect("empty YARA scanner"))
+    };
+
+    let yara_allowlist_paths =
+        scanner::normalize_allowlist_paths(&cfg.scanner.yara_allowlist_paths);
+
+    // 7. IOC engine
+    let ioc_engine = Arc::new(IocEngine::load(&cfg.ioc));
+
+    // 8. Detector store + hot-reload
+    let detectors = DetectorStore::new(
+        Arc::clone(&sigma_engine),
+        Arc::clone(&yara_scanner),
+        Arc::clone(&ioc_engine),
+    );
+
+    let mut reload_poller_handle = None;
+    let mut reload_worker_handle = None;
+    let mut reload_tx = None;
+    if cfg.reload.enabled {
+        let (tx, rx) = mpsc::unbounded_channel();
+        reload_worker_handle = Some(reload::spawn_reload_worker(
+            Arc::clone(&detectors),
+            cfg.scanner.clone(),
+            cfg.ioc.clone(),
+            cfg.reload.clone(),
+            cfg.logging.level.clone(),
+            cfg.alerts.match_debug,
+            rx,
+        ));
+        reload_poller_handle = Some(reload::spawn_reload_poller(
+            cfg.scanner.clone(),
+            cfg.ioc.clone(),
+            cfg.reload.clone(),
+            tx.clone(),
+        ));
+        reload_tx = Some(tx);
+    }
+
+    // 9. YARA background worker
+    let (yara_tx, yara_rx) = mpsc::channel::<(String, u32)>(1000);
+
+    let (yara_memory_tx, yara_memory_rx) =
+        if cfg.scanner.yara_enabled && cfg.scanner.yara_memory_enabled {
+            let capacity = cfg.scanner.yara_memory_queue_capacity.max(1);
+            let (tx, rx) = mpsc::channel::<YaraMemoryJob>(capacity);
+            (Some(tx), Some(rx))
+        } else {
+            (None, None)
+        };
+    let yara_worker_handle = runtime_yara::spawn_yara_file_worker(
+        Arc::clone(&detectors),
+        alert_sink.clone(),
+        response_engine.clone(),
+        cfg.alerts.match_debug,
+        yara_rx,
+        yara_allowlist_paths.clone(),
+        Platform::MacOS,
+        "esf",
+    );
+
+    // Spawn optional YARA memory scanning worker (macOS).
+    let yara_memory_worker_handle = if let Some(mem_rx) = yara_memory_rx {
+        let mem_cfg = MemoryScanConfig {
+            max_process_bytes: (cfg.scanner.yara_memory_max_process_mb * 1024 * 1024) as usize,
+            max_region_bytes: (cfg.scanner.yara_memory_max_region_mb * 1024 * 1024) as usize,
+            include_private: cfg.scanner.yara_memory_include_private,
+            include_image: cfg.scanner.yara_memory_include_image,
+            include_mapped: cfg.scanner.yara_memory_include_mapped,
+            delay_ms: cfg.scanner.yara_memory_delay_ms,
+        };
+        Some(runtime_yara::spawn_yara_memory_worker(
+            Arc::clone(&detectors),
+            alert_sink.clone(),
+            response_engine.clone(),
+            mem_cfg,
+            cfg.alerts.match_debug,
+            mem_rx,
+            Platform::MacOS,
+            "yara-memory",
+        ))
+    } else {
+        None
+    };
+
+    // 10. IOC hash background worker
+    let (ioc_hash_tx, mut ioc_hash_worker_handle) = if ioc_engine.is_enabled() {
+        let (hash_tx, hash_rx) = mpsc::channel::<(String, u32)>(1000);
+        let handle = runtime_ioc::spawn_ioc_hash_worker(
+            Arc::clone(&detectors),
+            alert_sink.clone(),
+            response_engine.clone(),
+            hash_rx,
+            Platform::MacOS,
+            "esf",
+        );
+        (Some(hash_tx), Some(handle))
+    } else {
+        (None, None)
+    };
+
+    // 11. Normalizer
+    let normalizer = Arc::new(Normalizer::new(
+        Arc::clone(&process_cache),
+        Arc::clone(&sid_cache),
+        Arc::clone(&dns_cache),
+        Arc::clone(&connection_aggregator),
+        cfg.network.aggregation_enabled,
+    ));
+
+    // 12. Detection handlers + router
+    let sigma_handler = SigmaDetectionHandler {
+        normalizer: Arc::clone(&normalizer),
+        detectors: Arc::clone(&detectors),
+        ioc_hash_tx,
+        alert_sink: alert_sink.clone(),
+        response_engine: response_engine.clone(),
+    };
+    let yara_handler = YaraEventHandler {
+        tx: yara_tx,
+        memory_tx: yara_memory_tx,
+        allowlist_paths: yara_allowlist_paths,
+    };
+    let mut router_inner = SensorEventRouter::new();
+    router_inner.register_handler(Box::new(sigma_handler));
+    router_inner.register_handler(Box::new(yara_handler));
+    let router = Arc::new(router_inner);
+
+    // 13. macOS sensor (placeholder until ESF/bpf sources land)
+    let sensor = Arc::new(PlaceholderSensor::new());
+
+    info!("Starting macOS sensor...");
+    info!("Press Ctrl+C to stop gracefully");
+
+    let (sensor_tx, mut sensor_rx) = mpsc::channel::<SensorEvent>(8192);
+    let router_for_worker = Arc::clone(&router);
+    let sensor_worker_handle = tokio::task::spawn_blocking(move || {
+        while let Some(event) = sensor_rx.blocking_recv() {
+            router_for_worker.route_event(&event);
+        }
+    });
+
+    let sensor_clone = Arc::clone(&sensor);
+    if let Err(e) = sensor_clone.start(sensor_tx) {
+        error!("macOS sensor failed to start: {:#}", e);
         return Err(e);
     }
 

--- a/src/models/ecs/event.rs
+++ b/src/models/ecs/event.rs
@@ -137,6 +137,7 @@ pub(super) fn host_os_type(platform: Platform) -> String {
     match platform {
         Platform::Windows => "windows".to_string(),
         Platform::Linux => "linux".to_string(),
+        Platform::MacOS => "macos".to_string(),
     }
 }
 
@@ -144,6 +145,8 @@ pub(super) fn host_os_family(platform: Platform) -> String {
     match platform {
         Platform::Windows => "windows".to_string(),
         Platform::Linux => "linux".to_string(),
+        // ECS uses the "darwin" OS family for macOS.
+        Platform::MacOS => "darwin".to_string(),
     }
 }
 
@@ -151,5 +154,17 @@ pub(super) fn network_direction_from_category(category: EventCategory) -> Option
     match category {
         EventCategory::Network | EventCategory::Dns => Some("egress".to_string()),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{host_os_family, host_os_type};
+    use crate::sensor::Platform;
+
+    #[test]
+    fn host_os_maps_macos_to_darwin_family() {
+        assert_eq!(host_os_type(Platform::MacOS), "macos");
+        assert_eq!(host_os_family(Platform::MacOS), "darwin");
     }
 }

--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -423,20 +423,20 @@ fn parse_pid(value: Option<&str>) -> Option<u32> {
 }
 
 fn normalize_path(value: &str) -> String {
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     {
         value.trim().to_ascii_lowercase()
     }
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
     {
         value.trim().replace('/', "\\").to_ascii_lowercase()
     }
 }
 
 fn normalize_allowlist_paths(values: &[String]) -> Vec<String> {
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     const SEP: char = '/';
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
     const SEP: char = '\\';
 
     values

--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -512,7 +512,7 @@ fn terminate_process(pid: u32) -> Result<(), String> {
     }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 fn terminate_process(pid: u32) -> Result<(), String> {
     let ret = unsafe { libc::kill(pid as libc::pid_t, libc::SIGKILL) };
     if ret == 0 {
@@ -523,7 +523,7 @@ fn terminate_process(pid: u32) -> Result<(), String> {
     }
 }
 
-#[cfg(not(any(windows, target_os = "linux")))]
+#[cfg(not(any(windows, target_os = "linux", target_os = "macos")))]
 fn terminate_process(_pid: u32) -> Result<(), String> {
     Err("Active response termination is not supported on this platform".to_string())
 }

--- a/src/runtime/logging.rs
+++ b/src/runtime/logging.rs
@@ -101,7 +101,7 @@ pub fn init_logging(
     (app_guard, alert_guard, alert_sink)
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 pub fn init_logging(
     cfg: &config::AppConfig,
 ) -> (

--- a/src/sensor/macos/mod.rs
+++ b/src/sensor/macos/mod.rs
@@ -1,0 +1,38 @@
+//! macOS sensor support.
+//!
+//! Phase 0 ships a no-op placeholder sensor so the macOS runtime compiles and
+//! runs the shared pipeline end to end. Real telemetry lands in later phases:
+//! Endpoint Security for process and file events, and `/dev/bpf` capture for
+//! network and DNS.
+
+use anyhow::Result;
+use tokio::sync::mpsc::Sender;
+
+use super::{Sensor, SensorEvent};
+
+/// Placeholder sensor that emits no events.
+///
+/// Satisfies the [`Sensor`] contract so the shared runtime can be exercised on
+/// macOS before the native telemetry sources exist. It is replaced by the
+/// Endpoint Security sensor in Phase 1.
+pub struct PlaceholderSensor;
+
+impl PlaceholderSensor {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for PlaceholderSensor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Sensor for PlaceholderSensor {
+    fn start(&self, _tx: Sender<SensorEvent>) -> Result<()> {
+        Ok(())
+    }
+
+    fn shutdown(&self) {}
+}

--- a/src/sensor/mod.rs
+++ b/src/sensor/mod.rs
@@ -41,6 +41,7 @@ pub trait SensorEventHandler: Send + Sync {
 pub enum Platform {
     Windows,
     Linux,
+    MacOS,
 }
 
 /// High-level action emitted by a sensor event.

--- a/src/sensor/mod.rs
+++ b/src/sensor/mod.rs
@@ -6,6 +6,8 @@
 
 #[cfg(target_os = "linux")]
 pub mod linux;
+#[cfg(target_os = "macos")]
+pub mod macos;
 #[cfg(windows)]
 pub mod windows;
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -72,34 +72,35 @@ pub fn provider_for(platform: Platform) -> &'static str {
     match platform {
         Platform::Windows => "etw",
         Platform::Linux => "ebpf",
+        Platform::MacOS => "esf",
     }
 }
 
 pub fn image_for(platform: Platform) -> &'static str {
     match platform {
         Platform::Windows => r"C:\Windows\System32\curl.exe",
-        Platform::Linux => "/usr/bin/curl",
+        Platform::Linux | Platform::MacOS => "/usr/bin/curl",
     }
 }
 
 pub fn parent_image_for(platform: Platform) -> &'static str {
     match platform {
         Platform::Windows => r"C:\Windows\explorer.exe",
-        Platform::Linux => "/usr/bin/bash",
+        Platform::Linux | Platform::MacOS => "/usr/bin/bash",
     }
 }
 
 pub fn test_file_path(platform: Platform) -> &'static str {
     match platform {
         Platform::Windows => r"C:\Users\alice\AppData\Local\Temp\rustinel-fixture.txt",
-        Platform::Linux => "/tmp/rustinel-fixture.txt",
+        Platform::Linux | Platform::MacOS => "/tmp/rustinel-fixture.txt",
     }
 }
 
 pub fn renamed_test_file_path(platform: Platform) -> &'static str {
     match platform {
         Platform::Windows => r"C:\Users\alice\AppData\Local\Temp\rustinel-renamed.txt",
-        Platform::Linux => "/tmp/rustinel-renamed.txt",
+        Platform::Linux | Platform::MacOS => "/tmp/rustinel-renamed.txt",
     }
 }
 
@@ -255,7 +256,7 @@ fn file_event(
 fn temp_current_directory(platform: Platform) -> &'static str {
     match platform {
         Platform::Windows => r"C:\Users\alice\AppData\Local\Temp",
-        Platform::Linux => "/tmp",
+        Platform::Linux | Platform::MacOS => "/tmp",
     }
 }
 
@@ -287,7 +288,7 @@ impl SigmaFixture {
         let product = platform_product(platform);
         let image_suffix = match platform {
             Platform::Windows => "curl.exe",
-            Platform::Linux => "/curl",
+            Platform::Linux | Platform::MacOS => "/curl",
         };
         self.write_rule(
             "process.yml",
@@ -562,5 +563,6 @@ fn platform_product(platform: Platform) -> &'static str {
     match platform {
         Platform::Windows => "windows",
         Platform::Linux => "linux",
+        Platform::MacOS => "macos",
     }
 }

--- a/tests/pipeline_sigma.rs
+++ b/tests/pipeline_sigma.rs
@@ -127,6 +127,7 @@ fn sigma_file_detection_pipeline_maps_create_delete_rename_and_ecs() {
         let product = match platform {
             Platform::Windows => "windows",
             Platform::Linux => "linux",
+            Platform::MacOS => "macos",
         };
         fixture.write_rule(
             "file_create.yml",

--- a/tests/pipeline_sigma.rs
+++ b/tests/pipeline_sigma.rs
@@ -34,7 +34,7 @@ fn assert_sigma_alert(alert: &rustinel::models::Alert, expected_rule: &str) {
 
 #[test]
 fn sigma_process_detection_pipeline_maps_to_ecs_for_windows_and_linux() {
-    for platform in [Platform::Windows, Platform::Linux] {
+    for platform in [Platform::Windows, Platform::Linux, Platform::MacOS] {
         let fixture = SigmaFixture::new();
         fixture.write_process_rule(platform);
         let engine = load_engine(platform, &fixture);
@@ -72,7 +72,7 @@ fn sigma_process_detection_pipeline_maps_to_ecs_for_windows_and_linux() {
 
 #[test]
 fn sigma_network_detection_pipeline_enriches_aggregates_and_maps_to_ecs() {
-    for platform in [Platform::Windows, Platform::Linux] {
+    for platform in [Platform::Windows, Platform::Linux, Platform::MacOS] {
         let fixture = SigmaFixture::new();
         fixture.write_network_rule(platform);
         let engine = load_engine(platform, &fixture);
@@ -122,7 +122,7 @@ fn sigma_network_detection_pipeline_enriches_aggregates_and_maps_to_ecs() {
 
 #[test]
 fn sigma_file_detection_pipeline_maps_create_delete_rename_and_ecs() {
-    for platform in [Platform::Windows, Platform::Linux] {
+    for platform in [Platform::Windows, Platform::Linux, Platform::MacOS] {
         let fixture = SigmaFixture::new();
         let product = match platform {
             Platform::Windows => "windows",

--- a/tests/platform_mapping.rs
+++ b/tests/platform_mapping.rs
@@ -183,7 +183,7 @@ level: medium
 "#,
     );
 
-    for platform in [Platform::Windows, Platform::Linux] {
+    for platform in [Platform::Windows, Platform::Linux, Platform::MacOS] {
         let mut engine = Engine::new_for_platform(platform);
         engine
             .load_rules(fixture.rules_dir())

--- a/tests/reload.rs
+++ b/tests/reload.rs
@@ -18,6 +18,8 @@ use tokio::sync::mpsc;
 fn host_platform() -> Platform {
     if cfg!(windows) {
         Platform::Windows
+    } else if cfg!(target_os = "macos") {
+        Platform::MacOS
     } else {
         Platform::Linux
     }
@@ -74,10 +76,10 @@ detection:
   condition: selection
 level: high
         "#,
-            product = if platform == Platform::Windows {
-                "windows"
-            } else {
-                "linux"
+            product = match platform {
+                Platform::Windows => "windows",
+                Platform::Linux => "linux",
+                Platform::MacOS => "macos",
             }
         ),
     );


### PR DESCRIPTION
## Summary
Introduces macOS as a first-class platform so the project builds, lints, tests, and runs the shared detection pipeline on macOS, ahead of the native sensors that follow. No telemetry is collected yet: a no-op placeholder sensor keeps the runtime exercised end to end.

- Add `Platform::MacOS` and route it through Sigma logsource handling, DNS alias generation, and ECS `host.os` mapping (using the `darwin` OS family).
- Add macOS allowlist defaults and POSIX path normalization, which previously fell through to the Windows backslash handling on non-Linux unix.
- Reuse the `SIGKILL` active-response path on macOS.
- Add the macOS runtime entry (`main`, runtime builder, `run_macos_edr`) mirroring the Linux path, backed by a placeholder sensor.

## Type of change
- [x] `feat` / `enhancement` - new feature

## Test plan
- [ ] Tested on Windows
- [ ] Tested on Linux
- [x] Tested on macOS (arm64): builds, loads rules, starts, and shuts down cleanly
- [x] Existing tests pass (`cargo test`)
- [x] New tests added (platform routing and ECS host.os mapping)

Note: all changes are gated to macOS, so Windows and Linux behavior is unchanged.

## Checklist
- [ ] Label added to this PR
- [x] Docs updated (if behaviour changed)

## Notes

This is the first PR from a series of four, all part of #41.
