### PR TITLE
ci: build, lint, and test on macOS

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -26,8 +26,9 @@ jobs:
         run: cargo fmt --all -- --check
 
   # ── Clippy ──────────────────────────────────────────────────────────────────
-  # Run on both platforms so Linux-specific code (aya, libc) and
-  # Windows-specific code (ferrisetw, windows-rs) are each linted natively.
+  # Run on all platforms so Linux-specific code (aya, libc), Windows-specific
+  # code (ferrisetw, windows-rs), and macOS-specific code are each linted
+  # natively.
   clippy-linux:
     name: Clippy (Linux)
     runs-on: ubuntu-latest
@@ -48,6 +49,17 @@ jobs:
   clippy-windows:
     name: Clippy (Windows)
     runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy --locked --all-targets -- -D clippy::all
+
+  clippy-macos:
+    name: Clippy (macOS)
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -118,6 +130,15 @@ jobs:
   test-windows:
     name: Tests (Windows)
     runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test --locked --verbose
+
+  test-macos:
+    name: Tests (macOS)
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -223,8 +244,10 @@ jobs:
       - fmt
       - clippy-linux
       - clippy-windows
+      - clippy-macos
       - test-linux
       - test-windows
+      - test-macos
       - build-linux-x86_64
       - build-linux-arm64
       - build-windows


### PR DESCRIPTION
## Summary
Adds macOS to CI so the newly supported macOS target is built, linted, and tested on every push — closing the gap that let a macOS-only test regression slip through review on #42.

- `clippy-macos` and `test-macos` jobs on `macos-latest`, mirroring the self-contained Windows jobs (no eBPF artifact needed).
- Wired both into the `release` gate alongside the existing Linux/Windows jobs.
- Updated the stale "both platforms" Clippy comment to "all platforms".

## Context
While reviewing #42 (first of the four-PR macOS series in #41), a `tests/reload.rs` failure was found that only reproduces on macOS — CI never would have caught it because there was no macOS runner. This adds that runner.

## Follow-up
After this merges, add `Clippy (macOS)` and `Tests (macOS)` to the branch-protection required status checks so they block, not just report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
