### PR TITLE
[codex] feat(cli): make run foreground + console by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Download Rustinel, start the agent, trigger a test command, and inspect the gene
 
 ```powershell
 cd .\rustinel-<version>-x86_64-pc-windows-msvc
-.\rustinel.exe run --console
+.\rustinel.exe run
 whoami /all
 type .\logs\alerts.json.*
 ```
@@ -184,7 +184,7 @@ Extract it, then run:
 
 ```powershell
 cd .\rustinel-<version>-x86_64-pc-windows-msvc
-.\rustinel.exe run --console
+.\rustinel.exe run
 whoami /all
 ```
 
@@ -235,7 +235,7 @@ If you prefer to build locally instead of using a published release, use `cargo 
 
 ```powershell
 cargo build --release
-.\target\release\rustinel.exe run --console
+.\target\release\rustinel.exe run
 ```
 
 ### Linux

--- a/config.toml
+++ b/config.toml
@@ -40,7 +40,7 @@ level = "info"              # trace, debug, info, warn, error
 # filter = "info,engine=info,scanner=info,ioc=info,rustinel::normalizer=info"
 directory = "logs"
 filename = "rustinel.log"
-console_output = true       # If true, duplicate logs to stdout (dev mode)
+console_output = false      # Default outside interactive `run`; use `run --no-console` to suppress console logs
 
 # 3. Security Alerts (The Detection Output)
 #    Writes to: {directory}/{filename}.<date>

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -165,7 +165,7 @@ powershell -ExecutionPolicy Bypass -File .\scripts\bench\windows.ps1 `
 ```
 
 If Rustinel is not already running, the script starts
-`.\target\release\rustinel.exe run --console` and stops that process when the
+`.\target\release\rustinel.exe run` and stops that process when the
 benchmark ends. When the script starts the agent, it creates a benchmark Sigma
 trigger rule and passes matching `EDR__` environment overrides so the agent uses
 the requested corpus.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -21,14 +21,14 @@ Running `rustinel` without a subcommand is equivalent to `rustinel run`.
 Run Rustinel in the foreground.
 
 ```text
-rustinel run [--console] [--log-level <LEVEL>]
+rustinel run [--no-console] [--console] [--log-level <LEVEL>]
 ```
 
 Examples:
 
 ```powershell
 rustinel run
-rustinel run --console
+rustinel run --no-console
 rustinel run --log-level debug
 ```
 
@@ -38,7 +38,9 @@ sudo ./rustinel run
 
 Notes:
 
-- `--console` is primarily relevant on Windows console runs.
+- `rustinel run` enables console output by default on every platform.
+- `--no-console` suppresses console output, for example when redirecting logs.
+- `--console` is kept as a compatibility alias and has the same effect as the default.
 - Linux foreground execution is the normal runtime model unless you wrap the binary in a service manager.
 
 ### `service`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -49,7 +49,7 @@ debounce_ms = 2000
 level = "info"
 directory = "logs"
 filename = "rustinel.log"
-console_output = true
+console_output = false
 
 [alerts]
 directory = "logs"
@@ -95,7 +95,7 @@ Use Windows path prefixes on Windows and Unix path prefixes on Linux.
 | `logging.level` | `info` |
 | `logging.directory` | `logs` |
 | `logging.filename` | `rustinel.log` |
-| `logging.console_output` | `true` |
+| `logging.console_output` | `false` |
 | `alerts.directory` | `logs` |
 | `alerts.filename` | `alerts.json` |
 | `alerts.match_debug` | `off` |
@@ -180,7 +180,7 @@ Propagation behavior:
 | `filter` | `null` | Optional `tracing_subscriber` filter expression; overrides `level` when valid |
 | `directory` | `logs` | Operational log directory |
 | `filename` | `rustinel.log` | Operational log filename with daily rotation |
-| `console_output` | `true` | Mirror logs to stdout. On Windows, colored output requires [Windows Terminal](https://aka.ms/terminal) — other terminals (cmd.exe, PowerShell host) will display plain text automatically. |
+| `console_output` | `false` | Default console mirroring when the runtime does not override console behavior. Interactive `rustinel run` enables console output by default; use `rustinel run --no-console` to suppress it. On Windows, colored output requires [Windows Terminal](https://aka.ms/terminal) — other terminals (cmd.exe, PowerShell host) will display plain text automatically. |
 
 ### Alerts
 
@@ -234,7 +234,7 @@ The environment prefix is `EDR__`. Nested keys use double underscores.
 $env:EDR__LOGGING__LEVEL="debug"
 $env:EDR__SCANNER__SIGMA_RULES_PATH="C:\\Rustinel\\rules\\sigma"
 $env:EDR__ALLOWLIST__PATHS='["C:\\Windows\\","C:\\Program Files\\"]'
-.\rustinel.exe run --console
+.\rustinel.exe run
 ```
 
 ### Bash
@@ -248,10 +248,11 @@ sudo /opt/rustinel/rustinel run
 
 ## CLI Overrides
 
-The only CLI override today is log level on interactive `run` usage. For repeatable cross-platform deployments, prefer `config.toml` and `EDR__...` environment variables.
+Interactive `run` accepts CLI overrides for log level and console output. For repeatable cross-platform deployments, prefer `config.toml` and `EDR__...` environment variables.
 
 ```powershell
 rustinel run --log-level debug
+rustinel run --no-console
 ```
 
 ## Practical Examples

--- a/docs/development.md
+++ b/docs/development.md
@@ -45,7 +45,7 @@ cd ..
 ### Windows
 
 ```powershell
-cargo run -- run --console
+cargo run -- run
 ```
 
 ### Linux

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -27,7 +27,7 @@ Download the package for your platform from [GitHub Releases](https://github.com
 1. Download `rustinel-<version>-x86_64-pc-windows-msvc.zip`.
 2. Extract it.
 3. Open an elevated PowerShell in the extracted directory.
-4. Run `.\rustinel.exe run --console`.
+4. Run `.\rustinel.exe run`.
 
 ### Linux
 
@@ -63,7 +63,7 @@ Use this path if you want to build the binary yourself instead of using a publis
 git clone https://github.com/Karib0u/rustinel.git
 cd rustinel
 cargo build --release
-.\target\release\rustinel.exe run --console
+.\target\release\rustinel.exe run
 ```
 
 ### Linux

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -8,7 +8,7 @@ Before changing config or rules, check these first:
 
 - Read the current operational log: `logs/rustinel.log.<date>`
 - Run in the foreground with a higher log level:
-  - Windows: `.\rustinel.exe run --console --log-level debug`
+  - Windows: `.\rustinel.exe run --log-level debug`
   - Linux: `sudo ./rustinel run --log-level debug`
 - Trigger a known bundled demo rule:
   - Windows: `whoami /all`

--- a/scripts/bench/windows.ps1
+++ b/scripts/bench/windows.ps1
@@ -2,7 +2,7 @@ param(
     [ValidateSet("baseline", "with-agent")]
     [string]$Mode = "with-agent",
     [string]$AgentPath = ".\target\release\rustinel.exe",
-    [string]$AgentArgs = "run --console",
+    [string]$AgentArgs = "run",
     [string]$ProcessName = "rustinel",
     [string]$OutputDir = ".\target\rustinel-bench",
     [int]$IdleSeconds = 60,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -18,11 +18,14 @@ impl Cli {
 
 #[derive(clap::Subcommand)]
 pub enum Commands {
-    /// Run in console mode (foreground)
+    /// Run in the foreground with console output
     Run {
-        /// Force console output
-        #[arg(long)]
+        /// Compatibility alias; console output is enabled by default
+        #[arg(long, conflicts_with = "no_console")]
         console: bool,
+        /// Disable console output
+        #[arg(long)]
+        no_console: bool,
     },
     /// Service management commands
     Service {
@@ -37,4 +40,68 @@ pub enum ServiceAction {
     Uninstall,
     Start,
     Stop,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[test]
+    fn run_defaults_to_console_output() {
+        let cli = Cli::try_parse_from(["rustinel", "run"]).expect("valid CLI");
+
+        match cli.command {
+            Some(Commands::Run {
+                console,
+                no_console,
+            }) => {
+                assert!(!console);
+                assert!(!no_console);
+            }
+            _ => panic!("expected run command"),
+        }
+    }
+
+    #[test]
+    fn run_accepts_compat_console_alias() {
+        let cli = Cli::try_parse_from(["rustinel", "run", "--console"]).expect("valid CLI");
+
+        match cli.command {
+            Some(Commands::Run {
+                console,
+                no_console,
+            }) => {
+                assert!(console);
+                assert!(!no_console);
+            }
+            _ => panic!("expected run command"),
+        }
+    }
+
+    #[test]
+    fn run_accepts_no_console() {
+        let cli = Cli::try_parse_from(["rustinel", "run", "--no-console"]).expect("valid CLI");
+
+        match cli.command {
+            Some(Commands::Run {
+                console,
+                no_console,
+            }) => {
+                assert!(!console);
+                assert!(no_console);
+            }
+            _ => panic!("expected run command"),
+        }
+    }
+
+    #[test]
+    fn run_rejects_console_and_no_console_together() {
+        let err = match Cli::try_parse_from(["rustinel", "run", "--console", "--no-console"]) {
+            Ok(_) => panic!("conflicting flags should fail"),
+            Err(err) => err,
+        };
+
+        assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -204,7 +204,7 @@ impl AppConfig {
             .set_default("logging.level", "info")?
             .set_default("logging.directory", "logs")?
             .set_default("logging.filename", "rustinel.log")?
-            .set_default("logging.console_output", true)?
+            .set_default("logging.console_output", false)?
             // Alerts
             .set_default("alerts.directory", "logs")?
             .set_default("alerts.filename", "alerts.json")?
@@ -295,7 +295,7 @@ impl Default for AppConfig {
                 filter: None,
                 directory: PathBuf::from("logs"),
                 filename: "rustinel.log".to_string(),
-                console_output: true,
+                console_output: false,
             },
             alerts: AlertConfig {
                 directory: PathBuf::from("logs"),
@@ -360,7 +360,7 @@ mod tests {
         assert!(cfg.scanner.sigma_enabled);
         assert_eq!(cfg.logging.level, "info");
         assert!(cfg.logging.filter.is_none());
-        assert!(cfg.logging.console_output);
+        assert!(!cfg.logging.console_output);
         assert!(!cfg.response.enabled);
         assert!(!cfg.response.prevention_enabled);
         assert_eq!(cfg.response.min_severity, "critical");

--- a/src/runtime/linux.rs
+++ b/src/runtime/linux.rs
@@ -17,22 +17,33 @@ use tokio::runtime::Builder;
 use tokio::sync::mpsc;
 use tracing::{error, info, warn};
 
-pub fn run() -> anyhow::Result<()> {
+pub fn run(console_output: bool, log_level: Option<String>) -> anyhow::Result<()> {
     let runtime = Builder::new_multi_thread().enable_all().build()?;
-    runtime.block_on(run_linux_edr())
+    runtime.block_on(run_linux_edr(Some(console_output), log_level))
 }
 
 /// Linux eBPF EDR main loop. Mirrors `run_edr` but replaces ETW with the
 /// eBPF sensor and omits Windows-only subsystems.
-async fn run_linux_edr() -> anyhow::Result<()> {
+async fn run_linux_edr(
+    console_output_override: Option<bool>,
+    log_level_override: Option<String>,
+) -> anyhow::Result<()> {
     // 1. Configuration
-    let cfg = match config::AppConfig::new() {
+    let mut cfg = match config::AppConfig::new() {
         Ok(cfg) => cfg,
         Err(err) => {
             eprintln!("Failed to load configuration: {}", err);
             return Err(anyhow::anyhow!("configuration error: {}", err));
         }
     };
+    if let Some(console_output) = console_output_override {
+        cfg.logging.console_output = console_output;
+    }
+    if let Some(level) = log_level_override {
+        if !level.trim().is_empty() {
+            cfg.logging.level = level;
+        }
+    }
 
     // 2. Logging
     let (app_guard, alert_guard, alert_sink) = init_logging(&cfg);

--- a/src/runtime/macos.rs
+++ b/src/runtime/macos.rs
@@ -17,24 +17,35 @@ use tokio::runtime::Builder;
 use tokio::sync::mpsc;
 use tracing::{error, info, warn};
 
-pub fn run() -> anyhow::Result<()> {
+pub fn run(console_output: bool, log_level: Option<String>) -> anyhow::Result<()> {
     let runtime = Builder::new_multi_thread().enable_all().build()?;
-    runtime.block_on(run_macos_edr())
+    runtime.block_on(run_macos_edr(Some(console_output), log_level))
 }
 
 /// macOS EDR main loop. Mirrors `run_linux_edr` but replaces the eBPF sensor
 /// with the macOS sensor. In Phase 0 this is a no-op placeholder sensor so the
 /// shared pipeline can be exercised end to end; the Endpoint Security and
 /// /dev/bpf sources land in later phases.
-async fn run_macos_edr() -> anyhow::Result<()> {
+async fn run_macos_edr(
+    console_output_override: Option<bool>,
+    log_level_override: Option<String>,
+) -> anyhow::Result<()> {
     // 1. Configuration
-    let cfg = match config::AppConfig::new() {
+    let mut cfg = match config::AppConfig::new() {
         Ok(cfg) => cfg,
         Err(err) => {
             eprintln!("Failed to load configuration: {}", err);
             return Err(anyhow::anyhow!("configuration error: {}", err));
         }
     };
+    if let Some(console_output) = console_output_override {
+        cfg.logging.console_output = console_output;
+    }
+    if let Some(level) = log_level_override {
+        if !level.trim().is_empty() {
+            cfg.logging.level = level;
+        }
+    }
 
     // 2. Logging
     let (app_guard, alert_guard, alert_sink) = init_logging(&cfg);

--- a/src/runtime/orchestration.rs
+++ b/src/runtime/orchestration.rs
@@ -14,10 +14,10 @@ pub fn run() -> anyhow::Result<()> {
     let cli = Cli::parse_args();
 
     match cli.command {
-        Some(Commands::Run { console }) => {
-            crate::runtime::windows::run_console(console, cli.log_level)
+        Some(Commands::Run { no_console, .. }) => {
+            crate::runtime::windows::run_console(!no_console, cli.log_level)
         }
-        None => crate::runtime::windows::run_console(false, cli.log_level),
+        None => crate::runtime::windows::run_console(true, cli.log_level),
         Some(Commands::Service { action }) => crate::platform::handle_service_command(action),
     }
 }
@@ -28,7 +28,10 @@ pub fn run() -> anyhow::Result<()> {
 
     match cli.command {
         Some(Commands::Service { action }) => crate::platform::handle_service_command(action),
-        Some(Commands::Run { .. }) | None => crate::runtime::linux::run(),
+        Some(Commands::Run { no_console, .. }) => {
+            crate::runtime::linux::run(!no_console, cli.log_level)
+        }
+        None => crate::runtime::linux::run(true, cli.log_level),
     }
 }
 
@@ -38,7 +41,10 @@ pub fn run() -> anyhow::Result<()> {
 
     match cli.command {
         Some(Commands::Service { action }) => crate::platform::handle_service_command(action),
-        Some(Commands::Run { .. }) | None => crate::runtime::macos::run(),
+        Some(Commands::Run { no_console, .. }) => {
+            crate::runtime::macos::run(!no_console, cli.log_level)
+        }
+        None => crate::runtime::macos::run(true, cli.log_level),
     }
 }
 

--- a/src/runtime/windows.rs
+++ b/src/runtime/windows.rs
@@ -22,9 +22,13 @@ enum ShutdownMode {
     Service(watch::Receiver<bool>),
 }
 
-pub fn run_console(force_console: bool, log_level: Option<String>) -> anyhow::Result<()> {
+pub fn run_console(console_output: bool, log_level: Option<String>) -> anyhow::Result<()> {
     let runtime = Builder::new_multi_thread().enable_all().build()?;
-    runtime.block_on(run_edr(ShutdownMode::Console, force_console, log_level))
+    runtime.block_on(run_edr(
+        ShutdownMode::Console,
+        Some(console_output),
+        log_level,
+    ))
 }
 
 pub extern "system" fn ffi_service_main(_args: u32, _raw_args: *mut *mut u16) {
@@ -99,7 +103,7 @@ fn service_main() -> anyhow::Result<()> {
             }
         });
 
-        let run_result = run_edr(ShutdownMode::Service(shutdown_rx), false, None).await;
+        let run_result = run_edr(ShutdownMode::Service(shutdown_rx), None, None).await;
         stop_task.abort();
         let _ = stop_task.await;
         run_result
@@ -153,7 +157,7 @@ fn spawn_shutdown_handler(
 
 async fn run_edr(
     shutdown_mode: ShutdownMode,
-    force_console: bool,
+    console_output_override: Option<bool>,
     log_level_override: Option<String>,
 ) -> anyhow::Result<()> {
     // 1. Load Configuration
@@ -165,8 +169,8 @@ async fn run_edr(
             return Err(anyhow::anyhow!("Failed to load configuration: {}", err));
         }
     };
-    if force_console {
-        cfg.logging.console_output = true;
+    if let Some(console_output) = console_output_override {
+        cfg.logging.console_output = console_output;
     }
     if let Some(level) = log_level_override {
         if !level.trim().is_empty() {


### PR DESCRIPTION
## Summary

Implements #31 by making interactive `rustinel run` behavior consistent across platforms:

- `rustinel run` and bare `rustinel` now run in the foreground with console output enabled by default.
- Adds `rustinel run --no-console` to suppress console output when needed.
- Keeps `--console` as a compatibility alias while documenting the new default command path.
- Keeps Windows service mode non-interactive by relying on the non-console config default.
- Updates docs, sample config, and the Windows benchmark script to use plain `run`.

## Validation

- `cargo test`
- `cargo clippy --all-targets -- -D clippy::all`
- `cargo run -- run --help`