### PR TITLE
docs: cross-doc audit cleanup (macOS parity, version, nav, dedup)

### DIFF
--- a/docs/active-response.md
+++ b/docs/active-response.md
@@ -1,6 +1,6 @@
 # Active Response
 
-Rustinel includes an optional response engine that can terminate processes when an alert reaches the configured minimum severity. It is disabled by default and should be tested in dry-run mode first.
+Rustinel includes an optional response engine that can terminate processes when an alert reaches the configured minimum severity. It is disabled by default and should be tested in dry-run mode first. Active response runs on **Windows and Linux only** — macOS is detection-only.
 
 ## Modes
 
@@ -14,6 +14,7 @@ Rustinel includes an optional response engine that can terminate processes when 
 | --- | --- |
 | Windows | Uses process termination APIs |
 | Linux | Sends `SIGKILL` |
+| macOS | Not supported — detection only |
 
 ## Severity Handling
 
@@ -30,27 +31,7 @@ Rustinel will not act on processes that match either of these:
 - `allowlist_images`: image basenames or full paths
 - `allowlist_paths`: trusted path prefixes
 
-By default, `response.allowlist_paths` inherits `allowlist.paths`.
-
-### Default Trusted Prefixes
-
-#### Windows
-
-- `C:\Windows\`
-- `C:\Program Files\`
-- `C:\Program Files (x86)\`
-
-#### Linux
-
-- `/usr/bin/`
-- `/usr/sbin/`
-- `/usr/lib/`
-- `/usr/lib64/`
-- `/usr/libexec/`
-- `/bin/`
-- `/sbin/`
-- `/lib/`
-- `/lib64/`
+By default, `response.allowlist_paths` inherits `allowlist.paths`, whose per-platform defaults are listed once in [Configuration → Default Trusted Paths](configuration.md#default-trusted-paths).
 
 ## Example Configuration
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -128,6 +128,17 @@ These defaults feed `allowlist.paths`, which then propagate to active response, 
 - `/lib/`
 - `/lib64/`
 
+#### macOS
+
+- `/usr/bin/`
+- `/usr/sbin/`
+- `/usr/libexec/`
+- `/bin/`
+- `/sbin/`
+- `/System/`
+
+`/Applications` is intentionally **not** allowlisted: it holds user-installed software and is a common location for macOS malware, so allowlisting it would blind scanning and response there.
+
 ## Options
 
 ### Scanner

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -6,7 +6,7 @@ This page answers the questions that come up most often when running, deploying,
 
 ### What does Rustinel do?
 
-Rustinel is a cross-platform EDR agent. It collects telemetry from ETW on Windows and eBPF on Linux, normalizes events into a shared model, evaluates Sigma, YARA, and IOC detections, writes ECS NDJSON alerts, and can optionally terminate offending processes.
+Rustinel is a cross-platform endpoint detection engine. It collects telemetry from ETW on Windows, eBPF on Linux, and Endpoint Security plus `/dev/bpf` on macOS, normalizes events into a shared model, evaluates Sigma, YARA, and IOC detections, writes ECS NDJSON alerts, and can optionally terminate offending processes (Windows and Linux only).
 
 See [Architecture](architecture.md) and [Detection](detection.md) for the detailed runtime flow.
 
@@ -14,8 +14,9 @@ See [Architecture](architecture.md) and [Detection](detection.md) for the detail
 
 - Windows 10/11 and Server 2016+
 - Linux with kernel 5.8+, BTF, and the required eBPF privileges
+- macOS 11+ (experimental) using Endpoint Security plus `/dev/bpf` capture
 
-Current telemetry coverage is broader on Windows than Linux. Windows includes process, image load, network, file, registry, DNS, PowerShell, WMI, service, and task telemetry. Linux currently covers process, network, file, and DNS.
+Current telemetry coverage is broadest on Windows, which includes process, image load, network, file, registry, DNS, PowerShell, WMI, service, and task telemetry. Linux and macOS currently cover process, network, file, and DNS. macOS support is experimental while the project waits for the required Endpoint Security entitlement.
 
 ### Do I need Administrator or root?
 
@@ -23,6 +24,7 @@ Yes.
 
 - Windows ETW collection requires Administrator privileges.
 - Linux eBPF collection requires root or equivalent capabilities such as `CAP_BPF` or `CAP_SYS_ADMIN`, depending on your setup.
+- macOS Endpoint Security collection requires root, plus the `com.apple.developer.endpoint-security.client` entitlement (or SIP/AMFI relaxed for local testing).
 
 ## Running And Deployment
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -50,11 +50,11 @@ After the agent starts, trigger the bundled rule:
 Install script options:
 
 ```bash
-scripts/install/install.sh --dir /opt/rustinel --version 1.1.0
+scripts/install/install.sh --dir /opt/rustinel --version 1.1.1
 ```
 
 ```powershell
-.\scripts\install\install.ps1 -InstallDir C:\Rustinel -Version 1.1.0
+.\scripts\install\install.ps1 -InstallDir C:\Rustinel -Version 1.1.1
 ```
 
 macOS support is experimental. Use the macOS release archive when it is present

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -30,6 +30,21 @@ C:\Rustinel\
 └── logs/
 ```
 
+### macOS
+
+```text
+/opt/rustinel/
+├── rustinel
+├── config.toml
+├── rules/
+│   ├── sigma/
+│   ├── yara/
+│   └── ioc/
+└── logs/
+```
+
+macOS support is experimental. The binary must be signed with the Endpoint Security entitlement, or run with SIP/AMFI relaxed on a dedicated test machine — see [Getting Started](getting-started.md) and [Development](development.md).
+
 Use absolute paths in `config.toml` once you move beyond the default repo layout.
 
 ## Working Directory Rules
@@ -79,7 +94,7 @@ Save as `/etc/systemd/system/rustinel.service`:
 
 ```ini
 [Unit]
-Description=Rustinel EDR Agent
+Description=Rustinel endpoint detection agent
 After=network.target
 
 [Service]
@@ -104,6 +119,16 @@ sudo systemctl status rustinel
 ```
 
 Because `config.toml` is loaded from `WorkingDirectory`, use absolute paths for all rules and log directories in that file when running under `systemd`.
+
+## macOS Runtime Model
+
+macOS support is experimental and detection-only (no active response). Rustinel does not ship macOS service-management commands; run it in the foreground as root, or wrap it in a `launchd` job for background execution:
+
+```bash
+sudo /opt/rustinel/rustinel run
+```
+
+The binary must be signed with the `com.apple.developer.endpoint-security.client` entitlement, or run with SIP/AMFI relaxed on a dedicated test machine. See [Development](development.md) for signing and notarization details.
 
 ## Upgrade Examples
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -25,7 +25,7 @@ Example:
 Field rendering varies by logger, but the message text is representative:
 
 ```text
-9:00 PM INFO  rustinel: Rustinel v1.0.0 (Linux eBPF)
+9:00 PM INFO  rustinel: Rustinel v1.1.1 (Linux eBPF)
 9:00 PM INFO  rustinel: Loading Sigma rules
 9:00:01 PM INFO  rustinel: YARA scanner initialized
 9:00:05 PM INFO  engine: Sigma detection triggered
@@ -56,7 +56,7 @@ Format:
 | `event.code` | Sysmon-style or native event ID string |
 | `event.module` | Always `edr` |
 | `event.dataset` | `edr.<category>` |
-| `event.provider` | `etw` on Windows, `ebpf` on Linux |
+| `event.provider` | `etw` (Windows), `ebpf` (Linux), `esf` / `bpf` (macOS), or `yara-memory` for memory-scan hits |
 | `rule.name` | Detection rule title |
 | `edr.rule.severity` | Low, Medium, High, or Critical |
 | `edr.rule.engine` | `Sigma`, `Yara`, or `Ioc` |
@@ -125,7 +125,7 @@ Format:
 | Service | `edr.service` |
 | Task | `edr.task` |
 
-The full field set depends on event type and platform. Windows alerts can include PE metadata, registry details, PowerShell content, and service or task context. Linux alerts currently focus on process, network, file, and DNS fields.
+The full field set depends on event type and platform. Windows alerts can include PE metadata, registry details, PowerShell content, and service or task context. Linux and macOS alerts currently focus on process, network, file, and DNS fields.
 
 ## SIEM Shipping
 

--- a/docs/why-rustinel.md
+++ b/docs/why-rustinel.md
@@ -26,11 +26,13 @@ On Windows, Rustinel uses ETW.
 
 On Linux, Rustinel uses eBPF.
 
+On macOS, Rustinel uses Apple's Endpoint Security framework plus `/dev/bpf` capture (experimental).
+
 The goal is to collect useful host telemetry without maintaining a traditional custom Windows kernel driver.
 
 ### Cross-platform detection
 
-Windows and Linux are different, but many detection engineering concepts are shared.
+Windows, Linux, and macOS are different, but many detection engineering concepts are shared.
 
 Rustinel normalizes events into a shared model so detection logic can be reused where possible.
 

--- a/zensical.toml
+++ b/zensical.toml
@@ -58,6 +58,7 @@ nav = [
         { "Getting Started" = "getting-started.md" },
         { "SIEM Demos" = "siem-demos.md" },
         { "Troubleshooting" = "troubleshooting.md" },
+        { "FAQ" = "faq.md" },
     ] },
 
     { "Using Rustinel" = [
@@ -71,6 +72,7 @@ nav = [
     { "How It Works" = [
         { "Architecture" = "architecture.md" },
         { "Detection" = "detection.md" },
+        { "Benchmarking" = "benchmarking.md" },
         { "Limitations" = "limitations.md" },
     ] },
 
@@ -188,7 +190,6 @@ features = [
     # https://zensical.org/docs/authoring/content-tabs/#linked-content-tabs
     "content.tabs.link",
 
-    # TODO: not sure I understand this one? Is there a demo of this in the docs?
     # https://zensical.org/docs/authoring/tooltips/#improved-tooltips
     # "content.tooltips",
 


### PR DESCRIPTION
Clean re-submission of the cross-doc audit cleanup against current `main`. The earlier #64 branch was based on the pre-squash README/limitations commits (now merged via #63), so this isolates just the audit work on a fresh branch — 8 files, no overlap with README or limitations.

## What's in here
- **macOS parity** — macOS was first-class in some docs and invisible in others. Brought it up to parity in faq, why-rustinel, active-response, output, configuration, and operations (ESF/`bpf` providers, the real macOS allowlist defaults, detection-only response, runtime model). Verified against `src/config.rs` and `packaging/macos/`.
- **Version drift** — fixed stale `v1.0.0` / `1.1.0` references to `1.1.1` (output sample log, getting-started install examples).
- **Navigation** — added the orphaned **FAQ** and **Benchmarking** pages to the site nav (they existed and were linked but missing from the sidebar); removed a leftover `TODO` comment in `zensical.toml`.
- **De-duplication** — collapsed the duplicated trusted-path list (active-response now points to the canonical list in configuration.md).
- **Voice** — aligned "EDR agent" wording to "endpoint detection engine/agent", matching the README's positioning.

## Scope
Docs + site nav only — no engine code touched.

Supersedes #64.