### PR TITLE
feat(macos): actionable Endpoint Security first-run errors

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -65,9 +65,11 @@ sudo env RUSTINEL_EBPF_OBJECT=$PWD/ebpf/rustinel-ebpf.o ./target/release/rustine
 ### macOS
 
 macOS telemetry uses Apple's Endpoint Security framework. Creating an ES client
-(`es_new_client`) requires three things: running as root, the
-`com.apple.developer.endpoint-security.client` entitlement, and user approval
-(TCC). Without them the agent exits at startup with a `NotPrivileged` error.
+(`es_new_client`) requires three things, and each missing piece surfaces a
+distinct startup error: running as root (`NotPrivileged` if not), the
+`com.apple.developer.endpoint-security.client` entitlement (`NotEntitled` if
+missing), and user approval via Full Disk Access / TCC (`NotPermitted` if not
+granted).
 
 After Apple approves the managed capability, enable Endpoint Security on the
 explicit App ID used for the request and download a matching macOS provisioning

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -140,12 +140,17 @@ cd rustinel-<version>-aarch64-apple-darwin
 sudo ./rustinel run
 ```
 
-If startup fails with `NotPrivileged`, the Endpoint Security client could not be
-created. Confirm that the app is signed, its embedded provisioning profile
-authorizes Endpoint Security, it has Full Disk Access, and it is running as
-root. Network and DNS capture additionally needs access to the `/dev/bpf*`
-device nodes; the agent continues with Endpoint Security only if capture cannot
-start.
+macOS requires a one-time approval before any Endpoint Security client can run,
+so on a fresh machine the first run usually exits with `NotPermitted`. Grant
+`Rustinel.app` **Full Disk Access** in System Settings → Privacy & Security →
+Full Disk Access, then re-run `sudo ./rustinel run`. (If you launched it from a
+terminal, that terminal app may also need Full Disk Access.) A `NotPrivileged`
+error instead means it is not running as root — re-run with `sudo`. See
+[Troubleshooting](troubleshooting.md#macos-endpoint-security-client-init-failed)
+for the full result-code table.
+
+Network and DNS capture additionally needs access to the `/dev/bpf*` device
+nodes; the agent continues with Endpoint Security only if capture cannot start.
 
 ## Compile From Source
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -106,27 +106,30 @@ If `ebpf/rustinel-ebpf.o` is missing, the build falls back to compiling the eBPF
 
 See [Getting Started](getting-started.md) and [Development](development.md).
 
-### macOS `Endpoint Security client init failed: ... NotPrivileged`
+### macOS `Endpoint Security client init failed`
 
-Creating an Endpoint Security client failed. The common causes are:
+Creating the Endpoint Security client failed at startup. The result code at the
+end of the error tells you exactly which requirement is missing:
 
-- not running as root
-- the app is not signed with the `com.apple.developer.endpoint-security.client` entitlement
-- `Contents/embedded.provisionprofile` is missing or does not authorize the entitlement
-- the user has not granted the app Full Disk Access
+| Result code | Cause | Fix |
+| --- | --- | --- |
+| `NotPrivileged` | Not running as root. | Re-run with `sudo`. |
+| `NotPermitted` | Running as root with the entitlement, but macOS has not granted the client Endpoint Security access (TCC). | Grant `Rustinel.app` **Full Disk Access** in System Settings → Privacy & Security → Full Disk Access, then re-run. If you launched it from a terminal, that terminal app may also need Full Disk Access. |
+| `NotEntitled` | The binary is not signed with `com.apple.developer.endpoint-security.client`, or its provisioning profile does not authorize the entitlement. | Run a signed `Rustinel.app` from a release, or repackage with `scripts/macos/package-app.sh` (see [Development](development.md)). |
 
-What to do:
+On a fresh machine the first run typically reports `NotPermitted`: signing and
+notarization are correct, and the only thing left is the one-time Full Disk
+Access approval that macOS requires for every Endpoint Security client.
 
-- run with `sudo`
-- inspect the signature with `codesign --display --entitlements - Rustinel.app`
-- decode the profile with `security cms -D -i Rustinel.app/Contents/embedded.provisionprofile`
-- grant `Rustinel.app` Full Disk Access
-- rebuild with the supported packaging script described in [Development](development.md)
+To inspect the bundle:
+
+- check the signature and entitlements: `codesign --display --entitlements - Rustinel.app`
+- decode the embedded profile: `security cms -D -i Rustinel.app/Contents/embedded.provisionprofile`
 
 Typical symptom in logs:
 
 ```text
-macOS Endpoint Security sensor failed to start: Endpoint Security client init failed: es_new_client failed: NotPrivileged
+macOS Endpoint Security sensor failed to start: Endpoint Security client init failed: es_new_client failed: NotPermitted: macOS has not granted Endpoint Security access. Grant Rustinel.app Full Disk Access ...
 ```
 
 ### macOS network or DNS events are missing

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -157,7 +157,25 @@ mkdir -p "$(dirname "$install_dir")"
 mkdir -p "$install_dir"
 cp -R "$package_dir/." "$install_dir/"
 
-cat <<EOF
+if [ "$os" = "Darwin" ]; then
+  cat <<EOF
+
+Rustinel $version installed to:
+  $install_dir
+
+macOS requires a one-time approval before Endpoint Security can start:
+  1. Grant Full Disk Access to:  $install_dir/Rustinel.app
+     (System Settings > Privacy & Security > Full Disk Access)
+  2. cd "$install_dir" && sudo ./rustinel run
+  3. Trigger the demo in another terminal:  whoami
+  4. Read the alert:  cat logs/alerts.json.*
+
+Before approval the agent exits with a NotPermitted error and opens the Full
+Disk Access pane for you; grant access, then run it again.
+
+EOF
+else
+  cat <<EOF
 
 Rustinel $version installed to:
   $install_dir
@@ -169,9 +187,15 @@ Try the bundled demo rule:
   cat logs/alerts.json.*
 
 EOF
+fi
 
 if [ "$run_after_install" -eq 1 ]; then
   cd "$install_dir"
+  if [ "$os" = "Darwin" ]; then
+    echo "Starting Rustinel. On macOS the first run needs Full Disk Access for" >&2
+    echo "$install_dir/Rustinel.app; if it exits with NotPermitted, grant access" >&2
+    echo "in System Settings > Privacy & Security > Full Disk Access, then re-run." >&2
+  fi
   if [ "$(id -u)" -eq 0 ]; then
     exec ./rustinel run
   else

--- a/src/sensor/macos/esf.rs
+++ b/src/sensor/macos/esf.rs
@@ -15,6 +15,7 @@
 //! relaxed.
 
 use std::ffi::OsStr;
+use std::io::IsTerminal;
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -27,7 +28,7 @@ use endpoint_sec::{
     Client, Event, EventClose, EventCreate, EventCreateDestinationFile, EventExec, EventRename,
     EventRenameDestinationFile, EventUnlink, Message,
 };
-use endpoint_sec_sys::es_event_type_t;
+use endpoint_sec_sys::{es_event_type_t, NewClientError};
 use tokio::sync::mpsc::Sender;
 use tracing::{info, warn};
 
@@ -120,6 +121,57 @@ impl Sensor for EsfSensor {
     }
 }
 
+/// Translate an `es_new_client` failure into an actionable message.
+///
+/// These failures are almost always environmental — missing TCC approval, not
+/// root, or an unsigned binary — rather than bugs, so we point at the concrete
+/// step that unblocks each one instead of surfacing a bare result code.
+fn new_client_error_hint(err: &NewClientError) -> String {
+    let remedy = match err {
+        NewClientError::NotPermitted => {
+            "macOS has not granted Endpoint Security access. Grant Rustinel.app Full Disk \
+             Access in System Settings > Privacy & Security > Full Disk Access, then re-run. \
+             If you launched it from a terminal, that terminal app may also need Full Disk \
+             Access."
+        }
+        NewClientError::NotPrivileged => "Endpoint Security requires root. Re-run with sudo.",
+        NewClientError::NotEntitled => {
+            "The binary lacks the com.apple.developer.endpoint-security.client entitlement. \
+             Run a signed Rustinel.app from a release, or repackage it with \
+             scripts/macos/package-app.sh."
+        }
+        NewClientError::TooManyClients => {
+            "The system reached its Endpoint Security client limit. Stop another Endpoint \
+             Security agent and retry."
+        }
+        _ => "Could not create the Endpoint Security client.",
+    };
+    format!("es_new_client failed: {err:?}: {remedy}")
+}
+
+/// Best-effort deep-link to the Full Disk Access settings pane.
+///
+/// `NotPermitted` means the user still has to grant Full Disk Access by hand, so
+/// for an interactive `sudo ./rustinel run` we open the right pane for them.
+/// Started with sudo the process is root, which has no GUI session, so we reopen
+/// in the invoking user's session via `launchctl asuser`. A LaunchDaemon has no
+/// controlling terminal and is skipped; any failure is ignored — this is a
+/// convenience, not a step the pipeline depends on.
+fn try_open_full_disk_access_settings() {
+    if !std::io::stderr().is_terminal() {
+        return;
+    }
+    const PANE: &str = "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles";
+    info!("Opening System Settings → Privacy & Security → Full Disk Access");
+    let status = match std::env::var("SUDO_UID") {
+        Ok(uid) => std::process::Command::new("launchctl")
+            .args(["asuser", &uid, "open", PANE])
+            .status(),
+        Err(_) => std::process::Command::new("open").arg(PANE).status(),
+    };
+    let _ = status;
+}
+
 /// Body of the Endpoint Security client thread.
 ///
 /// Creates the client, subscribes, signals readiness, then keeps the client
@@ -147,7 +199,10 @@ fn run_client(
     let mut client = match Client::new(handler) {
         Ok(client) => client,
         Err(e) => {
-            let _ = ready_tx.send(Err(format!("es_new_client failed: {e:?}")));
+            if matches!(e, NewClientError::NotPermitted) {
+                try_open_full_disk_access_settings();
+            }
+            let _ = ready_tx.send(Err(new_client_error_hint(&e)));
             return;
         }
     };
@@ -531,6 +586,19 @@ fn try_send(tx: &Sender<SensorEvent>, event: SensorEvent) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn not_permitted_hint_points_at_full_disk_access() {
+        let msg = new_client_error_hint(&NewClientError::NotPermitted);
+        assert!(msg.contains("NotPermitted"));
+        assert!(msg.contains("Full Disk Access"));
+    }
+
+    #[test]
+    fn not_privileged_hint_points_at_sudo() {
+        let msg = new_client_error_hint(&NewClientError::NotPrivileged);
+        assert!(msg.contains("sudo"));
+    }
 
     #[test]
     fn process_start_event_maps_exec_fields() {


### PR DESCRIPTION
## What & why

On macOS, an Endpoint Security client always fails on its **first run** with `NotPermitted` until the user grants Full Disk Access — an Apple requirement that no signed/notarized agent can bypass. Today the agent surfaces only a raw `es_new_client failed: NotPermitted` and exits, and the docs describe this case as `NotPrivileged`. So the very first thing every macOS user sees is a dead-end error with **no matching guidance** anywhere.

This PR makes that first-run failure self-service.

## Changes

**Runtime — `src/sensor/macos/esf.rs`**
- Map each `es_new_client` result code to the concrete fix in the error message:
  - `NotPrivileged` → run with `sudo`
  - `NotPermitted` → grant `Rustinel.app` Full Disk Access (+ terminal-attribution note)
  - `NotEntitled` → use a signed bundle / repackage
  - `TooManyClients` → another ES agent is running
- On `NotPermitted`, **deep-link the Full Disk Access settings pane**. Since a `sudo` process is root (no GUI session), it reopens in the invoking user's session via `launchctl asuser $SUDO_UID`. Guarded to interactive runs (`stderr().is_terminal()`), so a LaunchDaemon never tries to pop a window. Best-effort; failures are ignored.
- Adds unit tests asserting the `NotPermitted` hint mentions Full Disk Access and the `NotPrivileged` hint mentions sudo.

**Docs**
- `troubleshooting.md`: section retitled and rewritten as a result-code table covering `NotPermitted` (was `NotPrivileged`-only); notes a fresh machine's first run is normally `NotPermitted`.
- `getting-started.md`: leads with the Full Disk Access step and links the table.
- `development.md`: each missing requirement now maps to its distinct error code.

**Installer — `scripts/install/install.sh`**
- macOS-aware post-install message: numbered Full-Disk-Access-first steps instead of the Linux-style `sudo ./rustinel run` block, plus a heads-up before `--run`.

## Reviewer notes

- Code change is `cfg(target_os = "macos")` only — no effect on Linux/Windows builds.
- The installer message references the auto-open-pane behavior; that behavior ships in this same PR (`esf.rs`), so they're consistent once released. The shipped v1.1.3 binary still prints the old bare error — this lands in the next release.
- Verified locally on macOS arm64: `cargo fmt --check`, `cargo clippy --all-targets -D clippy::all`, and the macOS sensor tests all pass. The new error path was exercised live (non-root run → `NotPrivileged: Endpoint Security requires root. Re-run with sudo.`).

## Not in scope (follow-ups discussed)
- `rustinel service install` for macOS (the CLI advertises it but it's still Windows-only).
- Signed `.pkg` installer + PPPC `.mobileconfig` for MDM.