### PR TITLE
chore: fix release note categories

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -26,7 +26,10 @@ changelog:
     - title: Dependencies
       labels:
         - dependencies
+    - title: Maintenance
+      labels:
         - chore
+        - maintenance
     - title: Other Changes
       labels:
         - "*"


### PR DESCRIPTION
## Summary

- keep dependency updates separate from maintenance chores
- add a maintenance category for release housekeeping

## Verification

- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/release.yml")'