### PR TITLE
feat: ship signed macOS Endpoint Security bundles

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -237,9 +237,9 @@ jobs:
           retention-days: 1
 
   # macOS builds run on the arm64 runner; the x86_64 target cross-compiles
-  # there since the SDK ships both slices. The EndpointSecurity framework links
-  # at build time and only needs entitlements at runtime. Signing and
-  # notarization happen here (on macOS) and produce the final .tar.gz.
+  # there since the SDK ships both slices. Endpoint Security uses a restricted
+  # entitlement, so the daemon is packaged in an app-like bundle with its
+  # provisioning profile before signing and notarization.
   build-macos:
     name: Build macOS ${{ matrix.arch }}
     runs-on: macos-latest
@@ -258,24 +258,15 @@ jobs:
       - run: rustup target add ${{ matrix.target }}
       - run: cargo build --locked --release --target ${{ matrix.target }}
 
-      # Code signing and notarization run only when the maintainer's Apple
-      # Developer secrets are configured; otherwise the binary ships unsigned
-      # (runnable on hosts with SIP/AMFI relaxed). A bare Mach-O cannot be
-      # stapled, so Gatekeeper verifies the notarization ticket online.
-      - name: Sign and notarize
+      - name: Import signing identity
         env:
-          BIN: target/${{ matrix.target }}/release/rustinel
           SIGN_IDENTITY: ${{ secrets.MACOS_SIGN_IDENTITY }}
           CERT_P12_BASE64: ${{ secrets.MACOS_CERT_P12_BASE64 }}
           CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
-          NOTARY_APPLE_ID: ${{ secrets.MACOS_NOTARY_APPLE_ID }}
-          NOTARY_TEAM_ID: ${{ secrets.MACOS_NOTARY_TEAM_ID }}
-          NOTARY_PASSWORD: ${{ secrets.MACOS_NOTARY_PASSWORD }}
         run: |
-          if [ -z "$SIGN_IDENTITY" ] || [ -z "$CERT_P12_BASE64" ]; then
-            echo "::warning::macOS signing secrets not configured; shipping unsigned binary"
-            exit 0
-          fi
+          : "${SIGN_IDENTITY:?MACOS_SIGN_IDENTITY is required}"
+          : "${CERT_P12_BASE64:?MACOS_CERT_P12_BASE64 is required}"
+          : "${CERT_PASSWORD:?MACOS_CERT_PASSWORD is required}"
           KEYCHAIN="$RUNNER_TEMP/rustinel-signing.keychain-db"
           KEYCHAIN_PASSWORD="$(uuidgen)"
           security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
@@ -285,24 +276,47 @@ jobs:
           security import "$RUNNER_TEMP/cert.p12" -k "$KEYCHAIN" -P "$CERT_PASSWORD" -T /usr/bin/codesign
           security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
           security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | tr -d '"')
-          codesign --force --options runtime --timestamp \
-            --entitlements packaging/macos/rustinel.entitlements \
-            --sign "$SIGN_IDENTITY" "$BIN"
-          codesign --verify --strict --verbose=2 "$BIN"
-          if [ -n "$NOTARY_APPLE_ID" ]; then
-            ditto -c -k "$BIN" "$RUNNER_TEMP/notarize.zip"
-            xcrun notarytool submit "$RUNNER_TEMP/notarize.zip" \
-              --apple-id "$NOTARY_APPLE_ID" --team-id "$NOTARY_TEAM_ID" \
-              --password "$NOTARY_PASSWORD" --wait
-          fi
           rm -f "$RUNNER_TEMP/cert.p12"
+
+      - name: Build signed app bundle
+        env:
+          SIGN_IDENTITY: ${{ secrets.MACOS_SIGN_IDENTITY }}
+          PROVISION_PROFILE_BASE64: ${{ secrets.MACOS_PROVISIONING_PROFILE_BASE64 }}
+        run: |
+          : "${PROVISION_PROFILE_BASE64:?MACOS_PROVISIONING_PROFILE_BASE64 is required}"
+          echo "$PROVISION_PROFILE_BASE64" | base64 --decode > "$RUNNER_TEMP/rustinel.provisionprofile"
+          scripts/macos/package-app.sh \
+            --binary "target/${{ matrix.target }}/release/rustinel" \
+            --output "$RUNNER_TEMP/Rustinel.app" \
+            --profile "$RUNNER_TEMP/rustinel.provisionprofile" \
+            --identity "$SIGN_IDENTITY" \
+            --version "${GITHUB_REF_NAME#v}"
+
+      - name: Notarize and staple
+        env:
+          NOTARY_APPLE_ID: ${{ secrets.MACOS_NOTARY_APPLE_ID }}
+          NOTARY_TEAM_ID: ${{ secrets.MACOS_NOTARY_TEAM_ID }}
+          NOTARY_PASSWORD: ${{ secrets.MACOS_NOTARY_PASSWORD }}
+        run: |
+          : "${NOTARY_APPLE_ID:?MACOS_NOTARY_APPLE_ID is required}"
+          : "${NOTARY_TEAM_ID:?MACOS_NOTARY_TEAM_ID is required}"
+          : "${NOTARY_PASSWORD:?MACOS_NOTARY_PASSWORD is required}"
+          ditto -c -k --keepParent "$RUNNER_TEMP/Rustinel.app" "$RUNNER_TEMP/notarize.zip"
+          xcrun notarytool submit "$RUNNER_TEMP/notarize.zip" \
+            --apple-id "$NOTARY_APPLE_ID" \
+            --team-id "$NOTARY_TEAM_ID" \
+            --password "$NOTARY_PASSWORD" \
+            --wait
+          xcrun stapler staple "$RUNNER_TEMP/Rustinel.app"
+          xcrun stapler validate "$RUNNER_TEMP/Rustinel.app"
+          spctl --assess --type execute --verbose=4 "$RUNNER_TEMP/Rustinel.app"
 
       - name: Package macOS ${{ matrix.arch }}
         run: |
           PKG="rustinel-${GITHUB_REF_NAME#v}-${{ matrix.target }}"
           mkdir -p "$PKG/rules/sigma" "$PKG/rules/yara" "$PKG/rules/ioc" "$PKG/logs" "$PKG/scripts/install" "$PKG/examples"
-          cp target/${{ matrix.target }}/release/rustinel "$PKG/"
-          chmod +x "$PKG/rustinel"
+          ditto "$RUNNER_TEMP/Rustinel.app" "$PKG/Rustinel.app"
+          ln -s "Rustinel.app/Contents/MacOS/rustinel" "$PKG/rustinel"
           cp config.toml README.md packaging/macos/com.rustinel.agent.plist "$PKG/"
           cp scripts/install/install.sh scripts/install/install.ps1 "$PKG/scripts/install/"
           cp -r examples/siem "$PKG/examples/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "rustinel"
 version = "1.1.2"
 edition = "2021"
 authors = []
-description = "Open-source EDR for Windows (ETW) and Linux (eBPF) with Sigma, YARA, and IOC detection"
+description = "Open-source EDR for Windows, Linux, and macOS with Sigma, YARA, and IOC detection"
 license = "Apache-2.0"
 rust-version = "1.92"
 default-run = "rustinel"
@@ -29,9 +29,6 @@ hex = "0.4"
 md-5 = "0.11"
 sha1 = "0.11"
 sha2 = "0.11"
-
-# Yara scanning
-yara-x = "1.17"
 
 # Async runtime
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "time", "net"] }
@@ -59,9 +56,16 @@ config = "0.15.23"
 aya = { version = "0.13", default-features = false }
 libc = "0.2"
 
+# YARA-X uses its native JIT outside macOS.
+[target.'cfg(not(target_os = "macos"))'.dependencies]
+yara-x = "1.17"
+
 # macOS-specific
 [target.'cfg(target_os = "macos")'.dependencies]
 libc = "0.2"
+# Endpoint Security clients cannot use hardened runtime relaxation
+# entitlements, so use the Pulley interpreter instead of YARA-X's native JIT.
+yara-x = { version = "1.17", features = ["pulley"] }
 # Endpoint Security framework bindings (process and file telemetry).
 # macos_11_0_0 sets the minimum supported macOS to Big Sur and enables
 # reference-counted message handling.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ whoami
 
 Your alert lands in `logs/alerts.json.<date>` as ECS NDJSON — ready to ship straight to a SIEM.
 
-> **Prefer to read before you run?** Download the [install script](scripts/install/install.sh) and inspect it, or grab a binary from the [latest release](https://github.com/Karib0u/rustinel/releases/latest). The installer only pulls published release binaries — it never builds from source. macOS support is experimental and needs root plus an Endpoint Security entitlement; see [Getting Started](https://docs.rustinel.io/getting-started/).
+> **Prefer to read before you run?** Download the [install script](scripts/install/install.sh) and inspect it, or grab a binary from the [latest release](https://github.com/Karib0u/rustinel/releases/latest). The installer only pulls published release binaries. macOS support is experimental and needs root plus user approval for the signed Endpoint Security client; see [Getting Started](https://docs.rustinel.io/getting-started/).
 
 ---
 
@@ -79,7 +79,7 @@ A transparent endpoint detection engine you can read, run, test, and extend — 
 | Linux 5.8+ (BTF) | eBPF | Process, network, file, DNS | Stable |
 | macOS 11+ | Endpoint Security + `/dev/bpf` | Process, file, network, DNS | Experimental |
 
-Windows coverage is the broadest today; Linux and macOS focus on process, network, file, and DNS. macOS is experimental while the project awaits the Endpoint Security entitlement. Full notes in the [platform docs](https://docs.rustinel.io/architecture/).
+Windows coverage is the broadest today; Linux and macOS focus on process, network, file, and DNS. macOS remains experimental while signed and notarized release packaging is validated across supported versions. Full notes are in the [platform docs](https://docs.rustinel.io/architecture/).
 
 ---
 
@@ -130,10 +130,10 @@ Each pack materializes into folders you point `config.toml` straight at. Browse 
 
 ```bash
 cargo build --release
-sudo ./target/release/rustinel run   # macOS also needs codesigning with the ESF entitlement — see docs
+sudo ./target/release/rustinel run
 ```
 
-Full prerequisites, macOS signing steps, and validation: [Getting Started](https://docs.rustinel.io/getting-started/).
+macOS requires the app-like signed bundle described in [Getting Started](https://docs.rustinel.io/getting-started/).
 
 ---
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -69,22 +69,65 @@ macOS telemetry uses Apple's Endpoint Security framework. Creating an ES client
 `com.apple.developer.endpoint-security.client` entitlement, and user approval
 (TCC). Without them the agent exits at startup with a `NotPrivileged` error.
 
-For development and lab use you can avoid a provisioning profile by relaxing
-system protections (in a VM or a dedicated test machine, never a production
-host): disable SIP from Recovery (`csrutil disable`) and, if needed, disable
-AMFI. Then ad-hoc sign the binary with the entitlement and run it as root:
+After Apple approves the managed capability, enable Endpoint Security on the
+explicit App ID used for the request and download a matching macOS provisioning
+profile. Install the profile's signing certificate and private key in the login
+keychain. Confirm that macOS can see the identity:
+
+```bash
+security find-identity -v -p codesigning
+```
+
+Build the binary, then create the app-like daemon bundle required for a
+restricted entitlement:
 
 ```bash
 cargo build --release
-codesign --force --sign - \
-  --entitlements packaging/macos/rustinel.entitlements \
-  target/release/rustinel
-sudo ./target/release/rustinel run
+
+scripts/macos/package-app.sh \
+  --binary target/release/rustinel \
+  --output target/release/Rustinel.app \
+  --profile "$HOME/Downloads/rustinel.provisionprofile" \
+  --identity "Developer ID Application: Example (TEAMID)"
 ```
 
-For distributable builds, request the Endpoint Security entitlement from Apple,
-then sign with your Developer ID and notarize using the same entitlements file.
-The entitlement lives in `packaging/macos/rustinel.entitlements`.
+The script derives the bundle identifier from the profile, validates that the
+profile authorizes Endpoint Security, embeds it at
+`Contents/embedded.provisionprofile`, adds the profile App ID and Team ID to the
+signed entitlements, enables the hardened runtime, and verifies the bundle.
+On macOS, YARA-X uses Wasmtime's Pulley interpreter because Endpoint Security
+clients cannot use hardened runtime relaxation entitlements for JIT executable
+memory.
+
+Grant `Rustinel.app` Full Disk Access in System Settings, then run:
+
+```bash
+sudo ./target/release/Rustinel.app/Contents/MacOS/rustinel run
+```
+
+In another terminal, trigger and inspect the bundled demo:
+
+```bash
+whoami
+cat logs/alerts.json.*
+```
+
+For a SIP-disabled VM or dedicated test Mac, an ad-hoc bundle can still be
+created without a profile:
+
+```bash
+scripts/macos/package-app.sh \
+  --binary target/release/rustinel \
+  --output target/release/Rustinel.app \
+  --adhoc
+```
+
+Do not use the ad-hoc path on a normal SIP-enabled Mac. Release builds require
+the Developer ID identity, the Endpoint Security provisioning profile, and a
+successful notarization. CI expects `MACOS_SIGN_IDENTITY`,
+`MACOS_CERT_P12_BASE64`, `MACOS_CERT_PASSWORD`,
+`MACOS_PROVISIONING_PROFILE_BASE64`, `MACOS_NOTARY_APPLE_ID`,
+`MACOS_NOTARY_TEAM_ID`, and `MACOS_NOTARY_PASSWORD`.
 
 ## Testing
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -16,7 +16,7 @@ See [Architecture](architecture.md) and [Detection](detection.md) for the detail
 - Linux with kernel 5.8+, BTF, and the required eBPF privileges
 - macOS 11+ (experimental) using Endpoint Security plus `/dev/bpf` capture
 
-Current telemetry coverage is broadest on Windows, which includes process, image load, network, file, registry, DNS, PowerShell, WMI, service, and task telemetry. Linux and macOS currently cover process, network, file, and DNS. macOS support is experimental while the project waits for the required Endpoint Security entitlement.
+Current telemetry coverage is broadest on Windows, which includes process, image load, network, file, registry, DNS, PowerShell, WMI, service, and task telemetry. Linux and macOS currently cover process, network, file, and DNS. macOS support remains experimental while signed release packaging is validated across supported versions.
 
 ### Do I need Administrator or root?
 
@@ -24,7 +24,7 @@ Yes.
 
 - Windows ETW collection requires Administrator privileges.
 - Linux eBPF collection requires root or equivalent capabilities such as `CAP_BPF` or `CAP_SYS_ADMIN`, depending on your setup.
-- macOS Endpoint Security collection requires root, plus the `com.apple.developer.endpoint-security.client` entitlement (or SIP/AMFI relaxed for local testing).
+- macOS Endpoint Security collection requires root, Full Disk Access, and a signed app bundle whose embedded provisioning profile authorizes `com.apple.developer.endpoint-security.client`.
 
 ## Running And Deployment
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -83,11 +83,12 @@ OS or architecture, the script exits before changing the install directory.
 ### macOS
 
 - macOS 11+
-- Root, plus the `com.apple.developer.endpoint-security.client` entitlement on signed and notarized builds, or SIP/AMFI relaxed for local testing
+- Root and Full Disk Access for the signed Endpoint Security client
 - Access to the `/dev/bpf*` device nodes for network and DNS capture
 - Rust 1.92+ and the Xcode Command Line Tools if building from source
 
-macOS support is experimental while the project waits for the required Endpoint Security Framework entitlement.
+macOS support remains experimental while release packaging and runtime behavior
+are validated across supported versions.
 
 ## Quick Start
 
@@ -140,8 +141,9 @@ sudo ./rustinel run
 ```
 
 If startup fails with `NotPrivileged`, the Endpoint Security client could not be
-created. Run as root with a signed, entitled build, or relax SIP/AMFI on a test
-machine. Network and DNS capture additionally needs access to the `/dev/bpf*`
+created. Confirm that the app is signed, its embedded provisioning profile
+authorizes Endpoint Security, it has Full Disk Access, and it is running as
+root. Network and DNS capture additionally needs access to the `/dev/bpf*`
 device nodes; the agent continues with Endpoint Security only if capture cannot
 start.
 
@@ -173,14 +175,21 @@ sudo ./target/release/rustinel run
 git clone https://github.com/Karib0u/rustinel.git
 cd rustinel
 cargo build --release
-codesign --force --sign - \
-  --entitlements packaging/macos/rustinel.entitlements \
-  target/release/rustinel
-sudo ./target/release/rustinel run
+
+scripts/macos/package-app.sh \
+  --binary target/release/rustinel \
+  --output target/release/Rustinel.app \
+  --profile "$HOME/Downloads/rustinel.provisionprofile" \
+  --identity "Developer ID Application: Example (TEAMID)"
+
+sudo ./target/release/Rustinel.app/Contents/MacOS/rustinel run
 ```
 
-Ad-hoc signing with the entitlement only takes effect when SIP/AMFI is relaxed.
-See the [Development](development.md) guide for signing and notarization details.
+The profile must belong to the explicit App ID approved for the project and
+authorize `com.apple.developer.endpoint-security.client`. The packaging script
+derives the bundle identifier from that profile. Grant the resulting app bundle
+Full Disk Access before starting it. See [Development](development.md) for
+profile validation, ad-hoc lab builds, and release secrets.
 
 Notes:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,7 +43,8 @@ Rustinel currently provides:
 - Hot reload for rules and indicator files
 - Optional active response with dry-run and allowlists
 
-macOS support is experimental while the project waits for the required Endpoint Security Framework entitlement.
+macOS support is experimental while signed release packaging is validated
+across supported macOS versions.
 
 ## What Rustinel is not
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -21,7 +21,8 @@ C:\Rustinel\
 
 ```text
 /opt/rustinel/
-├── rustinel
+├── Rustinel.app/
+├── rustinel -> Rustinel.app/Contents/MacOS/rustinel
 ├── config.toml
 ├── rules/
 │   ├── sigma/
@@ -43,7 +44,9 @@ C:\Rustinel\
 └── logs/
 ```
 
-macOS support is experimental. The binary must be signed with the Endpoint Security entitlement, or run with SIP/AMFI relaxed on a dedicated test machine — see [Getting Started](getting-started.md) and [Development](development.md).
+macOS support is experimental. Release archives contain a signed and notarized
+app-like daemon bundle with the Endpoint Security provisioning profile. See
+[Getting Started](getting-started.md) and [Development](development.md).
 
 Use absolute paths in `config.toml` once you move beyond the default repo layout.
 
@@ -125,10 +128,13 @@ Because `config.toml` is loaded from `WorkingDirectory`, use absolute paths for 
 macOS support is experimental and detection-only (no active response). Rustinel does not ship macOS service-management commands; run it in the foreground as root, or wrap it in a `launchd` job for background execution:
 
 ```bash
-sudo /opt/rustinel/rustinel run
+sudo /opt/rustinel/Rustinel.app/Contents/MacOS/rustinel run
 ```
 
-The binary must be signed with the `com.apple.developer.endpoint-security.client` entitlement, or run with SIP/AMFI relaxed on a dedicated test machine. See [Development](development.md) for signing and notarization details.
+The app bundle must be signed with the
+`com.apple.developer.endpoint-security.client` entitlement, contain the
+authorizing provisioning profile, and have Full Disk Access. See
+[Development](development.md) for signing and notarization details.
 
 ## Upgrade Examples
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -111,14 +111,17 @@ See [Getting Started](getting-started.md) and [Development](development.md).
 Creating an Endpoint Security client failed. The common causes are:
 
 - not running as root
-- the binary is not signed with the `com.apple.developer.endpoint-security.client` entitlement, and SIP/AMFI is not relaxed
-- the user has not approved the agent (TCC)
+- the app is not signed with the `com.apple.developer.endpoint-security.client` entitlement
+- `Contents/embedded.provisionprofile` is missing or does not authorize the entitlement
+- the user has not granted the app Full Disk Access
 
 What to do:
 
 - run with `sudo`
-- for distributable builds, sign and notarize with the Endpoint Security entitlement
-- for local testing, relax SIP/AMFI on a dedicated test machine and ad-hoc sign with the entitlement (see [Development](development.md))
+- inspect the signature with `codesign --display --entitlements - Rustinel.app`
+- decode the profile with `security cms -D -i Rustinel.app/Contents/embedded.provisionprofile`
+- grant `Rustinel.app` Full Disk Access
+- rebuild with the supported packaging script described in [Development](development.md)
 
 Typical symptom in logs:
 

--- a/packaging/macos/com.rustinel.agent.plist
+++ b/packaging/macos/com.rustinel.agent.plist
@@ -9,7 +9,8 @@
 
     sudo launchctl bootstrap system /Library/LaunchDaemons/com.rustinel.agent.plist
 
-  Adjust the program path and working directory to match your install layout.
+  This template expects the release package to be installed under
+  /usr/local/var/rustinel.
 -->
 <plist version="1.0">
 <dict>
@@ -17,7 +18,7 @@
     <string>com.rustinel.agent</string>
     <key>ProgramArguments</key>
     <array>
-        <string>/usr/local/bin/rustinel</string>
+        <string>/usr/local/var/rustinel/Rustinel.app/Contents/MacOS/rustinel</string>
         <string>run</string>
     </array>
     <key>WorkingDirectory</key>

--- a/packaging/macos/rustinel.entitlements
+++ b/packaging/macos/rustinel.entitlements
@@ -4,9 +4,9 @@
 <dict>
     <!--
       Required to create an Endpoint Security client (es_new_client).
-      Apple grants this entitlement on request to your Developer ID account;
-      distributable builds must be signed and notarized with it. Dev and lab
-      builds can run with SIP/AMFI relaxed instead.
+      Apple grants this restricted entitlement on request. A normal macOS
+      build must embed an authorizing provisioning profile in an app-like
+      bundle, use a matching signing identity, and be notarized for release.
     -->
     <key>com.apple.developer.endpoint-security.client</key>
     <true/>

--- a/scripts/macos/package-app.sh
+++ b/scripts/macos/package-app.sh
@@ -1,0 +1,218 @@
+#!/bin/bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+
+binary=""
+output=""
+profile="${MACOS_PROVISIONING_PROFILE:-}"
+identity="${MACOS_SIGN_IDENTITY:-}"
+bundle_id="${MACOS_BUNDLE_ID:-}"
+version=""
+adhoc=0
+
+usage() {
+  cat <<'EOF'
+Build and sign the app-like bundle required by a macOS daemon that uses the
+Endpoint Security restricted entitlement.
+
+Usage:
+  package-app.sh --binary PATH --output PATH [options]
+
+Required:
+  --binary PATH       Compiled rustinel Mach-O binary
+  --output PATH       Destination app bundle, normally Rustinel.app
+
+Distribution signing:
+  --profile PATH      Developer ID provisioning profile with Endpoint Security
+  --identity NAME     Developer ID Application signing identity
+
+Options:
+  --bundle-id ID      Bundle identifier. Default: derived from the profile
+  --version VERSION   Bundle version. Default: Cargo package version
+  --adhoc             Ad-hoc sign without a profile for a SIP-disabled test Mac
+  -h, --help          Show this help
+
+The profile and identity can also be supplied with
+MACOS_PROVISIONING_PROFILE and MACOS_SIGN_IDENTITY.
+EOF
+}
+
+fail() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --binary)
+      binary="${2:?missing value for --binary}"
+      shift 2
+      ;;
+    --output)
+      output="${2:?missing value for --output}"
+      shift 2
+      ;;
+    --profile)
+      profile="${2:?missing value for --profile}"
+      shift 2
+      ;;
+    --identity)
+      identity="${2:?missing value for --identity}"
+      shift 2
+      ;;
+    --bundle-id)
+      bundle_id="${2:?missing value for --bundle-id}"
+      shift 2
+      ;;
+    --version)
+      version="${2:?missing value for --version}"
+      shift 2
+      ;;
+    --adhoc)
+      adhoc=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+[[ -n "$binary" ]] || fail "--binary is required"
+[[ -f "$binary" ]] || fail "binary not found: $binary"
+[[ -n "$output" ]] || fail "--output is required"
+[[ "$output" != "/" ]] || fail "refusing to use / as the output"
+
+if [[ -z "$version" ]]; then
+  version="$(
+    sed -n 's/^version = "\([^"]*\)"/\1/p' "$repo_root/Cargo.toml" | head -n 1
+  )"
+fi
+[[ -n "$version" ]] || fail "could not determine the package version"
+
+if [[ "$adhoc" -eq 1 ]]; then
+  [[ -z "$profile" ]] || fail "--adhoc cannot be combined with --profile"
+  [[ -z "$identity" || "$identity" == "-" ]] ||
+    fail "--adhoc cannot be combined with a signing identity"
+  identity="-"
+  if [[ -z "$bundle_id" ]]; then
+    bundle_id="com.rustinel.agent"
+  fi
+else
+  [[ -n "$profile" ]] || fail "--profile is required for an entitled build"
+  [[ -f "$profile" ]] || fail "provisioning profile not found: $profile"
+  [[ -n "$identity" ]] || fail "--identity is required for an entitled build"
+fi
+
+tmp_dir="$(mktemp -d)"
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+entitlements="$tmp_dir/rustinel.entitlements"
+cp "$repo_root/packaging/macos/rustinel.entitlements" "$entitlements"
+
+if [[ "$adhoc" -eq 0 ]]; then
+  profile_plist="$tmp_dir/profile.plist"
+  security cms -D -i "$profile" > "$profile_plist"
+
+  profile_es="$(
+    /usr/libexec/PlistBuddy \
+      -c 'Print :Entitlements:com.apple.developer.endpoint-security.client' \
+      "$profile_plist" 2>/dev/null || true
+  )"
+  [[ "$profile_es" == "true" ]] ||
+    fail "profile does not authorize Endpoint Security"
+
+  app_identifier="$(
+    /usr/libexec/PlistBuddy \
+      -c 'Print :Entitlements:com.apple.application-identifier' \
+      "$profile_plist"
+  )"
+  app_id_prefix="$(
+    /usr/libexec/PlistBuddy \
+      -c 'Print :ApplicationIdentifierPrefix:0' \
+      "$profile_plist"
+  )"
+  team_id="$(
+    /usr/libexec/PlistBuddy -c 'Print :TeamIdentifier:0' "$profile_plist"
+  )"
+  profile_bundle_id="${app_identifier#"${app_id_prefix}."}"
+
+  [[ "$profile_bundle_id" != "$app_identifier" ]] ||
+    fail "profile App ID has an unexpected prefix: $app_identifier"
+  if [[ -z "$bundle_id" ]]; then
+    [[ "$profile_bundle_id" != "*" ]] ||
+      fail "a wildcard profile requires --bundle-id"
+    bundle_id="$profile_bundle_id"
+  fi
+  expected_app_identifier="${app_id_prefix}.${bundle_id}"
+
+  if [[ "$app_identifier" != "$expected_app_identifier" &&
+        "$app_identifier" != "${app_id_prefix}.*" ]]; then
+    fail "profile App ID $app_identifier does not match $bundle_id"
+  fi
+
+  /usr/libexec/PlistBuddy \
+    -c "Add :com.apple.application-identifier string $expected_app_identifier" \
+    "$entitlements"
+  /usr/libexec/PlistBuddy \
+    -c "Add :com.apple.developer.team-identifier string $team_id" \
+    "$entitlements"
+fi
+
+rm -rf "$output"
+mkdir -p "$output/Contents/MacOS"
+cp "$binary" "$output/Contents/MacOS/rustinel"
+chmod 755 "$output/Contents/MacOS/rustinel"
+
+info_plist="$output/Contents/Info.plist"
+plutil -create xml1 "$info_plist"
+plutil -insert CFBundleDevelopmentRegion -string en "$info_plist"
+plutil -insert CFBundleDisplayName -string Rustinel "$info_plist"
+plutil -insert CFBundleExecutable -string rustinel "$info_plist"
+plutil -insert CFBundleIdentifier -string "$bundle_id" "$info_plist"
+plutil -insert CFBundleInfoDictionaryVersion -string 6.0 "$info_plist"
+plutil -insert CFBundleName -string Rustinel "$info_plist"
+plutil -insert CFBundlePackageType -string APPL "$info_plist"
+plutil -insert CFBundleShortVersionString -string "$version" "$info_plist"
+plutil -insert CFBundleVersion -string "$version" "$info_plist"
+plutil -insert LSBackgroundOnly -bool true "$info_plist"
+plutil -insert LSMinimumSystemVersion -string 11.0 "$info_plist"
+
+if [[ "$adhoc" -eq 0 ]]; then
+  cp "$profile" "$output/Contents/embedded.provisionprofile"
+fi
+
+if [[ "$identity" == "-" ]]; then
+  codesign --force --options runtime --timestamp=none \
+    --entitlements "$entitlements" \
+    --sign - \
+    "$output"
+else
+  codesign --force --options runtime --timestamp \
+    --entitlements "$entitlements" \
+    --sign "$identity" \
+    "$output"
+fi
+
+codesign --verify --strict --verbose=2 "$output"
+if [[ "$adhoc" -eq 0 ]]; then
+  signed_team_id="$(
+    codesign --display --verbose=4 "$output" 2>&1 |
+      sed -n 's/^TeamIdentifier=//p'
+  )"
+  [[ "$signed_team_id" == "$team_id" ]] ||
+    fail "signed Team ID $signed_team_id does not match profile Team ID $team_id"
+fi
+codesign --display --verbose=2 "$output"
+codesign --display --entitlements - "$output"
+
+echo "Created signed app bundle: $output"

--- a/src/sensor/macos/esf.rs
+++ b/src/sensor/macos/esf.rs
@@ -15,6 +15,7 @@
 //! relaxed.
 
 use std::ffi::OsStr;
+use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
@@ -129,11 +130,19 @@ fn run_client(
     shutdown: Arc<AtomicBool>,
     ready_tx: std::sync::mpsc::Sender<Result<(), String>>,
 ) {
-    let handler = move |_client: &mut Client<'_>, msg: Message| {
-        if let Some(event) = build_sensor_event(&msg) {
-            try_send(&tx, event);
-        }
-    };
+    let handler =
+        move |_client: &mut Client<'_>, msg: Message| match catch_unwind(AssertUnwindSafe(|| {
+            build_sensor_event(&msg)
+        })) {
+            Ok(Some(event)) => try_send(&tx, event),
+            Ok(None) => {}
+            Err(_) => {
+                warn!(
+                    event_type = ?msg.event_type(),
+                    "Endpoint Security event conversion panicked; dropping event"
+                );
+            }
+        };
 
     let mut client = match Client::new(handler) {
         Ok(client) => client,


### PR DESCRIPTION
## Summary

- add a macOS app bundle packaging script that validates the Endpoint Security provisioning profile, embeds it, derives the bundle identifier, and signs with the hardened runtime
- require macOS signing and notarization secrets in the release workflow, staple the notarization ticket, verify Gatekeeper, and package the signed app bundle
- use the YARA-X Pulley interpreter on macOS because Endpoint Security clients cannot use hardened runtime JIT relaxation entitlements
- harden the Endpoint Security callback against conversion panics
- update the launchd template and documentation for Full Disk Access, signed bundle execution, troubleshooting, and release configuration

## Root cause

The previous release flow signed a bare Mach-O without embedding the provisioning profile required for the restricted Endpoint Security entitlement. Once the entitled client started successfully, YARA-X used Wasmtime JIT memory and macOS terminated the process with a code-signing invalid-page error. Adding JIT relaxation entitlements is not allowed for Endpoint Security clients, so macOS builds now use Pulley instead.

## Validation

- `cargo build --locked --release`
- `cargo test --locked`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- plist, shell syntax, workflow YAML, and signature validation
- local signed app bundle launched as root with Full Disk Access
- Endpoint Security subscription and BPF capture initialized successfully
- `whoami` produced the expected macOS Sigma alert
- YARA scanning remained active without a new code-signing crash

## Follow-up

The repository secrets for the Apple signing certificate, provisioning profile, and notarization credentials must be configured before the tagged macOS release job can complete.