### PR TITLE
feat(macos): memory scanning, CI, signed releases, and docs

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -236,6 +236,41 @@ jobs:
           path: target/release/rustinel.exe
           retention-days: 1
 
+  # macOS builds run on the arm64 runner; the x86_64 target cross-compiles
+  # there since the SDK ships both slices. The EndpointSecurity framework links
+  # at build time and only needs entitlements at runtime.
+  build-macos-arm64:
+    name: Build macOS arm64
+    runs-on: macos-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: Swatinem/rust-cache@v2
+      - run: rustup target add aarch64-apple-darwin
+      - run: cargo build --locked --release --target aarch64-apple-darwin
+      - uses: actions/upload-artifact@v7
+        with:
+          name: rustinel-macos-arm64
+          path: target/aarch64-apple-darwin/release/rustinel
+          retention-days: 1
+
+  build-macos-x86_64:
+    name: Build macOS x86_64
+    runs-on: macos-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: Swatinem/rust-cache@v2
+      - run: rustup target add x86_64-apple-darwin
+      - run: cargo build --locked --release --target x86_64-apple-darwin
+      - uses: actions/upload-artifact@v7
+        with:
+          name: rustinel-macos-x86_64
+          path: target/x86_64-apple-darwin/release/rustinel
+          retention-days: 1
+
   # ── Release ─────────────────────────────────────────────────────────────────
   release:
     name: Create Release

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -238,37 +238,82 @@ jobs:
 
   # macOS builds run on the arm64 runner; the x86_64 target cross-compiles
   # there since the SDK ships both slices. The EndpointSecurity framework links
-  # at build time and only needs entitlements at runtime.
-  build-macos-arm64:
-    name: Build macOS arm64
+  # at build time and only needs entitlements at runtime. Signing and
+  # notarization happen here (on macOS) and produce the final .tar.gz.
+  build-macos:
+    name: Build macOS ${{ matrix.arch }}
     runs-on: macos-latest
     if: startsWith(github.ref, 'refs/tags/v')
+    strategy:
+      matrix:
+        include:
+          - arch: arm64
+            target: aarch64-apple-darwin
+          - arch: x86_64
+            target: x86_64-apple-darwin
     steps:
       - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - uses: Swatinem/rust-cache@v2
-      - run: rustup target add aarch64-apple-darwin
-      - run: cargo build --locked --release --target aarch64-apple-darwin
-      - uses: actions/upload-artifact@v7
-        with:
-          name: rustinel-macos-arm64
-          path: target/aarch64-apple-darwin/release/rustinel
-          retention-days: 1
+      - run: rustup target add ${{ matrix.target }}
+      - run: cargo build --locked --release --target ${{ matrix.target }}
 
-  build-macos-x86_64:
-    name: Build macOS x86_64
-    runs-on: macos-latest
-    if: startsWith(github.ref, 'refs/tags/v')
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - uses: Swatinem/rust-cache@v2
-      - run: rustup target add x86_64-apple-darwin
-      - run: cargo build --locked --release --target x86_64-apple-darwin
+      # Code signing and notarization run only when the maintainer's Apple
+      # Developer secrets are configured; otherwise the binary ships unsigned
+      # (runnable on hosts with SIP/AMFI relaxed). A bare Mach-O cannot be
+      # stapled, so Gatekeeper verifies the notarization ticket online.
+      - name: Sign and notarize
+        env:
+          BIN: target/${{ matrix.target }}/release/rustinel
+          SIGN_IDENTITY: ${{ secrets.MACOS_SIGN_IDENTITY }}
+          CERT_P12_BASE64: ${{ secrets.MACOS_CERT_P12_BASE64 }}
+          CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
+          NOTARY_APPLE_ID: ${{ secrets.MACOS_NOTARY_APPLE_ID }}
+          NOTARY_TEAM_ID: ${{ secrets.MACOS_NOTARY_TEAM_ID }}
+          NOTARY_PASSWORD: ${{ secrets.MACOS_NOTARY_PASSWORD }}
+        run: |
+          if [ -z "$SIGN_IDENTITY" ] || [ -z "$CERT_P12_BASE64" ]; then
+            echo "::warning::macOS signing secrets not configured; shipping unsigned binary"
+            exit 0
+          fi
+          KEYCHAIN="$RUNNER_TEMP/rustinel-signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(uuidgen)"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          echo "$CERT_P12_BASE64" | base64 --decode > "$RUNNER_TEMP/cert.p12"
+          security import "$RUNNER_TEMP/cert.p12" -k "$KEYCHAIN" -P "$CERT_PASSWORD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | tr -d '"')
+          codesign --force --options runtime --timestamp \
+            --entitlements packaging/macos/rustinel.entitlements \
+            --sign "$SIGN_IDENTITY" "$BIN"
+          codesign --verify --strict --verbose=2 "$BIN"
+          if [ -n "$NOTARY_APPLE_ID" ]; then
+            ditto -c -k "$BIN" "$RUNNER_TEMP/notarize.zip"
+            xcrun notarytool submit "$RUNNER_TEMP/notarize.zip" \
+              --apple-id "$NOTARY_APPLE_ID" --team-id "$NOTARY_TEAM_ID" \
+              --password "$NOTARY_PASSWORD" --wait
+          fi
+          rm -f "$RUNNER_TEMP/cert.p12"
+
+      - name: Package macOS ${{ matrix.arch }}
+        run: |
+          PKG="rustinel-${GITHUB_REF_NAME#v}-${{ matrix.target }}"
+          mkdir -p "$PKG/rules/sigma" "$PKG/rules/yara" "$PKG/rules/ioc" "$PKG/logs"
+          cp target/${{ matrix.target }}/release/rustinel "$PKG/"
+          chmod +x "$PKG/rustinel"
+          cp config.toml README.md packaging/macos/com.rustinel.agent.plist "$PKG/"
+          [[ -d rules/sigma ]] && cp -r rules/sigma/. "$PKG/rules/sigma/" || touch "$PKG/rules/sigma/.gitkeep"
+          [[ -d rules/yara  ]] && cp -r rules/yara/.  "$PKG/rules/yara/"  || touch "$PKG/rules/yara/.gitkeep"
+          [[ -d rules/ioc   ]] && cp -r rules/ioc/.   "$PKG/rules/ioc/"   || touch "$PKG/rules/ioc/.gitkeep"
+          touch "$PKG/logs/.gitkeep"
+          tar czf "$PKG.tar.gz" "$PKG"
+
       - uses: actions/upload-artifact@v7
         with:
-          name: rustinel-macos-x86_64
-          path: target/x86_64-apple-darwin/release/rustinel
+          name: rustinel-macos-${{ matrix.arch }}
+          path: rustinel-*-${{ matrix.target }}.tar.gz
           retention-days: 1
 
   # ── Release ─────────────────────────────────────────────────────────────────
@@ -286,6 +331,7 @@ jobs:
       - build-linux-x86_64
       - build-linux-arm64
       - build-windows
+      - build-macos
     if: startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: write
@@ -309,6 +355,18 @@ jobs:
         with:
           name: rustinel-windows-x86_64
           path: dist/windows-x86_64/
+
+      - name: Download macOS arm64 package
+        uses: actions/download-artifact@v8
+        with:
+          name: rustinel-macos-arm64
+          path: dist/macos-arm64/
+
+      - name: Download macOS x86_64 package
+        uses: actions/download-artifact@v8
+        with:
+          name: rustinel-macos-x86_64
+          path: dist/macos-x86_64/
 
       - name: Extract version from tag
         id: version
@@ -352,12 +410,21 @@ jobs:
           touch "$PKG/logs/.gitkeep"
           zip -r "$PKG.zip" "$PKG"
 
+      # The macOS archives are signed and packaged on the macOS runner; stage
+      # them next to the other release assets.
+      - name: Stage macOS packages
+        run: |
+          cp dist/macos-arm64/*.tar.gz .
+          cp dist/macos-x86_64/*.tar.gz .
+
       - name: Generate SHA256 checksums
         run: |
           sha256sum \
             rustinel-${{ steps.version.outputs.version }}-x86_64-unknown-linux-musl.tar.gz \
             rustinel-${{ steps.version.outputs.version }}-aarch64-unknown-linux-musl.tar.gz \
             rustinel-${{ steps.version.outputs.version }}-x86_64-pc-windows-msvc.zip \
+            rustinel-${{ steps.version.outputs.version }}-aarch64-apple-darwin.tar.gz \
+            rustinel-${{ steps.version.outputs.version }}-x86_64-apple-darwin.tar.gz \
             > rustinel-${{ steps.version.outputs.version }}-checksums-sha256.txt
 
       - name: Create GitHub Release
@@ -367,6 +434,8 @@ jobs:
             rustinel-${{ steps.version.outputs.version }}-x86_64-unknown-linux-musl.tar.gz
             rustinel-${{ steps.version.outputs.version }}-aarch64-unknown-linux-musl.tar.gz
             rustinel-${{ steps.version.outputs.version }}-x86_64-pc-windows-msvc.zip
+            rustinel-${{ steps.version.outputs.version }}-aarch64-apple-darwin.tar.gz
+            rustinel-${{ steps.version.outputs.version }}-x86_64-apple-darwin.tar.gz
             rustinel-${{ steps.version.outputs.version }}-checksums-sha256.txt
           generate_release_notes: true
           draft: false
@@ -380,6 +449,8 @@ jobs:
             | Linux | x86_64 | `rustinel-${{ steps.version.outputs.version }}-x86_64-unknown-linux-musl.tar.gz` |
             | Linux | arm64 | `rustinel-${{ steps.version.outputs.version }}-aarch64-unknown-linux-musl.tar.gz` |
             | Windows | x86_64 | `rustinel-${{ steps.version.outputs.version }}-x86_64-pc-windows-msvc.zip` |
+            | macOS | arm64 | `rustinel-${{ steps.version.outputs.version }}-aarch64-apple-darwin.tar.gz` |
+            | macOS | x86_64 | `rustinel-${{ steps.version.outputs.version }}-x86_64-apple-darwin.tar.gz` |
 
             ## Linux
 
@@ -401,3 +472,17 @@ jobs:
             3. Run as Administrator: `.\rustinel.exe run`
 
             **Requirements:** Windows 10/11 or Server 2016+ (x64), Administrator privileges.
+
+            ## macOS
+
+            ```sh
+            tar xzf rustinel-${{ steps.version.outputs.version }}-<arch>.tar.gz
+            cd rustinel-${{ steps.version.outputs.version }}-<arch>
+            # Customize config.toml, add rules to rules/
+            sudo ./rustinel run
+            ```
+
+            A `com.rustinel.agent.plist` LaunchDaemon is included for persistent deployment.
+
+            **Requirements:** macOS 11+, root, and the Endpoint Security entitlement
+            (signed and notarized builds), or SIP/AMFI relaxed for local testing.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1616,6 +1616,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dae608c151f68243f2b000364e1f7b186d9c29845f7d2d85bd31b9ad77ad552b"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2415,6 +2421,7 @@ dependencies = [
  "ipnetwork",
  "libc",
  "libproc",
+ "mach2 0.6.0",
  "md-5 0.11.0",
  "memmap2",
  "pelite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,8 @@ endpoint-sec = { version = "0.5", features = ["macos_11_0_0"] }
 endpoint-sec-sys = "0.5"
 # Process/socket inspection for best-effort PID attribution of captured flows.
 libproc = "0.14"
+# Mach VM APIs for YARA process-memory scanning (task_for_pid, mach_vm_read).
+mach2 = "0.6"
 
 # Windows-specific
 [target.'cfg(windows)'.dependencies]

--- a/README.md
+++ b/README.md
@@ -4,19 +4,20 @@
 
 # Rustinel
 
-**Open-source endpoint detection for Windows and Linux**
+**Open-source endpoint detection for Windows, Linux, and macOS**
 
 <p align="center">
   <a href="https://github.com/Karib0u/rustinel/actions/workflows/ci-cd.yml"><img src="https://github.com/Karib0u/rustinel/actions/workflows/ci-cd.yml/badge.svg" alt="CI"></a>
   <a href="https://github.com/Karib0u/rustinel/releases/latest"><img src="https://img.shields.io/github/v/release/Karib0u/rustinel" alt="Latest release"></a>
   <img src="https://img.shields.io/badge/platform-Windows%20ETW-blue?logo=windows" alt="Platform Windows ETW">
   <img src="https://img.shields.io/badge/platform-Linux%20eBPF-orange?logo=linux" alt="Platform Linux eBPF">
+  <img src="https://img.shields.io/badge/platform-macOS%20ESF-black?logo=apple" alt="Platform macOS ESF">
   <img src="https://img.shields.io/badge/license-Apache%202.0-green" alt="License">
 </p>
 
-Rustinel is an open-source endpoint detection project for **Windows** and **Linux**.
+Rustinel is an open-source endpoint detection project for **Windows**, **Linux**, and **macOS**.
 
-It collects native host telemetry using **ETW** on Windows and **eBPF** on Linux, normalizes events into a shared model, evaluates **Sigma**, **YARA**, and **IOC** detections, writes **ECS NDJSON** alerts, and can optionally terminate malicious processes.
+It collects native host telemetry using **ETW** on Windows, **eBPF** on Linux, and **Endpoint Security** plus **`/dev/bpf`** on macOS, normalizes events into a shared model, evaluates **Sigma**, **YARA**, and **IOC** detections, writes **ECS NDJSON** alerts, and can optionally terminate malicious processes.
 
 The goal is simple: give blue teams, researchers, and detection engineers a transparent endpoint detection engine they can inspect, run, test, and extend.
 
@@ -52,6 +53,7 @@ Rustinel currently provides:
 
 - Windows telemetry collection through ETW
 - Linux telemetry collection through eBPF
+- macOS telemetry collection through Endpoint Security and `/dev/bpf`
 - A shared event model across supported platforms
 - Sigma rule evaluation on normalized events
 - YARA scanning on process creation
@@ -61,16 +63,17 @@ Rustinel currently provides:
 - Optional active response with dry-run and allowlists
 - Windows service support
 - Linux foreground execution under root or a supervisor of your choice
+- macOS foreground execution under root, or a launchd daemon
 
 ---
 
 ## Architecture
 
 ```text
-Windows hosts                      Linux hosts
-   ETW                                eBPF
-    |                                  |
-    +---------------+------------------+
+Windows hosts        Linux hosts        macOS hosts
+   ETW                  eBPF             ESF + /dev/bpf
+    |                    |                    |
+    +--------------------+--------------------+
                     |
           Normalized event model
                     |
@@ -127,7 +130,7 @@ IOC matching provides fast deterministic checks against:
 - Domains
 - Path regexes
 
-IOC matching is useful for threat intelligence and incident response, but it is strongest when combined with behavioral detections and YARA scanning. Domain IOCs can match DNS `QueryName` on both Windows and Linux; Linux support covers outbound plaintext DNS queries observed by eBPF.
+IOC matching is useful for threat intelligence and incident response, but it is strongest when combined with behavioral detections and YARA scanning. Domain IOCs can match DNS `QueryName` on Windows, Linux, and macOS; Linux covers outbound plaintext DNS queries observed by eBPF, and macOS covers plaintext DNS queries observed via `/dev/bpf` capture.
 
 ---
 
@@ -137,8 +140,9 @@ IOC matching is useful for threat intelligence and incident response, but it is 
 | --- | --- | --- | --- |
 | Windows 10/11, Server 2016+ | ETW | Process, image load, network, file, registry, DNS, PowerShell, WMI, service, task | Foreground run or built-in Windows service commands |
 | Linux 5.8+ with BTF | eBPF | Process, network, file, DNS | Foreground run under root or your supervisor of choice |
+| macOS 11+ | Endpoint Security + `/dev/bpf` | Process, file, network, DNS | Foreground run under root (signed/entitled or SIP relaxed) or a launchd daemon |
 
-Windows telemetry coverage is broader today. Linux support currently focuses on process, network, file, and DNS telemetry through eBPF. Linux DNS events include outbound plaintext DNS `QueryName`; DNS response answers (`QueryResults`) are not parsed yet.
+Windows telemetry coverage is broader today. Linux and macOS support currently focus on process, network, file, and DNS telemetry. Linux DNS events include outbound plaintext DNS `QueryName`; DNS response answers (`QueryResults`) are not parsed yet. macOS collects process and file events through Endpoint Security and network and DNS through `/dev/bpf` capture; network events are attributed to a process on a best-effort basis.
 
 ---
 
@@ -163,6 +167,20 @@ sudo ./rustinel run
 whoami
 cat logs/alerts.json.*
 ```
+
+### macOS
+
+```bash
+cd rustinel-<version>-aarch64-apple-darwin
+sudo ./rustinel run
+whoami
+cat logs/alerts.json.*
+```
+
+Creating an Endpoint Security client requires root and the
+`com.apple.developer.endpoint-security.client` entitlement on signed,
+notarized builds. For local testing you can run with SIP/AMFI relaxed. See the
+[development docs](docs/development.md) for ad-hoc signing steps.
 
 The bundled demo rules are intended to validate that telemetry collection, rule evaluation, and alert output are working.
 
@@ -225,6 +243,28 @@ The bundled Sigma demo rule should write an alert to:
 logs/alerts.json.<date>
 ```
 
+### macOS
+
+Choose the archive that matches your architecture:
+
+```text
+rustinel-<version>-aarch64-apple-darwin.tar.gz
+rustinel-<version>-x86_64-apple-darwin.tar.gz
+```
+
+Extract and run as root:
+
+```bash
+tar xzf rustinel-<version>-aarch64-apple-darwin.tar.gz
+cd rustinel-<version>-aarch64-apple-darwin
+sudo ./rustinel run
+```
+
+If startup fails with `NotPrivileged`, the Endpoint Security client could not be
+created: run as root with a signed, entitled build, or relax SIP/AMFI for local
+testing. A `com.rustinel.agent.plist` LaunchDaemon is included for persistent
+deployment.
+
 ---
 
 ## Build from source
@@ -244,6 +284,19 @@ cargo build --release
 cargo build --release
 sudo ./target/release/rustinel run
 ```
+
+### macOS
+
+```bash
+cargo build --release
+codesign --force --sign - \
+  --entitlements packaging/macos/rustinel.entitlements \
+  target/release/rustinel
+sudo ./target/release/rustinel run
+```
+
+Ad-hoc signing with the entitlement only takes effect when SIP/AMFI is relaxed;
+distributable builds require a Developer ID and notarization.
 
 For full release setup, source-build prerequisites, and validation steps, see the [Getting Started](https://docs.rustinel.io/getting-started/) documentation.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -126,6 +126,27 @@ The current loader attaches a mix of tracepoints and kprobes, including:
 
 Requirements for the Linux sensor are kernel 5.8+, BTF, and eBPF privileges.
 
+### macOS
+
+macOS telemetry comes from two native sources feeding the same shared pipeline:
+
+- Endpoint Security (`EsfSensor`) for process and file events: process exec and
+  exit, and file create, delete, rename, and modify (the modify signal is a
+  close-after-write, which keeps the high-volume close stream down to real
+  content changes). Exec events carry the executable path, arguments, and
+  parent pid directly; the parent image is enriched via libproc.
+- `/dev/bpf` packet capture (`BpfSensor`) for network and DNS: outbound TCP
+  connection initiations (SYN) and DNS queries parsed from port 53 traffic,
+  reusing the shared DNS query-name parser. Connection events are attributed to
+  a process on a best-effort basis by matching the connection's ports against
+  open sockets via libproc.
+
+The Endpoint Security sensor is the primary source and is required; the bpf
+capture source is best-effort and the agent degrades to Endpoint Security only
+if it cannot start. Requirements for the macOS sensor are root, the
+`com.apple.developer.endpoint-security.client` entitlement (or SIP/AMFI relaxed
+for local testing), and access to the bpf device nodes.
+
 ## Shared Pipeline
 
 Once a platform sensor emits a raw `SensorEvent`, the rest of the runtime is shared:
@@ -194,20 +215,20 @@ On Windows, the agent also snapshots running processes during startup so `Proces
 - Optional and disabled by default
 - Alerts above the configured threshold are queued to a background worker
 - Windows uses process termination APIs
-- Linux uses `SIGKILL`
+- Linux and macOS use `SIGKILL`
 
 ## Current Cross-Platform Scope
 
-| Capability | Windows | Linux |
-| --- | --- | --- |
-| Process telemetry | Yes | Yes |
-| Network telemetry | Yes | Yes |
-| File telemetry | Yes | Yes |
-| DNS telemetry | Yes | Yes |
-| Registry telemetry | Yes | No |
-| Image load telemetry | Yes | No |
-| PowerShell telemetry | Yes | No |
-| WMI telemetry | Yes | No |
-| Service telemetry | Yes | No |
-| Task telemetry | Yes | No |
-| Built-in service management | Yes | No |
+| Capability | Windows | Linux | macOS |
+| --- | --- | --- | --- |
+| Process telemetry | Yes | Yes | Yes |
+| Network telemetry | Yes | Yes | Yes |
+| File telemetry | Yes | Yes | Yes |
+| DNS telemetry | Yes | Yes | Yes |
+| Registry telemetry | Yes | No | No |
+| Image load telemetry | Yes | No | No |
+| PowerShell telemetry | Yes | No | No |
+| WMI telemetry | Yes | No | No |
+| Service telemetry | Yes | No | No |
+| Task telemetry | Yes | No | No |
+| Built-in service management | Yes | No | No |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,6 +18,13 @@ This guide gets Rustinel to first telemetry and first alert on both supported pl
 - Rust 1.92+ if building from source
 - If `ebpf/rustinel-ebpf.o` is missing, nightly Rust, `rust-src`, and `bpf-linker` are also required for the first build
 
+### macOS
+
+- macOS 11+
+- Root, plus the `com.apple.developer.endpoint-security.client` entitlement on signed and notarized builds, or SIP/AMFI relaxed for local testing
+- Access to the `/dev/bpf*` device nodes for network and DNS capture
+- Rust 1.92+ and the Xcode Command Line Tools if building from source
+
 ## Quick Start
 
 Download the package for your platform from [GitHub Releases](https://github.com/Karib0u/rustinel/releases). The release archives already include `config.toml`, the bundled demo rules, and an empty `logs/` directory.
@@ -53,6 +60,27 @@ mount -t debugfs debugfs /sys/kernel/debug
 
 Some minimal Linux environments, including some WSL 2 distros, may start without these filesystems mounted.
 
+### macOS
+
+Choose the archive that matches your Mac:
+
+- `rustinel-<version>-aarch64-apple-darwin.tar.gz`
+- `rustinel-<version>-x86_64-apple-darwin.tar.gz`
+
+Then extract and run it as root:
+
+```bash
+tar xzf rustinel-<version>-aarch64-apple-darwin.tar.gz
+cd rustinel-<version>-aarch64-apple-darwin
+sudo ./rustinel run
+```
+
+If startup fails with `NotPrivileged`, the Endpoint Security client could not be
+created. Run as root with a signed, entitled build, or relax SIP/AMFI on a test
+machine. Network and DNS capture additionally needs access to the `/dev/bpf*`
+device nodes; the agent continues with Endpoint Security only if capture cannot
+start.
+
 ## Compile From Source
 
 Use this path if you want to build the binary yourself instead of using a published release.
@@ -74,6 +102,21 @@ cd rustinel
 cargo build --release
 sudo ./target/release/rustinel run
 ```
+
+### macOS
+
+```bash
+git clone https://github.com/Karib0u/rustinel.git
+cd rustinel
+cargo build --release
+codesign --force --sign - \
+  --entitlements packaging/macos/rustinel.entitlements \
+  target/release/rustinel
+sudo ./target/release/rustinel run
+```
+
+Ad-hoc signing with the entitlement only takes effect when SIP/AMFI is relaxed.
+See the [Development](development.md) guide for signing and notarization details.
 
 Notes:
 
@@ -115,6 +158,19 @@ whoami
 3. Confirm an alert was written to `logs/alerts.json.<date>`.
 
 The bundled rule is `rules/sigma/linux_whoami.yml`.
+
+### macOS Sigma Demo
+
+1. Keep Rustinel running.
+2. Execute:
+
+```bash
+whoami
+```
+
+3. Confirm an alert was written to `logs/alerts.json.<date>`.
+
+The bundled rule is `rules/sigma/macos_whoami.yml`.
 
 ### Cross-Platform YARA Demo
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,9 +4,9 @@
 
 # Rustinel Documentation
 
-**Rustinel** is an open-source endpoint detection project for Windows and Linux.
+**Rustinel** is an open-source endpoint detection project for Windows, Linux, and macOS.
 
-It collects native host telemetry using **ETW** on Windows and **eBPF** on Linux, normalizes events into a shared model, evaluates **Sigma**, **YARA**, and **IOC** detections, and writes alerts as **ECS NDJSON**.
+It collects native host telemetry using **ETW** on Windows, **eBPF** on Linux, and **Endpoint Security** plus **`/dev/bpf`** on macOS, normalizes events into a shared model, evaluates **Sigma**, **YARA**, and **IOC** detections, and writes alerts as **ECS NDJSON**.
 
 Rustinel is designed for blue teams, detection engineers, researchers, and anyone who wants a transparent endpoint detection engine they can inspect, run, test, and extend.
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -50,6 +50,27 @@ Encrypted C2 over trusted or common infrastructure may not be detected by simple
 
 Behavioral detection is needed to identify suspicious activity around the network communication.
 
+### macOS network and DNS attribution
+
+On macOS, network and DNS telemetry comes from `/dev/bpf` packet capture rather
+than a per-process hook. This has a few consequences:
+
+- Connections are attributed to a process on a best-effort basis by matching
+  ports against open sockets, which is racy: a short-lived socket may close
+  before it can be matched, leaving the connection unattributed.
+- DNS query events are not attributed to a process.
+- Capture binds to a single interface (default `en0`, override with
+  `RUSTINEL_BPF_INTERFACE`); traffic on other interfaces is not seen.
+
+A future NetworkExtension-based source would carry the owning process with each
+flow and remove these limitations.
+
+### macOS memory scanning
+
+YARA memory scanning on macOS uses `task_for_pid`, which is heavily restricted:
+it generally requires root and SIP/AMFI relaxation or a specific entitlement.
+When access is denied, memory scanning simply returns nothing.
+
 ## How to think about Rustinel
 
 Rustinel should be viewed as a transparent open-source detection engine.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -17,6 +17,16 @@ It is not a strict release commitment.
 - **ETW integrity checks** — detect ETW session tampering and provider blinding that could suppress telemetry.
 - **Deep inspection via stack walking** — identify shellcode and "floating code" executing outside mapped image regions.
 
+### macOS
+
+macOS support collects process and file telemetry through Endpoint Security and
+network and DNS through `/dev/bpf` capture. Future work:
+
+- **NetworkExtension flow source** — replace `/dev/bpf` capture with a Network Extension that carries the owning PID per flow, removing the best-effort socket-to-PID scan and its direction ambiguity.
+- **Interface selection** — capture across all active interfaces instead of the single `RUSTINEL_BPF_INTERFACE` (default `en0`).
+- **DNS response enrichment** — parse DNS answers for `QueryResults`, matching the Linux gap.
+- **AUTH-mode prevention** — block process execution before it happens via `ES_EVENT_TYPE_AUTH_EXEC`, beyond the current kill-after-the-fact response.
+
 ### Cross-Platform
 
 - **Periodic YARA sweeps** — scheduled background scans of running processes independent of creation events.
@@ -101,7 +111,7 @@ This may include recommendations around:
 
 Useful community contributions include:
 
-- Testing on different Windows and Linux versions
+- Testing on different Windows, Linux, and macOS versions
 - Reporting telemetry gaps
 - Improving documentation
 - Adding Sigma examples

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -10,9 +10,11 @@ Before changing config or rules, check these first:
 - Run in the foreground with a higher log level:
   - Windows: `.\rustinel.exe run --log-level debug`
   - Linux: `sudo ./rustinel run --log-level debug`
+  - macOS: `sudo ./rustinel run --log-level debug`
 - Trigger a known bundled demo rule:
   - Windows: `whoami /all`
   - Linux: `whoami`
+  - macOS: `whoami`
 - Confirm you are using the expected working directory and rule paths
 
 ## Quick Symptom Guide
@@ -103,6 +105,45 @@ If `ebpf/rustinel-ebpf.o` is missing, the build falls back to compiling the eBPF
 - `bpf-linker`
 
 See [Getting Started](getting-started.md) and [Development](development.md).
+
+### macOS `Endpoint Security client init failed: ... NotPrivileged`
+
+Creating an Endpoint Security client failed. The common causes are:
+
+- not running as root
+- the binary is not signed with the `com.apple.developer.endpoint-security.client` entitlement, and SIP/AMFI is not relaxed
+- the user has not approved the agent (TCC)
+
+What to do:
+
+- run with `sudo`
+- for distributable builds, sign and notarize with the Endpoint Security entitlement
+- for local testing, relax SIP/AMFI on a dedicated test machine and ad-hoc sign with the entitlement (see [Development](development.md))
+
+Typical symptom in logs:
+
+```text
+macOS Endpoint Security sensor failed to start: Endpoint Security client init failed: es_new_client failed: NotPrivileged
+```
+
+### macOS network or DNS events are missing
+
+Network and DNS telemetry on macOS comes from `/dev/bpf` capture, which is a
+separate, best-effort source. If it cannot start, the agent logs a warning and
+continues with Endpoint Security (process and file) only.
+
+Check these first:
+
+- access to the `/dev/bpf*` device nodes requires root
+- capture binds to one interface (default `en0`); set `RUSTINEL_BPF_INTERFACE` to match your active interface
+- DNS visibility requires plaintext DNS on port 53; DNS-over-HTTPS and DNS-over-TLS are not visible
+- network connection events are attributed to a process on a best-effort basis and may be unattributed
+
+Typical symptom in logs:
+
+```text
+macOS network/DNS sensor unavailable: ...; continuing with Endpoint Security only
+```
 
 ## Agent Runs But No Alerts
 
@@ -210,6 +251,13 @@ On Windows, `OpenProcess` with `PROCESS_VM_READ` may fail for:
 
 These failures are logged at `trace` and do not affect other detection paths.
 
+#### macOS memory scanning privileges
+
+On macOS, reading another process's memory uses `task_for_pid`, which is
+heavily restricted. It generally requires root and SIP/AMFI relaxation or a
+specific entitlement, and is denied for many system and protected processes.
+When access is denied the scan returns nothing, logged at `trace`.
+
 ### IOC hash matching did not fire
 
 Hash matching is more selective than inline IOC checks.
@@ -291,6 +339,7 @@ Common log lines include:
 ```text
 Sensor event channel full; dropping ETW event
 eBPF sensor: event channel full, dropping event
+bpf sensor: event channel full, dropping event
 YARA queue full; dropping scan job
 IOC hash queue full; dropping job
 Active response queue full, dropping task
@@ -370,5 +419,6 @@ Collect these first:
 - relevant operational log excerpt
 - whether the bundled `whoami` demo rule works
 - on Linux: kernel version, BTF availability, and whether an eBPF override object was used
+- on macOS: macOS version, whether running as root, and whether the build is signed/notarized or SIP/AMFI is relaxed
 
 If the problem is rule-related, include the minimal rule and the event type you expected it to match.

--- a/packaging/macos/com.rustinel.agent.plist
+++ b/packaging/macos/com.rustinel.agent.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  LaunchDaemon for Rustinel, the macOS analog of rustinel.service.
+
+  Rustinel needs root for Endpoint Security and /dev/bpf, so it runs as a
+  system daemon. Install to /Library/LaunchDaemons/com.rustinel.agent.plist
+  (owned by root:wheel) and load with:
+
+    sudo launchctl bootstrap system /Library/LaunchDaemons/com.rustinel.agent.plist
+
+  Adjust the program path and working directory to match your install layout.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.rustinel.agent</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/local/bin/rustinel</string>
+        <string>run</string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string>/usr/local/var/rustinel</string>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>ProcessType</key>
+    <string>Interactive</string>
+    <key>StandardOutPath</key>
+    <string>/usr/local/var/log/rustinel/launchd.out.log</string>
+    <key>StandardErrorPath</key>
+    <string>/usr/local/var/log/rustinel/launchd.err.log</string>
+</dict>
+</plist>

--- a/rules/sigma/macos_whoami.yml
+++ b/rules/sigma/macos_whoami.yml
@@ -1,0 +1,13 @@
+title: Example - Whoami Execution (macOS)
+id: b2c3d4e5-f6a7-8901-bcde-f23456789012
+status: experimental
+description: Detects execution of whoami (demo rule).
+author: Rustinel
+logsource:
+  category: process_creation
+  product: macos
+detection:
+  selection:
+    Image|endswith: '/whoami'
+  condition: selection
+level: low

--- a/src/memory/macos.rs
+++ b/src/memory/macos.rs
@@ -18,9 +18,7 @@ use mach2::port::{mach_port_t, MACH_PORT_NULL};
 use mach2::traps::{mach_task_self, task_for_pid};
 use mach2::vm::{mach_vm_read_overwrite, mach_vm_region};
 use mach2::vm_prot::{VM_PROT_EXECUTE, VM_PROT_READ, VM_PROT_WRITE};
-use mach2::vm_region::{
-    vm_region_basic_info_data_64_t, vm_region_info_t, VM_REGION_BASIC_INFO_64,
-};
+use mach2::vm_region::{vm_region_basic_info_data_64_t, vm_region_info_t, VM_REGION_BASIC_INFO_64};
 use mach2::vm_types::{mach_vm_address_t, mach_vm_size_t};
 
 /// Number of 32-bit words in `vm_region_basic_info_data_64_t`, as required by
@@ -164,7 +162,10 @@ mod tests {
     fn classify_region_by_filename_and_protection() {
         assert_eq!(classify(None, false), MemoryRegionKind::Private);
         assert_eq!(classify(None, true), MemoryRegionKind::Private);
-        assert_eq!(classify(Some("/usr/lib/dyld"), true), MemoryRegionKind::Image);
+        assert_eq!(
+            classify(Some("/usr/lib/dyld"), true),
+            MemoryRegionKind::Image
+        );
         assert_eq!(
             classify(Some("/Users/a/file.dat"), false),
             MemoryRegionKind::Mapped

--- a/src/memory/macos.rs
+++ b/src/memory/macos.rs
@@ -1,0 +1,188 @@
+//! macOS process-memory reader for YARA memory scanning.
+//!
+//! Uses Mach VM APIs to enumerate and read another process's memory:
+//! `task_for_pid` to obtain the task port, `mach_vm_region` to walk regions,
+//! and `mach_vm_read_overwrite` to copy region bytes. Regions are classified
+//! with libproc's `regionfilename` (the macOS analog of `/proc/<pid>/maps`).
+//!
+//! `task_for_pid` is privileged: it requires root and, depending on the host,
+//! SIP/AMFI relaxation or the appropriate entitlement. When it is denied this
+//! returns an empty result, exactly like the Linux reader does on permission
+//! errors, so memory scanning simply yields nothing rather than failing.
+
+use super::{MemoryChunk, MemoryRegion, MemoryRegionKind, MemoryScanConfig};
+use anyhow::Result;
+use mach2::kern_return::KERN_SUCCESS;
+use mach2::mach_port::mach_port_deallocate;
+use mach2::port::{mach_port_t, MACH_PORT_NULL};
+use mach2::traps::{mach_task_self, task_for_pid};
+use mach2::vm::{mach_vm_read_overwrite, mach_vm_region};
+use mach2::vm_prot::{VM_PROT_EXECUTE, VM_PROT_READ, VM_PROT_WRITE};
+use mach2::vm_region::{
+    vm_region_basic_info_data_64_t, vm_region_info_t, VM_REGION_BASIC_INFO_64,
+};
+use mach2::vm_types::{mach_vm_address_t, mach_vm_size_t};
+
+/// Number of 32-bit words in `vm_region_basic_info_data_64_t`, as required by
+/// `mach_vm_region`'s `info_count` argument.
+fn basic_info_count() -> mach2::message::mach_msg_type_number_t {
+    (std::mem::size_of::<vm_region_basic_info_data_64_t>() / std::mem::size_of::<i32>())
+        as mach2::message::mach_msg_type_number_t
+}
+
+fn classify(filename: Option<&str>, executable: bool) -> MemoryRegionKind {
+    match filename {
+        None => MemoryRegionKind::Private,
+        Some(_) if executable => MemoryRegionKind::Image,
+        Some(_) => MemoryRegionKind::Mapped,
+    }
+}
+
+pub fn read_process_memory_chunks(pid: u32, cfg: &MemoryScanConfig) -> Result<Vec<MemoryChunk>> {
+    let mut task: mach_port_t = MACH_PORT_NULL;
+    let kr = unsafe { task_for_pid(mach_task_self(), pid as i32, &mut task) };
+    if kr != KERN_SUCCESS {
+        tracing::trace!(
+            target: "scanner",
+            pid = pid,
+            kr = kr,
+            "YARA memory: task_for_pid denied (needs root and SIP/entitlement)"
+        );
+        return Ok(Vec::new());
+    }
+
+    let mut chunks = Vec::new();
+    let mut total_bytes: usize = 0;
+    let mut address: mach_vm_address_t = 0;
+
+    while total_bytes < cfg.max_process_bytes {
+        let mut size: mach_vm_size_t = 0;
+        let mut info = vm_region_basic_info_data_64_t::default();
+        let mut info_count = basic_info_count();
+        let mut object_name: mach_port_t = MACH_PORT_NULL;
+
+        let kr = unsafe {
+            mach_vm_region(
+                task,
+                &mut address,
+                &mut size,
+                VM_REGION_BASIC_INFO_64,
+                (&mut info as *mut vm_region_basic_info_data_64_t).cast::<i32>()
+                    as vm_region_info_t,
+                &mut info_count,
+                &mut object_name,
+            )
+        };
+        // A non-success return marks the end of the address space.
+        if kr != KERN_SUCCESS || size == 0 {
+            break;
+        }
+
+        let readable = info.protection & VM_PROT_READ != 0;
+        let executable = info.protection & VM_PROT_EXECUTE != 0;
+        let writable = info.protection & VM_PROT_WRITE != 0;
+
+        if readable {
+            let filename = libproc::proc_pid::regionfilename(pid as i32, address)
+                .ok()
+                .filter(|name| !name.is_empty());
+            let kind = classify(filename.as_deref(), executable);
+
+            let include = match kind {
+                MemoryRegionKind::Private => cfg.include_private,
+                MemoryRegionKind::Image => cfg.include_image,
+                MemoryRegionKind::Mapped => cfg.include_mapped,
+                MemoryRegionKind::Other => false,
+            };
+
+            if include {
+                let region_size = size as usize;
+                let read_size = region_size
+                    .min(cfg.max_region_bytes)
+                    .min(cfg.max_process_bytes - total_bytes);
+
+                if read_size > 0 {
+                    if let Some(bytes) = read_region(task, address, read_size) {
+                        total_bytes += bytes.len();
+                        let region = MemoryRegion {
+                            base: address,
+                            size: region_size,
+                            readable: true,
+                            writable,
+                            executable,
+                            kind,
+                        };
+                        chunks.push(MemoryChunk {
+                            base: address,
+                            bytes,
+                            region,
+                        });
+                    }
+                }
+            }
+        }
+
+        // Advance past this region; stop on overflow.
+        address = match address.checked_add(size) {
+            Some(next) => next,
+            None => break,
+        };
+    }
+
+    unsafe {
+        let _ = mach_port_deallocate(mach_task_self(), task);
+    }
+
+    Ok(chunks)
+}
+
+/// Read up to `len` bytes at `address` from `task`. Returns `None` on failure.
+fn read_region(task: mach_port_t, address: mach_vm_address_t, len: usize) -> Option<Vec<u8>> {
+    let mut buf = vec![0u8; len];
+    let mut out_size: mach_vm_size_t = 0;
+    let kr = unsafe {
+        mach_vm_read_overwrite(
+            task,
+            address,
+            len as mach_vm_size_t,
+            buf.as_mut_ptr() as mach_vm_address_t,
+            &mut out_size,
+        )
+    };
+    if kr != KERN_SUCCESS || out_size == 0 {
+        return None;
+    }
+    buf.truncate(out_size as usize);
+    Some(buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_region_by_filename_and_protection() {
+        assert_eq!(classify(None, false), MemoryRegionKind::Private);
+        assert_eq!(classify(None, true), MemoryRegionKind::Private);
+        assert_eq!(classify(Some("/usr/lib/dyld"), true), MemoryRegionKind::Image);
+        assert_eq!(
+            classify(Some("/Users/a/file.dat"), false),
+            MemoryRegionKind::Mapped
+        );
+    }
+
+    #[test]
+    fn read_nonexistent_pid_returns_empty() {
+        let cfg = MemoryScanConfig {
+            max_process_bytes: 1024,
+            max_region_bytes: 512,
+            include_private: true,
+            include_image: true,
+            include_mapped: true,
+            delay_ms: 0,
+        };
+        let result = read_process_memory_chunks(99_999_999, &cfg);
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_empty());
+    }
+}

--- a/src/memory/macos.rs
+++ b/src/memory/macos.rs
@@ -71,6 +71,15 @@ pub fn read_process_memory_chunks(pid: u32, cfg: &MemoryScanConfig) -> Result<Ve
                 &mut object_name,
             )
         };
+        // mach_vm_region hands back a send right to the region's named memory
+        // object, which we don't use. Release it so the loop does not leak a
+        // Mach port per region (this can run over many regions and repeatedly
+        // when memory scanning is enabled). On failure it stays MACH_PORT_NULL.
+        if object_name != MACH_PORT_NULL {
+            unsafe {
+                let _ = mach_port_deallocate(mach_task_self(), object_name);
+            }
+        }
         // A non-success return marks the end of the address space.
         if kr != KERN_SUCCESS || size == 0 {
             break;

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -8,7 +8,9 @@ mod types;
 
 #[cfg(target_os = "linux")]
 mod linux;
-#[cfg(not(any(windows, target_os = "linux")))]
+#[cfg(target_os = "macos")]
+mod macos;
+#[cfg(not(any(windows, target_os = "linux", target_os = "macos")))]
 mod unsupported;
 #[cfg(windows)]
 mod windows;
@@ -19,7 +21,9 @@ use anyhow::Result;
 
 #[cfg(target_os = "linux")]
 use linux as platform;
-#[cfg(not(any(windows, target_os = "linux")))]
+#[cfg(target_os = "macos")]
+use macos as platform;
+#[cfg(not(any(windows, target_os = "linux", target_os = "macos")))]
 use unsupported as platform;
 #[cfg(windows)]
 use windows as platform;

--- a/src/sensor/macos/esf.rs
+++ b/src/sensor/macos/esf.rs
@@ -182,6 +182,7 @@ struct RawExec {
     image: String,
     command_line: Option<String>,
     parent_pid: i32,
+    parent_image: Option<String>,
     current_directory: Option<String>,
     user: String,
     /// Process start time, as nanoseconds since the Unix epoch.
@@ -215,11 +216,17 @@ fn build_exec_event(msg: &Message, exec: &EventExec) -> Option<SensorEvent> {
         .map(system_time_nanos)
         .unwrap_or_else(|| system_time_nanos(event_time));
 
+    let parent_pid = target.ppid();
+    let parent_image = (parent_pid > 0)
+        .then(|| crate::utils::process_image_path(parent_pid as u32))
+        .flatten();
+
     Some(process_start_event(RawExec {
         pid: token.pid() as u32,
         image,
         command_line,
-        parent_pid: target.ppid(),
+        parent_pid,
+        parent_image,
         current_directory,
         user: token.ruid().to_string(),
         start_time,
@@ -255,8 +262,8 @@ fn process_start_event(raw: RawExec) -> SensorEvent {
             process_id: Some(raw.pid.to_string()),
             process_start_time: Some(raw.start_time),
             parent_process_id,
-            // Enriched later via libproc; ESF exec events do not carry it.
-            parent_image: None,
+            parent_image: raw.parent_image,
+            // ESF exec events do not carry the parent's command line.
             parent_command_line: None,
             current_directory: raw.current_directory,
             // Windows-specific; absent on macOS.
@@ -523,6 +530,7 @@ mod tests {
             image: "/usr/bin/curl".to_string(),
             command_line: Some("/usr/bin/curl https://example.test".to_string()),
             parent_pid: 501,
+            parent_image: Some("/bin/zsh".to_string()),
             current_directory: Some("/Users/alice".to_string()),
             user: "alice".to_string(),
             start_time: 1_700_000_000_000_000_000,
@@ -553,7 +561,7 @@ mod tests {
                 assert_eq!(fields.parent_process_id.as_deref(), Some("501"));
                 assert_eq!(fields.current_directory.as_deref(), Some("/Users/alice"));
                 assert_eq!(fields.user.as_deref(), Some("alice"));
-                assert!(fields.parent_image.is_none());
+                assert_eq!(fields.parent_image.as_deref(), Some("/bin/zsh"));
             }
             other => panic!("unexpected payload: {other:?}"),
         }
@@ -668,6 +676,7 @@ mod tests {
             image: "/sbin/launchd".to_string(),
             command_line: None,
             parent_pid: 0,
+            parent_image: None,
             current_directory: None,
             user: "root".to_string(),
             start_time: 0,

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -16,6 +16,8 @@ pub use log_rate_limiter::LogRateLimiter;
 pub use path::convert_nt_to_dos;
 #[cfg(windows)]
 pub use pe::parse_metadata;
+#[cfg(target_os = "macos")]
+pub use process::process_image_path;
 #[cfg(windows)]
 pub use process::query_process_command_line_from_handle;
 #[cfg(target_os = "linux")]

--- a/src/utils/process.rs
+++ b/src/utils/process.rs
@@ -143,6 +143,20 @@ pub fn query_process_command_line(_pid: u32) -> Option<String> {
     None
 }
 
+/// Resolve a process's executable path by PID (best-effort) on macOS.
+///
+/// Used to enrich events that only carry a PID (for example a parent process
+/// referenced by an exec event, or a flow attributed via socket inspection).
+#[cfg(target_os = "macos")]
+pub fn process_image_path(pid: u32) -> Option<String> {
+    if pid == 0 {
+        return None;
+    }
+    libproc::proc_pid::pidpath(pid as i32)
+        .ok()
+        .filter(|path| !path.is_empty())
+}
+
 #[cfg(target_os = "linux")]
 pub fn query_process_details(pid: u32) -> Option<ProcessDetails> {
     if pid == 0 {


### PR DESCRIPTION
## Summary
Completes macOS support with production polish: YARA process-memory scanning, native release builds, signed and notarized release archives, a launchd service unit, and full documentation. Fourth and final PR in the #41 series, on top of #42, #46, and #49 (all merged).

- Add YARA process-memory scanning via `task_for_pid`, `mach_vm_region`, and `mach_vm_read_overwrite`, classifying regions with libproc and returning nothing when access is denied (the worker is already wired in `runtime/macos.rs`; this fills in the macOS platform backend that previously fell back to the unsupported stub).
- Enrich exec events with the parent process image via libproc.
- Add macOS release build jobs (arm64 and x86_64) and produce signed and notarized `.tar.gz` release archives for the Darwin targets, wired into the release job's downloads, checksums, and body. Signing and notarization are gated on the maintainer's Apple Developer secrets and fall back to unsigned archives when those are absent. (The macOS clippy and test jobs already landed in #42.)
- Add a launchd LaunchDaemon, the macOS analog of the systemd unit.
- Document macOS across the README and the docs site (platform support, telemetry sources, getting started, build from source, signing and SIP, limitations, and troubleshooting), and add a macOS demo rule so the first-alert walkthrough works.

## Type of change
- [x] `feat` / `enhancement` - new feature
- [x] `ci` - CI/CD changes
- [x] `documentation` - docs

## Test plan
- [ ] Tested on Windows
- [ ] Tested on Linux
- [x] Tested on macOS: clippy, build, and unit tests for memory-region classification
- [x] Existing tests pass (`cargo test`, 168 passed)
- [x] New tests added (memory-region classification)

Note for maintainers: signed and notarized releases require these repository secrets: `MACOS_SIGN_IDENTITY`, `MACOS_CERT_P12_BASE64`, `MACOS_CERT_PASSWORD`, `MACOS_NOTARY_APPLE_ID`, `MACOS_NOTARY_TEAM_ID`, and `MACOS_NOTARY_PASSWORD`. Without them CI still builds and ships unsigned archives (runnable on hosts with SIP/AMFI relaxed). I don't have an Apple Developer account to exercise the live signing path, so that branch of the workflow is unverified end to end.

## Checklist
- [ ] Label added to this PR
- [x] Docs updated (if behaviour changed)

Verified on macOS arm64: `cargo fmt --all -- --check`, `cargo clippy --locked --all-targets -- -D clippy::all`, and `cargo test --locked` (168 passed) are all clean; the release workflow YAML validates.

Fixes #41.
