### PR TITLE
fix(install): drop broken HEAD precheck in install.ps1

### DIFF
--- a/scripts/install/install.ps1
+++ b/scripts/install/install.ps1
@@ -30,21 +30,22 @@ $checksums = "rustinel-$Version-checksums-sha256.txt"
 $baseUrl = "https://github.com/$Repo/releases/download/v$Version"
 $tmp = Join-Path ([System.IO.Path]::GetTempPath()) "rustinel-install-$([System.Guid]::NewGuid())"
 
-try {
-    Invoke-WebRequest -Uri "$baseUrl/$asset" -Method Head | Out-Null
-} catch {
-    Show-InstallScope
-    throw "No published release asset found for this host: $asset. Release page: https://github.com/$Repo/releases/tag/v$Version"
-}
-
 New-Item -ItemType Directory -Path $tmp | Out-Null
 
 try {
     $assetPath = Join-Path $tmp $asset
     $checksumsPath = Join-Path $tmp $checksums
 
+    # GitHub redirects release assets to a presigned CDN URL signed for GET, so a
+    # HEAD probe is rejected and Invoke-WebRequest throws a false "not found".
+    # Let the actual GET download be the existence check instead.
     Write-Host "Downloading $asset"
-    Invoke-WebRequest -Uri "$baseUrl/$asset" -OutFile $assetPath
+    try {
+        Invoke-WebRequest -Uri "$baseUrl/$asset" -OutFile $assetPath
+    } catch {
+        Show-InstallScope
+        throw "No published release asset found for this host: $asset. Release page: https://github.com/$Repo/releases/tag/v$Version"
+    }
     Invoke-WebRequest -Uri "$baseUrl/$checksums" -OutFile $checksumsPath
 
     $expected = Get-Content $checksumsPath |


### PR DESCRIPTION
## Problem

`install.ps1` fails on **every** Windows host with a false:

> No published release asset found for this host: rustinel-X.Y.Z-x86_64-pc-windows-msvc.zip

even when the asset exists. GitHub 302-redirects release-asset URLs to a presigned CDN URL that is signed for **GET**, so the existence probe

```powershell
Invoke-WebRequest -Uri "$baseUrl/$asset" -Method Head
```

is rejected at the CDN and `Invoke-WebRequest` throws. `install.sh` is unaffected because `curl -fsIL` follows the redirect and the HEAD succeeds there.

Verified against v1.1.0:
- `curl -sIL <asset>` (HEAD, follow) → 200
- `curl -sL -r 0-0 <asset>` (GET) → 206
- pwsh `Invoke-WebRequest -Method Head` → throws

## Fix

Remove the redundant HEAD precheck and let the actual GET download (which already runs immediately after) be the existence check, preserving the same `Show-InstallScope` + friendly message on a genuine 404.

## How found

Discovered while wiring up the new atomic firing-test CI in `rustinel-rules` (installs the released engine on real Win/Linux runners). The Linux job passed end-to-end; the Windows job failed here at engine install. With this merged to `main`, that CI will pick up the fixed script automatically.