### PR TITLE
docs: add official site and macOS support note

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
   <img src="https://img.shields.io/badge/license-Apache%202.0-green" alt="License">
 </p>
 
+[Official site](https://rustinel.io/) · [Documentation](https://docs.rustinel.io/) · [GitHub Releases](https://github.com/Karib0u/rustinel/releases)
+
 Rustinel is an open-source endpoint detection project for **Windows**, **Linux**, and **macOS**.
 
 It collects native host telemetry using **ETW** on Windows, **eBPF** on Linux, and **Endpoint Security** plus **`/dev/bpf`** on macOS, normalizes events into a shared model, evaluates **Sigma**, **YARA**, and **IOC** detections, writes **ECS NDJSON** alerts, and can optionally terminate malicious processes.
@@ -140,9 +142,11 @@ IOC matching is useful for threat intelligence and incident response, but it is 
 | --- | --- | --- | --- |
 | Windows 10/11, Server 2016+ | ETW | Process, image load, network, file, registry, DNS, PowerShell, WMI, service, task | Foreground run or built-in Windows service commands |
 | Linux 5.8+ with BTF | eBPF | Process, network, file, DNS | Foreground run under root or your supervisor of choice |
-| macOS 11+ | Endpoint Security + `/dev/bpf` | Process, file, network, DNS | Foreground run under root (signed/entitled or SIP relaxed) or a launchd daemon |
+| macOS 11+ | Endpoint Security + `/dev/bpf` | Process, file, network, DNS | Experimental; foreground run under root (signed/entitled or SIP relaxed) or a launchd daemon |
 
 Windows telemetry coverage is broader today. Linux and macOS support currently focus on process, network, file, and DNS telemetry. Linux DNS events include outbound plaintext DNS `QueryName`; DNS response answers (`QueryResults`) are not parsed yet. macOS collects process and file events through Endpoint Security and network and DNS through `/dev/bpf` capture; network events are attributed to a process on a best-effort basis.
+
+macOS support is experimental while the project waits for the required Endpoint Security Framework entitlement.
 
 ---
 
@@ -357,6 +361,7 @@ See the [full roadmap](docs/roadmap.md) for details.
 
 ## Documentation
 
+- [Official Site](https://rustinel.io/)
 - [Documentation Home](https://docs.rustinel.io/)
 - [Getting Started](https://docs.rustinel.io/getting-started/)
 - [Configuration](https://docs.rustinel.io/configuration/)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -25,6 +25,8 @@ This guide gets Rustinel to first telemetry and first alert on both supported pl
 - Access to the `/dev/bpf*` device nodes for network and DNS capture
 - Rust 1.92+ and the Xcode Command Line Tools if building from source
 
+macOS support is experimental while the project waits for the required Endpoint Security Framework entitlement.
+
 ## Quick Start
 
 Download the package for your platform from [GitHub Releases](https://github.com/Karib0u/rustinel/releases). The release archives already include `config.toml`, the bundled demo rules, and an empty `logs/` directory.

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,8 @@ It collects native host telemetry using **ETW** on Windows, **eBPF** on Linux, a
 
 Rustinel is designed for blue teams, detection engineers, researchers, and anyone who wants a transparent endpoint detection engine they can inspect, run, test, and extend.
 
+Visit the [official Rustinel site](https://rustinel.io/) for the main project home.
+
 ## Start here
 
 - [Getting Started](getting-started.md) — install and run Rustinel
@@ -38,6 +40,8 @@ Rustinel currently provides:
 - ECS NDJSON alert output
 - Hot reload for rules and indicator files
 - Optional active response with dry-run and allowlists
+
+macOS support is experimental while the project waits for the required Endpoint Security Framework entitlement.
 
 ## What Rustinel is not
 

--- a/zensical.toml
+++ b/zensical.toml
@@ -32,6 +32,10 @@ site_url = "https://docs.rustinel.io/"
 # The repo_url is the URL of your project's repository.
 repo_url = "https://github.com/Karib0u/rustinel"
 
+# Zensical derives source/edit links from repo_url. Pin them to the repository's
+# main branch and docs directory instead of the default master branch.
+edit_uri = "edit/main/docs/"
+
 # The copyright notice appears in the page footer and can contain an HTML
 # fragment.
 #
@@ -327,6 +331,9 @@ toggle.name = "Switch to light mode"
 # The "extra" section contains miscellaneous settings.
 # ----------------------------------------------------------------------------
 [[project.extra.social]]
+icon = "lucide/globe"
+link = "https://rustinel.io/"
+
+[[project.extra.social]]
 icon = "fontawesome/brands/github"
 link = "https://github.com/Karib0u/rustinel"
-


### PR DESCRIPTION
## Summary

- Add rustinel.io as the official site link in the README and documentation site metadata.
- Pin Zensical source/edit links to the main branch under docs/.
- Document macOS support as experimental while the project waits for the Endpoint Security Framework entitlement.

## Validation

- `zensical build`
- `git diff --check -- README.md docs/getting-started.md docs/index.md zensical.toml`