### PR TITLE
fix(config): search executable directory for config.toml (#43)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,19 +1,25 @@
 # Configuration
 
-Rustinel loads configuration from four sources in this order:
+Rustinel loads configuration from these sources, highest priority first:
 
 1. CLI flags where supported
 2. Environment variables using the `EDR__` prefix
 3. `config.toml` in the current working directory
-4. Built-in defaults
+4. `config.toml` in the directory containing the executable
+5. Built-in defaults
 
 ## Configuration File
 
-Place `config.toml` in the directory you launch Rustinel from, or use absolute paths throughout.
+Place `config.toml` in the directory you launch Rustinel from, alongside the
+`rustinel` executable, or use absolute paths throughout. When both a working-directory
+and an executable-directory config exist, the working-directory file takes precedence
+on conflicting keys.
 
 Production note:
 
 - Windows services often run with `C:\Windows\System32` as the working directory.
+  Because the executable directory is also searched, you can keep `config.toml` next
+  to `rustinel.exe` (for example in `C:\Rustinel`) without copying it into `System32`.
 - Linux service managers can also start in a directory that is not your install root.
 - For production, prefer absolute paths for rules, logs, and alerts.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -71,7 +71,11 @@ Configuration precedence is:
 1. CLI flags where supported
 2. `EDR__...` environment variables
 3. `config.toml` in the current working directory
-4. Built-in defaults
+4. `config.toml` in the directory containing the executable
+5. Built-in defaults
+
+This means you can keep `config.toml` next to the `rustinel` executable even when
+the working directory differs (such as `C:\Windows\System32` for a Windows service).
 
 See [Configuration](configuration.md).
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -34,9 +34,11 @@ Use absolute paths in `config.toml` once you move beyond the default repo layout
 
 ## Working Directory Rules
 
-- `config.toml` is loaded from the current working directory.
-- Relative rule and log paths resolve from that same directory.
-- Windows services often start in `C:\Windows\System32`; use absolute paths there.
+- `config.toml` is loaded from the current working directory, falling back to the
+  directory containing the executable (the working-directory copy wins on conflicts).
+- Relative rule and log paths resolve from the current working directory.
+- Windows services often start in `C:\Windows\System32`; keep `config.toml` next to
+  `rustinel.exe` (it will still be found) and use absolute paths for rules and logs.
 - Linux supervisors should also use absolute paths for predictable upgrades and restarts.
 
 ## Windows Service Lifecycle

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -32,7 +32,7 @@ Before changing config or rules, check these first:
 
 This usually means one of these:
 
-- `config.toml` is not in the current working directory
+- `config.toml` is not in the current working directory or next to the executable
 - the TOML syntax is invalid
 - an `EDR__...` environment override has the wrong shape or type
 - a relative path assumes a different working directory than the one Rustinel is using

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,7 +3,9 @@
 //! Provides structured configuration for the Rustinel agent.
 //! Configuration can be loaded from:
 //! 1. Default values (hardcoded)
-//! 2. config.toml file (optional)
+//! 2. `config` file (optional) — searched first in the directory of the
+//!    running executable, then in the current working directory (the latter
+//!    takes precedence on conflicting keys)
 //! 3. Environment variables with EDR__ prefix
 //!
 //! Example environment variable override:
@@ -14,6 +16,29 @@ use serde::Deserialize;
 use std::path::PathBuf;
 
 use crate::models::MatchDebugLevel;
+
+/// Build an optional config-file source rooted at the directory containing the
+/// running executable.
+///
+/// Windows services start with `C:\Windows\System32` as their working
+/// directory, so a `config.toml` placed next to `rustinel.exe` (e.g. in
+/// `C:\Rustinel`) is otherwise never found. This lets operators keep all
+/// Rustinel files in one directory. The current working directory is still
+/// searched and takes precedence, preserving the previous behavior.
+fn exe_dir_config_source() -> Option<config::File<config::FileSourceFile, config::FileFormat>> {
+    let config_base = exe_dir_config_base()?;
+    let config_base = config_base.to_str()?;
+    Some(config::File::with_name(config_base).required(false))
+}
+
+/// Compute the extension-less config file base path next to the running
+/// executable (e.g. `C:\Rustinel\config`). The `config` crate appends the
+/// supported extensions (`.toml`, `.yaml`, ...) when searching.
+fn exe_dir_config_base() -> Option<PathBuf> {
+    let exe_path = std::env::current_exe().ok()?;
+    let exe_dir = exe_path.parent()?;
+    Some(exe_dir.join("config"))
+}
 
 /// Default trusted paths for the allowlist, chosen per platform.
 /// These prevent YARA, IOC hash scanning, and active response from acting
@@ -159,7 +184,7 @@ pub struct ReloadConfig {
 impl AppConfig {
     /// Load configuration from defaults, config.toml, and environment variables
     pub fn new() -> Result<Self, config::ConfigError> {
-        let s = config::Config::builder()
+        let builder = config::Config::builder()
             // --- Defaults ---
             // Scanner
             .set_default("scanner.sigma_enabled", true)?
@@ -210,8 +235,19 @@ impl AppConfig {
             .set_default("ioc.hash_allowlist_paths", Vec::<String>::new())?
             // Hot Reload
             .set_default("reload.enabled", true)?
-            .set_default("reload.debounce_ms", 2000)?
-            // --- Sources ---
+            .set_default("reload.debounce_ms", 2000)?;
+
+        // --- Sources ---
+        // Config files are searched in two locations, lowest priority first.
+        // The executable's directory is the fallback; the current working
+        // directory overrides it on conflicting keys, preserving the historical
+        // behavior where `config.toml` is read from the launch directory
+        // (e.g. `C:\Windows\System32` for a service).
+        let builder = match exe_dir_config_source() {
+            Some(source) => builder.add_source(source),
+            None => builder,
+        };
+        let s = builder
             .add_source(config::File::with_name("config").required(false))
             .add_source(config::Environment::with_prefix("EDR").separator("__"))
             .build()?;
@@ -306,6 +342,17 @@ impl Default for AppConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_exe_dir_config_base_is_next_to_executable() {
+        let exe = std::env::current_exe().expect("current exe path");
+        let base = exe_dir_config_base().expect("exe dir config base");
+
+        // The base lives in the same directory as the executable and is named
+        // `config` (extension-less; the config crate appends .toml/.yaml/...).
+        assert_eq!(base.parent(), exe.parent());
+        assert_eq!(base.file_name().and_then(|n| n.to_str()), Some("config"));
+    }
 
     #[test]
     fn test_config_loads_defaults() {


### PR DESCRIPTION
## Summary

Fixes #43.

Windows services start with `C:\Windows\System32` as their working directory, so a `config.toml` placed next to `rustinel.exe` (e.g. in `C:\Rustinel`) was never loaded — config was only ever read from the current working directory.

This adds the executable's directory as an additional config-file source, giving the search order requested in the issue:

1. `EDR__...` environment variables
2. `config.toml` in the current working directory
3. `config.toml` in the directory containing the executable
4. Built-in defaults

The current working directory still takes precedence on conflicting keys, so existing behavior is preserved. Operators can now keep all Rustinel files in one directory regardless of the service working directory. The change is cross-platform and also helps Linux/macOS supervisors that start outside the install root.

## Changes

- `src/config.rs`: add `exe_dir_config_source()` / `exe_dir_config_base()` and wire the exe-dir source in below the CWD source. Degrades cleanly to the original behavior if `current_exe()` fails.
- Unit test asserting the config base resolves next to the executable.
- Docs updated (`configuration.md`, `faq.md`, `operations.md`, `troubleshooting.md`) to describe the new search order.

## Testing

- `cargo clippy --lib` — clean
- `cargo test --lib config::` and `cargo test --test config_integration` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)