### PR TITLE
fix(sigma): make windash honor the string operator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2403,7 +2403,7 @@ dependencies = [
 
 [[package]]
 name = "rustinel"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustinel"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 authors = []
 description = "Open-source EDR for Windows (ETW) and Linux (eBPF) with Sigma, YARA, and IOC detection"

--- a/src/engine/matcher.rs
+++ b/src/engine/matcher.rs
@@ -385,12 +385,24 @@ impl Engine {
                             warn!("Invalid Regex in rule: {}", s);
                         }
                     } else if is_windash {
-                        // 5. Handle Windash (Converts to Regex)
+                        // 5. Handle Windash (Converts to Regex), honoring the
+                        // string operator. windash is almost always paired with
+                        // `contains` (command-line flag detection), so anchoring
+                        // with ^...$ unconditionally made those rules unmatchable.
                         let windash_pattern = Self::apply_windash(s);
-                        let re_str = if is_cased {
-                            format!("^{}$", windash_pattern)
+                        let body = if modifiers.contains(&"contains") {
+                            windash_pattern
+                        } else if modifiers.contains(&"startswith") {
+                            format!("^{}", windash_pattern)
+                        } else if modifiers.contains(&"endswith") {
+                            format!("{}$", windash_pattern)
                         } else {
-                            format!("(?i)^{}$", windash_pattern)
+                            format!("^{}$", windash_pattern)
+                        };
+                        let re_str = if is_cased {
+                            body
+                        } else {
+                            format!("(?i){}", body)
                         };
                         if let Ok(re) = Regex::new(&re_str) {
                             patterns.push(FieldPattern::Regex(re));

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -420,6 +420,81 @@ detection:
     }
 
     #[test]
+    fn test_windash_contains_matches_substring() {
+        // Regression: `contains|windash` must match a substring, not require the
+        // whole field to equal the pattern (the encoded-PowerShell case).
+        let engine = Engine::new();
+        let rule_yaml = r#"
+title: WindashContains
+logsource:
+  category: process_creation
+detection:
+  selection:
+    CommandLine|contains|windash:
+      - ' -encodedcommand '
+  condition: selection
+"#;
+
+        let rule: SigmaRule = serde_yaml::from_str(rule_yaml).unwrap();
+        let compiled = engine.compile_rule(rule).unwrap();
+
+        let mut engine = Engine::new();
+        engine
+            .rules_by_logsource
+            .entry(compiled.logsource.clone())
+            .or_default()
+            .push(compiled);
+
+        let make_event = |cmd: &str| NormalizedEvent {
+            timestamp: "2025-01-01T00:00:00Z".to_string(),
+            platform: Platform::Windows,
+            provider: "etw".to_string(),
+            category: EventCategory::Process,
+            event_id: 1,
+            event_id_string: "1".to_string(),
+            opcode: 1,
+            fields: EventFields::ProcessCreation(ProcessCreationFields {
+                image: Some(
+                    "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe".to_string(),
+                ),
+                original_file_name: None,
+                product: None,
+                description: None,
+                target_image: None,
+                command_line: Some(cmd.to_string()),
+                process_id: Some("1234".to_string()),
+                process_start_time: None,
+                parent_process_id: None,
+                parent_image: None,
+                parent_command_line: None,
+                current_directory: None,
+                integrity_level: None,
+                user: None,
+                logon_id: None,
+                logon_guid: None,
+            }),
+            process_context: None,
+        };
+
+        // Real-world casing, as a substring (this used to NOT match).
+        assert!(engine
+            .check_event(&make_event(
+                "powershell.exe -NoProfile -EncodedCommand SQBFAFgA"
+            ))
+            .is_some());
+
+        // windash dash/slash variant also matches.
+        assert!(engine
+            .check_event(&make_event("powershell.exe /EncodedCommand SQBFAFgA"))
+            .is_some());
+
+        // Negative: no encoded-command flag present.
+        assert!(engine
+            .check_event(&make_event("powershell.exe -NoProfile -File script.ps1"))
+            .is_none());
+    }
+
+    #[test]
     fn test_rule_loading() {
         let mut engine = Engine::new();
 


### PR DESCRIPTION
## Problem

The `windash` modifier was compiled as an **anchored full-match** regex regardless of the string operator it was paired with:

```rust
} else if is_windash {
    let windash_pattern = Self::apply_windash(s);
    let re_str = if is_cased { format!("^{}$", windash_pattern) }
                 else        { format!("(?i)^{}$", windash_pattern) };
```

`windash` is almost always paired with `contains` (command-line flag detection), so ` -encodedcommand ` compiled to `(?i)^ -encodedcommand $` — requiring the **entire** CommandLine to equal that string. Result: every `|contains|windash` rule was effectively unmatchable. In the content repo that's `proc_creation_win_susp_encoded_powershell` and `proc_creation_win_susp_schtasks_create` — a real `powershell -EncodedCommand ...` would not be detected.

## Fix

Build the regex from the operator:
- `contains` → substring (no anchors)
- `startswith` → `^…`
- `endswith` → `…$`
- else → exact `^…$`

(`(?i)` still applied unless `cased`.) Adds `test_windash_contains_matches_substring` asserting `CommandLine|contains|windash` matches a real `-EncodedCommand` substring plus a dash/slash variant, and rejects a non-match.

`cargo test --lib engine::tests` → 30 passed. fmt + clippy clean.

## How found

The new atomic firing-test CI in `rustinel-rules`: the encoded-PowerShell rule never fired on a real Windows runner even though the process ran with `-EncodedCommand` (verified in the engine alert log), while non-windash rules (certutil, registry Run key) fired. Root-caused to this branch.