### PR TITLE
feat(macos): network and DNS telemetry via `/dev/bpf`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,6 +273,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.11.1",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.2",
+ "shlex",
+ "syn",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -370,6 +388,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom 7.1.3",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -386,6 +413,17 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -1180,6 +1218,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "globset"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1404,6 +1448,15 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -1466,10 +1519,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libproc"
+version = "0.14.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a54ad7278b8bc5301d5ffd2a94251c004feb971feba96c971ea4063645990757"
+dependencies = [
+ "bindgen",
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -2340,6 +2414,7 @@ dependencies = [
  "hex",
  "ipnetwork",
  "libc",
+ "libproc",
  "md-5 0.11.0",
  "memmap2",
  "pelite",
@@ -3335,7 +3410,7 @@ dependencies = [
  "cranelift-frontend",
  "cranelift-native",
  "gimli 0.33.0",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "object 0.38.1",
  "pulley-interpreter",
@@ -3876,7 +3951,7 @@ dependencies = [
  "intaglio",
  "inventory",
  "ipnet",
- "itertools",
+ "itertools 0.14.0",
  "js-sys",
  "md-5 0.10.6",
  "md2",
@@ -3939,7 +4014,7 @@ dependencies = [
  "bitflags 2.11.1",
  "bstr",
  "indexmap",
- "itertools",
+ "itertools 0.14.0",
  "logos",
  "num-traits",
  "rowan",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,8 @@ libc = "0.2"
 # reference-counted message handling.
 endpoint-sec = { version = "0.5", features = ["macos_11_0_0"] }
 endpoint-sec-sys = "0.5"
+# Process/socket inspection for best-effort PID attribution of captured flows.
+libproc = "0.14"
 
 # Windows-specific
 [target.'cfg(windows)'.dependencies]

--- a/src/runtime/macos.rs
+++ b/src/runtime/macos.rs
@@ -7,7 +7,7 @@ use crate::response::ResponseEngine;
 use crate::runtime::logging::{init_logging, log_startup_banner};
 use crate::runtime::{ioc as runtime_ioc, yara as runtime_yara};
 use crate::scanner::{YaraEventHandler, YaraMemoryJob};
-use crate::sensor::macos::EsfSensor;
+use crate::sensor::macos::{BpfSensor, EsfSensor};
 use crate::sensor::{Platform, Sensor, SensorEvent, SensorEventRouter};
 use crate::state::{ConnectionAggregator, DnsCache, ProcessCache, SidCache};
 use crate::{config, reload, scanner};
@@ -22,10 +22,9 @@ pub fn run(console_output: bool, log_level: Option<String>) -> anyhow::Result<()
     runtime.block_on(run_macos_edr(Some(console_output), log_level))
 }
 
-/// macOS EDR main loop. Mirrors `run_linux_edr` but replaces the eBPF sensor
-/// with the macOS sensor. In Phase 0 this is a no-op placeholder sensor so the
-/// shared pipeline can be exercised end to end; the Endpoint Security and
-/// /dev/bpf sources land in later phases.
+/// macOS EDR main loop. Mirrors `run_linux_edr`, sourcing process and file
+/// events from Endpoint Security and network and DNS events from a /dev/bpf
+/// capture sensor.
 async fn run_macos_edr(
     console_output_override: Option<bool>,
     log_level_override: Option<String>,
@@ -234,10 +233,11 @@ async fn run_macos_edr(
     router_inner.register_handler(Box::new(yara_handler));
     let router = Arc::new(router_inner);
 
-    // 13. macOS Endpoint Security sensor
-    let sensor = Arc::new(EsfSensor::new());
+    // 13. macOS sensors: Endpoint Security (process/file) and bpf (network/DNS)
+    let esf_sensor = Arc::new(EsfSensor::new());
+    let bpf_sensor = Arc::new(BpfSensor::new());
 
-    info!("Starting macOS sensor...");
+    info!("Starting macOS sensors...");
     info!("Press Ctrl+C to stop gracefully");
 
     let (sensor_tx, mut sensor_rx) = mpsc::channel::<SensorEvent>(8192);
@@ -248,10 +248,20 @@ async fn run_macos_edr(
         }
     });
 
-    let sensor_clone = Arc::clone(&sensor);
-    if let Err(e) = sensor_clone.start(sensor_tx) {
-        error!("macOS sensor failed to start: {:#}", e);
+    // Endpoint Security is the primary source; failing to start it is fatal.
+    let esf_clone = Arc::clone(&esf_sensor);
+    if let Err(e) = esf_clone.start(sensor_tx.clone()) {
+        error!("macOS Endpoint Security sensor failed to start: {:#}", e);
         return Err(e);
+    }
+
+    // Network/DNS capture is best-effort; degrade to ESF-only if it fails.
+    let bpf_clone = Arc::clone(&bpf_sensor);
+    if let Err(e) = bpf_clone.start(sensor_tx) {
+        warn!(
+            "macOS network/DNS sensor unavailable: {:#}; continuing with Endpoint Security only",
+            e
+        );
     }
 
     // 14. Wait for Ctrl+C
@@ -259,7 +269,8 @@ async fn run_macos_edr(
         Ok(()) => info!("Received Ctrl+C, shutting down"),
         Err(e) => error!("Failed to listen for Ctrl+C: {}", e),
     }
-    sensor.shutdown();
+    esf_sensor.shutdown();
+    bpf_sensor.shutdown();
 
     // Drain workers
     drop(router);

--- a/src/sensor/dns.rs
+++ b/src/sensor/dns.rs
@@ -1,0 +1,122 @@
+//! Shared DNS wire-format parsing used by platform sensors.
+//!
+//! Both the Linux eBPF sensor and the macOS `/dev/bpf` sensor observe raw DNS
+//! query payloads and need to extract the queried name. This module holds the
+//! single, defensive parser they share.
+
+/// DNS message header length in bytes.
+pub(crate) const HEADER_LEN: usize = 12;
+/// Top two bits of a label length byte mark a compression pointer.
+const LABEL_POINTER_MASK: u8 = 0xc0;
+/// Maximum length of a single DNS label.
+const LABEL_MAX_LEN: usize = 63;
+
+/// Parse the first question name (QNAME) from a raw DNS message payload.
+///
+/// Returns `None` for responses (QR bit set), empty question sections,
+/// truncated payloads, or names that use compression pointers (which do not
+/// appear in the question section of a well-formed query). The parser never
+/// follows pointers, keeping it bounded and safe against malformed input.
+pub(crate) fn parse_query_name(payload: &[u8]) -> Option<String> {
+    if payload.len() < HEADER_LEN {
+        return None;
+    }
+
+    let flags = u16::from_be_bytes([payload[2], payload[3]]);
+    let qdcount = u16::from_be_bytes([payload[4], payload[5]]);
+    if flags & 0x8000 != 0 || qdcount == 0 {
+        return None;
+    }
+
+    let mut pos = HEADER_LEN;
+    let mut labels: Vec<String> = Vec::new();
+    while pos < payload.len() {
+        let label_len = payload[pos];
+        pos += 1;
+
+        if label_len == 0 {
+            return if labels.is_empty() {
+                Some(".".to_string())
+            } else {
+                Some(labels.join("."))
+            };
+        }
+
+        if label_len & LABEL_POINTER_MASK != 0 {
+            return None;
+        }
+
+        let label_len = usize::from(label_len);
+        if label_len > LABEL_MAX_LEN || pos + label_len > payload.len() {
+            return None;
+        }
+
+        labels.push(String::from_utf8_lossy(&payload[pos..pos + label_len]).into_owned());
+        pos += label_len;
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a minimal single-question DNS query payload for `name`.
+    fn query_payload(name: &str) -> Vec<u8> {
+        let mut payload = vec![0u8; HEADER_LEN];
+        payload[5] = 1; // qdcount = 1
+        for label in name.split('.') {
+            payload.push(label.len() as u8);
+            payload.extend_from_slice(label.as_bytes());
+        }
+        payload.push(0); // root label
+        payload.extend_from_slice(&1u16.to_be_bytes()); // qtype = A
+        payload.extend_from_slice(&1u16.to_be_bytes()); // qclass = IN
+        payload
+    }
+
+    #[test]
+    fn parses_simple_query_name() {
+        let payload = query_payload("sub.example.test");
+        assert_eq!(parse_query_name(&payload).as_deref(), Some("sub.example.test"));
+    }
+
+    #[test]
+    fn rejects_short_payload() {
+        assert_eq!(parse_query_name(&[0u8; HEADER_LEN - 1]), None);
+    }
+
+    #[test]
+    fn rejects_response_messages() {
+        let mut payload = query_payload("example.test");
+        payload[2] = 0x80; // set QR bit
+        assert_eq!(parse_query_name(&payload), None);
+    }
+
+    #[test]
+    fn rejects_zero_question_count() {
+        let mut payload = query_payload("example.test");
+        payload[4] = 0;
+        payload[5] = 0;
+        assert_eq!(parse_query_name(&payload), None);
+    }
+
+    #[test]
+    fn rejects_compression_pointer() {
+        let mut payload = vec![0u8; HEADER_LEN];
+        payload[5] = 1;
+        payload.push(LABEL_POINTER_MASK); // pointer instead of a label length
+        payload.push(0x00);
+        assert_eq!(parse_query_name(&payload), None);
+    }
+
+    #[test]
+    fn rejects_truncated_label() {
+        let mut payload = vec![0u8; HEADER_LEN];
+        payload[5] = 1;
+        payload.push(10); // claims a 10-byte label
+        payload.extend_from_slice(b"abc"); // but only 3 bytes follow
+        assert_eq!(parse_query_name(&payload), None);
+    }
+}

--- a/src/sensor/dns.rs
+++ b/src/sensor/dns.rs
@@ -11,13 +11,14 @@ const LABEL_POINTER_MASK: u8 = 0xc0;
 /// Maximum length of a single DNS label.
 const LABEL_MAX_LEN: usize = 63;
 
-/// Parse the first question name (QNAME) from a raw DNS message payload.
+/// Parse the first question (QNAME and QTYPE) from a raw DNS query payload.
 ///
 /// Returns `None` for responses (QR bit set), empty question sections,
 /// truncated payloads, or names that use compression pointers (which do not
 /// appear in the question section of a well-formed query). The parser never
-/// follows pointers, keeping it bounded and safe against malformed input.
-pub(crate) fn parse_query_name(payload: &[u8]) -> Option<String> {
+/// follows pointers, keeping it bounded and safe against malformed input. The
+/// QTYPE is `0` when the payload is truncated right after the name.
+pub(crate) fn parse_question(payload: &[u8]) -> Option<(String, u16)> {
     if payload.len() < HEADER_LEN {
         return None;
     }
@@ -35,11 +36,16 @@ pub(crate) fn parse_query_name(payload: &[u8]) -> Option<String> {
         pos += 1;
 
         if label_len == 0 {
-            return if labels.is_empty() {
-                Some(".".to_string())
+            let name = if labels.is_empty() {
+                ".".to_string()
             } else {
-                Some(labels.join("."))
+                labels.join(".")
             };
+            let qtype = match (payload.get(pos), payload.get(pos + 1)) {
+                (Some(hi), Some(lo)) => u16::from_be_bytes([*hi, *lo]),
+                _ => 0,
+            };
+            return Some((name, qtype));
         }
 
         if label_len & LABEL_POINTER_MASK != 0 {
@@ -76,22 +82,34 @@ mod tests {
         payload
     }
 
+    fn query_name(payload: &[u8]) -> Option<String> {
+        parse_question(payload).map(|(name, _qtype)| name)
+    }
+
     #[test]
     fn parses_simple_query_name() {
         let payload = query_payload("sub.example.test");
-        assert_eq!(parse_query_name(&payload).as_deref(), Some("sub.example.test"));
+        assert_eq!(query_name(&payload).as_deref(), Some("sub.example.test"));
+    }
+
+    #[test]
+    fn parses_question_name_and_qtype() {
+        let payload = query_payload("example.test");
+        let (name, qtype) = parse_question(&payload).expect("question should parse");
+        assert_eq!(name, "example.test");
+        assert_eq!(qtype, 1); // A
     }
 
     #[test]
     fn rejects_short_payload() {
-        assert_eq!(parse_query_name(&[0u8; HEADER_LEN - 1]), None);
+        assert_eq!(parse_question(&[0u8; HEADER_LEN - 1]), None);
     }
 
     #[test]
     fn rejects_response_messages() {
         let mut payload = query_payload("example.test");
         payload[2] = 0x80; // set QR bit
-        assert_eq!(parse_query_name(&payload), None);
+        assert_eq!(parse_question(&payload), None);
     }
 
     #[test]
@@ -99,7 +117,7 @@ mod tests {
         let mut payload = query_payload("example.test");
         payload[4] = 0;
         payload[5] = 0;
-        assert_eq!(parse_query_name(&payload), None);
+        assert_eq!(parse_question(&payload), None);
     }
 
     #[test]
@@ -108,7 +126,7 @@ mod tests {
         payload[5] = 1;
         payload.push(LABEL_POINTER_MASK); // pointer instead of a label length
         payload.push(0x00);
-        assert_eq!(parse_query_name(&payload), None);
+        assert_eq!(parse_question(&payload), None);
     }
 
     #[test]
@@ -117,6 +135,6 @@ mod tests {
         payload[5] = 1;
         payload.push(10); // claims a 10-byte label
         payload.extend_from_slice(b"abc"); // but only 3 bytes follow
-        assert_eq!(parse_query_name(&payload), None);
+        assert_eq!(parse_question(&payload), None);
     }
 }

--- a/src/sensor/linux/ebpf.rs
+++ b/src/sensor/linux/ebpf.rs
@@ -49,9 +49,6 @@ const EVENT_ID_DNS_QUERY: u16 = 22;
 
 const PROCESS_EVENT_EXEC: u32 = 1;
 const PROCESS_EVENT_EXIT: u32 = 2;
-const DNS_HEADER_LEN: usize = 12;
-const DNS_LABEL_POINTER_MASK: u8 = 0xc0;
-const DNS_LABEL_MAX_LEN: usize = 63;
 
 /// Linux eBPF sensor. Implements [`Sensor`]; call `start()` from within a
 /// tokio runtime context.
@@ -571,44 +568,7 @@ fn build_dns_event(ev: &DnsEvent) -> Option<SensorEvent> {
 fn parse_dns_query_name(ev: &DnsEvent) -> Option<String> {
     let payload_len = usize::from(ev.payload_len).min(ev.payload.len());
     let payload = ev.payload.get(..payload_len)?;
-    if payload.len() < DNS_HEADER_LEN {
-        return None;
-    }
-
-    let flags = u16::from_be_bytes([payload[2], payload[3]]);
-    let qdcount = u16::from_be_bytes([payload[4], payload[5]]);
-    if flags & 0x8000 != 0 || qdcount == 0 {
-        return None;
-    }
-
-    let mut pos = DNS_HEADER_LEN;
-    let mut labels: Vec<String> = Vec::new();
-    while pos < payload.len() {
-        let label_len = payload[pos];
-        pos += 1;
-
-        if label_len == 0 {
-            return if labels.is_empty() {
-                Some(".".to_string())
-            } else {
-                Some(labels.join("."))
-            };
-        }
-
-        if label_len & DNS_LABEL_POINTER_MASK != 0 {
-            return None;
-        }
-
-        let label_len = usize::from(label_len);
-        if label_len > DNS_LABEL_MAX_LEN || pos + label_len > payload.len() {
-            return None;
-        }
-
-        labels.push(String::from_utf8_lossy(&payload[pos..pos + label_len]).into_owned());
-        pos += label_len;
-    }
-
-    None
+    crate::sensor::dns::parse_query_name(payload)
 }
 
 // ── Utilities ────────────────────────────────────────────────────────────────
@@ -701,7 +661,7 @@ mod tests {
         payload[4] = 0;
         payload[5] = 1;
 
-        let mut pos = DNS_HEADER_LEN;
+        let mut pos = crate::sensor::dns::HEADER_LEN;
         for label in name.split('.') {
             let bytes = label.as_bytes();
             payload[pos] = bytes.len() as u8;
@@ -1057,7 +1017,7 @@ mod tests {
             pid: 4242,
             uid: 1000,
             fd: 5,
-            payload_len: payload_len.min((DNS_HEADER_LEN + 4) as u16),
+            payload_len: payload_len.min((crate::sensor::dns::HEADER_LEN + 4) as u16),
             _pad0: 0,
             query_name: [0u8; 96],
             query_results: [0u8; 96],

--- a/src/sensor/linux/ebpf.rs
+++ b/src/sensor/linux/ebpf.rs
@@ -568,7 +568,7 @@ fn build_dns_event(ev: &DnsEvent) -> Option<SensorEvent> {
 fn parse_dns_query_name(ev: &DnsEvent) -> Option<String> {
     let payload_len = usize::from(ev.payload_len).min(ev.payload.len());
     let payload = ev.payload.get(..payload_len)?;
-    crate::sensor::dns::parse_query_name(payload)
+    crate::sensor::dns::parse_question(payload).map(|(name, _qtype)| name)
 }
 
 // ── Utilities ────────────────────────────────────────────────────────────────

--- a/src/sensor/macos/bpf.rs
+++ b/src/sensor/macos/bpf.rs
@@ -15,13 +15,20 @@ use std::os::unix::io::RawFd;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 
 use anyhow::{anyhow, Result};
 use tokio::sync::mpsc::Sender;
 use tracing::{info, warn};
 
-use crate::sensor::{Sensor, SensorEvent};
+use super::packet::{self, ParsedPacket, Transport, TCP_FLAG_ACK, TCP_FLAG_SYN};
+use crate::models::NetworkConnectionFields;
+use crate::sensor::{
+    Platform, Sensor, SensorAction, SensorEvent, SensorNormalization, SensorPayload,
+};
+
+/// Sysmon-compatible event ID emitted for network-connect events.
+const EVENT_ID_NETWORK_CONNECT: u16 = 3;
 
 /// Environment variable overriding the capture interface (default `en0`).
 const INTERFACE_ENV: &str = "RUSTINEL_BPF_INTERFACE";
@@ -296,9 +303,68 @@ fn for_each_packet(buf: &[u8], mut handle: impl FnMut(&[u8])) {
     }
 }
 
-/// Dispatch a captured link-layer frame. Network and DNS translation are added
-/// in following commits; for now frames are consumed without emitting events.
-fn handle_packet(_link_type: u32, _packet: &[u8], _tx: &Sender<SensorEvent>) {}
+/// Parse a captured frame and emit any resulting [`SensorEvent`].
+fn handle_packet(link_type: u32, frame: &[u8], tx: &Sender<SensorEvent>) {
+    let Some(parsed) = packet::parse(link_type, frame) else {
+        return;
+    };
+    if let Some(event) = build_network_event(&parsed) {
+        try_send(tx, event);
+    }
+}
+
+/// Build a network-connection event from a TCP connection initiation.
+///
+/// Only SYN segments with ACK clear are treated as new connections. PID and
+/// image attribution are filled in by the libproc socket lookup in a later
+/// commit; the normalizer enriches the rest.
+fn build_network_event(packet: &ParsedPacket) -> Option<SensorEvent> {
+    let Transport::Tcp {
+        src_port,
+        dst_port,
+        flags,
+        ..
+    } = &packet.transport;
+    if flags & TCP_FLAG_SYN == 0 || flags & TCP_FLAG_ACK != 0 {
+        return None;
+    }
+
+    Some(SensorEvent {
+        platform: Platform::MacOS,
+        provider: "bpf",
+        action: SensorAction::Connect,
+        normalization: SensorNormalization {
+            event_id: EVENT_ID_NETWORK_CONNECT,
+            action_code: 0,
+        },
+        pid: None,
+        timestamp: SystemTime::now(),
+        process_start_key: None,
+        payload: SensorPayload::Network(NetworkConnectionFields {
+            destination_ip: Some(packet.dst_ip.to_string()),
+            source_ip: Some(packet.src_ip.to_string()),
+            destination_port: Some(dst_port.to_string()),
+            source_port: Some(src_port.to_string()),
+            process_id: None,
+            image: None,
+            user: None,
+            destination_hostname: None,
+            protocol: Some("tcp".to_string()),
+        }),
+    })
+}
+
+fn try_send(tx: &Sender<SensorEvent>, event: SensorEvent) {
+    match tx.try_send(event) {
+        Ok(_) => {}
+        Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+            warn!("bpf sensor: event channel full, dropping event");
+        }
+        Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+            // Pipeline has shut down; stop logging.
+        }
+    }
+}
 
 fn read_u32(buf: &[u8], at: usize) -> u32 {
     u32::from_ne_bytes([buf[at], buf[at + 1], buf[at + 2], buf[at + 3]])
@@ -368,5 +434,41 @@ mod tests {
         assert_eq!(bpf_word_align(1), 4);
         assert_eq!(bpf_word_align(18), 20);
         assert_eq!(bpf_word_align(20), 20);
+    }
+
+    fn tcp_packet(flags: u8) -> ParsedPacket<'static> {
+        ParsedPacket {
+            src_ip: "10.0.0.5".parse().unwrap(),
+            dst_ip: "93.184.216.34".parse().unwrap(),
+            transport: Transport::Tcp {
+                src_port: 51324,
+                dst_port: 443,
+                flags,
+                payload: &[],
+            },
+        }
+    }
+
+    #[test]
+    fn build_network_event_emits_on_syn() {
+        let event = build_network_event(&tcp_packet(TCP_FLAG_SYN)).expect("syn should emit");
+        assert_eq!(event.provider, "bpf");
+        assert_eq!(event.action, SensorAction::Connect);
+        assert_eq!(event.normalization.event_id, EVENT_ID_NETWORK_CONNECT);
+        match event.payload {
+            SensorPayload::Network(fields) => {
+                assert_eq!(fields.destination_ip.as_deref(), Some("93.184.216.34"));
+                assert_eq!(fields.source_ip.as_deref(), Some("10.0.0.5"));
+                assert_eq!(fields.destination_port.as_deref(), Some("443"));
+                assert_eq!(fields.protocol.as_deref(), Some("tcp"));
+            }
+            other => panic!("unexpected payload: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn build_network_event_ignores_syn_ack_and_established() {
+        assert!(build_network_event(&tcp_packet(TCP_FLAG_SYN | TCP_FLAG_ACK)).is_none());
+        assert!(build_network_event(&tcp_packet(TCP_FLAG_ACK)).is_none());
     }
 }

--- a/src/sensor/macos/bpf.rs
+++ b/src/sensor/macos/bpf.rs
@@ -161,7 +161,9 @@ impl BpfDevice {
             }),
             Err(e) => {
                 close_fd(fd);
-                Err(anyhow!("failed to configure bpf device for {interface}: {e}"))
+                Err(anyhow!(
+                    "failed to configure bpf device for {interface}: {e}"
+                ))
             }
         }
     }

--- a/src/sensor/macos/bpf.rs
+++ b/src/sensor/macos/bpf.rs
@@ -22,13 +22,17 @@ use tokio::sync::mpsc::Sender;
 use tracing::{info, warn};
 
 use super::packet::{self, ParsedPacket, Transport, TCP_FLAG_ACK, TCP_FLAG_SYN};
-use crate::models::NetworkConnectionFields;
+use crate::models::{DnsQueryFields, NetworkConnectionFields};
 use crate::sensor::{
     Platform, Sensor, SensorAction, SensorEvent, SensorNormalization, SensorPayload,
 };
 
 /// Sysmon-compatible event ID emitted for network-connect events.
 const EVENT_ID_NETWORK_CONNECT: u16 = 3;
+/// Sysmon-compatible event ID emitted for DNS-query events.
+const EVENT_ID_DNS_QUERY: u16 = 22;
+/// Destination port that identifies DNS query traffic.
+const DNS_PORT: u16 = 53;
 
 /// Environment variable overriding the capture interface (default `en0`).
 const INTERFACE_ENV: &str = "RUSTINEL_BPF_INTERFACE";
@@ -311,6 +315,9 @@ fn handle_packet(link_type: u32, frame: &[u8], tx: &Sender<SensorEvent>) {
     if let Some(event) = build_network_event(&parsed) {
         try_send(tx, event);
     }
+    if let Some(event) = build_dns_event(&parsed) {
+        try_send(tx, event);
+    }
 }
 
 /// Build a network-connection event from a TCP connection initiation.
@@ -324,7 +331,10 @@ fn build_network_event(packet: &ParsedPacket) -> Option<SensorEvent> {
         dst_port,
         flags,
         ..
-    } = &packet.transport;
+    } = &packet.transport
+    else {
+        return None;
+    };
     if flags & TCP_FLAG_SYN == 0 || flags & TCP_FLAG_ACK != 0 {
         return None;
     }
@@ -352,6 +362,63 @@ fn build_network_event(packet: &ParsedPacket) -> Option<SensorEvent> {
             protocol: Some("tcp".to_string()),
         }),
     })
+}
+
+/// Build a DNS-query event from a packet destined to port 53.
+///
+/// Handles UDP queries directly and DNS-over-TCP by skipping the 2-byte length
+/// prefix. Responses are rejected by the shared parser (QR bit).
+fn build_dns_event(packet: &ParsedPacket) -> Option<SensorEvent> {
+    let (dst_port, dns_payload) = match &packet.transport {
+        Transport::Udp { dst_port, payload } => (*dst_port, *payload),
+        Transport::Tcp {
+            dst_port, payload, ..
+        } => (*dst_port, payload.get(2..)?),
+    };
+    if dst_port != DNS_PORT {
+        return None;
+    }
+
+    let (query_name, qtype) = crate::sensor::dns::parse_question(dns_payload)?;
+
+    Some(SensorEvent {
+        platform: Platform::MacOS,
+        provider: "bpf",
+        action: SensorAction::Query,
+        normalization: SensorNormalization {
+            event_id: EVENT_ID_DNS_QUERY,
+            action_code: 0,
+        },
+        pid: None,
+        timestamp: SystemTime::now(),
+        process_start_key: None,
+        payload: SensorPayload::Dns(DnsQueryFields {
+            query_name: Some(query_name),
+            query_results: None,
+            record_type: record_type_name(qtype).map(str::to_string),
+            query_status: None,
+            process_id: None,
+            image: None,
+        }),
+    })
+}
+
+/// Map a DNS QTYPE to its record-type name, for the common types.
+fn record_type_name(qtype: u16) -> Option<&'static str> {
+    let name = match qtype {
+        1 => "A",
+        2 => "NS",
+        5 => "CNAME",
+        6 => "SOA",
+        12 => "PTR",
+        15 => "MX",
+        16 => "TXT",
+        28 => "AAAA",
+        33 => "SRV",
+        255 => "ANY",
+        _ => return None,
+    };
+    Some(name)
 }
 
 fn try_send(tx: &Sender<SensorEvent>, event: SensorEvent) {
@@ -470,5 +537,108 @@ mod tests {
     fn build_network_event_ignores_syn_ack_and_established() {
         assert!(build_network_event(&tcp_packet(TCP_FLAG_SYN | TCP_FLAG_ACK)).is_none());
         assert!(build_network_event(&tcp_packet(TCP_FLAG_ACK)).is_none());
+    }
+
+    /// Minimal single-question DNS query payload for `name` with the given qtype.
+    fn dns_query(name: &str, qtype: u16) -> Vec<u8> {
+        let mut payload = vec![0u8; 12];
+        payload[5] = 1; // qdcount = 1
+        for label in name.split('.') {
+            payload.push(label.len() as u8);
+            payload.extend_from_slice(label.as_bytes());
+        }
+        payload.push(0);
+        payload.extend_from_slice(&qtype.to_be_bytes());
+        payload.extend_from_slice(&1u16.to_be_bytes()); // qclass = IN
+        payload
+    }
+
+    fn udp_packet(dst_port: u16, payload: Vec<u8>) -> ParsedPacket<'static> {
+        ParsedPacket {
+            src_ip: "10.0.0.5".parse().unwrap(),
+            dst_ip: "1.1.1.1".parse().unwrap(),
+            transport: Transport::Udp {
+                dst_port,
+                payload: Box::leak(payload.into_boxed_slice()),
+            },
+        }
+    }
+
+    #[test]
+    fn build_dns_event_maps_udp_query() {
+        let event = build_dns_event(&udp_packet(DNS_PORT, dns_query("sub.example.test", 28)))
+            .expect("dns query should emit");
+        assert_eq!(event.provider, "bpf");
+        assert_eq!(event.action, SensorAction::Query);
+        assert_eq!(event.normalization.event_id, EVENT_ID_DNS_QUERY);
+        match event.payload {
+            SensorPayload::Dns(fields) => {
+                assert_eq!(fields.query_name.as_deref(), Some("sub.example.test"));
+                assert_eq!(fields.record_type.as_deref(), Some("AAAA"));
+            }
+            other => panic!("unexpected payload: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn build_dns_event_ignores_non_dns_port() {
+        assert!(build_dns_event(&udp_packet(123, dns_query("example.test", 1))).is_none());
+    }
+
+    #[test]
+    fn record_type_name_maps_known_types() {
+        assert_eq!(record_type_name(1), Some("A"));
+        assert_eq!(record_type_name(28), Some("AAAA"));
+        assert_eq!(record_type_name(64000), None);
+    }
+
+    fn test_normalizer() -> crate::normalizer::Normalizer {
+        use crate::state::{ConnectionAggregator, DnsCache, ProcessCache, SidCache};
+        crate::normalizer::Normalizer::new(
+            Arc::new(ProcessCache::new()),
+            Arc::new(SidCache::new()),
+            Arc::new(DnsCache::new()),
+            Arc::new(ConnectionAggregator::new()),
+            false,
+        )
+    }
+
+    #[test]
+    fn macos_dns_query_matches_product_macos_sigma_rule() {
+        use crate::engine::Engine;
+        use crate::sensor::Platform;
+
+        let tempdir = tempfile::tempdir().expect("create sigma tempdir");
+        let rules_dir = tempdir.path().join("sigma");
+        std::fs::create_dir_all(&rules_dir).expect("create sigma rules dir");
+        std::fs::write(
+            rules_dir.join("dns.yml"),
+            r#"title: macOS DNS QueryName
+logsource:
+  product: macos
+  category: dns_query
+detection:
+  selection:
+    QueryName|endswith: ".example.test"
+  condition: selection
+level: high
+"#,
+        )
+        .expect("write sigma rule");
+
+        let mut engine = Engine::new_for_platform(Platform::MacOS);
+        engine.load_rules(&rules_dir).expect("load sigma rule");
+
+        let event = build_dns_event(&udp_packet(DNS_PORT, dns_query("sub.example.test", 1)))
+            .expect("dns event should build");
+        let normalized = test_normalizer()
+            .normalize(&event)
+            .expect("dns event should normalize");
+        assert_eq!(normalized.get_field("QueryName"), Some("sub.example.test"));
+
+        let alert = engine
+            .check_event(&normalized)
+            .expect("macOS dns Sigma rule should match parsed QueryName");
+        assert_eq!(alert.rule_name, "macOS DNS QueryName");
     }
 }

--- a/src/sensor/macos/bpf.rs
+++ b/src/sensor/macos/bpf.rs
@@ -13,6 +13,7 @@ use std::ffi::CString;
 use std::io;
 use std::os::unix::io::RawFd;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{Receiver, SyncSender, TrySendError};
 use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
 use std::time::{Duration, SystemTime};
@@ -45,6 +46,11 @@ const BPF_BUFFER_LEN: u32 = 1 << 18; // 256 KiB
 
 /// Read timeout so the capture loop wakes periodically to observe shutdown.
 const READ_TIMEOUT: Duration = Duration::from_millis(200);
+
+/// Bound on connection-attribution jobs queued for the worker thread. When the
+/// worker falls behind (a burst of new connections), the capture thread emits
+/// the event unattributed rather than blocking the read loop.
+const ATTRIBUTION_QUEUE_CAP: usize = 1024;
 
 // BPF ioctl request codes for 64-bit macOS, from <net/bpf.h>. Encoded with the
 // _IOW/_IOR/_IOWR macros; verified against the SDK headers.
@@ -345,8 +351,27 @@ fn close_fd(fd: RawFd) {
     }
 }
 
+/// A network-connection event awaiting best-effort process attribution.
+struct AttributionJob {
+    event: SensorEvent,
+    local_port: u16,
+    remote_port: u16,
+}
+
 /// Capture loop: read batches of bpf records and dispatch each packet.
+///
+/// Socket-to-process attribution is offloaded to a dedicated worker so the
+/// `O(processes x descriptors)` scan never blocks draining the bpf device,
+/// which is exactly when the kernel would otherwise drop packets.
 fn run_capture(device: BpfDevice, tx: Sender<SensorEvent>, shutdown: Arc<AtomicBool>) {
+    let (attribution_tx, attribution_rx) = std::sync::mpsc::sync_channel(ATTRIBUTION_QUEUE_CAP);
+    let worker_tx = tx.clone();
+    let attribution_worker = std::thread::Builder::new()
+        .name("rustinel-bpf-attr".to_string())
+        .spawn(move || run_attribution_worker(attribution_rx, worker_tx))
+        .map_err(|e| warn!("failed to spawn bpf attribution worker: {e}"))
+        .ok();
+
     let mut buf = vec![0u8; device.buffer_len as usize];
     while !shutdown.load(Ordering::Relaxed) {
         let n = unsafe { libc::read(device.fd, buf.as_mut_ptr().cast(), buf.len()) };
@@ -369,9 +394,29 @@ fn run_capture(device: BpfDevice, tx: Sender<SensorEvent>, shutdown: Arc<AtomicB
             continue;
         }
         let data = &buf[..n as usize];
-        for_each_packet(data, |packet| handle_packet(device.link_type, packet, &tx));
+        for_each_packet(data, |packet| {
+            handle_packet(device.link_type, packet, &tx, &attribution_tx)
+        });
+    }
+
+    // Drop our sender so the worker observes the channel closing and exits,
+    // then wait for it to finish any in-flight lookup.
+    drop(attribution_tx);
+    if let Some(handle) = attribution_worker {
+        let _ = handle.join();
     }
     info!("bpf sensor shutting down");
+}
+
+/// Attribution worker: receive connection events that still need an owning
+/// process, perform the libproc socket lookup off the capture thread, and
+/// forward the (now best-effort attributed) event to the pipeline. Exits when
+/// the capture thread drops its sender.
+fn run_attribution_worker(rx: Receiver<AttributionJob>, tx: Sender<SensorEvent>) {
+    while let Ok(mut job) = rx.recv() {
+        apply_socket_owner(&mut job.event, job.local_port, job.remote_port);
+        try_send(&tx, job.event);
+    }
 }
 
 /// Iterate the packets in a bpf read buffer, calling `handle` with each
@@ -399,31 +444,60 @@ fn for_each_packet(buf: &[u8], mut handle: impl FnMut(&[u8])) {
 }
 
 /// Parse a captured frame and emit any resulting [`SensorEvent`].
-fn handle_packet(link_type: u32, frame: &[u8], tx: &Sender<SensorEvent>) {
+///
+/// Network-connection events are queued for off-thread attribution; DNS events
+/// need no PID lookup and go straight to the pipeline.
+fn handle_packet(
+    link_type: u32,
+    frame: &[u8],
+    tx: &Sender<SensorEvent>,
+    attribution_tx: &SyncSender<AttributionJob>,
+) {
     let Some(parsed) = packet::parse(link_type, frame) else {
         return;
     };
-    if let Some(mut event) = build_network_event(&parsed) {
-        attribute_connection_owner(&mut event, &parsed);
-        try_send(tx, event);
+    if let Some(event) = build_network_event(&parsed) {
+        match connection_ports(&parsed) {
+            Some((local_port, remote_port)) => {
+                enqueue_attribution(attribution_tx, tx, event, local_port, remote_port)
+            }
+            None => try_send(tx, event),
+        }
     }
     if let Some(event) = build_dns_event(&parsed) {
         try_send(tx, event);
     }
 }
 
-/// Best-effort: attribute a network-connection event to the owning process by
-/// matching its ports against open sockets. Runs once per connection
-/// initiation; failures leave the event unattributed (the normalizer still
-/// enriches by destination).
-fn attribute_connection_owner(event: &mut SensorEvent, packet: &ParsedPacket) {
-    let Transport::Tcp {
-        src_port, dst_port, ..
-    } = &packet.transport
-    else {
-        return;
+/// Hand a connection event to the attribution worker, falling back to emitting
+/// it unattributed if the worker is saturated or gone. The capture thread never
+/// blocks and the event is never lost; only its attribution is best-effort.
+fn enqueue_attribution(
+    attribution_tx: &SyncSender<AttributionJob>,
+    tx: &Sender<SensorEvent>,
+    event: SensorEvent,
+    local_port: u16,
+    remote_port: u16,
+) {
+    let job = AttributionJob {
+        event,
+        local_port,
+        remote_port,
     };
-    let Some(owner) = socket::find_tcp_socket_owner(*src_port, *dst_port) else {
+    match attribution_tx.try_send(job) {
+        Ok(()) => {}
+        Err(TrySendError::Full(job)) | Err(TrySendError::Disconnected(job)) => {
+            try_send(tx, job.event)
+        }
+    }
+}
+
+/// Best-effort: attribute a connection event to its owning process by matching
+/// the connection's ports against open sockets. Failures leave the event
+/// unattributed (the normalizer still enriches by destination). Runs on the
+/// attribution worker, never on the capture thread.
+fn apply_socket_owner(event: &mut SensorEvent, local_port: u16, remote_port: u16) {
+    let Some(owner) = socket::find_tcp_socket_owner(local_port, remote_port) else {
         return;
     };
     event.pid = Some(owner.pid);
@@ -433,11 +507,21 @@ fn attribute_connection_owner(event: &mut SensorEvent, packet: &ParsedPacket) {
     }
 }
 
+/// The local and remote ports of a TCP packet, used to key socket attribution.
+fn connection_ports(packet: &ParsedPacket) -> Option<(u16, u16)> {
+    match &packet.transport {
+        Transport::Tcp {
+            src_port, dst_port, ..
+        } => Some((*src_port, *dst_port)),
+        Transport::Udp { .. } => None,
+    }
+}
+
 /// Build a network-connection event from a TCP connection initiation.
 ///
 /// Only SYN segments with ACK clear are treated as new connections. PID and
-/// image attribution are filled in by the libproc socket lookup in a later
-/// commit; the normalizer enriches the rest.
+/// image attribution are filled in best-effort by the attribution worker; the
+/// normalizer enriches the rest.
 fn build_network_event(packet: &ParsedPacket) -> Option<SensorEvent> {
     let Transport::Tcp {
         src_port,
@@ -666,6 +750,36 @@ mod tests {
     fn build_network_event_ignores_syn_ack_and_established() {
         assert!(build_network_event(&tcp_packet(TCP_FLAG_SYN | TCP_FLAG_ACK)).is_none());
         assert!(build_network_event(&tcp_packet(TCP_FLAG_ACK)).is_none());
+    }
+
+    #[test]
+    fn enqueue_attribution_emits_unattributed_when_worker_saturated() {
+        // A rendezvous channel with no worker receiving: try_send always reports
+        // the queue full, so the capture thread must emit the event itself
+        // rather than block or drop it.
+        let (attribution_tx, _attribution_rx) = std::sync::mpsc::sync_channel::<AttributionJob>(0);
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<SensorEvent>(8);
+
+        let event = build_network_event(&tcp_packet(TCP_FLAG_SYN)).expect("syn should emit");
+        enqueue_attribution(&attribution_tx, &tx, event, 51324, 443);
+
+        let received = rx
+            .try_recv()
+            .expect("event should still reach the pipeline");
+        assert!(received.pid.is_none(), "event should be unattributed");
+        match received.payload {
+            SensorPayload::Network(fields) => assert!(fields.process_id.is_none()),
+            other => panic!("unexpected payload: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn connection_ports_reads_tcp_only() {
+        assert_eq!(
+            connection_ports(&tcp_packet(TCP_FLAG_SYN)),
+            Some((51324, 443))
+        );
+        assert_eq!(connection_ports(&udp_packet(DNS_PORT, vec![])), None);
     }
 
     /// Minimal single-question DNS query payload for `name` with the given qtype.

--- a/src/sensor/macos/bpf.rs
+++ b/src/sensor/macos/bpf.rs
@@ -22,6 +22,7 @@ use tokio::sync::mpsc::Sender;
 use tracing::{info, warn};
 
 use super::packet::{self, ParsedPacket, Transport, TCP_FLAG_ACK, TCP_FLAG_SYN};
+use super::socket;
 use crate::models::{DnsQueryFields, NetworkConnectionFields};
 use crate::sensor::{
     Platform, Sensor, SensorAction, SensorEvent, SensorNormalization, SensorPayload,
@@ -312,11 +313,33 @@ fn handle_packet(link_type: u32, frame: &[u8], tx: &Sender<SensorEvent>) {
     let Some(parsed) = packet::parse(link_type, frame) else {
         return;
     };
-    if let Some(event) = build_network_event(&parsed) {
+    if let Some(mut event) = build_network_event(&parsed) {
+        attribute_connection_owner(&mut event, &parsed);
         try_send(tx, event);
     }
     if let Some(event) = build_dns_event(&parsed) {
         try_send(tx, event);
+    }
+}
+
+/// Best-effort: attribute a network-connection event to the owning process by
+/// matching its ports against open sockets. Runs once per connection
+/// initiation; failures leave the event unattributed (the normalizer still
+/// enriches by destination).
+fn attribute_connection_owner(event: &mut SensorEvent, packet: &ParsedPacket) {
+    let Transport::Tcp {
+        src_port, dst_port, ..
+    } = &packet.transport
+    else {
+        return;
+    };
+    let Some(owner) = socket::find_tcp_socket_owner(*src_port, *dst_port) else {
+        return;
+    };
+    event.pid = Some(owner.pid);
+    if let SensorPayload::Network(fields) = &mut event.payload {
+        fields.process_id = Some(owner.pid.to_string());
+        fields.image = owner.image;
     }
 }
 

--- a/src/sensor/macos/bpf.rs
+++ b/src/sensor/macos/bpf.rs
@@ -93,41 +93,54 @@ struct BpfProgram {
 }
 
 /// Coarse in-kernel pre-filter for Ethernet links: accept TCP connection
-/// initiations (SYN set, ACK clear) and any port-53 traffic, and drop the rest
-/// so the kernel never copies the ~99% of frames userspace would discard. This
-/// is the macOS analogue of attaching the Linux probe to `sys_enter_connect`
-/// rather than tapping every packet; [`packet`] stays the precise tier, so the
-/// filter only has to be a volume reducer and over-matching is harmless.
+/// initiations (SYN set, ACK clear) over IPv4 and IPv6, plus any port-53
+/// traffic, and drop the rest so the kernel never copies the ~99% of frames
+/// userspace would discard. This is the macOS analogue of attaching the Linux
+/// probe to `sys_enter_connect` rather than tapping every packet; [`packet`]
+/// stays the precise tier, so over-matching here is harmless. It must not
+/// *under*-match relative to the parser, which is why the IPv6 SYN term is
+/// spelled out explicitly rather than relying on `tcp[tcpflags]`.
 ///
 /// Generated with libpcap against a dead `DLT_EN10MB` handle, equivalent to:
-///   `tcpdump -dd -y EN10MB 'tcp[tcpflags] & (tcp-syn|tcp-ack) = tcp-syn or port 53'`
-/// Regenerate if the expression or link type changes; the offsets are
-/// Ethernet-specific, so it is only installed when `BIOCGDLT` reports
-/// `DLT_EN10MB`.
+///   `(tcp[tcpflags] & (tcp-syn|tcp-ack) = tcp-syn)`
+///   `  or (ip6 and ip6[6] = 6 and (ip6[53] & 0x12) = 2)`
+///   `  or port 53`
+/// The `tcp[tcpflags]` primitive only compiles to IPv4 code, so the IPv6 SYN
+/// term is written by hand: `ip6[6]` is the next header and `ip6[53]` the TCP
+/// flags byte (the IPv6 header is a fixed 40 bytes plus the TCP flags at offset
+/// 13). It assumes no IPv6 extension headers, matching `parse_ipv6`'s own
+/// first-next-header-only behavior, so the two tiers stay consistent.
+/// Regenerate if the expression changes; the offsets are Ethernet-specific, so
+/// it is only installed when `BIOCGDLT` reports `DLT_EN10MB`.
 #[rustfmt::skip]
-const BPF_FILTER_EN10MB: [BpfInsn; 32] = [
+const BPF_FILTER_EN10MB: [BpfInsn; 37] = [
     BpfInsn { code: 0x0028, jt: 0,  jf: 0,  k: 0x0000000c },
     BpfInsn { code: 0x0015, jt: 0,  jf: 19, k: 0x00000800 },
     BpfInsn { code: 0x0030, jt: 0,  jf: 0,  k: 0x00000017 },
     BpfInsn { code: 0x0015, jt: 0,  jf: 8,  k: 0x00000006 },
     BpfInsn { code: 0x0028, jt: 0,  jf: 0,  k: 0x00000014 },
-    BpfInsn { code: 0x0045, jt: 25, jf: 0,  k: 0x00001fff },
+    BpfInsn { code: 0x0045, jt: 30, jf: 0,  k: 0x00001fff },
     BpfInsn { code: 0x00b1, jt: 0,  jf: 0,  k: 0x0000000e },
     BpfInsn { code: 0x0050, jt: 0,  jf: 0,  k: 0x0000001b },
     BpfInsn { code: 0x0054, jt: 0,  jf: 0,  k: 0x00000012 },
-    BpfInsn { code: 0x0015, jt: 20, jf: 0,  k: 0x00000002 },
+    BpfInsn { code: 0x0015, jt: 25, jf: 0,  k: 0x00000002 },
     BpfInsn { code: 0x0048, jt: 0,  jf: 0,  k: 0x0000000e },
-    BpfInsn { code: 0x0015, jt: 18, jf: 7,  k: 0x00000035 },
+    BpfInsn { code: 0x0015, jt: 23, jf: 7,  k: 0x00000035 },
     BpfInsn { code: 0x0015, jt: 1,  jf: 0,  k: 0x00000084 },
-    BpfInsn { code: 0x0015, jt: 0,  jf: 17, k: 0x00000011 },
+    BpfInsn { code: 0x0015, jt: 0,  jf: 22, k: 0x00000011 },
     BpfInsn { code: 0x0028, jt: 0,  jf: 0,  k: 0x00000014 },
-    BpfInsn { code: 0x0045, jt: 15, jf: 0,  k: 0x00001fff },
+    BpfInsn { code: 0x0045, jt: 20, jf: 0,  k: 0x00001fff },
     BpfInsn { code: 0x00b1, jt: 0,  jf: 0,  k: 0x0000000e },
     BpfInsn { code: 0x0048, jt: 0,  jf: 0,  k: 0x0000000e },
-    BpfInsn { code: 0x0015, jt: 11, jf: 0,  k: 0x00000035 },
+    BpfInsn { code: 0x0015, jt: 16, jf: 0,  k: 0x00000035 },
     BpfInsn { code: 0x0048, jt: 0,  jf: 0,  k: 0x00000010 },
-    BpfInsn { code: 0x0015, jt: 9,  jf: 10, k: 0x00000035 },
-    BpfInsn { code: 0x0015, jt: 0,  jf: 9,  k: 0x000086dd },
+    BpfInsn { code: 0x0015, jt: 14, jf: 15, k: 0x00000035 },
+    BpfInsn { code: 0x0015, jt: 0,  jf: 14, k: 0x000086dd },
+    BpfInsn { code: 0x0030, jt: 0,  jf: 0,  k: 0x00000014 },
+    BpfInsn { code: 0x0015, jt: 0,  jf: 3,  k: 0x00000006 },
+    BpfInsn { code: 0x0030, jt: 0,  jf: 0,  k: 0x00000043 },
+    BpfInsn { code: 0x0054, jt: 0,  jf: 0,  k: 0x00000012 },
+    BpfInsn { code: 0x0015, jt: 8,  jf: 0,  k: 0x00000002 },
     BpfInsn { code: 0x0030, jt: 0,  jf: 0,  k: 0x00000014 },
     BpfInsn { code: 0x0015, jt: 2,  jf: 0,  k: 0x00000084 },
     BpfInsn { code: 0x0015, jt: 1,  jf: 0,  k: 0x00000006 },

--- a/src/sensor/macos/bpf.rs
+++ b/src/sensor/macos/bpf.rs
@@ -21,7 +21,7 @@ use anyhow::{anyhow, Result};
 use tokio::sync::mpsc::Sender;
 use tracing::{info, warn};
 
-use super::packet::{self, ParsedPacket, Transport, TCP_FLAG_ACK, TCP_FLAG_SYN};
+use super::packet::{self, ParsedPacket, Transport, DLT_EN10MB, TCP_FLAG_ACK, TCP_FLAG_SYN};
 use super::socket;
 use crate::models::{DnsQueryFields, NetworkConnectionFields};
 use crate::sensor::{
@@ -49,6 +49,7 @@ const READ_TIMEOUT: Duration = Duration::from_millis(200);
 // BPF ioctl request codes for 64-bit macOS, from <net/bpf.h>. Encoded with the
 // _IOW/_IOR/_IOWR macros; verified against the SDK headers.
 const BIOCSBLEN: libc::c_ulong = 0xc004_4266; // _IOWR('B', 102, u_int)
+const BIOCSETF: libc::c_ulong = 0x8010_4267; // _IOW('B', 103, struct bpf_program)
 const BIOCGDLT: libc::c_ulong = 0x4004_426a; // _IOR('B', 106, u_int)
 const BIOCSETIF: libc::c_ulong = 0x8020_426c; // _IOW('B', 108, struct ifreq)
 const BIOCSRTIMEOUT: libc::c_ulong = 0x8010_426d; // _IOW('B', 109, struct timeval)
@@ -67,6 +68,71 @@ struct IfReq {
     ifr_name: [libc::c_char; 16],
     ifr_ifru: [u8; 16],
 }
+
+/// A classic-BPF instruction (`struct bpf_insn`): opcode, two jump offsets, and
+/// a generic operand. Eight bytes, matching the kernel layout.
+#[repr(C)]
+struct BpfInsn {
+    code: u16,
+    jt: u8,
+    jf: u8,
+    k: u32,
+}
+
+/// A classic-BPF filter program (`struct bpf_program`) passed to `BIOCSETF`.
+#[repr(C)]
+struct BpfProgram {
+    bf_len: u32,
+    bf_insns: *const BpfInsn,
+}
+
+/// Coarse in-kernel pre-filter for Ethernet links: accept TCP connection
+/// initiations (SYN set, ACK clear) and any port-53 traffic, and drop the rest
+/// so the kernel never copies the ~99% of frames userspace would discard. This
+/// is the macOS analogue of attaching the Linux probe to `sys_enter_connect`
+/// rather than tapping every packet; [`packet`] stays the precise tier, so the
+/// filter only has to be a volume reducer and over-matching is harmless.
+///
+/// Generated with libpcap against a dead `DLT_EN10MB` handle, equivalent to:
+///   `tcpdump -dd -y EN10MB 'tcp[tcpflags] & (tcp-syn|tcp-ack) = tcp-syn or port 53'`
+/// Regenerate if the expression or link type changes; the offsets are
+/// Ethernet-specific, so it is only installed when `BIOCGDLT` reports
+/// `DLT_EN10MB`.
+#[rustfmt::skip]
+const BPF_FILTER_EN10MB: [BpfInsn; 32] = [
+    BpfInsn { code: 0x0028, jt: 0,  jf: 0,  k: 0x0000000c },
+    BpfInsn { code: 0x0015, jt: 0,  jf: 19, k: 0x00000800 },
+    BpfInsn { code: 0x0030, jt: 0,  jf: 0,  k: 0x00000017 },
+    BpfInsn { code: 0x0015, jt: 0,  jf: 8,  k: 0x00000006 },
+    BpfInsn { code: 0x0028, jt: 0,  jf: 0,  k: 0x00000014 },
+    BpfInsn { code: 0x0045, jt: 25, jf: 0,  k: 0x00001fff },
+    BpfInsn { code: 0x00b1, jt: 0,  jf: 0,  k: 0x0000000e },
+    BpfInsn { code: 0x0050, jt: 0,  jf: 0,  k: 0x0000001b },
+    BpfInsn { code: 0x0054, jt: 0,  jf: 0,  k: 0x00000012 },
+    BpfInsn { code: 0x0015, jt: 20, jf: 0,  k: 0x00000002 },
+    BpfInsn { code: 0x0048, jt: 0,  jf: 0,  k: 0x0000000e },
+    BpfInsn { code: 0x0015, jt: 18, jf: 7,  k: 0x00000035 },
+    BpfInsn { code: 0x0015, jt: 1,  jf: 0,  k: 0x00000084 },
+    BpfInsn { code: 0x0015, jt: 0,  jf: 17, k: 0x00000011 },
+    BpfInsn { code: 0x0028, jt: 0,  jf: 0,  k: 0x00000014 },
+    BpfInsn { code: 0x0045, jt: 15, jf: 0,  k: 0x00001fff },
+    BpfInsn { code: 0x00b1, jt: 0,  jf: 0,  k: 0x0000000e },
+    BpfInsn { code: 0x0048, jt: 0,  jf: 0,  k: 0x0000000e },
+    BpfInsn { code: 0x0015, jt: 11, jf: 0,  k: 0x00000035 },
+    BpfInsn { code: 0x0048, jt: 0,  jf: 0,  k: 0x00000010 },
+    BpfInsn { code: 0x0015, jt: 9,  jf: 10, k: 0x00000035 },
+    BpfInsn { code: 0x0015, jt: 0,  jf: 9,  k: 0x000086dd },
+    BpfInsn { code: 0x0030, jt: 0,  jf: 0,  k: 0x00000014 },
+    BpfInsn { code: 0x0015, jt: 2,  jf: 0,  k: 0x00000084 },
+    BpfInsn { code: 0x0015, jt: 1,  jf: 0,  k: 0x00000006 },
+    BpfInsn { code: 0x0015, jt: 0,  jf: 5,  k: 0x00000011 },
+    BpfInsn { code: 0x0028, jt: 0,  jf: 0,  k: 0x00000036 },
+    BpfInsn { code: 0x0015, jt: 2,  jf: 0,  k: 0x00000035 },
+    BpfInsn { code: 0x0028, jt: 0,  jf: 0,  k: 0x00000038 },
+    BpfInsn { code: 0x0015, jt: 0,  jf: 1,  k: 0x00000035 },
+    BpfInsn { code: 0x0006, jt: 0,  jf: 0,  k: 0x00040000 },
+    BpfInsn { code: 0x0006, jt: 0,  jf: 0,  k: 0x00000000 },
+];
 
 /// macOS `/dev/bpf` network/DNS sensor. Implements [`Sensor`].
 pub struct BpfSensor {
@@ -149,9 +215,18 @@ impl BpfDevice {
         };
         let configure = || -> io::Result<u32> {
             bind_interface(fd, interface)?;
+            let link_type = get_u32(fd, BIOCGDLT)?;
+            // Install a coarse kernel filter right after binding so the kernel
+            // drops everything but SYNs and port-53 traffic before it reaches
+            // userspace. The program uses Ethernet offsets, so it is only
+            // applied when the link type matches; other link types fall back to
+            // capturing everything and filtering in userspace.
+            if link_type == DLT_EN10MB {
+                set_filter(fd, &BPF_FILTER_EN10MB)?;
+            }
             set_u32(fd, BIOCIMMEDIATE, 1)?;
             set_read_timeout(fd, READ_TIMEOUT)?;
-            get_u32(fd, BIOCGDLT)
+            Ok(link_type)
         };
         match configure() {
             Ok(link_type) => Ok(Self {
@@ -206,6 +281,19 @@ fn bind_interface(fd: RawFd, interface: &str) -> io::Result<()> {
         *slot = *byte as libc::c_char;
     }
     let rc = unsafe { libc::ioctl(fd, BIOCSETIF, &req as *const IfReq) };
+    if rc < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+/// Install a classic-BPF filter program on the device via `BIOCSETF`.
+fn set_filter(fd: RawFd, program: &[BpfInsn]) -> io::Result<()> {
+    let prog = BpfProgram {
+        bf_len: program.len() as u32,
+        bf_insns: program.as_ptr(),
+    };
+    let rc = unsafe { libc::ioctl(fd, BIOCSETF, &prog as *const BpfProgram) };
     if rc < 0 {
         return Err(io::Error::last_os_error());
     }
@@ -485,6 +573,22 @@ mod tests {
         record.extend_from_slice(payload);
         record.resize(bpf_word_align(hdrlen as usize + payload.len()), 0);
         record
+    }
+
+    #[test]
+    fn bpf_filter_accepts_and_ends_with_a_drop() {
+        // BPF_RET | BPF_K: a terminating return with an immediate operand.
+        const BPF_RET_K: u16 = 0x0006;
+        let last = BPF_FILTER_EN10MB
+            .last()
+            .expect("filter program is not empty");
+        // The program must end by dropping non-matching frames (return 0)...
+        assert_eq!(last.code, BPF_RET_K);
+        assert_eq!(last.k, 0);
+        // ...and must contain at least one accepting return (non-zero length).
+        assert!(BPF_FILTER_EN10MB
+            .iter()
+            .any(|insn| insn.code == BPF_RET_K && insn.k > 0));
     }
 
     #[test]

--- a/src/sensor/macos/bpf.rs
+++ b/src/sensor/macos/bpf.rs
@@ -1,0 +1,372 @@
+//! macOS network and DNS sensor backed by `/dev/bpf` packet capture.
+//!
+//! Endpoint Security does not surface network connections or DNS, so the macOS
+//! sensor pairs ESF with a BPF capture device. [`BpfSensor`] opens a `/dev/bpf`
+//! device, binds it to an interface, and reads link-layer frames on a
+//! dedicated thread. Captured frames are parsed into [`SensorEvent`] values
+//! (network connections and DNS queries) for the shared pipeline.
+//!
+//! Requirements: root (or access to the bpf device nodes). PID attribution for
+//! captured flows is best-effort via libproc; see the socket helper.
+
+use std::ffi::CString;
+use std::io;
+use std::os::unix::io::RawFd;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread::JoinHandle;
+use std::time::Duration;
+
+use anyhow::{anyhow, Result};
+use tokio::sync::mpsc::Sender;
+use tracing::{info, warn};
+
+use crate::sensor::{Sensor, SensorEvent};
+
+/// Environment variable overriding the capture interface (default `en0`).
+const INTERFACE_ENV: &str = "RUSTINEL_BPF_INTERFACE";
+const DEFAULT_INTERFACE: &str = "en0";
+
+/// Requested BPF read-buffer size, set via `BIOCSBLEN` before binding. The
+/// kernel may cap this; the effective size is read back and used for reads.
+const BPF_BUFFER_LEN: u32 = 1 << 18; // 256 KiB
+
+/// Read timeout so the capture loop wakes periodically to observe shutdown.
+const READ_TIMEOUT: Duration = Duration::from_millis(200);
+
+// BPF ioctl request codes for 64-bit macOS, from <net/bpf.h>. Encoded with the
+// _IOW/_IOR/_IOWR macros; verified against the SDK headers.
+const BIOCSBLEN: libc::c_ulong = 0xc004_4266; // _IOWR('B', 102, u_int)
+const BIOCGDLT: libc::c_ulong = 0x4004_426a; // _IOR('B', 106, u_int)
+const BIOCSETIF: libc::c_ulong = 0x8020_426c; // _IOW('B', 108, struct ifreq)
+const BIOCSRTIMEOUT: libc::c_ulong = 0x8010_426d; // _IOW('B', 109, struct timeval)
+const BIOCIMMEDIATE: libc::c_ulong = 0x8004_4270; // _IOW('B', 112, u_int)
+
+// struct bpf_hdr field offsets on 64-bit macOS (sizeof == 20; bh_tstamp is a
+// 32-bit timeval, so caplen/hdrlen sit earlier than a 64-bit timeval suggests).
+// The packet payload starts bh_hdrlen bytes into each record.
+const BH_CAPLEN_OFFSET: usize = 8;
+const BH_HDRLEN_OFFSET: usize = 16;
+/// Smallest prefix needed to read bh_caplen and bh_hdrlen from a record.
+const BPF_HDR_FIELDS_LEN: usize = 18;
+
+#[repr(C)]
+struct IfReq {
+    ifr_name: [libc::c_char; 16],
+    ifr_ifru: [u8; 16],
+}
+
+/// macOS `/dev/bpf` network/DNS sensor. Implements [`Sensor`].
+pub struct BpfSensor {
+    shutdown: Arc<AtomicBool>,
+    thread: Mutex<Option<JoinHandle<()>>>,
+}
+
+impl BpfSensor {
+    pub fn new() -> Self {
+        Self {
+            shutdown: Arc::new(AtomicBool::new(false)),
+            thread: Mutex::new(None),
+        }
+    }
+}
+
+impl Default for BpfSensor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Sensor for BpfSensor {
+    /// Open and configure the bpf device synchronously so failures (no device
+    /// nodes, no privileges, unknown interface) surface to the caller, then
+    /// spawn the capture loop on a dedicated thread.
+    fn start(&self, tx: Sender<SensorEvent>) -> Result<()> {
+        let interface =
+            std::env::var(INTERFACE_ENV).unwrap_or_else(|_| DEFAULT_INTERFACE.to_string());
+        let device = BpfDevice::open(&interface)?;
+        let link_type = device.link_type;
+        info!(
+            interface = %interface,
+            link_type,
+            buffer_len = device.buffer_len,
+            "bpf capture device ready"
+        );
+
+        let shutdown = Arc::clone(&self.shutdown);
+        let handle = std::thread::Builder::new()
+            .name("rustinel-bpf".to_string())
+            .spawn(move || run_capture(device, tx, shutdown))
+            .map_err(|e| anyhow!("failed to spawn bpf capture thread: {e}"))?;
+        *self.thread.lock().expect("bpf thread mutex poisoned") = Some(handle);
+
+        Ok(())
+    }
+
+    fn shutdown(&self) {
+        self.shutdown.store(true, Ordering::SeqCst);
+        if let Some(handle) = self
+            .thread
+            .lock()
+            .expect("bpf thread mutex poisoned")
+            .take()
+        {
+            let _ = handle.join();
+        }
+    }
+}
+
+/// An open, configured bpf capture device. Closes its fd on drop.
+struct BpfDevice {
+    fd: RawFd,
+    link_type: u32,
+    buffer_len: u32,
+}
+
+impl BpfDevice {
+    fn open(interface: &str) -> Result<Self> {
+        let fd = open_bpf_device()?;
+        // BIOCSBLEN must be set before binding the interface; the kernel may
+        // adjust the requested size, so use the value it reports back.
+        let buffer_len = match set_buffer_len(fd, BPF_BUFFER_LEN) {
+            Ok(len) => len,
+            Err(e) => {
+                close_fd(fd);
+                return Err(anyhow!("BIOCSBLEN failed: {e}"));
+            }
+        };
+        let configure = || -> io::Result<u32> {
+            bind_interface(fd, interface)?;
+            set_u32(fd, BIOCIMMEDIATE, 1)?;
+            set_read_timeout(fd, READ_TIMEOUT)?;
+            get_u32(fd, BIOCGDLT)
+        };
+        match configure() {
+            Ok(link_type) => Ok(Self {
+                fd,
+                link_type,
+                buffer_len,
+            }),
+            Err(e) => {
+                close_fd(fd);
+                Err(anyhow!("failed to configure bpf device for {interface}: {e}"))
+            }
+        }
+    }
+}
+
+impl Drop for BpfDevice {
+    fn drop(&mut self) {
+        close_fd(self.fd);
+    }
+}
+
+/// Open the first available `/dev/bpfN` cloning device.
+fn open_bpf_device() -> Result<RawFd> {
+    let mut last_err = io::Error::new(io::ErrorKind::NotFound, "no /dev/bpf device available");
+    for n in 0..256 {
+        let path = CString::new(format!("/dev/bpf{n}")).expect("device path has no NUL");
+        let fd = unsafe { libc::open(path.as_ptr(), libc::O_RDWR) };
+        if fd >= 0 {
+            return Ok(fd);
+        }
+        let err = io::Error::last_os_error();
+        // EBUSY means the device is taken by another client; try the next one.
+        // Anything else (e.g. EACCES, ENOENT) is recorded and we keep trying a
+        // few more in case only some nodes are restricted.
+        last_err = err;
+    }
+    Err(anyhow!("could not open any /dev/bpf device: {last_err}"))
+}
+
+fn bind_interface(fd: RawFd, interface: &str) -> io::Result<()> {
+    let mut req: IfReq = unsafe { std::mem::zeroed() };
+    let bytes = interface.as_bytes();
+    if bytes.len() >= req.ifr_name.len() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "interface name too long",
+        ));
+    }
+    for (slot, byte) in req.ifr_name.iter_mut().zip(bytes) {
+        *slot = *byte as libc::c_char;
+    }
+    let rc = unsafe { libc::ioctl(fd, BIOCSETIF, &req as *const IfReq) };
+    if rc < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+fn set_buffer_len(fd: RawFd, len: u32) -> io::Result<u32> {
+    let mut value: libc::c_uint = len;
+    let rc = unsafe { libc::ioctl(fd, BIOCSBLEN, &mut value as *mut libc::c_uint) };
+    if rc < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(value as u32)
+}
+
+fn set_u32(fd: RawFd, request: libc::c_ulong, value: u32) -> io::Result<()> {
+    let value: libc::c_uint = value;
+    let rc = unsafe { libc::ioctl(fd, request, &value as *const libc::c_uint) };
+    if rc < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+fn get_u32(fd: RawFd, request: libc::c_ulong) -> io::Result<u32> {
+    let mut value: libc::c_uint = 0;
+    let rc = unsafe { libc::ioctl(fd, request, &mut value as *mut libc::c_uint) };
+    if rc < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(value as u32)
+}
+
+fn set_read_timeout(fd: RawFd, timeout: Duration) -> io::Result<()> {
+    let tv = libc::timeval {
+        tv_sec: timeout.as_secs() as libc::time_t,
+        tv_usec: timeout.subsec_micros() as libc::suseconds_t,
+    };
+    let rc = unsafe { libc::ioctl(fd, BIOCSRTIMEOUT, &tv as *const libc::timeval) };
+    if rc < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+fn close_fd(fd: RawFd) {
+    unsafe {
+        libc::close(fd);
+    }
+}
+
+/// Capture loop: read batches of bpf records and dispatch each packet.
+fn run_capture(device: BpfDevice, tx: Sender<SensorEvent>, shutdown: Arc<AtomicBool>) {
+    let mut buf = vec![0u8; device.buffer_len as usize];
+    while !shutdown.load(Ordering::Relaxed) {
+        let n = unsafe { libc::read(device.fd, buf.as_mut_ptr().cast(), buf.len()) };
+        if n < 0 {
+            let err = io::Error::last_os_error();
+            match err.raw_os_error() {
+                // EINTR/EAGAIN: interrupted or read timeout elapsed with no
+                // data. Loop back and re-check the shutdown flag.
+                Some(libc::EINTR) | Some(libc::EAGAIN) => continue,
+                _ => {
+                    if !shutdown.load(Ordering::Relaxed) {
+                        warn!("bpf read error: {err}");
+                        std::thread::sleep(READ_TIMEOUT);
+                    }
+                    continue;
+                }
+            }
+        }
+        if n == 0 {
+            continue;
+        }
+        let data = &buf[..n as usize];
+        for_each_packet(data, |packet| handle_packet(device.link_type, packet, &tx));
+    }
+    info!("bpf sensor shutting down");
+}
+
+/// Iterate the packets in a bpf read buffer, calling `handle` with each
+/// captured frame. Records are prefixed with a `struct bpf_hdr` and aligned to
+/// `BPF_ALIGNMENT` (4 bytes) boundaries.
+fn for_each_packet(buf: &[u8], mut handle: impl FnMut(&[u8])) {
+    let mut offset = 0usize;
+    while offset + BPF_HDR_FIELDS_LEN <= buf.len() {
+        let caplen = read_u32(buf, offset + BH_CAPLEN_OFFSET) as usize;
+        let hdrlen = read_u16(buf, offset + BH_HDRLEN_OFFSET) as usize;
+
+        let start = offset + hdrlen;
+        let end = match start.checked_add(caplen) {
+            Some(end) if end <= buf.len() && start <= buf.len() => end,
+            _ => break,
+        };
+        handle(&buf[start..end]);
+
+        let advance = bpf_word_align(hdrlen + caplen);
+        if advance == 0 {
+            break;
+        }
+        offset += advance;
+    }
+}
+
+/// Dispatch a captured link-layer frame. Network and DNS translation are added
+/// in following commits; for now frames are consumed without emitting events.
+fn handle_packet(_link_type: u32, _packet: &[u8], _tx: &Sender<SensorEvent>) {}
+
+fn read_u32(buf: &[u8], at: usize) -> u32 {
+    u32::from_ne_bytes([buf[at], buf[at + 1], buf[at + 2], buf[at + 3]])
+}
+
+fn read_u16(buf: &[u8], at: usize) -> u16 {
+    u16::from_ne_bytes([buf[at], buf[at + 1]])
+}
+
+/// Round up to the next `BPF_ALIGNMENT` (4-byte) boundary.
+fn bpf_word_align(value: usize) -> usize {
+    (value + 3) & !3
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a bpf record (20-byte header + payload) padded to word alignment.
+    fn bpf_record(payload: &[u8]) -> Vec<u8> {
+        let hdrlen: u16 = 18;
+        let caplen = payload.len() as u32;
+        let mut record = vec![0u8; hdrlen as usize];
+        record[BH_CAPLEN_OFFSET..BH_CAPLEN_OFFSET + 4].copy_from_slice(&caplen.to_ne_bytes());
+        record[BH_HDRLEN_OFFSET..BH_HDRLEN_OFFSET + 2].copy_from_slice(&hdrlen.to_ne_bytes());
+        record.extend_from_slice(payload);
+        record.resize(bpf_word_align(hdrlen as usize + payload.len()), 0);
+        record
+    }
+
+    #[test]
+    fn for_each_packet_yields_each_record() {
+        let mut buf = bpf_record(&[1, 2, 3]);
+        buf.extend(bpf_record(&[9, 8, 7, 6, 5]));
+
+        let mut packets: Vec<Vec<u8>> = Vec::new();
+        for_each_packet(&buf, |packet| packets.push(packet.to_vec()));
+
+        assert_eq!(packets, vec![vec![1, 2, 3], vec![9, 8, 7, 6, 5]]);
+    }
+
+    #[test]
+    fn for_each_packet_ignores_trailing_partial_header() {
+        let mut buf = bpf_record(&[1, 2, 3, 4]);
+        buf.extend_from_slice(&[0u8; 5]); // shorter than a header
+
+        let mut count = 0;
+        for_each_packet(&buf, |_| count += 1);
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn for_each_packet_stops_on_truncated_capture() {
+        let mut buf = vec![0u8; 18];
+        // Claim a 100-byte capture that the buffer cannot satisfy.
+        buf[BH_CAPLEN_OFFSET..BH_CAPLEN_OFFSET + 4].copy_from_slice(&100u32.to_ne_bytes());
+        buf[BH_HDRLEN_OFFSET..BH_HDRLEN_OFFSET + 2].copy_from_slice(&18u16.to_ne_bytes());
+
+        let mut count = 0;
+        for_each_packet(&buf, |_| count += 1);
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn bpf_word_align_rounds_up_to_four() {
+        assert_eq!(bpf_word_align(0), 0);
+        assert_eq!(bpf_word_align(1), 4);
+        assert_eq!(bpf_word_align(18), 20);
+        assert_eq!(bpf_word_align(20), 20);
+    }
+}

--- a/src/sensor/macos/mod.rs
+++ b/src/sensor/macos/mod.rs
@@ -8,6 +8,7 @@
 pub mod bpf;
 pub mod esf;
 mod packet;
+mod socket;
 
 pub use bpf::BpfSensor;
 pub use esf::EsfSensor;

--- a/src/sensor/macos/mod.rs
+++ b/src/sensor/macos/mod.rs
@@ -5,6 +5,8 @@
 //! - Endpoint Security ([`esf`]) for process and file events.
 //! - `/dev/bpf` capture (later phase) for network and DNS.
 
+pub mod bpf;
 pub mod esf;
 
+pub use bpf::BpfSensor;
 pub use esf::EsfSensor;

--- a/src/sensor/macos/mod.rs
+++ b/src/sensor/macos/mod.rs
@@ -7,6 +7,7 @@
 
 pub mod bpf;
 pub mod esf;
+mod packet;
 
 pub use bpf::BpfSensor;
 pub use esf::EsfSensor;

--- a/src/sensor/macos/packet.rs
+++ b/src/sensor/macos/packet.rs
@@ -1,0 +1,215 @@
+//! Pure packet parsing for the macOS `/dev/bpf` sensor.
+//!
+//! Parses a captured link-layer frame down to its transport header. The parser
+//! is deliberately defensive: it consumes untrusted bytes off the wire, never
+//! panics, and bails out (`None`) on anything malformed or unsupported.
+
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+/// Link-layer header types reported by `BIOCGDLT`.
+const DLT_NULL: u32 = 0;
+const DLT_EN10MB: u32 = 1;
+
+const ETHERTYPE_IPV4: u16 = 0x0800;
+const ETHERTYPE_IPV6: u16 = 0x86dd;
+const ETHERTYPE_VLAN: u16 = 0x8100;
+
+const IPPROTO_TCP: u8 = 6;
+
+/// TCP control-flag bits used to detect connection initiations.
+pub(super) const TCP_FLAG_SYN: u8 = 0x02;
+pub(super) const TCP_FLAG_ACK: u8 = 0x10;
+
+/// Parsed transport header for a captured packet.
+pub(super) enum Transport<'a> {
+    Tcp {
+        src_port: u16,
+        dst_port: u16,
+        flags: u8,
+        #[allow(dead_code)] // consumed by the DNS parser in a later commit
+        payload: &'a [u8],
+    },
+}
+
+/// A captured packet parsed down to its transport layer.
+pub(super) struct ParsedPacket<'a> {
+    pub src_ip: IpAddr,
+    pub dst_ip: IpAddr,
+    pub transport: Transport<'a>,
+}
+
+/// Parse a captured link-layer frame into a [`ParsedPacket`].
+pub(super) fn parse(link_type: u32, frame: &[u8]) -> Option<ParsedPacket<'_>> {
+    let l3 = strip_link_layer(link_type, frame)?;
+    parse_ip(l3)
+}
+
+/// Strip the link-layer header and return the network-layer (L3) bytes.
+fn strip_link_layer(link_type: u32, frame: &[u8]) -> Option<&[u8]> {
+    match link_type {
+        // Loopback/null: a 4-byte address-family prefix. The IP version nibble
+        // disambiguates v4/v6, so the family value itself is not needed.
+        DLT_NULL => frame.get(4..),
+        DLT_EN10MB => {
+            let ethertype = u16::from_be_bytes([*frame.get(12)?, *frame.get(13)?]);
+            match ethertype {
+                ETHERTYPE_IPV4 | ETHERTYPE_IPV6 => frame.get(14..),
+                ETHERTYPE_VLAN => {
+                    let inner = u16::from_be_bytes([*frame.get(16)?, *frame.get(17)?]);
+                    match inner {
+                        ETHERTYPE_IPV4 | ETHERTYPE_IPV6 => frame.get(18..),
+                        _ => None,
+                    }
+                }
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+fn parse_ip(l3: &[u8]) -> Option<ParsedPacket<'_>> {
+    match l3.first()? >> 4 {
+        4 => parse_ipv4(l3),
+        6 => parse_ipv6(l3),
+        _ => None,
+    }
+}
+
+fn parse_ipv4(l3: &[u8]) -> Option<ParsedPacket<'_>> {
+    if l3.len() < 20 {
+        return None;
+    }
+    let ihl = usize::from(l3[0] & 0x0f) * 4;
+    if ihl < 20 || l3.len() < ihl {
+        return None;
+    }
+    let protocol = l3[9];
+    let src = Ipv4Addr::new(l3[12], l3[13], l3[14], l3[15]);
+    let dst = Ipv4Addr::new(l3[16], l3[17], l3[18], l3[19]);
+    let transport = parse_transport(protocol, l3.get(ihl..)?)?;
+    Some(ParsedPacket {
+        src_ip: IpAddr::V4(src),
+        dst_ip: IpAddr::V4(dst),
+        transport,
+    })
+}
+
+fn parse_ipv6(l3: &[u8]) -> Option<ParsedPacket<'_>> {
+    if l3.len() < 40 {
+        return None;
+    }
+    // Extension headers are not followed; only packets whose first next-header
+    // is a transport we handle are parsed.
+    let next_header = l3[6];
+    let mut src = [0u8; 16];
+    src.copy_from_slice(&l3[8..24]);
+    let mut dst = [0u8; 16];
+    dst.copy_from_slice(&l3[24..40]);
+    let transport = parse_transport(next_header, l3.get(40..)?)?;
+    Some(ParsedPacket {
+        src_ip: IpAddr::V6(Ipv6Addr::from(src)),
+        dst_ip: IpAddr::V6(Ipv6Addr::from(dst)),
+        transport,
+    })
+}
+
+fn parse_transport(protocol: u8, l4: &[u8]) -> Option<Transport<'_>> {
+    match protocol {
+        IPPROTO_TCP => {
+            if l4.len() < 20 {
+                return None;
+            }
+            let src_port = u16::from_be_bytes([l4[0], l4[1]]);
+            let dst_port = u16::from_be_bytes([l4[2], l4[3]]);
+            let data_offset = usize::from(l4[12] >> 4) * 4;
+            if data_offset < 20 || l4.len() < data_offset {
+                return None;
+            }
+            Some(Transport::Tcp {
+                src_port,
+                dst_port,
+                flags: l4[13],
+                payload: l4.get(data_offset..).unwrap_or(&[]),
+            })
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build an Ethernet + IPv4 + TCP frame with the given ports and flags.
+    fn ethernet_ipv4_tcp(
+        src: [u8; 4],
+        dst: [u8; 4],
+        src_port: u16,
+        dst_port: u16,
+        flags: u8,
+    ) -> Vec<u8> {
+        let mut frame = vec![0u8; 14];
+        frame[12..14].copy_from_slice(&ETHERTYPE_IPV4.to_be_bytes());
+        // IPv4 header (20 bytes, IHL=5).
+        let mut ip = vec![0u8; 20];
+        ip[0] = 0x45;
+        ip[9] = IPPROTO_TCP;
+        ip[12..16].copy_from_slice(&src);
+        ip[16..20].copy_from_slice(&dst);
+        // TCP header (20 bytes, data offset = 5).
+        let mut tcp = vec![0u8; 20];
+        tcp[0..2].copy_from_slice(&src_port.to_be_bytes());
+        tcp[2..4].copy_from_slice(&dst_port.to_be_bytes());
+        tcp[12] = 5 << 4;
+        tcp[13] = flags;
+        frame.extend(ip);
+        frame.extend(tcp);
+        frame
+    }
+
+    #[test]
+    fn parses_ethernet_ipv4_tcp() {
+        let frame = ethernet_ipv4_tcp([10, 0, 0, 5], [93, 184, 216, 34], 51324, 443, TCP_FLAG_SYN);
+        let parsed = parse(DLT_EN10MB, &frame).expect("frame should parse");
+        assert_eq!(parsed.src_ip.to_string(), "10.0.0.5");
+        assert_eq!(parsed.dst_ip.to_string(), "93.184.216.34");
+        match parsed.transport {
+            Transport::Tcp {
+                src_port,
+                dst_port,
+                flags,
+                ..
+            } => {
+                assert_eq!(src_port, 51324);
+                assert_eq!(dst_port, 443);
+                assert_eq!(flags, TCP_FLAG_SYN);
+            }
+        }
+    }
+
+    #[test]
+    fn parses_null_link_layer() {
+        let mut frame = vec![0u8; 4]; // 4-byte address family prefix
+        frame[0] = 2; // AF_INET, ignored by the parser
+        let tcp_frame = ethernet_ipv4_tcp([127, 0, 0, 1], [127, 0, 0, 1], 1, 53, TCP_FLAG_SYN);
+        frame.extend_from_slice(&tcp_frame[14..]); // IP + TCP, no ethernet header
+        let parsed = parse(DLT_NULL, &frame).expect("null frame should parse");
+        assert_eq!(parsed.dst_ip.to_string(), "127.0.0.1");
+    }
+
+    #[test]
+    fn rejects_non_ip_ethertype() {
+        let mut frame = vec![0u8; 60];
+        frame[12..14].copy_from_slice(&0x0806u16.to_be_bytes()); // ARP
+        assert!(parse(DLT_EN10MB, &frame).is_none());
+    }
+
+    #[test]
+    fn rejects_truncated_ip_header() {
+        let mut frame = vec![0u8; 14];
+        frame[12..14].copy_from_slice(&ETHERTYPE_IPV4.to_be_bytes());
+        frame.extend_from_slice(&[0x45, 0, 0]); // partial IPv4 header
+        assert!(parse(DLT_EN10MB, &frame).is_none());
+    }
+}

--- a/src/sensor/macos/packet.rs
+++ b/src/sensor/macos/packet.rs
@@ -8,7 +8,7 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 /// Link-layer header types reported by `BIOCGDLT`.
 const DLT_NULL: u32 = 0;
-const DLT_EN10MB: u32 = 1;
+pub(super) const DLT_EN10MB: u32 = 1;
 
 const ETHERTYPE_IPV4: u16 = 0x0800;
 const ETHERTYPE_IPV6: u16 = 0x86dd;

--- a/src/sensor/macos/packet.rs
+++ b/src/sensor/macos/packet.rs
@@ -15,6 +15,7 @@ const ETHERTYPE_IPV6: u16 = 0x86dd;
 const ETHERTYPE_VLAN: u16 = 0x8100;
 
 const IPPROTO_TCP: u8 = 6;
+const IPPROTO_UDP: u8 = 17;
 
 /// TCP control-flag bits used to detect connection initiations.
 pub(super) const TCP_FLAG_SYN: u8 = 0x02;
@@ -26,7 +27,10 @@ pub(super) enum Transport<'a> {
         src_port: u16,
         dst_port: u16,
         flags: u8,
-        #[allow(dead_code)] // consumed by the DNS parser in a later commit
+        payload: &'a [u8],
+    },
+    Udp {
+        dst_port: u16,
         payload: &'a [u8],
     },
 }
@@ -133,6 +137,15 @@ fn parse_transport(protocol: u8, l4: &[u8]) -> Option<Transport<'_>> {
                 payload: l4.get(data_offset..).unwrap_or(&[]),
             })
         }
+        IPPROTO_UDP => {
+            if l4.len() < 8 {
+                return None;
+            }
+            Some(Transport::Udp {
+                dst_port: u16::from_be_bytes([l4[2], l4[3]]),
+                payload: l4.get(8..).unwrap_or(&[]),
+            })
+        }
         _ => None,
     }
 }
@@ -185,6 +198,44 @@ mod tests {
                 assert_eq!(dst_port, 443);
                 assert_eq!(flags, TCP_FLAG_SYN);
             }
+            other => panic!("unexpected transport: {}", transport_kind(&other)),
+        }
+    }
+
+    fn transport_kind(transport: &Transport) -> &'static str {
+        match transport {
+            Transport::Tcp { .. } => "tcp",
+            Transport::Udp { .. } => "udp",
+        }
+    }
+
+    /// Build an Ethernet + IPv4 + UDP frame carrying `udp_payload`.
+    fn ethernet_ipv4_udp(dst_port: u16, udp_payload: &[u8]) -> Vec<u8> {
+        let mut frame = vec![0u8; 14];
+        frame[12..14].copy_from_slice(&ETHERTYPE_IPV4.to_be_bytes());
+        let mut ip = vec![0u8; 20];
+        ip[0] = 0x45;
+        ip[9] = IPPROTO_UDP;
+        ip[12..16].copy_from_slice(&[10, 0, 0, 5]);
+        ip[16..20].copy_from_slice(&[1, 1, 1, 1]);
+        let mut udp = vec![0u8; 8];
+        udp[2..4].copy_from_slice(&dst_port.to_be_bytes());
+        frame.extend(ip);
+        frame.extend(udp);
+        frame.extend_from_slice(udp_payload);
+        frame
+    }
+
+    #[test]
+    fn parses_ethernet_ipv4_udp() {
+        let frame = ethernet_ipv4_udp(53, &[0xab, 0xcd]);
+        let parsed = parse(DLT_EN10MB, &frame).expect("udp frame should parse");
+        match parsed.transport {
+            Transport::Udp { dst_port, payload } => {
+                assert_eq!(dst_port, 53);
+                assert_eq!(payload, &[0xab, 0xcd]);
+            }
+            other => panic!("unexpected transport: {}", transport_kind(&other)),
         }
     }
 

--- a/src/sensor/macos/socket.rs
+++ b/src/sensor/macos/socket.rs
@@ -1,0 +1,117 @@
+//! Best-effort socket-to-process attribution for captured flows.
+//!
+//! The bpf sensor observes packets on the wire without an owning process, so
+//! this module maps a connection back to a PID by scanning every process's
+//! socket descriptors (the macOS equivalent of walking `/proc/net` on Linux).
+//!
+//! This is inherently best-effort and racy: the socket may have closed by the
+//! time we scan, and the scan is `O(processes x descriptors)`. It is therefore
+//! used only for TCP connection initiations (one lookup per connection), not
+//! for every DNS query. The NetworkExtension framework is the future
+//! high-fidelity alternative that carries the owning PID with each flow.
+
+use libc::c_int;
+use libproc::file_info::{pidfdinfo, ListFDs, ProcFDType};
+use libproc::net_info::{SocketFDInfo, SocketInfoKind};
+use libproc::proc_pid::{listpidinfo, pidpath};
+use libproc::processes::{pids_by_type, ProcFilter};
+
+/// Maximum file descriptors inspected per process. Processes with more open
+/// descriptors than this may not be matched (rare in practice).
+const MAX_FDS: usize = 1024;
+
+/// Owner of a captured connection.
+pub(super) struct SocketOwner {
+    pub pid: u32,
+    pub image: Option<String>,
+}
+
+/// Find the process owning a TCP connection identified by its local and remote
+/// ports. Returns `None` when no live socket matches or inspection is denied.
+///
+/// Matching on the local (ephemeral) port plus remote port is reliable because
+/// the local port is effectively unique to a single active connection.
+pub(super) fn find_tcp_socket_owner(local_port: u16, remote_port: u16) -> Option<SocketOwner> {
+    let pids = pids_by_type(ProcFilter::All).ok()?;
+    for pid in pids {
+        if pid == 0 {
+            continue;
+        }
+        let pid = pid as i32;
+        let Ok(fds) = listpidinfo::<ListFDs>(pid, MAX_FDS) else {
+            continue;
+        };
+        for fd in fds {
+            if fd.proc_fdtype != ProcFDType::Socket as u32 {
+                continue;
+            }
+            let Ok(socket) = pidfdinfo::<SocketFDInfo>(pid, fd.proc_fd) else {
+                continue;
+            };
+            if tcp_ports_match(&socket, local_port, remote_port) {
+                return Some(SocketOwner {
+                    pid: pid as u32,
+                    image: pidpath(pid).ok(),
+                });
+            }
+        }
+    }
+    None
+}
+
+/// Whether a socket descriptor is a TCP socket with the given local and remote
+/// ports.
+fn tcp_ports_match(socket: &SocketFDInfo, local_port: u16, remote_port: u16) -> bool {
+    let info = &socket.psi;
+    if !matches!(SocketInfoKind::from(info.soi_kind), SocketInfoKind::Tcp) {
+        return false;
+    }
+    // SAFETY: soi_kind == Tcp guarantees the TCP arm of the proto union is the
+    // active variant, so reading pri_tcp is sound.
+    let in_info = unsafe { info.soi_proto.pri_tcp.tcpsi_ini };
+    port_from_network(in_info.insi_lport) == local_port
+        && port_from_network(in_info.insi_fport) == remote_port
+}
+
+/// Convert a port stored in network byte order (low 16 bits of a `c_int`) to a
+/// host-order `u16`.
+fn port_from_network(port: c_int) -> u16 {
+    u16::from_be(port as u16)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use libproc::net_info::{InSockInfo, TcpSockInfo};
+
+    // The proto union has no nameable type to construct via struct literal, so
+    // the FFI structs are built by field assignment after Default.
+    #[allow(clippy::field_reassign_with_default)]
+    fn tcp_socket(local_port: u16, remote_port: u16) -> SocketFDInfo {
+        let mut ini = InSockInfo::default();
+        ini.insi_lport = i32::from(local_port.to_be());
+        ini.insi_fport = i32::from(remote_port.to_be());
+        let mut tcp = TcpSockInfo::default();
+        tcp.tcpsi_ini = ini;
+
+        let mut socket = SocketFDInfo::default();
+        socket.psi.soi_kind = SocketInfoKind::Tcp as c_int;
+        socket.psi.soi_proto.pri_tcp = tcp;
+        socket
+    }
+
+    #[test]
+    fn matches_tcp_socket_by_ports() {
+        let socket = tcp_socket(51324, 443);
+        assert!(tcp_ports_match(&socket, 51324, 443));
+        assert!(!tcp_ports_match(&socket, 51324, 80));
+        assert!(!tcp_ports_match(&socket, 1234, 443));
+    }
+
+    #[test]
+    fn ignores_non_tcp_sockets() {
+        let mut socket = tcp_socket(51324, 443);
+        socket.psi.soi_kind = SocketInfoKind::In as c_int;
+        assert!(!tcp_ports_match(&socket, 51324, 443));
+    }
+}

--- a/src/sensor/mod.rs
+++ b/src/sensor/mod.rs
@@ -4,6 +4,8 @@
 //! Linux eBPF can feed the same downstream pipeline without leaking sensor-
 //! specific record types into shared code.
 
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+pub(crate) mod dns;
 #[cfg(target_os = "linux")]
 pub mod linux;
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
## Summary
Adds a `/dev/bpf` packet-capture sensor for outbound TCP connections and DNS queries. It runs alongside Endpoint Security and degrades gracefully to Endpoint Security only if capture cannot start. This brings macOS to the same process, file, network, and DNS coverage as Linux.

- Add a `BpfSensor` that opens and configures a bpf device (buffer length, interface bind, immediate mode, read timeout) and reads frames on a dedicated thread, iterating the bpf records.
- Add a defensive packet parser for the Ethernet and null link layers, IPv4 and IPv6, and TCP and UDP.
- Extract the DNS query-name parser into a shared module (the Linux sensor delegates to it) and reuse it here.
- Emit network-connection events from TCP connection initiations (SYN set, ACK clear).
- Emit DNS-query events from port 53 traffic using the shared parser, including the record type.
- Attribute connections to a process on a best-effort basis with libproc by matching the connection ports against open sockets.

## Type of change
- [x] `feat` / `enhancement` - new feature

## Test plan
- [ ] Tested on Windows
- [ ] Tested on Linux
- [x] Tested on macOS: unit tests for the packet parser, the bpf record iterator, and socket matching, plus an end-to-end test that a parsed DNS query matches a `product: macos` Sigma rule
- [x] Existing tests pass (`cargo test`)
- [x] New tests added (parser, iterator, socket match, DNS detection)

Note for maintainers: capture requires root and access to the `/dev/bpf*` device nodes. It binds to a single interface (default `en0`, override with `RUSTINEL_BPF_INTERFACE`). Connection-to-process attribution is best-effort and may be unattributed for short-lived sockets.

## Checklist
- [ ] Label added to this PR
- [x] Docs updated (if behaviour changed)

## Notes
Third of four in the #41 series, on top of #46 (merged). Verified on macOS arm64: `cargo fmt --all -- --check`, `cargo clippy --locked --all-targets -- -D clippy::all`, and `cargo test --locked` (158 passed) are all clean.

Part of #41.
