### PR TITLE
Add rule ID field to alert structure

### DIFF
--- a/docs/output.md
+++ b/docs/output.md
@@ -45,22 +45,23 @@ Format:
 
 ### Important Fields
 
-| Field | Meaning |
-| --- | --- |
-| `@timestamp` | Event time in UTC |
-| `ecs.version` | Always `9.4.0` |
-| `event.kind` | Always `alert` |
-| `event.category` | ECS category array |
-| `event.type` | ECS type array |
-| `event.action` | Normalized action keyword |
-| `event.code` | Sysmon-style or native event ID string |
-| `event.module` | Always `edr` |
-| `event.dataset` | `edr.<category>` |
-| `event.provider` | `etw` (Windows), `ebpf` (Linux), `esf` / `bpf` (macOS), or `yara-memory` for memory-scan hits |
-| `rule.name` | Detection rule title |
-| `edr.rule.severity` | Low, Medium, High, or Critical |
-| `edr.rule.engine` | `Sigma`, `Yara`, or `Ioc` |
-| `event.count` | *(rollup only)* Total occurrences of this alert within the dedup window (present only on aggregate rollup alerts, not on the first live emission) |
+| Field               | Meaning                                                                                                                                                                                               |
+|---------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `@timestamp`        | Event time in UTC                                                                                                                                                                                     |
+| `ecs.version`       | Always `9.4.0`                                                                                                                                                                                        |
+| `event.kind`        | Always `alert`                                                                                                                                                                                        |
+| `event.category`    | ECS category array                                                                                                                                                                                    |
+| `event.type`        | ECS type array                                                                                                                                                                                        |
+| `event.action`      | Normalized action keyword                                                                                                                                                                             |
+| `event.code`        | Sysmon-style or native event ID string                                                                                                                                                                |
+| `event.module`      | Always `edr`                                                                                                                                                                                          |
+| `event.dataset`     | `edr.<category>`                                                                                                                                                                                      |
+| `event.provider`    | `etw` (Windows), `ebpf` (Linux), `esf` / `bpf` (macOS), or `yara-memory` for memory-scan hits                                                                                                         |
+| `rule.name`         | Detection rule title                                                                                                                                                                                  |
+| `rule.id`           | Optional detection rule identifier, unique amongs the rustinel rules. Formatted as: `sigma::<uuid>` for Sigma, `yara::<id>` for YARA (if metadata ID is defined), or `ioc::<type>::<value>` for IOCs. |
+| `edr.rule.severity` | Low, Medium, High, or Critical                                                                                                                                                                        |
+| `edr.rule.engine`   | `Sigma`, `Yara`, or `Ioc`                                                                                                                                                                             |
+| `event.count`       | *(rollup only)* Total occurrences of this alert within the dedup window (present only on aggregate rollup alerts, not on the first live emission)                                                     |
 
 ### Linux Process Alert Example
 
@@ -77,6 +78,7 @@ Format:
   "event.dataset": "edr.process",
   "event.provider": "ebpf",
   "rule.name": "Example - Whoami Execution (Linux)",
+  "rule.id": "sigma::9b92f7e7-ee12-4fb3-b4d2-f674514a3821",
   "edr.rule.severity": "Low",
   "edr.rule.engine": "Sigma",
   "host.os.type": "linux",
@@ -102,6 +104,7 @@ Format:
   "event.dataset": "edr.process",
   "event.provider": "etw",
   "rule.name": "Example - Whoami Execution (CommandLine + Image)",
+  "rule.id": "sigma::d3b073c6-e265-4f40-a1c1-42e8f17a9c67",
   "edr.rule.severity": "Low",
   "edr.rule.engine": "Sigma",
   "host.os.type": "windows",

--- a/src/alerts/dedup.rs
+++ b/src/alerts/dedup.rs
@@ -207,6 +207,7 @@ mod tests {
             severity: AlertSeverity::High,
             rule_name: rule.to_string(),
             rule_description: None,
+            rule_id: None,
             engine: DetectionEngine::Sigma,
             event: NormalizedEvent {
                 timestamp: "2026-06-09T00:00:00Z".to_string(),

--- a/src/alerts/dedup.rs
+++ b/src/alerts/dedup.rs
@@ -5,7 +5,7 @@
 //! occurrence always emits immediately — there is zero added latency for novel alerts.
 //!
 //! # Key
-//! `(engine, rule_name, process_executable, process_parent_executable, user_name)`
+//! `(engine, rule_id_or_name, process_executable, process_parent_executable, user_name)`
 //!
 //! # Window semantics
 //! Each key starts a *tumbling* window anchored to the first emission.  Once
@@ -24,7 +24,7 @@ use tracing::info;
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct DedupKey {
     engine: String,
-    rule_name: String,
+    rule_id_or_name: String,
     executable: String,
     parent_executable: String,
     user_name: String,
@@ -34,7 +34,10 @@ impl DedupKey {
     fn from_ecs(ecs: &EcsAlert) -> Self {
         Self {
             engine: ecs.edr_rule_engine.clone(),
-            rule_name: ecs.rule_name.clone(),
+            rule_id_or_name: ecs
+                .rule_id
+                .clone()
+                .unwrap_or_else(|| format!("name::{}", ecs.rule_name)),
             executable: ecs.process_executable.clone().unwrap_or_default(),
             parent_executable: ecs.process_parent_executable.clone().unwrap_or_default(),
             user_name: ecs.user_name.clone().unwrap_or_default(),
@@ -367,5 +370,46 @@ mod tests {
         dedup.flush_expired(&sink);
 
         assert_eq!(dedup.counters.aggregated_total.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn equal_names_with_different_ids_tracked_separately() {
+        let dedup = Deduplicator::new(60, 1000);
+
+        let mut alert_a = make_alert("Rule A", "/usr/bin/curl");
+        alert_a.rule_id = Some("id-123".to_string());
+
+        let mut alert_b = make_alert("Rule A", "/usr/bin/curl");
+        alert_b.rule_id = Some("id-456".to_string());
+
+        let mut alert_c = make_alert("Rule A", "/usr/bin/curl");
+        alert_c.rule_id = None;
+
+        // An alert where the ID matches the raw name of alert_c.
+        // The prefixing of fallback names prevents collision with this alert's ID.
+        let mut alert_d = make_alert("Other Name", "/usr/bin/curl");
+        alert_d.rule_id = Some("Rule A".to_string());
+
+        let ecs_a = EcsAlert::from(&alert_a);
+        let ecs_b = EcsAlert::from(&alert_b);
+        let ecs_c = EcsAlert::from(&alert_c);
+        let ecs_d = EcsAlert::from(&alert_d);
+
+        assert!(
+            dedup.record(&ecs_a, &alert_a),
+            "first alert with id-123 must emit"
+        );
+        assert!(
+            dedup.record(&ecs_b, &alert_b),
+            "different alert with same name but id-456 must also emit"
+        );
+        assert!(
+            dedup.record(&ecs_c, &alert_c),
+            "alert with same name but no id must also emit"
+        );
+        assert!(
+            dedup.record(&ecs_d, &alert_d),
+            "alert with id matching another rule's name must not collide and must emit"
+        );
     }
 }

--- a/src/engine/alert.rs
+++ b/src/engine/alert.rs
@@ -420,10 +420,16 @@ impl Engine {
                         _ => AlertSeverity::Low,
                     };
 
+                    let rule_id = compiled_rule
+                        .rule
+                        .id
+                        .as_ref()
+                        .map(|id| format!("sigma::{}", id));
                     return Some(Alert {
                         severity,
                         rule_name: compiled_rule.rule.title.clone(),
                         rule_description: compiled_rule.rule.description.clone(),
+                        rule_id,
                         engine: DetectionEngine::Sigma,
                         event: event.clone(),
                         match_details: self.build_sigma_match_details(

--- a/src/ioc/mod.rs
+++ b/src/ioc/mod.rs
@@ -186,10 +186,13 @@ impl IocEngine {
     }
 
     pub fn build_alert_for_match(&self, m: &IocMatch, event: &NormalizedEvent) -> Alert {
+        let name = ioc_rule_name(m);
+        let ioc_id = format!("ioc::{}::{}", m.kind.as_str(), m.indicator);
         Alert {
             severity: self.severity,
-            rule_name: ioc_rule_name(m),
+            rule_name: name,
             rule_description: ioc_rule_description(m),
+            rule_id: Some(ioc_id),
             engine: DetectionEngine::Ioc,
             event: event.clone(),
             match_details: None,
@@ -204,10 +207,13 @@ impl IocEngine {
         platform: Platform,
         provider: &str,
     ) -> Alert {
+        let name = ioc_rule_name(m);
+        let ioc_id = format!("ioc::{}::{}", m.kind.as_str(), m.indicator);
         Alert {
             severity: self.severity,
-            rule_name: ioc_rule_name(m),
+            rule_name: name,
             rule_description: ioc_rule_description(m),
+            rule_id: Some(ioc_id),
             engine: DetectionEngine::Ioc,
             event: NormalizedEvent {
                 timestamp: crate::utils::now_timestamp_string(),

--- a/src/models/alert.rs
+++ b/src/models/alert.rs
@@ -11,6 +11,9 @@ pub struct Alert {
     /// Optional rule description / context (e.g., IOC comment)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rule_description: Option<String>,
+    /// Rule ID
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rule_id: Option<String>,
     /// Detection engine type
     pub engine: DetectionEngine,
     /// Associated event data

--- a/src/models/ecs/alert.rs
+++ b/src/models/ecs/alert.rs
@@ -76,6 +76,10 @@ pub struct EcsAlert {
     #[serde(rename = "rule.description", skip_serializing_if = "Option::is_none")]
     pub rule_description: Option<String>,
 
+    /// Detection rule ID
+    #[serde(rename = "rule.id", skip_serializing_if = "Option::is_none")]
+    pub rule_id: Option<String>,
+
     /// Detection severity (critical, high, medium, low)
     #[serde(rename = "edr.rule.severity")]
     pub edr_rule_severity: String,

--- a/src/models/ecs/mod.rs
+++ b/src/models/ecs/mod.rs
@@ -56,6 +56,7 @@ impl From<&Alert> for EcsAlert {
             host_os_family: host_os_family(alert.event.platform),
             rule_name: alert.rule_name.clone(),
             rule_description: alert.rule_description.clone(),
+            rule_id: alert.rule_id.clone(),
             edr_rule_severity: format!("{:?}", alert.severity),
             edr_rule_engine: format!("{:?}", alert.engine),
             process_executable: None,
@@ -356,6 +357,7 @@ mod tests {
             severity: AlertSeverity::High,
             rule_name: "Test Rule".to_string(),
             rule_description: None,
+            rule_id: Some("sigma::test-rule-id".to_string()),
             engine: DetectionEngine::Sigma,
             event: NormalizedEvent {
                 timestamp: "2026-01-06T00:00:00Z".to_string(),
@@ -402,6 +404,7 @@ mod tests {
         assert_eq!(ecs.event_code.as_deref(), Some("1"));
         assert_eq!(ecs.event_severity, Some(75));
         assert_eq!(ecs.rule_name, "Test Rule");
+        assert_eq!(ecs.rule_id.as_deref(), Some("sigma::test-rule-id"));
         assert_eq!(ecs.edr_rule_severity, "High");
         assert_eq!(ecs.edr_rule_engine, "Sigma");
         assert_eq!(
@@ -419,6 +422,7 @@ mod tests {
             severity: AlertSeverity::Critical,
             rule_name: "Suspicious Service".to_string(),
             rule_description: None,
+            rule_id: None,
             engine: DetectionEngine::Sigma,
             event: NormalizedEvent {
                 timestamp: "2026-01-06T00:00:00Z".to_string(),
@@ -461,6 +465,7 @@ mod tests {
             severity: AlertSeverity::High,
             rule_name: "Context Test".to_string(),
             rule_description: None,
+            rule_id: None,
             engine: DetectionEngine::Sigma,
             event: NormalizedEvent {
                 timestamp: "2026-01-06T00:00:00Z".to_string(),
@@ -526,6 +531,7 @@ mod tests {
             severity: AlertSeverity::Medium,
             rule_name: "Registry Test".to_string(),
             rule_description: None,
+            rule_id: None,
             engine: DetectionEngine::Sigma,
             event: NormalizedEvent {
                 timestamp: "2026-01-06T00:00:00Z".to_string(),
@@ -566,6 +572,7 @@ mod tests {
             severity: AlertSeverity::Low,
             rule_name: "DNS Test".to_string(),
             rule_description: None,
+            rule_id: None,
             engine: DetectionEngine::Sigma,
             event: NormalizedEvent {
                 timestamp: "2026-01-06T00:00:00Z".to_string(),
@@ -611,6 +618,7 @@ mod tests {
             severity: AlertSeverity::Low,
             rule_name: "File Test".to_string(),
             rule_description: None,
+            rule_id: None,
             engine: DetectionEngine::Sigma,
             event: NormalizedEvent {
                 timestamp: "2026-01-06T00:00:00Z".to_string(),
@@ -647,6 +655,7 @@ mod tests {
             severity: AlertSeverity::Low,
             rule_name: "Match Details".to_string(),
             rule_description: None,
+            rule_id: None,
             engine: DetectionEngine::Sigma,
             event: NormalizedEvent {
                 timestamp: "2026-02-04T00:00:00Z".to_string(),

--- a/src/models/match_details.rs
+++ b/src/models/match_details.rs
@@ -66,6 +66,8 @@ pub struct YaraMatchDetails {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct YaraRuleMatch {
     pub rule: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata_id: Option<String>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub tags: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -42,6 +42,7 @@ mod tests {
             severity: AlertSeverity::High,
             rule_name: "test_rule".to_string(),
             rule_description: None,
+            rule_id: None,
             engine: DetectionEngine::Sigma,
             event,
             match_details: None,

--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -743,6 +743,7 @@ mod tests {
             severity: AlertSeverity::High,
             rule_name: "Test".to_string(),
             rule_description: None,
+            rule_id: None,
             engine: DetectionEngine::Sigma,
             event: NormalizedEvent {
                 timestamp: "2026-02-03T00:00:00Z".to_string(),

--- a/src/runtime/yara.rs
+++ b/src/runtime/yara.rs
@@ -58,16 +58,19 @@ pub fn build_yara_match_details(
 
 pub fn build_yara_alert(
     rule_name: &str,
+    metadata_id: Option<String>,
     path: &str,
     pid: u32,
     match_details: Option<MatchDetails>,
     platform: Platform,
     provider: &str,
 ) -> Alert {
+    let rule_id = metadata_id.map(|id| format!("yara::{}", id));
     Alert {
         severity: AlertSeverity::Critical,
         rule_name: rule_name.to_string(),
         rule_description: None,
+        rule_id,
         engine: DetectionEngine::Yara,
         event: NormalizedEvent {
             timestamp: utils::now_timestamp_string(),
@@ -134,16 +137,19 @@ pub fn build_yara_memory_match_details(
 
 pub fn build_yara_memory_alert(
     rule_name: &str,
+    metadata_id: Option<String>,
     image: &str,
     pid: u32,
     match_details: Option<MatchDetails>,
     platform: Platform,
     provider: &str,
 ) -> Alert {
+    let rule_id = metadata_id.map(|id| format!("yara::{}", id));
     Alert {
         severity: AlertSeverity::Critical,
         rule_name: rule_name.to_string(),
         rule_description: None,
+        rule_id,
         engine: DetectionEngine::Yara,
         event: NormalizedEvent {
             timestamp: utils::now_timestamp_string(),
@@ -231,6 +237,7 @@ pub fn spawn_yara_file_worker(
                             let match_details = build_yara_match_details(match_debug, rule_match);
                             let alert = build_yara_alert(
                                 &rule_match.rule,
+                                rule_match.metadata_id.clone(),
                                 &path,
                                 pid,
                                 match_details,
@@ -328,6 +335,7 @@ pub fn spawn_yara_memory_worker(
                             build_yara_memory_match_details(match_debug, rule_match, chunk);
                         let alert = build_yara_memory_alert(
                             &rule_match.rule,
+                            rule_match.metadata_id.clone(),
                             &job.image,
                             job.pid,
                             details,

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -404,8 +404,18 @@ fn collect_yara_matches(
             }
         }
 
+        let mut metadata_id = None;
+        for (identifier, value) in rule.metadata() {
+            if identifier == "id" {
+                if let yara_x::MetaValue::String(s) = value {
+                    metadata_id = Some(s.to_string());
+                }
+            }
+        }
+
         matches.push(YaraRuleMatch {
             rule: rule_name,
+            metadata_id,
             tags,
             namespace,
             strings,
@@ -578,6 +588,7 @@ mod tests {
         };
         let expected = vec![YaraRuleMatch {
             rule: "TestRule".to_string(),
+            metadata_id: None,
             tags: Vec::new(),
             namespace: None,
             strings: Vec::new(),

--- a/tests/active_response.rs
+++ b/tests/active_response.rs
@@ -35,6 +35,7 @@ fn build_yara_alert(pid: u32, image: &str) -> Alert {
         severity: AlertSeverity::Critical,
         rule_name: "ExampleMarkerString".to_string(),
         rule_description: None,
+        rule_id: None,
         engine: DetectionEngine::Yara,
         event: NormalizedEvent {
             timestamp: "2026-01-01T00:00:00Z".to_string(),

--- a/tests/alert_output.rs
+++ b/tests/alert_output.rs
@@ -29,6 +29,7 @@ fn alert_sink_writes_single_valid_ecs_ndjson_line() {
             severity: AlertSeverity::High,
             rule_name: "Test Process Curl".to_string(),
             rule_description: Some("process test alert".to_string()),
+            rule_id: None,
             engine: DetectionEngine::Sigma,
             event,
             match_details: None,

--- a/tests/dedup_integration.rs
+++ b/tests/dedup_integration.rs
@@ -20,6 +20,7 @@ fn make_alert(rule: &str, image: &str) -> Alert {
         severity: AlertSeverity::High,
         rule_name: rule.to_string(),
         rule_description: None,
+        rule_id: None,
         engine: DetectionEngine::Sigma,
         event: NormalizedEvent {
             timestamp: "2026-06-09T00:00:00Z".to_string(),

--- a/tests/ecs_contract.rs
+++ b/tests/ecs_contract.rs
@@ -21,6 +21,7 @@ fn alert(category: EventCategory, event_id: u16, opcode: u8, fields: EventFields
         severity: AlertSeverity::High,
         rule_name: format!("{category:?} Test"),
         rule_description: None,
+        rule_id: None,
         engine: DetectionEngine::Sigma,
         event: NormalizedEvent {
             timestamp: "2026-01-01T00:00:00Z".to_string(),
@@ -366,6 +367,7 @@ fn macos_file_create_alert_maps_ecs_fields() {
         severity: AlertSeverity::High,
         rule_name: "macOS File Create".to_string(),
         rule_description: None,
+        rule_id: None,
         engine: DetectionEngine::Sigma,
         event: normalized,
         match_details: None,
@@ -427,4 +429,105 @@ fn ecs_version_field_is_9_4_0() {
         }),
     ));
     assert_ecs_field_eq(&json, "ecs.version", "9.4.0");
+}
+
+#[test]
+fn test_rule_id_mapping_and_omit_behavior() {
+    // 1. Sigma with ID
+    let alert_sigma_with_id = Alert {
+        severity: AlertSeverity::High,
+        rule_name: "Test Rule".to_string(),
+        rule_description: None,
+        rule_id: Some("sigma::abc-123".to_string()),
+        engine: DetectionEngine::Sigma,
+        event: NormalizedEvent {
+            timestamp: "2026-01-01T00:00:00Z".to_string(),
+            platform: Platform::Windows,
+            provider: "test".to_string(),
+            category: EventCategory::Process,
+            event_id: 1,
+            event_id_string: "1".to_string(),
+            opcode: 1,
+            fields: EventFields::ProcessCreation(ProcessCreationFields {
+                image: Some(r"C:\Windows\System32\cmd.exe".to_string()),
+                command_line: None,
+                process_id: None,
+                process_start_time: None,
+                parent_image: None,
+                parent_process_id: None,
+                parent_command_line: None,
+                current_directory: None,
+                integrity_level: None,
+                user: None,
+                original_file_name: None,
+                product: None,
+                description: None,
+                target_image: None,
+                logon_id: None,
+                logon_guid: None,
+            }),
+            process_context: None,
+        },
+        match_details: None,
+    };
+    let json_sigma_with_id = ecs_json(&alert_sigma_with_id);
+    assert_ecs_field_eq(&json_sigma_with_id, "rule.id", "sigma::abc-123");
+
+    // 2. Sigma without ID (omitted)
+    let alert_sigma_no_id = Alert {
+        severity: AlertSeverity::High,
+        rule_name: "Test Rule".to_string(),
+        rule_description: None,
+        rule_id: None,
+        engine: DetectionEngine::Sigma,
+        event: alert_sigma_with_id.event.clone(),
+        match_details: None,
+    };
+    let json_sigma_no_id = ecs_json(&alert_sigma_no_id);
+    assert!(json_sigma_no_id
+        .get("rule")
+        .and_then(|r| r.get("id"))
+        .is_none());
+
+    // 3. YARA with ID
+    let alert_yara_with_id = Alert {
+        severity: AlertSeverity::Critical,
+        rule_name: "YaraRule".to_string(),
+        rule_description: None,
+        rule_id: Some("yara::yara-rule-uuid".to_string()),
+        engine: DetectionEngine::Yara,
+        event: alert_sigma_with_id.event.clone(),
+        match_details: None,
+    };
+    let json_yara_with_id = ecs_json(&alert_yara_with_id);
+    assert_ecs_field_eq(&json_yara_with_id, "rule.id", "yara::yara-rule-uuid");
+
+    // 4. YARA without ID (omitted)
+    let alert_yara_no_id = Alert {
+        severity: AlertSeverity::Critical,
+        rule_name: "YaraRule".to_string(),
+        rule_description: None,
+        rule_id: None,
+        engine: DetectionEngine::Yara,
+        event: alert_sigma_with_id.event.clone(),
+        match_details: None,
+    };
+    let json_yara_no_id = ecs_json(&alert_yara_no_id);
+    assert!(json_yara_no_id
+        .get("rule")
+        .and_then(|r| r.get("id"))
+        .is_none());
+
+    // 5. IOC (always present, formatted as ioc::kind::indicator)
+    let alert_ioc = Alert {
+        severity: AlertSeverity::Medium,
+        rule_name: "ioc:domain:example.com".to_string(),
+        rule_description: None,
+        rule_id: Some("ioc::domain::example.com".to_string()),
+        engine: DetectionEngine::Ioc,
+        event: alert_sigma_with_id.event.clone(),
+        match_details: None,
+    };
+    let json_ioc = ecs_json(&alert_ioc);
+    assert_ecs_field_eq(&json_ioc, "rule.id", "ioc::domain::example.com");
 }

--- a/tests/yara_disk.rs
+++ b/tests/yara_disk.rs
@@ -70,6 +70,7 @@ fn build_yara_alert(
         severity: AlertSeverity::Critical,
         rule_name: rule_match.rule.clone(),
         rule_description: None,
+        rule_id: None,
         engine: DetectionEngine::Yara,
         event: NormalizedEvent {
             timestamp: chrono::DateTime::<chrono::Utc>::from(test_time()).to_rfc3339(),


### PR DESCRIPTION
## Summary

This PR adds `rule.id` field to the rule JSON alert's data in compliance with [ECS Rule fields](https://www.elastic.co/docs/reference/ecs/ecs-rule). This will allow to match the alert with exact rule even in case multiple rule packs are enabled, which can be used to gain insights into which rules/rule packs are responsible for which percentage of overall alert volume. Using rule ID instead of rule name keeps this future-proof in case the name changes.

The ID is prefixed with the engine (`yara`, `sigma`, `ioc`) so that is is assured to be unique within the rustinel rules (as the specs require).

### Detailed changes

1. Added `rule.id` ( `<type>::<actual id>` ):
     - Sigma rules: If the rule file contains an explicit  id  (e.g., UUID), formats the output  rule.id  field as  `sigma::<uuid>` . If no ID is specified, the `rule.id` field is omitted from the JSON alert entirely.
    - YARA rules: If the rule block contains an  id  field in its metadata section (e.g., `id = "yara-lnx-xmrig-coinminer"` ), formats the output  rule.id  field as `yara::<metadata_id>`. Otherwise, the field is omitted from the JSON alert.
    - IoC rules: The rule ID is formatted as `ioc::<kind>::<indicator>`  (e.g.  `ioc::domain::example.com`  or ioc::hash::0c2674... ), referencing the type of indicator matched and the indicator value itself.
2. Added Integration Tests:
    - Added a new integration test suite `test_rule_id_mapping_and_omit_behavior`  to `tests/ecs_contract.rs` to verify that when `rule_id`  is defined, it is formatted and serialized correctly, and when it is absent, it is omitted from the alert JSON payload.

## Type of change
<!-- Add the matching label to this PR before merging -->
- [x] `feat` / `enhancement` — new feature
- [ ] `bug` — bug fix
- [ ] `refactor` — refactoring, no behaviour change
- [ ] `documentation` — docs only
- [ ] `ci` — CI/CD changes
- [ ] `dependencies` — dependency update

## Test plan
- [ ] Tested on Windows
- [x] Tested on Linux
- [x] Existing tests pass (`cargo test`)
- [x] New tests added (if applicable)

## Checklist
- [ ] Label added to this PR
- [x] Docs updated (if behaviour changed)