### PR TITLE
chore: bump release version to 1.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2394,7 +2394,7 @@ dependencies = [
 
 [[package]]
 name = "rustinel"
-version = "1.1.3"
+version = "1.1.4"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustinel"
-version = "1.1.3"
+version = "1.1.4"
 edition = "2021"
 authors = []
 description = "Open-source EDR for Windows, Linux, and macOS with Sigma, YARA, and IOC detection"


### PR DESCRIPTION
Bumps `Cargo.toml` + `Cargo.lock` to **1.1.4** to cut the next release.

## What ships in v1.1.4 (vs v1.1.3)
- **#84** — actionable macOS Endpoint Security first-run errors + auto-open Full Disk Access pane
- **#86** — `endpoint-sec` 0.5 → 0.6 (newer ES bindings)
- **#80** — regex patch bump

## Verified
- `cargo clippy --all-targets -D clippy::all` clean on current `main` (with endpoint-sec 0.6)
- All 141 lib tests pass
- 2-file change, matching prior bump commits

## Release trigger
Merging this does **not** publish anything. The signed/notarized release is triggered by pushing the `v1.1.4` tag (CI builds + signs + notarizes all platforms). See the release checklist in the PR discussion.

> Recommend merging the docs cleanup (#87) **before** tagging so the release archives bundle the corrected macOS README/getting-started.