### PR TITLE
chore(deps): bump endpoint security crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1021,25 +1021,25 @@ dependencies = [
 
 [[package]]
 name = "endpoint-sec"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cf926f62142f03513a96f5f9052801b7ed6a7633fa3c2f9a47a11c1c6efee9f"
+checksum = "a37bc1280abfdd574108258b46e0c043d455537ba6192ce9a6a087535c1d9edf"
 dependencies = [
  "endpoint-sec-sys",
  "libc",
- "mach2 0.5.0",
+ "mach2 0.6.0",
  "static_assertions",
 ]
 
 [[package]]
 name = "endpoint-sec-sys"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b0482467bde1c4ffbe95538dd7c6bfee009e21dd36d5c848436454aeccd4f46"
+checksum = "62affe30ea9e777d4148d7b910d62cbda65b602fb3b9a9ce58ce4079f39bc8b1"
 dependencies = [
  "block2",
  "libc",
- "mach2 0.5.0",
+ "mach2 0.6.0",
  "objc2",
 ]
 
@@ -1602,15 +1602,6 @@ name = "mach2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "mach2"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a1b95cd5421ec55b445b5ae102f5ea0e768de1f82bd3001e11f426c269c3aea"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,8 +69,8 @@ yara-x = { version = "1.17", features = ["pulley"] }
 # Endpoint Security framework bindings (process and file telemetry).
 # macos_11_0_0 sets the minimum supported macOS to Big Sur and enables
 # reference-counted message handling.
-endpoint-sec = { version = "0.5", features = ["macos_11_0_0"] }
-endpoint-sec-sys = "0.5"
+endpoint-sec = { version = "0.6", features = ["macos_11_0_0"] }
+endpoint-sec-sys = "0.6"
 # Process/socket inspection for best-effort PID attribution of captured flows.
 libproc = "0.14"
 # Mach VM APIs for YARA process-memory scanning (task_for_pid, mach_vm_read).

--- a/src/sensor/macos/esf.rs
+++ b/src/sensor/macos/esf.rs
@@ -503,12 +503,13 @@ fn build_close_event(msg: &Message, close: &EventClose) -> Option<SensorEvent> {
 /// Resolve the absolute path of a create destination.
 fn create_destination_path(dest: EventCreateDestinationFile) -> Option<String> {
     let path = match dest {
-        EventCreateDestinationFile::ExistingFile(file) => osstr_to_string(file.path()),
+        EventCreateDestinationFile::ExistingFile { file, .. } => osstr_to_string(file.path()),
         EventCreateDestinationFile::NewPath {
             directory,
             filename,
             ..
         } => join_path(directory.path(), filename),
+        _ => return None,
     };
     (!path.is_empty()).then_some(path)
 }
@@ -516,11 +517,13 @@ fn create_destination_path(dest: EventCreateDestinationFile) -> Option<String> {
 /// Resolve the absolute path of a rename destination.
 fn rename_destination_path(dest: EventRenameDestinationFile) -> Option<String> {
     let path = match dest {
-        EventRenameDestinationFile::ExistingFile(file) => osstr_to_string(file.path()),
+        EventRenameDestinationFile::ExistingFile { file, .. } => osstr_to_string(file.path()),
         EventRenameDestinationFile::NewPath {
             directory,
             filename,
+            ..
         } => join_path(directory.path(), filename),
+        _ => return None,
     };
     (!path.is_empty()).then_some(path)
 }


### PR DESCRIPTION
## Summary
- Bumps endpoint-sec and endpoint-sec-sys to 0.6.0 in one PR.
- Updates the lockfile and removes the duplicate mach2 0.5.0 entry.
- Adjusts macOS Endpoint Security destination patterns for the 0.6.0 API.

## Context
Consolidates the dependency changes from #81 and #82.

## Validation
- cargo fmt --check
- cargo check --all-targets
- cargo test
- cargo clippy --all-targets -- -D warnings