### PR TITLE
chore: bump release version to 1.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2403,7 +2403,7 @@ dependencies = [
 
 [[package]]
 name = "rustinel"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustinel"
-version = "1.1.1"
+version = "1.1.2"
 edition = "2021"
 authors = []
 description = "Open-source EDR for Windows (ETW) and Linux (eBPF) with Sigma, YARA, and IOC detection"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -50,11 +50,11 @@ After the agent starts, trigger the bundled rule:
 Install script options:
 
 ```bash
-scripts/install/install.sh --dir /opt/rustinel --version 1.1.2
+scripts/install/install.sh --dir /opt/rustinel
 ```
 
 ```powershell
-.\scripts\install\install.ps1 -InstallDir C:\Rustinel -Version 1.1.2
+.\scripts\install\install.ps1 -InstallDir C:\Rustinel
 ```
 
 macOS support is experimental. Use the macOS release archive when it is present

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -50,11 +50,11 @@ After the agent starts, trigger the bundled rule:
 Install script options:
 
 ```bash
-scripts/install/install.sh --dir /opt/rustinel --version 1.1.1
+scripts/install/install.sh --dir /opt/rustinel --version 1.1.2
 ```
 
 ```powershell
-.\scripts\install\install.ps1 -InstallDir C:\Rustinel -Version 1.1.1
+.\scripts\install\install.ps1 -InstallDir C:\Rustinel -Version 1.1.2
 ```
 
 macOS support is experimental. Use the macOS release archive when it is present

--- a/docs/output.md
+++ b/docs/output.md
@@ -25,7 +25,7 @@ Example:
 Field rendering varies by logger, but the message text is representative:
 
 ```text
-9:00 PM INFO  rustinel: Rustinel v1.1.1 (Linux eBPF)
+9:00 PM INFO  rustinel: Rustinel v1.1.2 (Linux eBPF)
 9:00 PM INFO  rustinel: Loading Sigma rules
 9:00:01 PM INFO  rustinel: YARA scanner initialized
 9:00:05 PM INFO  engine: Sigma detection triggered

--- a/docs/output.md
+++ b/docs/output.md
@@ -25,7 +25,7 @@ Example:
 Field rendering varies by logger, but the message text is representative:
 
 ```text
-9:00 PM INFO  rustinel: Rustinel v1.1.2 (Linux eBPF)
+9:00 PM INFO  rustinel: Rustinel (Linux eBPF)
 9:00 PM INFO  rustinel: Loading Sigma rules
 9:00:01 PM INFO  rustinel: YARA scanner initialized
 9:00:05 PM INFO  engine: Sigma detection triggered


### PR DESCRIPTION
## Summary

- bump package metadata to 1.1.2
- update release-version examples in docs

## Verification

- cargo fmt --all -- --check
- cargo test --locked
- cargo package --locked --allow-dirty --no-verify