### PR TITLE
chore(ci): slim release notes to lean install + downloads

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -463,68 +463,19 @@ jobs:
             | macOS | arm64 | `rustinel-${{ steps.version.outputs.version }}-aarch64-apple-darwin.tar.gz` |
             | macOS | x86_64 | `rustinel-${{ steps.version.outputs.version }}-x86_64-apple-darwin.tar.gz` |
 
-            ## Fast install
+            ## Install
 
-            Linux and macOS:
+            **Linux / macOS**
 
             ```sh
             curl -fsSL https://raw.githubusercontent.com/Karib0u/rustinel/main/scripts/install/install.sh | sh -s -- --version ${{ steps.version.outputs.version }} --run
             ```
 
-            To inspect the script first:
-
-            ```sh
-            curl -fsSLO https://raw.githubusercontent.com/Karib0u/rustinel/main/scripts/install/install.sh
-            less install.sh
-            sh install.sh --version ${{ steps.version.outputs.version }} --run
-            ```
-
-            Windows PowerShell:
+            **Windows (PowerShell)**
 
             ```powershell
-            Invoke-WebRequest https://raw.githubusercontent.com/Karib0u/rustinel/main/scripts/install/install.ps1 -OutFile install-rustinel.ps1
-            powershell -ExecutionPolicy Bypass -File .\install-rustinel.ps1 -Version ${{ steps.version.outputs.version }} -Run
+            iwr https://raw.githubusercontent.com/Karib0u/rustinel/main/scripts/install/install.ps1 -OutFile install-rustinel.ps1; powershell -ExecutionPolicy Bypass -File .\install-rustinel.ps1 -Version ${{ steps.version.outputs.version }} -Run
             ```
 
-            The install scripts only install published release binaries. They do
-            not install Rust, Cargo, or build from source.
-
-            ## Linux
-
-            ```sh
-            tar xzf rustinel-${{ steps.version.outputs.version }}-<arch>.tar.gz
-            cd rustinel-${{ steps.version.outputs.version }}-<arch>
-            # Customize config.toml, add rules to rules/
-            sudo ./rustinel run
-            ```
-
-            A `rustinel.service` systemd unit file is included in the archive for persistent deployment.
-
-            **Requirements:** Linux 5.8+ with BTF enabled, `CAP_BPF` or root.
-
-            ## Windows
-
-            1. Extract the ZIP
-            2. Customize `config.toml`, add rules to `rules/`
-            3. Run as Administrator: `.\rustinel.exe run`
-
-            **Requirements:** Windows 10/11 or Server 2016+ (x64), Administrator privileges.
-
-            ## macOS
-
-            ```sh
-            tar xzf rustinel-${{ steps.version.outputs.version }}-<arch>.tar.gz
-            cd rustinel-${{ steps.version.outputs.version }}-<arch>
-            # Customize config.toml, add rules to rules/
-            sudo ./rustinel run
-            ```
-
-            A `com.rustinel.agent.plist` LaunchDaemon is included for persistent deployment.
-
-            **Requirements:** macOS 11+, root, and the Endpoint Security entitlement
-            (signed and notarized builds), or SIP/AMFI relaxed for local testing.
-
-            ## SIEM demos
-
-            Release archives include `examples/siem/elastic` and
-            `examples/siem/splunk` for local Elastic and Splunk ingestion tests.
+            📖 Full install, configuration & SIEM ingestion guides → https://docs.rustinel.io/getting-started/
+            🔒 Scripts install published release binaries only (no build from source). Verify downloads with `rustinel-${{ steps.version.outputs.version }}-checksums-sha256.txt`.


### PR DESCRIPTION
## What

Trims the release-note template in `.github/workflows/ci-cd.yml`. The `body:` previously hard-coded ~75 lines of static, every-release install tutorial (`Fast install`, per-OS `Linux`/`Windows`/`macOS` run blocks, requirements matrices, `SIEM demos`) — all duplicated from the README/docs — which buried the version-specific `## What's Changed` at the very bottom.

## After

The body is now lean (~25 lines):
- **Downloads** — platform → filename table (kept; version-specific).
- **Install** — one-liner per OS (Linux/macOS curl, Windows PowerShell).
- A link to the full install/config/SIEM guides at https://docs.rustinel.io/getting-started/.
- A checksum-verification note.

`generate_release_notes: true` still appends `## What's Changed` right after, so the changelog now sits near the top instead of after a wall of boilerplate.

## Rationale

Standard FOSS practice: release notes carry "what changed / should I upgrade," not a from-scratch install guide. Static how-to has one canonical home (README + docs); the release links to it. The live v1.1.0 notes were updated by hand to match this structure.

## Validation
- Workflow YAML parses (`ruby -ryaml`).