### PR TITLE
[codex] Document macOS detection coverage

### DIFF
--- a/docs/detection.md
+++ b/docs/detection.md
@@ -31,22 +31,24 @@ All detection hits are written as ECS NDJSON alerts. The same alerts can also fe
 
 ### Supported Logsource Families
 
-| Family | Windows ETW | Linux eBPF | Notes |
-| --- | --- | --- | --- |
-| `process_creation` | Yes | Yes | Sysmon-style process events |
-| `network_connection` | Yes | Yes | Generic `service: connection`, `category: network` is also supported |
-| `file_event` | Yes | Yes | Base file family |
-| `file_create` | Yes | Yes | Derived from file event ID / opcode |
-| `file_delete` | Yes | Yes | Derived from file event ID / opcode |
-| `file_change` | Yes | Yes | Derived from file event ID / opcode |
-| `file_rename` | Yes | Yes | Derived from file event ID / opcode |
-| `dns_query` | Yes | Yes | Generic `category: dns` and `service: dns`, `category: network` are also supported |
-| `registry_event` / `registry_*` | Yes | No | Windows only |
-| `image_load` | Yes | No | Windows only |
-| `ps_script` | Yes | No | Windows only |
-| `wmi_event` | Yes | No | Windows only |
-| `service_creation` | Yes | No | Windows only |
-| `task_creation` | Yes | No | Windows only |
+| Family | Windows ETW | Linux eBPF | macOS ESF/bpf | Notes |
+| --- | --- | --- | --- | --- |
+| `process_creation` | Yes | Yes | Yes | Sysmon-style process events |
+| `network_connection` | Yes | Yes | Yes | Generic `service: connection`, `category: network` is also supported; macOS connections are best-effort process-attributed |
+| `file_event` | Yes | Yes | Yes | Base file family |
+| `file_create` | Yes | Yes | Yes | Derived from file event ID / opcode (ESF event type on macOS) |
+| `file_delete` | Yes | Yes | Yes | Derived from file event ID / opcode (ESF event type on macOS) |
+| `file_change` | Yes | Yes | Yes | Derived from file event ID / opcode (ESF event type on macOS) |
+| `file_rename` | Yes | Yes | Yes | Derived from file event ID / opcode (ESF event type on macOS) |
+| `dns_query` | Yes | Yes | Yes | Generic `category: dns` and `service: dns`, `category: network` are also supported |
+| `registry_event` / `registry_*` | Yes | No | No | Windows only |
+| `image_load` | Yes | No | No | Windows only |
+| `ps_script` | Yes | No | No | Windows only |
+| `wmi_event` | Yes | No | No | Windows only |
+| `service_creation` | Yes | No | No | Windows only |
+| `task_creation` | Yes | No | No | Windows only |
+
+macOS telemetry comes from two sources: Endpoint Security (ESF) for process and file events (`provider: esf`), and `/dev/bpf` packet capture for network and DNS (`provider: bpf`). Its coverage mirrors Linux; the Windows-only families above are not collected on macOS.
 
 ### Field Model
 
@@ -56,18 +58,25 @@ All detection hits are written as ECS NDJSON alerts. The same alerts can also fe
 - Shared file fields include `TargetFilename`, `Image`, `ProcessId`, and `User`.
 - DNS rules can use either Sysmon-style names such as `QueryName` and `QueryResults` or the generic aliases `query`, `answer`, and `record_type`.
 
+Per-platform process field notes:
+
+- On Linux, the kernel exec event carries only `Image`, `ProcessId`, and `User`; `CommandLine`, `ParentImage`, `ParentProcessId`, `ParentCommandLine`, and `CurrentDirectory` are enriched from `/proc/<pid>` and may be absent for very short-lived processes.
+- On macOS, ESF exec events carry `CommandLine` (argv), `ParentImage`, `ParentProcessId`, and `CurrentDirectory` natively. `ParentCommandLine` is **not** provided by ESF exec events, and `IntegrityLevel` / `LogonId` / `LogonGuid` are Windows-only.
+
 DNS field availability differs by platform:
 
-| Field | Windows ETW | Linux eBPF |
-| --- | --- | --- |
-| `QueryName` | Yes | Yes |
-| `QueryResults` | Yes | No |
-| `QueryStatus` | Yes | No |
-| `RecordType` | Yes | Yes |
-| `Image` | Yes | Yes |
-| `ProcessId` | Yes | Yes |
+| Field | Windows ETW | Linux eBPF | macOS bpf |
+| --- | --- | --- | --- |
+| `QueryName` | Yes | Yes | Yes |
+| `QueryResults` | Yes | No | No |
+| `QueryStatus` | Yes | No | No |
+| `RecordType` | Yes | Yes | Yes |
+| `Image` | Yes | Yes | No |
+| `ProcessId` | Yes | Yes | No |
 
 On Linux, `QueryName` is extracted in userspace from the bounded raw DNS payload emitted by the eBPF `sendto` path. This covers outbound plaintext DNS queries observed on port 53. It does not cover DNS-over-HTTPS, DNS-over-TLS, cached resolver answers that do not send a packet, or DNS response answers. `QueryResults` and `QueryStatus` remain Windows-only today.
+
+On macOS, `QueryName` and `RecordType` are parsed from `/dev/bpf` packet capture of outbound port-53 traffic, so the same plaintext-only limitations apply. Because capture is packet-based rather than per-process, macOS DNS events are **not** attributed to a process; `Image` and `ProcessId` are empty. Likewise, macOS `network_connection` events do not populate `DestinationHostname`, and their process attribution is best-effort. See [Limitations](limitations.md#macos-network-and-dns-attribution).
 
 After a Sigma hit, Rustinel enriches non-process alerts with `process_context` from the process cache when that context is available.
 
@@ -114,7 +123,7 @@ Rustinel truncates long match metadata to keep alerts bounded.
 
 ## YARA
 
-YARA scanning is shared across both supported platforms.
+YARA scanning runs on all supported platforms (Windows, Linux, and macOS).
 
 ### Behavior
 
@@ -143,11 +152,13 @@ YARA memory scanning is optional and disabled by default (`scanner.yara_memory_e
 
 When enabled, Rustinel queues process IDs from process-start events to a bounded background worker. The worker waits a configurable delay (`yara_memory_delay_ms`, default 750 ms) to allow packers or loaders to finish unpacking, then reads a limited amount of selected process memory and scans it with the active YARA ruleset.
 
-Default behavior scans private readable memory only and avoids mapped or image-backed regions to reduce overhead and false positives. Each matching YARA rule emits its own `critical` alert. The alert `provider` field is set to `yara-memory` to distinguish memory hits from file hits (`etw` or `ebpf`).
+Default behavior scans private readable memory only and avoids mapped or image-backed regions to reduce overhead and false positives. Each matching YARA rule emits its own `critical` alert. The alert `provider` field is set to `yara-memory` to distinguish memory hits from file hits (`etw`, `ebpf`, or `esf`).
 
 Memory scanning follows the same allowlist as file YARA: process paths allowlisted via `scanner.yara_allowlist_paths` are not queued for memory scanning either.
 
 The worker uses `try_send` so a full queue drops jobs rather than blocking the sensor event path.
+
+On macOS, memory scanning additionally depends on `task_for_pid` access, which is heavily restricted (it generally requires root plus SIP/AMFI relaxation or a specific entitlement); when access is denied, memory scanning simply yields nothing. File YARA scanning is unaffected. See [Limitations](limitations.md#macos-memory-scanning).
 
 ## IOC
 
@@ -170,7 +181,7 @@ The IOC engine hot reloads indicator files and splits work between inline event 
 - Hash results are cached by file identity with a 10,000-entry cap and a 6-hour TTL.
 - Inline IOC matching can emit multiple alerts from a single event.
 
-Domain IOC matching works on both Windows DNS events and Linux outbound DNS query events through `QueryName`. IOC matching on DNS answer IPs still depends on `QueryResults`, so it is effectively Windows-only today.
+Domain IOC matching works on Windows DNS events and on Linux and macOS outbound DNS query events through `QueryName`. IOC matching on DNS answer IPs still depends on `QueryResults`, so it is effectively Windows-only today.
 
 ### IOC File Format
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,6 +33,7 @@ Rustinel currently provides:
 
 - Windows telemetry collection through ETW
 - Linux telemetry collection through eBPF
+- macOS telemetry collection through Endpoint Security and `/dev/bpf`
 - A shared event model across supported platforms
 - Sigma rule evaluation on normalized events
 - YARA scanning on process creation


### PR DESCRIPTION
## Summary

- Add macOS ESF/bpf coverage to the detection support matrix.
- Document macOS process, DNS, network attribution, YARA memory scanning, and IOC behavior.
- Add macOS telemetry to the docs landing page feature list.

## Validation

- `cargo test --manifest-path /Users/theo/src/rustinel/Cargo.toml` did not complete locally. The build failed before tests in `libproc` bindgen because the local macOS toolchain reports `arm64-apple-darwin` while bindgen expected `aarch64-apple-darwin`.