### PR TITLE
docs(macos): clean up the macOS install/run journey

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Invoke-WebRequest https://raw.githubusercontent.com/Karib0u/rustinel/main/script
 powershell -ExecutionPolicy Bypass -File .\install-rustinel.ps1 -Run
 ```
 
-**macOS** (experimental) — install the same way (drop `--run`), then grant Full Disk Access before the first start: Endpoint Security needs a one-time macOS approval, so the agent exits with `NotPermitted` and opens the right Settings pane until you grant it. Full walkthrough in [Getting Started](https://docs.rustinel.io/getting-started/).
+**macOS** (experimental) — install the same way (drop `--run`), then grant Full Disk Access to your terminal app before the first start: Endpoint Security needs a one-time macOS approval, so the agent exits with `NotPermitted` and opens the right Settings pane until you grant it. Full walkthrough in [Getting Started](https://docs.rustinel.io/getting-started/).
 
 With the agent running, fire the bundled demo rule — same command on every platform:
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 
 Rustinel ships as a single binary with bundled demo rules. Install it, trigger a test command, and read the alert.
 
-**Linux & macOS**
+**Linux**
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/Karib0u/rustinel/main/scripts/install/install.sh | sh -s -- --run
@@ -46,6 +46,8 @@ curl -fsSL https://raw.githubusercontent.com/Karib0u/rustinel/main/scripts/insta
 Invoke-WebRequest https://raw.githubusercontent.com/Karib0u/rustinel/main/scripts/install/install.ps1 -OutFile install-rustinel.ps1
 powershell -ExecutionPolicy Bypass -File .\install-rustinel.ps1 -Run
 ```
+
+**macOS** (experimental) — install the same way (drop `--run`), then grant Full Disk Access before the first start: Endpoint Security needs a one-time macOS approval, so the agent exits with `NotPermitted` and opens the right Settings pane until you grant it. Full walkthrough in [Getting Started](https://docs.rustinel.io/getting-started/).
 
 With the agent running, fire the bundled demo rule — same command on every platform:
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -53,6 +53,12 @@ Yes, but Rustinel does not include built-in Linux service-management commands. R
 
 See [Operations and Upgrade Guide](operations.md) for the example `systemd` unit.
 
+### Can I run Rustinel as a macOS service?
+
+Yes, but like Linux it has no built-in service-management commands (those are Windows-only today). Run it in the foreground as root, or load the bundled `com.rustinel.agent.plist` as a `launchd` LaunchDaemon for background execution. Either way, the signed app bundle needs Full Disk Access.
+
+See [Operations and Upgrade Guide](operations.md) for the launchd layout.
+
 ### Why does Rustinel look in the wrong directory for rules or logs?
 
 Because relative paths resolve from the current working directory.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -57,8 +57,33 @@ scripts/install/install.sh --dir /opt/rustinel
 .\scripts\install\install.ps1 -InstallDir C:\Rustinel
 ```
 
-macOS support is experimental. Use the macOS release archive when it is present
-on the release page, or follow the source build path below.
+### macOS (experimental)
+
+The same installer works on macOS, but Endpoint Security needs a one-time Full
+Disk Access approval, so install **without** `--run`:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Karib0u/rustinel/main/scripts/install/install.sh | sh
+```
+
+Then, before the first start:
+
+1. Grant **Full Disk Access** to `Rustinel.app` — and, for an interactive `sudo`
+   run, to your terminal app — in System Settings → Privacy & Security → Full
+   Disk Access.
+2. Start it and trigger the demo:
+
+   ```bash
+   cd rustinel && sudo ./rustinel run
+   # in another terminal:
+   whoami
+   cat logs/alerts.json.*
+   ```
+
+Install to a stable location — macOS does not retain a Full Disk Access grant for
+an app under a temporary path such as `/tmp`. If the first run exits with
+`NotPermitted`, Full Disk Access is not attached yet; the agent opens the right
+Settings pane for you, so grant access and re-run.
 
 The install scripts only install published release binaries. They do not install
 Rust, Cargo, or build Rustinel from source. If no release asset exists for your
@@ -132,20 +157,30 @@ Choose the archive that matches your Mac:
 - `rustinel-<version>-aarch64-apple-darwin.tar.gz`
 - `rustinel-<version>-x86_64-apple-darwin.tar.gz`
 
-Then extract and run it as root:
+macOS requires a one-time Full Disk Access approval before any Endpoint Security
+client can start, so the order matters:
 
-```bash
-tar xzf rustinel-<version>-aarch64-apple-darwin.tar.gz
-cd rustinel-<version>-aarch64-apple-darwin
-sudo ./rustinel run
-```
+1. Extract it to a stable location (not `/tmp` — macOS will not keep a Full Disk
+   Access grant for an app there):
 
-macOS requires a one-time approval before any Endpoint Security client can run,
-so on a fresh machine the first run usually exits with `NotPermitted`. Grant
-`Rustinel.app` **Full Disk Access** in System Settings → Privacy & Security →
-Full Disk Access, then re-run `sudo ./rustinel run`. (If you launched it from a
-terminal, that terminal app may also need Full Disk Access.) A `NotPrivileged`
-error instead means it is not running as root — re-run with `sudo`. See
+   ```bash
+   tar xzf rustinel-<version>-aarch64-apple-darwin.tar.gz
+   cd rustinel-<version>-aarch64-apple-darwin
+   ```
+
+2. Grant **Full Disk Access** to `Rustinel.app` — and, if you start it from a
+   terminal, to that terminal app — in System Settings → Privacy & Security →
+   Full Disk Access.
+
+3. Run it as root:
+
+   ```bash
+   sudo ./rustinel run
+   ```
+
+If startup exits with `NotPermitted`, Full Disk Access is not attached yet; the
+agent opens the right Settings pane, so grant access and re-run. A
+`NotPrivileged` error means it is not running as root — re-run with `sudo`. See
 [Troubleshooting](troubleshooting.md#macos-endpoint-security-client-init-failed)
 for the full result-code table.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -68,9 +68,12 @@ curl -fsSL https://raw.githubusercontent.com/Karib0u/rustinel/main/scripts/insta
 
 Then, before the first start:
 
-1. Grant **Full Disk Access** to `Rustinel.app` — and, for an interactive `sudo`
-   run, to your terminal app — in System Settings → Privacy & Security → Full
-   Disk Access.
+1. Grant **Full Disk Access** to your **terminal app** (Terminal, iTerm, Ghostty,
+   …) in System Settings → Privacy & Security → Full Disk Access, then fully quit
+   and reopen it. Launched with `sudo` from a terminal, macOS attributes the
+   permission to the terminal — so Rustinel itself will not appear in the list,
+   and that is expected. (Grant `Rustinel.app` directly only when running it as a
+   background LaunchDaemon.)
 2. Start it and trigger the demo:
 
    ```bash
@@ -168,9 +171,11 @@ client can start, so the order matters:
    cd rustinel-<version>-aarch64-apple-darwin
    ```
 
-2. Grant **Full Disk Access** to `Rustinel.app` — and, if you start it from a
-   terminal, to that terminal app — in System Settings → Privacy & Security →
-   Full Disk Access.
+2. Grant **Full Disk Access** to your **terminal app** (Terminal, iTerm, …) in
+   System Settings → Privacy & Security → Full Disk Access, then quit and reopen
+   it. Launched with `sudo` from a terminal, the permission is attributed to the
+   terminal, so `Rustinel.app` will not show up in the list itself — that is
+   normal. (You grant `Rustinel.app` directly only for a background LaunchDaemon.)
 
 3. Run it as root:
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -21,8 +21,7 @@ C:\Rustinel\
 
 ```text
 /opt/rustinel/
-├── Rustinel.app/
-├── rustinel -> Rustinel.app/Contents/MacOS/rustinel
+├── rustinel
 ├── config.toml
 ├── rules/
 │   ├── sigma/
@@ -34,8 +33,9 @@ C:\Rustinel\
 ### macOS
 
 ```text
-/opt/rustinel/
-├── rustinel
+/usr/local/var/rustinel/
+├── Rustinel.app/
+├── rustinel -> Rustinel.app/Contents/MacOS/rustinel
 ├── config.toml
 ├── rules/
 │   ├── sigma/
@@ -45,8 +45,9 @@ C:\Rustinel\
 ```
 
 macOS support is experimental. Release archives contain a signed and notarized
-app-like daemon bundle with the Endpoint Security provisioning profile. See
-[Getting Started](getting-started.md) and [Development](development.md).
+app-like daemon bundle (`Rustinel.app`) plus a `rustinel` symlink into it. The
+bundled `com.rustinel.agent.plist` LaunchDaemon expects this `/usr/local/var/rustinel`
+layout. See [Getting Started](getting-started.md) and [Development](development.md).
 
 Use absolute paths in `config.toml` once you move beyond the default repo layout.
 
@@ -125,15 +126,18 @@ Because `config.toml` is loaded from `WorkingDirectory`, use absolute paths for 
 
 ## macOS Runtime Model
 
-macOS support is experimental and detection-only (no active response). Rustinel does not ship macOS service-management commands; run it in the foreground as root, or wrap it in a `launchd` job for background execution:
+macOS support is experimental and detection-only (no active response). Rustinel does not ship macOS service-management commands yet (those are Windows-only); run it in the foreground as root:
 
 ```bash
-sudo /opt/rustinel/Rustinel.app/Contents/MacOS/rustinel run
+sudo /usr/local/var/rustinel/rustinel run
 ```
+
+For background execution, install the release package under `/usr/local/var/rustinel` and load the bundled `com.rustinel.agent.plist` as a `launchd` LaunchDaemon — the plist contains the exact `launchctl bootstrap` command and expects that path.
 
 The app bundle must be signed with the
 `com.apple.developer.endpoint-security.client` entitlement, contain the
-authorizing provisioning profile, and have Full Disk Access. See
+authorizing provisioning profile, and have Full Disk Access (a LaunchDaemon needs
+it granted to `Rustinel.app`, or provisioned via an MDM PPPC profile). See
 [Development](development.md) for signing and notarization details.
 
 ## Upgrade Examples

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -114,7 +114,7 @@ end of the error tells you exactly which requirement is missing:
 | Result code | Cause | Fix |
 | --- | --- | --- |
 | `NotPrivileged` | Not running as root. | Re-run with `sudo`. |
-| `NotPermitted` | Running as root with the entitlement, but macOS has not granted the client Endpoint Security access (TCC). | Grant `Rustinel.app` **Full Disk Access** in System Settings → Privacy & Security → Full Disk Access, then re-run. If you launched it from a terminal, that terminal app may also need Full Disk Access. |
+| `NotPermitted` | Running as root with the entitlement, but macOS has not granted the client Endpoint Security access (TCC). | For an interactive `sudo` run from a terminal, grant **Full Disk Access to that terminal app** (Terminal/iTerm/…) and reopen it — macOS attributes the permission to the terminal, so Rustinel itself will not appear in the list. For a background LaunchDaemon, grant `Rustinel.app` directly (or use an MDM PPPC profile). |
 | `NotEntitled` | The binary is not signed with `com.apple.developer.endpoint-security.client`, or its provisioning profile does not authorize the entitlement. | Run a signed `Rustinel.app` from a release, or repackage with `scripts/macos/package-app.sh` (see [Development](development.md)). |
 
 On a fresh machine the first run typically reports `NotPermitted`: signing and


### PR DESCRIPTION
## Why

Follow-up to #84. With the runtime/troubleshooting UX fixed there, this cleans up the remaining macOS documentation gaps found while validating the v1.1.3 release end-to-end. Several were inaccurate or set false expectations for a first-time macOS user.

## What was wrong

- **README overpromised.** The "first alert in 60 seconds" flow grouped macOS with Linux under one `… | sh -s -- --run` one-liner — but on macOS that always fails on first run with `NotPermitted` until Full Disk Access is granted. The caveat was soft and buried below the flow.
- **getting-started punted on macOS.** The Fastest Path had Linux/Windows install commands but told macOS users to "use the release archive… or build from source." The Quick Start framed Full Disk Access as a *failure footnote* ("run it; if it fails, grant access") rather than a required step.
- **operations.md had the Linux and macOS layouts swapped.** The Linux block showed `Rustinel.app/` + a symlink (that's macOS); the macOS block showed a flat `rustinel` binary (that's Linux). Verified against the actual release archives.
- **Path mismatch.** operations.md used `/opt/rustinel` for macOS while the shipped `com.rustinel.agent.plist` LaunchDaemon expects `/usr/local/var/rustinel`.
- **FAQ had no macOS-service entry** — only Windows and Linux.

## Changes

- **README.md** — macOS gets its own honest note: install the same way but drop `--run`, grant Full Disk Access first (the agent opens the right Settings pane until you do).
- **docs/getting-started.md** — real macOS Fastest Path (installer + FDA steps); Quick Start reordered into explicit numbered steps with **Full Disk Access before the run**, plus the "don't install to `/tmp`" caveat we hit during validation.
- **docs/operations.md** — un-swapped the Linux/macOS directory layouts; aligned the macOS layout/runtime path to `/usr/local/var/rustinel` to match the bundled launchd plist; pointed at the plist for background deployment.
- **docs/faq.md** — added "Can I run Rustinel as a macOS service?".

## Notes for the reviewer

- Docs only — no code.
- I intentionally did **not** add a full copy-paste `launchctl bootstrap` sequence for the LaunchDaemon path: that flow (granting a LaunchDaemon Full Disk Access) hasn't been validated end-to-end yet, so the docs point at the plist's own inline instructions instead of inventing unverified commands.
- The end-to-end `whoami → alert` pipeline on the v1.1.3 signed/notarized binary was confirmed working on macOS 26.5.1 (after granting FDA) while writing these.