### PR TITLE
feat(output): upgrade alert schema to ECS 9.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ A transparent endpoint detection engine you can read, run, test, and extend — 
 - **Native telemetry** — ETW on Windows, eBPF on Linux, Endpoint Security + `/dev/bpf` on macOS, normalized into one shared event model.
 - **Three detection layers** — Sigma for behavior, YARA for files and memory, IOC matching for hashes, IPs, domains, and path regexes.
 - **Reuse community rules** — bring existing Sigma and YARA rules instead of rewriting them into a proprietary format.
-- **SIEM-ready output** — ECS 9.3.0 NDJSON alerts that drop into Elastic, Splunk, and friends.
+- **SIEM-ready output** — ECS 9.4.0 NDJSON alerts that drop into Elastic, Splunk, and friends.
 - **Operational basics** — hot-reload for rules and IOCs, optional active response with dry-run + allowlists, Windows service and launchd support.
 
 ---

--- a/docs/output.md
+++ b/docs/output.md
@@ -41,14 +41,14 @@ Location:
 Format:
 
 - One ECS JSON document per line
-- ECS version `9.3.0`
+- ECS version `9.4.0`
 
 ### Important Fields
 
 | Field | Meaning |
 | --- | --- |
 | `@timestamp` | Event time in UTC |
-| `ecs.version` | Always `9.3.0` |
+| `ecs.version` | Always `9.4.0` |
 | `event.kind` | Always `alert` |
 | `event.category` | ECS category array |
 | `event.type` | ECS type array |
@@ -66,7 +66,7 @@ Format:
 ```json
 {
   "@timestamp": "<date>T21:00:05Z",
-  "ecs.version": "9.3.0",
+  "ecs.version": "9.4.0",
   "event.kind": "alert",
   "event.category": ["process"],
   "event.type": ["start"],
@@ -91,7 +91,7 @@ Format:
 ```json
 {
   "@timestamp": "<date>T21:00:05Z",
-  "ecs.version": "9.3.0",
+  "ecs.version": "9.4.0",
   "event.kind": "alert",
   "event.category": ["process"],
   "event.type": ["start"],

--- a/src/models/ecs/mod.rs
+++ b/src/models/ecs/mod.rs
@@ -23,7 +23,7 @@ use network::{extract_ips, network_transport_from_opcode, network_type_from_ip};
 use registry::split_registry_path;
 use user::apply_user_fields;
 
-const ECS_VERSION: &str = "9.3.0";
+const ECS_VERSION: &str = "9.4.0";
 const EVENT_MODULE: &str = "edr";
 
 impl From<&Alert> for EcsAlert {

--- a/tests/ecs_contract.rs
+++ b/tests/ecs_contract.rs
@@ -400,3 +400,31 @@ fn dns_alert_populates_category_specific_fields() {
     assert_ecs_field_eq(&json, "dns.resolved_ip", json!([TEST_DESTINATION_IP]));
     assert_ecs_field_eq(&json, "network.protocol", "dns");
 }
+
+#[test]
+fn ecs_version_field_is_9_4_0() {
+    let json = ecs_json(&alert(
+        EventCategory::Process,
+        1,
+        1,
+        EventFields::ProcessCreation(ProcessCreationFields {
+            image: Some(r"C:\Windows\System32\cmd.exe".to_string()),
+            command_line: None,
+            process_id: None,
+            process_start_time: None,
+            parent_image: None,
+            parent_process_id: None,
+            parent_command_line: None,
+            current_directory: None,
+            integrity_level: None,
+            user: None,
+            original_file_name: None,
+            product: None,
+            description: None,
+            target_image: None,
+            logon_id: None,
+            logon_guid: None,
+        }),
+    ));
+    assert_ecs_field_eq(&json, "ecs.version", "9.4.0");
+}


### PR DESCRIPTION
Closes #38

## Summary

- Bumps `ECS_VERSION` constant from `9.3.0` to `9.4.0` in `src/models/ecs/mod.rs`
- Adds `ecs_version_field_is_9_4_0` contract test in `tests/ecs_contract.rs` that asserts the literal wire value, pinning it for future regressions
- Updates all `ecs.version` references in `docs/output.md` and `README.md`

## Field-mapping review

ECS 9.3.0 → 9.4.0 only adds `entity.*` relationship fields (`entity.attributes.*`, `entity.lifecycle.last_activity`, `entity.relationships.*`) and tooling changes (alpha maturity attribute, higher `total_fields.limit`). No fields Rustinel emits were renamed, deprecated, or removed — zero remapping required.

## Test plan

- [x] `cargo test --test ecs_contract` — all 6 tests pass including the new version assertion
- [x] `grep` confirms no stray `9.3.0` ECS references remain (Elastic Stack image `9.3.5` in `docker-compose.yml` intentionally untouched)