### PR TITLE
docs: refresh + cross-doc audit cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,436 +1,162 @@
 <p align="center">
-  <img src="docs/images/logo-rustinel.png" alt="Rustinel logo" width="280">
+  <img src="docs/images/logo-rustinel.png" alt="Rustinel" width="240">
 </p>
 
-# Rustinel
+<h1 align="center">Rustinel</h1>
 
-**Open-source endpoint detection for Windows, Linux, and macOS**
+<p align="center">
+  <b>Open-source endpoint detection for Windows, Linux, and macOS.</b><br>
+  Native telemetry → Sigma / YARA / IOC detection → SIEM-ready alerts. Written in Rust.
+</p>
 
 <p align="center">
   <a href="https://github.com/Karib0u/rustinel/actions/workflows/ci-cd.yml"><img src="https://github.com/Karib0u/rustinel/actions/workflows/ci-cd.yml/badge.svg?style=flat-square" alt="CI"></a>
   <a href="https://github.com/Karib0u/rustinel/releases/latest"><img src="https://img.shields.io/github/v/release/Karib0u/rustinel?style=flat-square&color=ff8a3d" alt="Latest release"></a>
   <a href="https://github.com/Karib0u/rustinel/releases"><img src="https://img.shields.io/github/downloads/Karib0u/rustinel/total?style=flat-square&color=ff8a3d" alt="Downloads"></a>
   <a href="https://github.com/Karib0u/rustinel/stargazers"><img src="https://img.shields.io/github/stars/Karib0u/rustinel?style=flat-square&color=ff8a3d" alt="Stars"></a>
-  <br>
-  <img src="https://img.shields.io/badge/platform-Windows%20ETW-blue?style=flat-square&logo=windows" alt="Platform Windows ETW">
-  <img src="https://img.shields.io/badge/platform-Linux%20eBPF-orange?style=flat-square&logo=linux" alt="Platform Linux eBPF">
-  <img src="https://img.shields.io/badge/platform-macOS%20ESF-black?style=flat-square&logo=apple" alt="Platform macOS ESF">
-  <a href="https://docs.rustinel.io/"><img src="https://img.shields.io/badge/docs-rustinel.io-d97835?style=flat-square" alt="Docs"></a>
-  <img src="https://img.shields.io/badge/license-Apache%202.0-ff8a3d?style=flat-square" alt="License">
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-ff8a3d?style=flat-square" alt="License"></a>
 </p>
 
-[Official site](https://rustinel.io/) · [Documentation](https://docs.rustinel.io/) · [Latest Release](https://github.com/Karib0u/rustinel/releases/latest) · [SIEM demos](docs/siem-demos.md)
-
-Rustinel is an open-source endpoint detection project for **Windows**, **Linux**, and **macOS**.
-
-It collects native host telemetry using **ETW** on Windows, **eBPF** on Linux, and **Endpoint Security** plus **`/dev/bpf`** on macOS, normalizes events into a shared model, evaluates **Sigma**, **YARA**, and **IOC** detections, writes **ECS NDJSON** alerts, and can optionally terminate malicious processes.
-
-The goal is simple: give blue teams, researchers, and detection engineers a transparent endpoint detection engine they can inspect, run, test, and extend.
+<p align="center">
+  <a href="https://rustinel.io/">Website</a> ·
+  <a href="https://docs.rustinel.io/">Docs</a> ·
+  <a href="https://github.com/Karib0u/rustinel/releases/latest">Download</a> ·
+  <a href="docs/siem-demos.md">SIEM demos</a>
+</p>
 
 <p align="center">
-  <img src="docs/images/demo.gif" alt="Rustinel Demo" width="900">
+  <img src="docs/images/demo.gif" alt="Rustinel demo" width="860">
 </p>
 
 ---
 
-## Try the latest release
+## Get your first alert in 60 seconds
 
-Use this path if you want to see a first alert quickly. The release archives
-include `config.toml`, bundled demo rules, IOC files, and an empty `logs/`
-directory.
+Rustinel ships as a single binary with bundled demo rules. Install it, trigger a test command, and read the alert.
 
-### Linux
+**Linux & macOS**
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/Karib0u/rustinel/main/scripts/install/install.sh | sh -s -- --run
 ```
 
-Prefer to inspect first:
-
-```bash
-curl -fsSLO https://raw.githubusercontent.com/Karib0u/rustinel/main/scripts/install/install.sh
-less install.sh
-sh install.sh --run
-```
-
-### Windows
-
-Run from an elevated PowerShell:
+**Windows** — from an elevated PowerShell:
 
 ```powershell
 Invoke-WebRequest https://raw.githubusercontent.com/Karib0u/rustinel/main/scripts/install/install.ps1 -OutFile install-rustinel.ps1
 powershell -ExecutionPolicy Bypass -File .\install-rustinel.ps1 -Run
 ```
 
-Then trigger the bundled demo rule:
+With the agent running, fire the bundled demo rule — same command on every platform:
 
-```text
-Linux:   whoami
-Windows: whoami /all
+```bash
+whoami
 ```
 
-Alerts are written to `logs/alerts.json.<date>`. To ingest them locally, use the
-[Elastic and Splunk demos](docs/siem-demos.md).
+Your alert lands in `logs/alerts.json.<date>` as ECS NDJSON — ready to ship straight to a SIEM.
 
-The install scripts only install published release binaries. They do not install
-Rust, Cargo, or build from source. If your OS or architecture has no release
-asset, they exit with a link to the [source build path](docs/getting-started.md#compile-from-source).
-
-Prefer manual downloads? Use the [latest GitHub Release](https://github.com/Karib0u/rustinel/releases/latest).
+> **Prefer to read before you run?** Download the [install script](scripts/install/install.sh) and inspect it, or grab a binary from the [latest release](https://github.com/Karib0u/rustinel/releases/latest). The installer only pulls published release binaries — it never builds from source. macOS support is experimental and needs root plus an Endpoint Security entitlement; see [Getting Started](https://docs.rustinel.io/getting-started/).
 
 ---
 
-## Why Rustinel exists
+## Why Rustinel
 
-Rustinel was created because there was a real gap in the open-source endpoint detection space.
+A transparent endpoint detection engine you can read, run, test, and extend — no black box.
 
-The project aims to combine:
-
-- Native Windows telemetry through **ETW**
-- Native Linux telemetry through **eBPF**
-- A single cross-platform detection pipeline
-- Support for community detection formats like **Sigma** and **YARA**
-- IOC matching for hashes, IPs, domains, and path regexes
-- ECS NDJSON alert output for SIEM-friendly ingestion
-- A performant, memory-safe implementation in **Rust**
-
-Some tools solve parts of this problem, but Rustinel brings these pieces together in one transparent and extensible agent.
-
-Rustinel is not trying to hide behind a black box. The project is designed so defenders can understand exactly what telemetry is collected, how detections are evaluated, and where the current limits are.
-
----
-
-## What Rustinel does today
-
-Rustinel currently provides:
-
-- Windows telemetry collection through ETW
-- Linux telemetry collection through eBPF
-- macOS telemetry collection through Endpoint Security and `/dev/bpf`
-- A shared event model across supported platforms
-- Sigma rule evaluation on normalized events
-- YARA scanning on process creation
-- IOC matching for file hashes, IPs, domains, and path regexes
-- ECS NDJSON alert output
-- Hot reload for rules and indicator files
-- Optional active response with dry-run and allowlists
-- Windows service support
-- Linux foreground execution under root or a supervisor of your choice
-- macOS foreground execution under root, or a launchd daemon
-
----
-
-## Architecture
-
-```text
-Windows hosts        Linux hosts        macOS hosts
-   ETW                  eBPF             ESF + /dev/bpf
-    |                    |                    |
-    +--------------------+--------------------+
-                    |
-          Normalized event model
-                    |
-        +-----------+-----------+
-        |           |           |
-      Sigma        YARA        IOC
-   behavior     process      hashes,
-   rules        creation     IPs,
-                scanning     domains,
-                             path regexes
-        |           |           |
-        +-----------+-----------+
-                    |
-             ECS NDJSON alerts
-                    |
-          Optional active response
-```
-
----
-
-## Detection model
-
-Rustinel combines three detection layers.
-
-### Sigma
-
-Sigma is used for behavioral detections on normalized endpoint events.
-
-Examples include:
-
-- Suspicious PowerShell activity
-- WMI execution
-- Service creation
-- Scheduled task creation
-- Suspicious process execution
-- Linux process, network, file, and DNS query activity
-
-Sigma support makes Rustinel practical for detection engineers because existing community rules can be reused and adapted instead of being rewritten into a proprietary format.
-
-### YARA
-
-YARA is used for file and tooling detection.
-
-Today, Rustinel scans executables on process creation. This provides a practical high-signal scanning point without trying to behave like a full antivirus engine scanning everything on disk all the time.
-
-YARA memory scanning is also supported, targeting private executable regions to detect packed, obfuscated, or runtime-unpacked payloads.
-
-### IOC matching
-
-IOC matching provides fast deterministic checks against:
-
-- File hashes
-- IP addresses
-- Domains
-- Path regexes
-
-IOC matching is useful for threat intelligence and incident response, but it is strongest when combined with behavioral detections and YARA scanning. Domain IOCs can match DNS `QueryName` on Windows, Linux, and macOS; Linux covers outbound plaintext DNS queries observed by eBPF, and macOS covers plaintext DNS queries observed via `/dev/bpf` capture.
+- **Native telemetry** — ETW on Windows, eBPF on Linux, Endpoint Security + `/dev/bpf` on macOS, normalized into one shared event model.
+- **Three detection layers** — Sigma for behavior, YARA for files and memory, IOC matching for hashes, IPs, domains, and path regexes.
+- **Reuse community rules** — bring existing Sigma and YARA rules instead of rewriting them into a proprietary format.
+- **SIEM-ready output** — ECS 9.3.0 NDJSON alerts that drop into Elastic, Splunk, and friends.
+- **Operational basics** — hot-reload for rules and IOCs, optional active response with dry-run + allowlists, Windows service and launchd support.
 
 ---
 
 ## Platform support
 
-| Platform | Sensor | Current coverage | Runtime model |
+| Platform | Sensor | Telemetry | Status |
 | --- | --- | --- | --- |
-| Windows 10/11, Server 2016+ | ETW | Process, image load, network, file, registry, DNS, PowerShell, WMI, service, task | Foreground run or built-in Windows service commands |
-| Linux 5.8+ with BTF | eBPF | Process, network, file, DNS | Foreground run under root or your supervisor of choice |
-| macOS 11+ | Endpoint Security + `/dev/bpf` | Process, file, network, DNS | Experimental; foreground run under root (signed/entitled or SIP relaxed) or a launchd daemon |
+| Windows 10/11, Server 2016+ | ETW | Process, image load, network, file, registry, DNS, PowerShell, WMI, service, task | Stable |
+| Linux 5.8+ (BTF) | eBPF | Process, network, file, DNS | Stable |
+| macOS 11+ | Endpoint Security + `/dev/bpf` | Process, file, network, DNS | Experimental |
 
-Windows telemetry coverage is broader today. Linux and macOS support currently focus on process, network, file, and DNS telemetry. Linux DNS events include outbound plaintext DNS `QueryName`; DNS response answers (`QueryResults`) are not parsed yet. macOS collects process and file events through Endpoint Security and network and DNS through `/dev/bpf` capture; network events are attributed to a process on a best-effort basis.
-
-macOS support is experimental while the project waits for the required Endpoint Security Framework entitlement.
+Windows coverage is the broadest today; Linux and macOS focus on process, network, file, and DNS. macOS is experimental while the project awaits the Endpoint Security entitlement. Full notes in the [platform docs](https://docs.rustinel.io/architecture/).
 
 ---
 
-## 60-second demo
+## How detection works
 
-Download Rustinel, start the agent, trigger a test command, and inspect the generated alert.
-
-### Windows
-
-```powershell
-cd .\rustinel-<version>-x86_64-pc-windows-msvc
-.\rustinel.exe run
-whoami /all
-type .\logs\alerts.json.*
+```text
+  ETW (Windows) · eBPF (Linux) · ESF + /dev/bpf (macOS)
+                        │
+              Normalized event model
+                        │
+        ┌───────────────┼───────────────┐
+      Sigma            YARA             IOC
+    behavior        files +         hashes, IPs,
+      rules          memory         domains, paths
+        └───────────────┼───────────────┘
+                        │
+                ECS NDJSON alerts
+                        │
+              Optional active response
 ```
 
-### Linux
-
-```bash
-cd rustinel-<version>-x86_64-unknown-linux-musl
-sudo ./rustinel run
-whoami
-cat logs/alerts.json.*
-```
-
-### macOS
-
-```bash
-cd rustinel-<version>-aarch64-apple-darwin
-sudo ./rustinel run
-whoami
-cat logs/alerts.json.*
-```
-
-Creating an Endpoint Security client requires root and the
-`com.apple.developer.endpoint-security.client` entitlement on signed,
-notarized builds. For local testing you can run with SIP/AMFI relaxed. See the
-[development docs](docs/development.md) for ad-hoc signing steps.
-
-The bundled demo rules are intended to validate that telemetry collection, rule evaluation, and alert output are working.
+See the [detection docs](https://docs.rustinel.io/detection/) for rule authoring, YARA memory scanning, and IOC formats.
 
 ---
 
-## Quick start
+## Detection packs
 
-Download the release package for your platform from [GitHub Releases](https://github.com/Karib0u/rustinel/releases) and extract it.
-
-### Windows
-
-Download:
+The bundled rules just prove the pipeline works. For real coverage, load curated content from **[rustinel-rules](https://github.com/Karib0u/rustinel-rules)** — the official, versioned, CI-tested detection repository.
 
 ```text
-rustinel-<version>-x86_64-pc-windows-msvc.zip
+rustinel        →  the engine that collects telemetry and evaluates rules
+rustinel-rules  →  the Sigma / YARA / IOC packs it loads  (no conversion step)
 ```
 
-Extract it, then run:
+Each pack materializes into folders you point `config.toml` straight at. Browse the [pack catalog](https://github.com/Karib0u/rustinel-rules) to get started.
 
-```powershell
-cd .\rustinel-<version>-x86_64-pc-windows-msvc
-.\rustinel.exe run
-whoami /all
-```
+---
 
-The bundled Sigma demo rule should write an alert to:
+## Good for / not for
 
-```text
-logs/alerts.json.<date>
-```
+**Use it for** detection engineering, rule development and testing, blue-team labs, cross-platform detection research, and SIEM pipeline validation.
 
-### Linux
-
-Choose the archive that matches your architecture:
-
-```text
-rustinel-<version>-x86_64-unknown-linux-musl.tar.gz
-rustinel-<version>-aarch64-unknown-linux-musl.tar.gz
-```
-
-Extract and run:
-
-```bash
-tar xzf rustinel-<version>-x86_64-unknown-linux-musl.tar.gz
-cd rustinel-<version>-x86_64-unknown-linux-musl
-sudo ./rustinel run
-whoami
-```
-
-If startup fails with `tracefs not found`, mount the tracing filesystems and retry:
-
-```bash
-mount -t tracefs tracefs /sys/kernel/tracing
-mount -t debugfs debugfs /sys/kernel/debug
-```
-
-The bundled Sigma demo rule should write an alert to:
-
-```text
-logs/alerts.json.<date>
-```
-
-### macOS
-
-Choose the archive that matches your architecture:
-
-```text
-rustinel-<version>-aarch64-apple-darwin.tar.gz
-rustinel-<version>-x86_64-apple-darwin.tar.gz
-```
-
-Extract and run as root:
-
-```bash
-tar xzf rustinel-<version>-aarch64-apple-darwin.tar.gz
-cd rustinel-<version>-aarch64-apple-darwin
-sudo ./rustinel run
-```
-
-If startup fails with `NotPrivileged`, the Endpoint Security client could not be
-created: run as root with a signed, entitled build, or relax SIP/AMFI for local
-testing. A `com.rustinel.agent.plist` LaunchDaemon is included for persistent
-deployment.
+**It is not** a drop-in replacement for a mature commercial EDR. Rustinel does not provide kernel-level self-protection, pre-execution blocking, or anti-tamper guarantees, and a sufficiently privileged attacker may interfere with user-mode telemetry. It is a transparent detection engine — not a managed response platform.
 
 ---
 
 ## Build from source
 
-If you prefer to build locally instead of using a published release, use `cargo build --release`.
-
-### Windows
-
-```powershell
-cargo build --release
-.\target\release\rustinel.exe run
-```
-
-### Linux
-
 ```bash
 cargo build --release
-sudo ./target/release/rustinel run
+sudo ./target/release/rustinel run   # macOS also needs codesigning with the ESF entitlement — see docs
 ```
 
-### macOS
-
-```bash
-cargo build --release
-codesign --force --sign - \
-  --entitlements packaging/macos/rustinel.entitlements \
-  target/release/rustinel
-sudo ./target/release/rustinel run
-```
-
-Ad-hoc signing with the entitlement only takes effect when SIP/AMFI is relaxed;
-distributable builds require a Developer ID and notarization.
-
-For full release setup, source-build prerequisites, and validation steps, see the [Getting Started](https://docs.rustinel.io/getting-started/) documentation.
-
----
-
-## Output
-
-Rustinel writes operational logs and alerts to disk.
-
-```text
-logs/rustinel.log.<date>
-logs/alerts.json.<date>
-```
-
-Alert format:
-
-```text
-ECS 9.3.0 NDJSON
-```
-
-This makes Rustinel alerts easy to ingest into SIEM and log pipelines.
-
----
-
-## Best for
-
-Rustinel is currently best suited for:
-
-- Lab deployments and evaluations
-- Detection engineering
-- Rule development and testing
-- Blue teams that want transparent host telemetry
-- Cross-platform detection research
-- SIEM pipeline testing
-- Learning how ETW, eBPF, Sigma, YARA, and IOCs can fit together
-
----
-
-## What Rustinel is not
-
-Rustinel is not a full replacement for every capability of a mature commercial EDR.
-
-Today, Rustinel does not try to provide the same kernel-level self-protection, pre-execution blocking, anti-tamper guarantees, or managed response capabilities that commercial EDR products may provide.
-
-A sufficiently privileged attacker may be able to interfere with user-mode components or telemetry sources. Kernel-level threats, telemetry tampering, and heavily obfuscated activity may require additional controls or future Rustinel capabilities.
-
-Rustinel is designed as a transparent open-source detection engine focused on telemetry collection, rule-based detection, alert generation, and research.
-
----
-
-## Roadmap
-
-Near-term focus is on first-run experience, a curated detection pack, and deployment reliability. Telemetry expansion and advanced EDR capabilities come after the basics are solid.
-
-See the [full roadmap](docs/roadmap.md) for details.
+Full prerequisites, macOS signing steps, and validation: [Getting Started](https://docs.rustinel.io/getting-started/).
 
 ---
 
 ## Documentation
 
-- [Official Site](https://rustinel.io/)
-- [Documentation Home](https://docs.rustinel.io/)
-- [Getting Started](https://docs.rustinel.io/getting-started/)
-- [Configuration](https://docs.rustinel.io/configuration/)
-- [Detection](https://docs.rustinel.io/detection/)
-- [Architecture](https://docs.rustinel.io/architecture/)
-- [Development](https://docs.rustinel.io/development/)
-- [Operations and Upgrade Guide](https://docs.rustinel.io/operations/)
-- [Troubleshooting](https://docs.rustinel.io/troubleshooting/)
-- [FAQ](https://docs.rustinel.io/faq/)
+[Website](https://rustinel.io/) ·
+[Docs home](https://docs.rustinel.io/) ·
+[Getting Started](https://docs.rustinel.io/getting-started/) ·
+[Configuration](https://docs.rustinel.io/configuration/) ·
+[Detection](https://docs.rustinel.io/detection/) ·
+[Architecture](https://docs.rustinel.io/architecture/) ·
+[Operations](https://docs.rustinel.io/operations/) ·
+[Troubleshooting](https://docs.rustinel.io/troubleshooting/) ·
+[FAQ](https://docs.rustinel.io/faq/) ·
+[Detection rules](https://github.com/Karib0u/rustinel-rules) ·
+[Roadmap](docs/roadmap.md)
 
 ---
 
 ## Contributing
 
-Contributions, testing, feedback, and detection ideas are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) to get started.
-
----
+Testing, feedback, and detection ideas are all welcome — see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 
-Apache 2.0. See [`LICENSE`](LICENSE).
+[Apache 2.0](LICENSE).

--- a/docs/active-response.md
+++ b/docs/active-response.md
@@ -1,6 +1,6 @@
 # Active Response
 
-Rustinel includes an optional response engine that can terminate processes when an alert reaches the configured minimum severity. It is disabled by default and should be tested in dry-run mode first.
+Rustinel includes an optional response engine that can terminate processes when an alert reaches the configured minimum severity. It is disabled by default and should be tested in dry-run mode first. Active response runs on **Windows and Linux only** — macOS is detection-only.
 
 ## Modes
 
@@ -14,6 +14,7 @@ Rustinel includes an optional response engine that can terminate processes when 
 | --- | --- |
 | Windows | Uses process termination APIs |
 | Linux | Sends `SIGKILL` |
+| macOS | Not supported — detection only |
 
 ## Severity Handling
 
@@ -30,27 +31,7 @@ Rustinel will not act on processes that match either of these:
 - `allowlist_images`: image basenames or full paths
 - `allowlist_paths`: trusted path prefixes
 
-By default, `response.allowlist_paths` inherits `allowlist.paths`.
-
-### Default Trusted Prefixes
-
-#### Windows
-
-- `C:\Windows\`
-- `C:\Program Files\`
-- `C:\Program Files (x86)\`
-
-#### Linux
-
-- `/usr/bin/`
-- `/usr/sbin/`
-- `/usr/lib/`
-- `/usr/lib64/`
-- `/usr/libexec/`
-- `/bin/`
-- `/sbin/`
-- `/lib/`
-- `/lib64/`
+By default, `response.allowlist_paths` inherits `allowlist.paths`, whose per-platform defaults are listed once in [Configuration → Default Trusted Paths](configuration.md#default-trusted-paths).
 
 ## Example Configuration
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -128,6 +128,17 @@ These defaults feed `allowlist.paths`, which then propagate to active response, 
 - `/lib/`
 - `/lib64/`
 
+#### macOS
+
+- `/usr/bin/`
+- `/usr/sbin/`
+- `/usr/libexec/`
+- `/bin/`
+- `/sbin/`
+- `/System/`
+
+`/Applications` is intentionally **not** allowlisted: it holds user-installed software and is a common location for macOS malware, so allowlisting it would blind scanning and response there.
+
 ## Options
 
 ### Scanner

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -6,7 +6,7 @@ This page answers the questions that come up most often when running, deploying,
 
 ### What does Rustinel do?
 
-Rustinel is a cross-platform EDR agent. It collects telemetry from ETW on Windows and eBPF on Linux, normalizes events into a shared model, evaluates Sigma, YARA, and IOC detections, writes ECS NDJSON alerts, and can optionally terminate offending processes.
+Rustinel is a cross-platform endpoint detection engine. It collects telemetry from ETW on Windows, eBPF on Linux, and Endpoint Security plus `/dev/bpf` on macOS, normalizes events into a shared model, evaluates Sigma, YARA, and IOC detections, writes ECS NDJSON alerts, and can optionally terminate offending processes (Windows and Linux only).
 
 See [Architecture](architecture.md) and [Detection](detection.md) for the detailed runtime flow.
 
@@ -14,8 +14,9 @@ See [Architecture](architecture.md) and [Detection](detection.md) for the detail
 
 - Windows 10/11 and Server 2016+
 - Linux with kernel 5.8+, BTF, and the required eBPF privileges
+- macOS 11+ (experimental) using Endpoint Security plus `/dev/bpf` capture
 
-Current telemetry coverage is broader on Windows than Linux. Windows includes process, image load, network, file, registry, DNS, PowerShell, WMI, service, and task telemetry. Linux currently covers process, network, file, and DNS.
+Current telemetry coverage is broadest on Windows, which includes process, image load, network, file, registry, DNS, PowerShell, WMI, service, and task telemetry. Linux and macOS currently cover process, network, file, and DNS. macOS support is experimental while the project waits for the required Endpoint Security entitlement.
 
 ### Do I need Administrator or root?
 
@@ -23,6 +24,7 @@ Yes.
 
 - Windows ETW collection requires Administrator privileges.
 - Linux eBPF collection requires root or equivalent capabilities such as `CAP_BPF` or `CAP_SYS_ADMIN`, depending on your setup.
+- macOS Endpoint Security collection requires root, plus the `com.apple.developer.endpoint-security.client` entitlement (or SIP/AMFI relaxed for local testing).
 
 ## Running And Deployment
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -50,11 +50,11 @@ After the agent starts, trigger the bundled rule:
 Install script options:
 
 ```bash
-scripts/install/install.sh --dir /opt/rustinel --version 1.1.0
+scripts/install/install.sh --dir /opt/rustinel --version 1.1.1
 ```
 
 ```powershell
-.\scripts\install\install.ps1 -InstallDir C:\Rustinel -Version 1.1.0
+.\scripts\install\install.ps1 -InstallDir C:\Rustinel -Version 1.1.1
 ```
 
 macOS support is experimental. Use the macOS release archive when it is present

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1,98 +1,155 @@
 # Limitations
 
-Rustinel is designed for transparent, rule-based endpoint detection.
+Rustinel is a transparent, rule-based endpoint detection engine. Like any
+detection system it has boundaries — and because Rustinel is open source, we
+document them in full rather than hide them.
 
-Like any detection system, it has boundaries. This page documents them clearly.
+This page documents Rustinel's known limitations for the current release.
 
-## Current limitations
+> **Reading guide.** Items marked **⚠ silent** are the most important: they can
+> cause a rule to *not fire* — or match the wrong thing — with no error. Check
+> these before you rely on a detection.
 
-### No commercial EDR-style self-protection
+## Highest impact: detections that can silently not fire
 
-Rustinel does not currently provide the same anti-tamper or self-protection capabilities as mature commercial EDR agents.
+| Limitation | Area |
+| --- | --- |
+| Registry value *data* is never captured; `Details` holds the value *name* instead | Windows |
+| Process events carry no hashes (`Hashes` / `Imphash`) | Windows |
+| Command line is lost for short-lived processes | Windows · Linux |
+| No correlation, aggregation, or temporal rules | Engine |
+| Rules are silently inert when no collector backs their logsource | Engine |
+| Telemetry is dropped under burst load (no backpressure) | Pipeline |
 
-A sufficiently privileged attacker may be able to stop, disable, or interfere with user-mode components or telemetry sources.
+---
 
-### No traditional Windows kernel driver
+## Windows (ETW)
 
-Rustinel uses ETW on Windows rather than a custom Windows kernel driver.
+Rustinel collects Windows telemetry through ETW rather than a kernel driver.
+Coverage is the broadest of the three platforms, but several Sysmon-style fields
+are unavailable.
 
-This improves stability and keeps the design simpler, but it also means Rustinel does not have the same visibility or enforcement points as a driver-backed agent.
+- **Registry value data is not captured. ⚠ silent** Unlike Sysmon, `Details`
+  maps to the registry *value name*, not the data written to it — the
+  Kernel-Registry provider doesn't emit value data. A rule matching on written
+  content silently matches the value name instead.
+- **Registry `TargetObject` is a relative path. ⚠ silent** Full key paths
+  (e.g. `HKLM\...\Run`) aren't resolved, so `endswith`-style key matches may miss.
+- **No process or image-load hashes. ⚠ silent** There is no `Hashes`/`Imphash`
+  on process or image-load events, so the many Sigma rules keyed on them can
+  never fire. Hash matching exists only in the file/IOC scanner.
+- **Some process fields are always empty.** `IntegrityLevel`, `User`, `LogonId`,
+  `LogonGuid`, `ParentCommandLine`, and often `CurrentDirectory` aren't populated
+  by the provider; rules filtering on them won't match.
+- **Command line lost for short-lived processes. ⚠ silent** When ETW omits
+  `CommandLine`, it is back-filled by querying the live process — fast-exiting
+  processes are already gone, exactly when it matters most.
+- **PowerShell 7 (`pwsh`) is not covered.** Only Windows PowerShell 5.1
+  script-block telemetry is collected; PowerShell Core uses a different provider.
+  No module logging.
+- **No network data-volume telemetry.** Only connect / disconnect / accept
+  survive; bytes-sent/received events are dropped, so exfil-by-volume heuristics
+  aren't possible.
+- **DNS `QueryType` is always empty.** The DNS record type is not populated on
+  Windows.
+- **No injection or driver-load visibility.** No equivalent of CreateRemoteThread,
+  ProcessAccess, named-pipe, or driver-load providers — injection-based TTPs leave
+  little telemetry.
 
-### Kernel-level threats
+## Linux (eBPF)
 
-Rustinel is not designed today to detect or stop kernel-mode rootkits.
+The Linux sensor covers process, network, file, and DNS.
 
-Kernel-level threats, vulnerable driver abuse, and direct telemetry tampering may require additional controls.
+- **Process argv isn't captured in the kernel. ⚠ silent** Command line is read
+  from `/proc/<pid>/cmdline` in userspace, so short-lived processes yield an
+  empty command line — the dominant Linux gap, since most Linux Sigma rules match
+  `CommandLine`.
+- **Paths are truncated.** The image path is capped at 128 bytes and `comm` at
+  16, which can break `Image|endswith` matches.
+- **DNS is UDP port 53 only.** DNS-over-TCP, DoH (443), and DoT (853) are
+  invisible; long query names are dropped, QTYPE is limited to
+  A/NS/CNAME/PTR/TXT/AAAA, and answers (`QueryResults`) aren't parsed.
+- **Network is outbound `connect()` only.** No inbound / `accept()` visibility;
+  failed connections are still logged (captured at syscall entry); plain UDP
+  `sendto` isn't seen; only AF_INET / AF_INET6.
+- **No library-load, module-load, or ptrace events.** Sigma rules in those Linux
+  categories never match.
+- **Kernel requirements.** Needs Linux 5.8+ with BTF and
+  `CAP_BPF` / `CAP_SYS_ADMIN`; older or BTF-less kernels and many restricted
+  containers are unsupported.
 
-### Memory-only payloads
+## macOS (ESF) — experimental
 
-Payloads that exist only in memory can be harder to detect if they do not create useful telemetry or leave a file that can be scanned.
+macOS support is experimental and detection-only.
 
-YARA memory scanning is available but optional and privilege-dependent. It can improve coverage against packed, obfuscated, and runtime-unpacked payloads, but access to another process's memory may be blocked by operating-system policy, process protection, sandboxing, or missing privileges.
+- **Process and file events only from Endpoint Security.** No image-load, script,
+  WMI, service, or task equivalents.
+- **Network/DNS attribution is best-effort.** Telemetry comes from `/dev/bpf`
+  capture, not a per-process hook: connections are matched to processes by port
+  (racy), DNS events aren't attributed to a process, and capture binds to a
+  single interface (default `en0`, override with `RUSTINEL_BPF_INTERFACE`).
+- **Memory scanning is restricted.** YARA memory scanning uses `task_for_pid`,
+  which generally needs root plus SIP/AMFI relaxation or an entitlement; when
+  denied it returns nothing.
+- **No active response.** Process termination is unsupported on macOS —
+  detection only.
 
-### Living-off-the-land activity
+## Detection engine (Sigma)
 
-Legitimate administrative tools can be abused by attackers.
+- **No correlation, aggregation, or temporal rules. ⚠ silent** Each event is
+  matched independently — no state, window, count, or throttle. Sigma correlation
+  (`event_count`, `value_count`, `temporal`, `temporal_ordered`) and legacy
+  aggregations (`| count() by ...`, `near`) are unsupported, so brute-force,
+  beaconing, and "N events in M minutes" detections can't be expressed.
+- **Unsupported modifiers reject the whole rule.** A rule using a modifier
+  outside the supported set (e.g. `|expand`, `|gzip`, `|minlength`) is dropped at
+  load, not partially matched.
+- **Rules are inert without a backing collector. ⚠ silent** Rules for a
+  product/category the running platform doesn't collect will load but never fire.
+  On Linux/macOS a large share of a Windows-oriented ruleset is effectively dead
+  weight — don't read rule count as coverage.
 
-Rustinel can detect suspicious behavior when matching Sigma rules exist, but heavily obfuscated or context-dependent living-off-the-land activity may still evade detection.
+## Pipeline & operations
 
-### IOC limitations
+- **Telemetry is dropped under load. ⚠ silent** Sensor channels are bounded and
+  drop on overflow, with only a periodic warning. Under burst load you get silent
+  detection gaps, not slowdown.
+- **Active response is kill-after-the-fact.** The only response is process
+  termination, fired after the event is processed — the process may already have
+  done its work or exited. A PID-reuse race is narrowed by identity checks but not
+  eliminated. There is no quarantine, file deletion, network isolation, or
+  registry rollback.
+- **No self-protection or tamper resistance.** A privileged attacker can stop the
+  ETW trace, unload eBPF, or kill the agent.
 
-IOC matching is deterministic.
+## Detection philosophy & posture
 
-It depends on the quality and relevance of the provided indicators.
-
-Hashes, IPs, domains, and path regexes are useful, but they should not be the only detection layer.
-
-### Encrypted C2
-
-Encrypted C2 over trusted or common infrastructure may not be detected by simple IOC matching alone.
-
-Behavioral detection is needed to identify suspicious activity around the network communication.
-
-### macOS network and DNS attribution
-
-On macOS, network and DNS telemetry comes from `/dev/bpf` packet capture rather
-than a per-process hook. This has a few consequences:
-
-- Connections are attributed to a process on a best-effort basis by matching
-  ports against open sockets, which is racy: a short-lived socket may close
-  before it can be matched, leaving the connection unattributed.
-- DNS query events are not attributed to a process.
-- Capture binds to a single interface (default `en0`, override with
-  `RUSTINEL_BPF_INTERFACE`); traffic on other interfaces is not seen.
-
-A future NetworkExtension-based source would carry the owning process with each
-flow and remove these limitations.
-
-### macOS memory scanning
-
-YARA memory scanning on macOS uses `task_for_pid`, which is heavily restricted:
-it generally requires root and SIP/AMFI relaxation or a specific entitlement.
-When access is denied, memory scanning simply returns nothing.
+- **Not a commercial EDR replacement.** Rustinel uses ETW on Windows rather than
+  a kernel driver — simpler and more stable, but without a driver's visibility or
+  enforcement points. It is not designed to detect kernel-mode rootkits,
+  vulnerable-driver abuse, or direct telemetry tampering.
+- **IOC matching is only as good as its indicators.** It is deterministic and
+  fast, but hashes, IPs, domains, and path regexes should complement behavioral
+  detection, not stand alone. Encrypted C2 over trusted infrastructure often
+  evades IOC matching and needs behavioral signals.
+- **Memory-only and living-off-the-land activity is hard.** Payloads that never
+  touch disk, and abuse of legitimate admin tools, may produce little useful
+  telemetry. YARA memory scanning helps against packed and runtime-unpacked
+  payloads but is optional and privilege-dependent.
 
 ## How to think about Rustinel
 
-Rustinel should be viewed as a transparent open-source detection engine.
-
-It is useful for:
-
-- Detection engineering
-- Endpoint telemetry collection
-- Rule testing
-- SIEM pipeline testing
-- Research
-- Lab deployments
-- Blue-team experimentation
-
-It should not be presented as a full commercial EDR replacement today.
+Rustinel is a transparent open-source detection engine — best for detection
+engineering, telemetry collection, rule development and testing, SIEM pipeline
+validation, research, lab deployments, and blue-team experimentation. It should
+not be presented as a full commercial EDR replacement today.
 
 ## Planned improvements
 
-Areas planned for improvement include:
-
+- Richer process telemetry (hashes, more reliable command line) and additional
+  providers
+- Correlation / temporal rule support
+- Backpressure and load-shedding visibility
 - Scheduled YARA memory sweeps and richer memory match metadata
-- Expanded telemetry coverage
-- More detection examples
-- More deployment hardening options
-- Better documentation around operational security and limitations
+- macOS hardening toward production readiness
+- Continued documentation of operational security and limitations

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -30,6 +30,21 @@ C:\Rustinel\
 └── logs/
 ```
 
+### macOS
+
+```text
+/opt/rustinel/
+├── rustinel
+├── config.toml
+├── rules/
+│   ├── sigma/
+│   ├── yara/
+│   └── ioc/
+└── logs/
+```
+
+macOS support is experimental. The binary must be signed with the Endpoint Security entitlement, or run with SIP/AMFI relaxed on a dedicated test machine — see [Getting Started](getting-started.md) and [Development](development.md).
+
 Use absolute paths in `config.toml` once you move beyond the default repo layout.
 
 ## Working Directory Rules
@@ -79,7 +94,7 @@ Save as `/etc/systemd/system/rustinel.service`:
 
 ```ini
 [Unit]
-Description=Rustinel EDR Agent
+Description=Rustinel endpoint detection agent
 After=network.target
 
 [Service]
@@ -104,6 +119,16 @@ sudo systemctl status rustinel
 ```
 
 Because `config.toml` is loaded from `WorkingDirectory`, use absolute paths for all rules and log directories in that file when running under `systemd`.
+
+## macOS Runtime Model
+
+macOS support is experimental and detection-only (no active response). Rustinel does not ship macOS service-management commands; run it in the foreground as root, or wrap it in a `launchd` job for background execution:
+
+```bash
+sudo /opt/rustinel/rustinel run
+```
+
+The binary must be signed with the `com.apple.developer.endpoint-security.client` entitlement, or run with SIP/AMFI relaxed on a dedicated test machine. See [Development](development.md) for signing and notarization details.
 
 ## Upgrade Examples
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -25,7 +25,7 @@ Example:
 Field rendering varies by logger, but the message text is representative:
 
 ```text
-9:00 PM INFO  rustinel: Rustinel v1.0.0 (Linux eBPF)
+9:00 PM INFO  rustinel: Rustinel v1.1.1 (Linux eBPF)
 9:00 PM INFO  rustinel: Loading Sigma rules
 9:00:01 PM INFO  rustinel: YARA scanner initialized
 9:00:05 PM INFO  engine: Sigma detection triggered
@@ -56,7 +56,7 @@ Format:
 | `event.code` | Sysmon-style or native event ID string |
 | `event.module` | Always `edr` |
 | `event.dataset` | `edr.<category>` |
-| `event.provider` | `etw` on Windows, `ebpf` on Linux |
+| `event.provider` | `etw` (Windows), `ebpf` (Linux), `esf` / `bpf` (macOS), or `yara-memory` for memory-scan hits |
 | `rule.name` | Detection rule title |
 | `edr.rule.severity` | Low, Medium, High, or Critical |
 | `edr.rule.engine` | `Sigma`, `Yara`, or `Ioc` |
@@ -125,7 +125,7 @@ Format:
 | Service | `edr.service` |
 | Task | `edr.task` |
 
-The full field set depends on event type and platform. Windows alerts can include PE metadata, registry details, PowerShell content, and service or task context. Linux alerts currently focus on process, network, file, and DNS fields.
+The full field set depends on event type and platform. Windows alerts can include PE metadata, registry details, PowerShell content, and service or task context. Linux and macOS alerts currently focus on process, network, file, and DNS fields.
 
 ## SIEM Shipping
 

--- a/docs/why-rustinel.md
+++ b/docs/why-rustinel.md
@@ -26,11 +26,13 @@ On Windows, Rustinel uses ETW.
 
 On Linux, Rustinel uses eBPF.
 
+On macOS, Rustinel uses Apple's Endpoint Security framework plus `/dev/bpf` capture (experimental).
+
 The goal is to collect useful host telemetry without maintaining a traditional custom Windows kernel driver.
 
 ### Cross-platform detection
 
-Windows and Linux are different, but many detection engineering concepts are shared.
+Windows, Linux, and macOS are different, but many detection engineering concepts are shared.
 
 Rustinel normalizes events into a shared model so detection logic can be reused where possible.
 

--- a/rules/sigma/windows_whoami.yml
+++ b/rules/sigma/windows_whoami.yml
@@ -1,15 +1,13 @@
-title: Example - Whoami Execution (CommandLine + Image)
+title: Example - Whoami Execution (Windows)
 id: d4f5e6b2-3c7a-4e1b-9f2a-123456789abc
 status: experimental
-description: Detects whoami.exe with the /all switch (demo rule).
+description: Detects execution of whoami.exe (demo rule).
 author: Rustinel
 logsource:
   category: process_creation
   product: windows
 detection:
-  selection_img:
+  selection:
     Image|endswith: '\whoami.exe'
-  selection_cmd:
-    CommandLine|contains: ' /all'
-  condition: selection_img and selection_cmd
+  condition: selection
 level: low

--- a/zensical.toml
+++ b/zensical.toml
@@ -58,6 +58,7 @@ nav = [
         { "Getting Started" = "getting-started.md" },
         { "SIEM Demos" = "siem-demos.md" },
         { "Troubleshooting" = "troubleshooting.md" },
+        { "FAQ" = "faq.md" },
     ] },
 
     { "Using Rustinel" = [
@@ -71,6 +72,7 @@ nav = [
     { "How It Works" = [
         { "Architecture" = "architecture.md" },
         { "Detection" = "detection.md" },
+        { "Benchmarking" = "benchmarking.md" },
         { "Limitations" = "limitations.md" },
     ] },
 
@@ -188,7 +190,6 @@ features = [
     # https://zensical.org/docs/authoring/content-tabs/#linked-content-tabs
     "content.tabs.link",
 
-    # TODO: not sure I understand this one? Is there a demo of this in the docs?
     # https://zensical.org/docs/authoring/tooltips/#improved-tooltips
     # "content.tooltips",
 


### PR DESCRIPTION
Documentation refresh for the engine repo. The first two commits were already on this branch; the third is a cross-doc audit pass for consistency, accuracy, and simplicity.

## What's in here
**README + limitations** (prior commits)
- Rewrote README for clarity and activation; unified the `whoami` demo across platforms
- Rebuilt the Limitations page from the engineering audit

**Cross-doc audit cleanup** (new)
- **macOS parity** — macOS was first-class in some docs and invisible in others. Brought it up to parity in faq, why-rustinel, active-response, output, configuration, and operations (ESF/`bpf` providers, the real macOS allowlist defaults, detection-only response, runtime model). Verified against `src/config.rs`.
- **Version drift** — fixed stale `v1.0.0` / `1.1.0` references to `1.1.1` (output sample log, getting-started install examples).
- **Navigation** — added the orphaned **FAQ** and **Benchmarking** pages to the site nav (they existed and were linked but missing from the sidebar); removed a leftover `TODO` comment in `zensical.toml`.
- **De-duplication** — collapsed the duplicated trusted-path list (active-response now points to the canonical list in configuration.md).
- **Voice** — aligned "EDR agent" wording to "endpoint detection engine/agent", matching the README's deliberate positioning.

Also removed a stray internal scratch file (`docs/limitations-audit.md`) that was untracked, so it's not in the diff — just noting it's gone locally.

## Scope
Docs + site nav only — no engine code touched.