### PR TITLE
Clean up docs and release notes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,12 +3,12 @@
 
 ## Type of change
 <!-- Add the matching label to this PR before merging -->
-- [ ] `feat` / `enhancement` — new feature
-- [ ] `bug` — bug fix
-- [ ] `refactor` — refactoring, no behaviour change
-- [ ] `documentation` — docs only
-- [ ] `ci` — CI/CD changes
-- [ ] `dependencies` — dependency update
+- [ ] `feat` / `enhancement` - new feature
+- [ ] `bug` - bug fix
+- [ ] `refactor` - refactoring, no behaviour change
+- [ ] `documentation` - docs only
+- [ ] `ci` - CI/CD changes
+- [ ] `dependencies` - dependency update
 
 ## Test plan
 - [ ] Tested on Windows

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -477,12 +477,25 @@ jobs:
             | macOS | arm64 | `rustinel-${{ steps.version.outputs.version }}-aarch64-apple-darwin.tar.gz` |
             | macOS | x86_64 | `rustinel-${{ steps.version.outputs.version }}-x86_64-apple-darwin.tar.gz` |
 
-            ## Install
+            ## Installer
 
-            **Linux / macOS**
+            **Linux**
 
             ```sh
             curl -fsSL https://raw.githubusercontent.com/Karib0u/rustinel/main/scripts/install/install.sh | sh -s -- --version ${{ steps.version.outputs.version }} --run
+            ```
+
+            **macOS**
+
+            ```sh
+            curl -fsSL https://raw.githubusercontent.com/Karib0u/rustinel/main/scripts/install/install.sh | sh -s -- --version ${{ steps.version.outputs.version }}
+            cd rustinel
+            ```
+
+            macOS support is experimental. Endpoint Security requires root and a one-time Full Disk Access approval before the first successful start. See the install guide for the interactive terminal and LaunchDaemon approval paths, then run:
+
+            ```sh
+            sudo ./rustinel run
             ```
 
             **Windows (PowerShell)**
@@ -491,5 +504,6 @@ jobs:
             iwr https://raw.githubusercontent.com/Karib0u/rustinel/main/scripts/install/install.ps1 -OutFile install-rustinel.ps1; powershell -ExecutionPolicy Bypass -File .\install-rustinel.ps1 -Version ${{ steps.version.outputs.version }} -Run
             ```
 
-            📖 Full install, configuration & SIEM ingestion guides → https://docs.rustinel.io/getting-started/
-            🔒 Scripts install published release binaries only (no build from source). Verify downloads with `rustinel-${{ steps.version.outputs.version }}-checksums-sha256.txt`.
+            Full install, configuration, and SIEM ingestion guides: https://docs.rustinel.io/getting-started/
+
+            Scripts install published release binaries only. Verify downloads with `rustinel-${{ steps.version.outputs.version }}-checksums-sha256.txt`.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <b>Open-source endpoint detection for Windows, Linux, and macOS.</b><br>
-  Native telemetry → Sigma / YARA / IOC detection → SIEM-ready alerts. Written in Rust.
+  Native telemetry to Sigma, YARA, IOC detection, and SIEM-ready alerts. Written in Rust.
 </p>
 
 <p align="center">
@@ -18,9 +18,9 @@
 </p>
 
 <p align="center">
-  <a href="https://rustinel.io/">Website</a> ·
-  <a href="https://docs.rustinel.io/">Docs</a> ·
-  <a href="https://github.com/Karib0u/rustinel/releases/latest">Download</a> ·
+  <a href="https://rustinel.io/">Website</a> |
+  <a href="https://docs.rustinel.io/">Docs</a> |
+  <a href="https://github.com/Karib0u/rustinel/releases/latest">Download</a> |
   <a href="docs/siem-demos.md">SIEM demos</a>
 </p>
 
@@ -30,9 +30,10 @@
 
 ---
 
-## Get your first alert in 60 seconds
+## Get Your First Alert
 
-Rustinel ships as a single binary with bundled demo rules. Install it, trigger a test command, and read the alert.
+Rustinel ships release archives with a binary, default config, demo rules, and a
+`logs/` directory.
 
 **Linux**
 
@@ -40,36 +41,51 @@ Rustinel ships as a single binary with bundled demo rules. Install it, trigger a
 curl -fsSL https://raw.githubusercontent.com/Karib0u/rustinel/main/scripts/install/install.sh | sh -s -- --run
 ```
 
-**Windows** — from an elevated PowerShell:
+**Windows** - from an elevated PowerShell:
 
 ```powershell
 Invoke-WebRequest https://raw.githubusercontent.com/Karib0u/rustinel/main/scripts/install/install.ps1 -OutFile install-rustinel.ps1
 powershell -ExecutionPolicy Bypass -File .\install-rustinel.ps1 -Run
 ```
 
-**macOS** (experimental) — install the same way (drop `--run`), then grant Full Disk Access to your terminal app before the first start: Endpoint Security needs a one-time macOS approval, so the agent exits with `NotPermitted` and opens the right Settings pane until you grant it. Full walkthrough in [Getting Started](https://docs.rustinel.io/getting-started/).
+**macOS** (experimental)
 
-With the agent running, fire the bundled demo rule — same command on every platform:
+```bash
+curl -fsSL https://raw.githubusercontent.com/Karib0u/rustinel/main/scripts/install/install.sh | sh
+cd rustinel
+```
+
+macOS requires a one-time Full Disk Access approval before Endpoint Security can
+start. Follow the [Getting Started](https://docs.rustinel.io/getting-started/)
+macOS notes before using it beyond a first test.
+
+```bash
+sudo ./rustinel run
+```
+
+With the agent running, trigger the bundled demo rule:
 
 ```bash
 whoami
 ```
 
-Your alert lands in `logs/alerts.json.<date>` as ECS NDJSON — ready to ship straight to a SIEM.
+Alerts are written to `logs/alerts.json.<date>` as ECS NDJSON.
 
-> **Prefer to read before you run?** Download the [install script](scripts/install/install.sh) and inspect it, or grab a binary from the [latest release](https://github.com/Karib0u/rustinel/releases/latest). The installer only pulls published release binaries. macOS support is experimental and needs root plus user approval for the signed Endpoint Security client; see [Getting Started](https://docs.rustinel.io/getting-started/).
+Prefer to inspect first? Download the [install script](scripts/install/install.sh)
+or a package from the [latest release](https://github.com/Karib0u/rustinel/releases/latest).
+Installers only download published release binaries.
 
 ---
 
 ## Why Rustinel
 
-A transparent endpoint detection engine you can read, run, test, and extend — no black box.
+A transparent endpoint detection engine you can read, run, test, and extend.
 
-- **Native telemetry** — ETW on Windows, eBPF on Linux, Endpoint Security + `/dev/bpf` on macOS, normalized into one shared event model.
-- **Three detection layers** — Sigma for behavior, YARA for files and memory, IOC matching for hashes, IPs, domains, and path regexes.
-- **Reuse community rules** — bring existing Sigma and YARA rules instead of rewriting them into a proprietary format.
-- **SIEM-ready output** — ECS 9.4.0 NDJSON alerts that drop into Elastic, Splunk, and friends.
-- **Operational basics** — hot-reload for rules and IOCs, optional active response with dry-run + allowlists, Windows service and launchd support.
+- **Native telemetry:** ETW on Windows, eBPF on Linux, Endpoint Security and `/dev/bpf` on macOS.
+- **Detection formats:** Sigma for behavior, YARA for files and memory, IOC matching for hashes, IPs, domains, and path regexes.
+- **Rule reuse:** bring existing Sigma and YARA rules instead of rewriting them into a proprietary format.
+- **SIEM output:** ECS 9.4.0 NDJSON alerts for Elastic, Splunk, and other log pipelines.
+- **Operations:** hot reload for rules and IOCs, optional active response on Windows and Linux, Windows service support, and launchd packaging notes.
 
 ---
 
@@ -81,14 +97,16 @@ A transparent endpoint detection engine you can read, run, test, and extend — 
 | Linux 5.8+ (BTF) | eBPF | Process, network, file, DNS | Stable |
 | macOS 11+ | Endpoint Security + `/dev/bpf` | Process, file, network, DNS | Experimental |
 
-Windows coverage is the broadest today; Linux and macOS focus on process, network, file, and DNS. macOS remains experimental while signed and notarized release packaging is validated across supported versions. Full notes are in the [platform docs](https://docs.rustinel.io/architecture/).
+Windows coverage is the broadest today. Linux and macOS focus on process,
+network, file, and DNS telemetry. macOS remains experimental. Current gaps are
+listed in [Limitations](https://docs.rustinel.io/limitations/).
 
 ---
 
 ## How detection works
 
 ```text
-  ETW (Windows) · eBPF (Linux) · ESF + /dev/bpf (macOS)
+  ETW (Windows) | eBPF (Linux) | ESF + /dev/bpf (macOS)
                         │
               Normalized event model
                         │
@@ -109,11 +127,13 @@ See the [detection docs](https://docs.rustinel.io/detection/) for rule authoring
 
 ## Detection packs
 
-The bundled rules just prove the pipeline works. For real coverage, load curated content from **[rustinel-rules](https://github.com/Karib0u/rustinel-rules)** — the official, versioned, CI-tested detection repository.
+The bundled rules only prove that the pipeline works. For real coverage, load
+curated content from **[rustinel-rules](https://github.com/Karib0u/rustinel-rules)**,
+the official versioned detection repository.
 
 ```text
-rustinel        →  the engine that collects telemetry and evaluates rules
-rustinel-rules  →  the Sigma / YARA / IOC packs it loads  (no conversion step)
+rustinel        ->  the engine that collects telemetry and evaluates rules
+rustinel-rules  ->  the Sigma, YARA, and IOC packs it loads
 ```
 
 Each pack materializes into folders you point `config.toml` straight at. Browse the [pack catalog](https://github.com/Karib0u/rustinel-rules) to get started.
@@ -124,7 +144,10 @@ Each pack materializes into folders you point `config.toml` straight at. Browse 
 
 **Use it for** detection engineering, rule development and testing, blue-team labs, cross-platform detection research, and SIEM pipeline validation.
 
-**It is not** a drop-in replacement for a mature commercial EDR. Rustinel does not provide kernel-level self-protection, pre-execution blocking, or anti-tamper guarantees, and a sufficiently privileged attacker may interfere with user-mode telemetry. It is a transparent detection engine — not a managed response platform.
+**It is not** a drop-in replacement for a mature commercial EDR. Rustinel does
+not provide kernel-level self-protection, pre-execution blocking, anti-tamper
+guarantees, or managed response. A sufficiently privileged attacker may interfere
+with user-mode telemetry.
 
 ---
 
@@ -141,23 +164,23 @@ macOS requires the app-like signed bundle described in [Getting Started](https:/
 
 ## Documentation
 
-[Website](https://rustinel.io/) ·
-[Docs home](https://docs.rustinel.io/) ·
-[Getting Started](https://docs.rustinel.io/getting-started/) ·
-[Configuration](https://docs.rustinel.io/configuration/) ·
-[Detection](https://docs.rustinel.io/detection/) ·
-[Architecture](https://docs.rustinel.io/architecture/) ·
-[Operations](https://docs.rustinel.io/operations/) ·
-[Troubleshooting](https://docs.rustinel.io/troubleshooting/) ·
-[FAQ](https://docs.rustinel.io/faq/) ·
-[Detection rules](https://github.com/Karib0u/rustinel-rules) ·
+[Website](https://rustinel.io/) |
+[Docs home](https://docs.rustinel.io/) |
+[Getting Started](https://docs.rustinel.io/getting-started/) |
+[Configuration](https://docs.rustinel.io/configuration/) |
+[Detection](https://docs.rustinel.io/detection/) |
+[Architecture](https://docs.rustinel.io/architecture/) |
+[Operations](https://docs.rustinel.io/operations/) |
+[Troubleshooting](https://docs.rustinel.io/troubleshooting/) |
+[FAQ](https://docs.rustinel.io/faq/) |
+[Detection rules](https://github.com/Karib0u/rustinel-rules) |
 [Roadmap](docs/roadmap.md)
 
 ---
 
 ## Contributing
 
-Testing, feedback, and detection ideas are all welcome — see [CONTRIBUTING.md](CONTRIBUTING.md).
+Testing, feedback, and detection ideas are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 

--- a/docs/active-response.md
+++ b/docs/active-response.md
@@ -1,6 +1,11 @@
 # Active Response
 
-Rustinel includes an optional response engine that can terminate processes when an alert reaches the configured minimum severity. It is disabled by default and should be tested in dry-run mode first. Active response runs on **Windows and Linux only** — macOS is detection-only.
+Rustinel includes an optional response engine that can terminate processes when
+an alert reaches the configured minimum severity. It is disabled by default and
+should be tested in dry-run mode first.
+
+Active response currently runs on **Windows and Linux only**. macOS support is
+detection-only.
 
 ## Modes
 
@@ -14,7 +19,7 @@ Rustinel includes an optional response engine that can terminate processes when 
 | --- | --- |
 | Windows | Uses process termination APIs |
 | Linux | Sends `SIGKILL` |
-| macOS | Not supported — detection only |
+| macOS | Not supported; detection only |
 
 ## Severity Handling
 
@@ -31,7 +36,7 @@ Rustinel will not act on processes that match either of these:
 - `allowlist_images`: image basenames or full paths
 - `allowlist_paths`: trusted path prefixes
 
-By default, `response.allowlist_paths` inherits `allowlist.paths`, whose per-platform defaults are listed once in [Configuration → Default Trusted Paths](configuration.md#default-trusted-paths).
+By default, `response.allowlist_paths` inherits `allowlist.paths`, whose per-platform defaults are listed once in [Configuration -> Default Trusted Paths](configuration.md#default-trusted-paths).
 
 ## Example Configuration
 
@@ -83,7 +88,7 @@ response: Active response skipped: allowlisted pid=4321 image="/usr/bin/bash"
 The response engine skips termination when:
 
 - PID is missing
-- PID is in the protected low system range (PIDs 0–4 on both platforms)
+- PID is in the protected low system range (PIDs 0-4 on both platforms)
 - The target is the Rustinel process itself
 - The process image path is not known
 - The image or path is allowlisted
@@ -123,7 +128,7 @@ rustc .\examples\yara_demo.rs -o .\examples\yara_demo.exe
 Windows:
 
 ```powershell
-whoami /all
+whoami
 ```
 
 Linux:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -199,7 +199,7 @@ Propagation behavior:
 | `filter` | `null` | Optional `tracing_subscriber` filter expression; overrides `level` when valid |
 | `directory` | `logs` | Operational log directory |
 | `filename` | `rustinel.log` | Operational log filename with daily rotation |
-| `console_output` | `false` | Default console mirroring when the runtime does not override console behavior. Interactive `rustinel run` enables console output by default; use `rustinel run --no-console` to suppress it. On Windows, colored output requires [Windows Terminal](https://aka.ms/terminal) — other terminals (cmd.exe, PowerShell host) will display plain text automatically. |
+| `console_output` | `false` | Default console mirroring when the runtime does not override console behavior. Interactive `rustinel run` enables console output by default; use `rustinel run --no-console` to suppress it. On Windows, colored output requires [Windows Terminal](https://aka.ms/terminal) - other terminals (cmd.exe, PowerShell host) will display plain text automatically. |
 
 ### Alerts
 
@@ -211,7 +211,7 @@ Propagation behavior:
 
 ### Deduplication
 
-Alert deduplication collapses repeated identical alerts within a sliding window into a single rollup alert. The **first occurrence always emits immediately** — there is no added detection latency for novel alerts. Only repeats of the same alert within the window are suppressed.
+Alert deduplication collapses repeated identical alerts within a sliding window into a single rollup alert. The **first occurrence always emits immediately** - there is no added detection latency for novel alerts. Only repeats of the same alert within the window are suppressed.
 
 A rollup alert is written at window close carrying `event.count` with the total number of occurrences (including the first).
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -64,6 +64,10 @@ sudo env RUSTINEL_EBPF_OBJECT=$PWD/ebpf/rustinel-ebpf.o ./target/release/rustine
 
 ### macOS
 
+For normal contributor work, start with `cargo check`, `cargo build`, and the
+regular test suite. The signed app-bundle path below is only required when you
+need live Endpoint Security telemetry on macOS or when preparing a release.
+
 macOS telemetry uses Apple's Endpoint Security framework. Creating an ES client
 (`es_new_client`) requires three things, and each missing piece surfaces a
 distinct startup error: running as root (`NotPrivileged` if not), the
@@ -71,10 +75,11 @@ distinct startup error: running as root (`NotPrivileged` if not), the
 missing), and user approval via Full Disk Access / TCC (`NotPermitted` if not
 granted).
 
-After Apple approves the managed capability, enable Endpoint Security on the
-explicit App ID used for the request and download a matching macOS provisioning
-profile. Install the profile's signing certificate and private key in the login
-keychain. Confirm that macOS can see the identity:
+Maintainer release builds require Apple to approve the managed Endpoint Security
+capability. After approval, enable Endpoint Security on the explicit App ID used
+for the request and download a matching macOS provisioning profile. Install the
+profile's signing certificate and private key in the login keychain. Confirm
+that macOS can see the identity:
 
 ```bash
 security find-identity -v -p codesigning

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -26,7 +26,7 @@ Yes.
 - Linux eBPF collection requires root or equivalent capabilities such as `CAP_BPF` or `CAP_SYS_ADMIN`, depending on your setup.
 - macOS Endpoint Security collection requires root, Full Disk Access, and a signed app bundle whose embedded provisioning profile authorizes `com.apple.developer.endpoint-security.client`.
 
-## Running And Deployment
+## Running and Deployment
 
 ### What happens if I run `rustinel` without a subcommand?
 
@@ -99,7 +99,7 @@ sudo env RUSTINEL_EBPF_OBJECT=/opt/rustinel/ebpf/rustinel-ebpf.o ./rustinel run
 
 See [CLI Reference](cli.md).
 
-## Alerts, Logs, And Validation
+## Alerts, Logs, and Validation
 
 ### Where do logs and alerts go?
 
@@ -116,8 +116,9 @@ See [Output Format](output.md) and [Configuration](configuration.md).
 
 Use the bundled demo Sigma rules:
 
-- Windows: run `whoami /all`
+- Windows: run `whoami`
 - Linux: run `whoami`
+- macOS: run `whoami`
 
 Then confirm:
 
@@ -226,7 +227,7 @@ It controls how much match metadata is attached to alerts.
 
 See [Detection](detection.md) and [Output Format](output.md).
 
-## Active Response And Allowlists
+## Active Response and Allowlists
 
 ### Why didn’t active response kill the process?
 
@@ -268,7 +269,7 @@ prevention_enabled = false
 
 Then trigger a known benign bundled rule such as:
 
-- `whoami /all` on Windows
+- `whoami` on Windows
 - `whoami` on Linux
 
 After you confirm the log output looks correct, enable prevention mode.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,12 +1,11 @@
 # Getting Started
 
-This guide gets Rustinel to first telemetry and first alert on supported
-platforms.
+This guide gets Rustinel installed, running, and producing its first alert.
 
-## Fastest Path
+## Install From A Release
 
-Use the install scripts when you want a release binary, bundled demo rules, and
-the default `logs/` layout without choosing an asset by hand.
+Use the install scripts when you want a published binary, bundled demo rules,
+`config.toml`, and the default `logs/` layout.
 
 ### Linux
 
@@ -14,7 +13,7 @@ the default `logs/` layout without choosing an asset by hand.
 curl -fsSL https://raw.githubusercontent.com/Karib0u/rustinel/main/scripts/install/install.sh | sh -s -- --run
 ```
 
-If you prefer to inspect the script first:
+To inspect the script first:
 
 ```bash
 curl -fsSLO https://raw.githubusercontent.com/Karib0u/rustinel/main/scripts/install/install.sh
@@ -31,23 +30,70 @@ Invoke-WebRequest https://raw.githubusercontent.com/Karib0u/rustinel/main/script
 powershell -ExecutionPolicy Bypass -File .\install-rustinel.ps1 -Run
 ```
 
-After the agent starts, trigger the bundled rule:
+### macOS
+
+macOS support is experimental. Install without `--run` so you can grant the
+required Full Disk Access approval before the first real start:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Karib0u/rustinel/main/scripts/install/install.sh | sh
+cd rustinel
+```
+
+If the first run exits with `NotPermitted`, grant Full Disk Access and run it
+again. For an interactive `sudo` run from Terminal, iTerm, Ghostty, or another
+terminal, grant Full Disk Access to that terminal app, then fully quit and
+reopen it. For a background LaunchDaemon, grant Full Disk Access to
+`Rustinel.app` directly or deploy a PPPC profile.
+
+Install macOS packages in a stable location. macOS does not retain the approval
+reliably for an app launched from a temporary path such as `/tmp`.
+
+After approval, start Rustinel:
+
+```bash
+sudo ./rustinel run
+```
+
+## Verify The Demo Rule
+
+Keep Rustinel running, then execute:
+
+```bash
+whoami
+```
+
+Confirm that an alert was written:
 
 === "Linux"
 
     ```bash
-    whoami
     cat logs/alerts.json.*
     ```
 
 === "Windows"
 
     ```powershell
-    whoami /all
     Get-Content .\logs\alerts.json.*
     ```
 
-Install script options:
+=== "macOS"
+
+    ```bash
+    cat logs/alerts.json.*
+    ```
+
+Bundled demo rules:
+
+| Platform | Rule |
+| --- | --- |
+| Windows | `rules/sigma/windows_whoami.yml` |
+| Linux | `rules/sigma/linux_whoami.yml` |
+| macOS | `rules/sigma/macos_whoami.yml` |
+
+## Install Options
+
+Install to a specific directory:
 
 ```bash
 scripts/install/install.sh --dir /opt/rustinel
@@ -57,86 +103,47 @@ scripts/install/install.sh --dir /opt/rustinel
 .\scripts\install\install.ps1 -InstallDir C:\Rustinel
 ```
 
-### macOS (experimental)
-
-The same installer works on macOS, but Endpoint Security needs a one-time Full
-Disk Access approval, so install **without** `--run`:
+Install a specific version:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Karib0u/rustinel/main/scripts/install/install.sh | sh
+scripts/install/install.sh --version 1.0.2
 ```
 
-Then, before the first start:
+```powershell
+.\scripts\install\install.ps1 -Version 1.0.2
+```
 
-1. Grant **Full Disk Access** to your **terminal app** (Terminal, iTerm, Ghostty,
-   …) in System Settings → Privacy & Security → Full Disk Access, then fully quit
-   and reopen it. Launched with `sudo` from a terminal, macOS attributes the
-   permission to the terminal — so Rustinel itself will not appear in the list,
-   and that is expected. (Grant `Rustinel.app` directly only when running it as a
-   background LaunchDaemon.)
-2. Start it and trigger the demo:
-
-   ```bash
-   cd rustinel && sudo ./rustinel run
-   # in another terminal:
-   whoami
-   cat logs/alerts.json.*
-   ```
-
-Install to a stable location — macOS does not retain a Full Disk Access grant for
-an app under a temporary path such as `/tmp`. If the first run exits with
-`NotPermitted`, Full Disk Access is not attached yet; the agent opens the right
-Settings pane for you, so grant access and re-run.
-
-The install scripts only install published release binaries. They do not install
-Rust, Cargo, or build Rustinel from source. If no release asset exists for your
+The install scripts only download published release binaries. They do not
+install Rust, Cargo, or build from source. If no release asset exists for your
 OS or architecture, the script exits before changing the install directory.
 
-## Minimum Requirements
+## Manual Package Install
+
+Download the package for your platform from
+[GitHub Releases](https://github.com/Karib0u/rustinel/releases).
+
+| Platform | Package |
+| --- | --- |
+| Windows x86_64 | `rustinel-<version>-x86_64-pc-windows-msvc.zip` |
+| Linux x86_64 | `rustinel-<version>-x86_64-unknown-linux-musl.tar.gz` |
+| Linux arm64 | `rustinel-<version>-aarch64-unknown-linux-musl.tar.gz` |
+| macOS Apple Silicon | `rustinel-<version>-aarch64-apple-darwin.tar.gz` |
+| macOS Intel | `rustinel-<version>-x86_64-apple-darwin.tar.gz` |
+
+Release packages already include `config.toml`, bundled demo rules, install
+scripts, examples, and an empty `logs/` directory.
 
 ### Windows
 
-- Windows 10/11 or Server 2016+
-- Administrator privileges
-- Rust 1.92+ and Visual Studio Build Tools if building from source
+1. Extract the zip archive.
+2. Open an elevated PowerShell in the extracted directory.
+3. Run:
+
+```powershell
+.\rustinel.exe run
+```
 
 ### Linux
-
-- Linux kernel 5.8+ with BTF
-- Root, or eBPF capabilities such as `CAP_BPF` or `CAP_SYS_ADMIN`
-- `tracefs` available at `/sys/kernel/tracing` and `debugfs` available at `/sys/kernel/debug`
-- Rust 1.92+ if building from source
-- If `ebpf/rustinel-ebpf.o` is missing, nightly Rust, `rust-src`, and `bpf-linker` are also required for the first build
-
-### macOS
-
-- macOS 11+
-- Root and Full Disk Access for the signed Endpoint Security client
-- Access to the `/dev/bpf*` device nodes for network and DNS capture
-- Rust 1.92+ and the Xcode Command Line Tools if building from source
-
-macOS support remains experimental while release packaging and runtime behavior
-are validated across supported versions.
-
-## Quick Start
-
-Download the package for your platform from [GitHub Releases](https://github.com/Karib0u/rustinel/releases). The release archives already include `config.toml`, the bundled demo rules, and an empty `logs/` directory.
-
-### Windows
-
-1. Download `rustinel-<version>-x86_64-pc-windows-msvc.zip`.
-2. Extract it.
-3. Open an elevated PowerShell in the extracted directory.
-4. Run `.\rustinel.exe run`.
-
-### Linux
-
-Choose the archive that matches your target system:
-
-- `rustinel-<version>-x86_64-unknown-linux-musl.tar.gz`
-- `rustinel-<version>-aarch64-unknown-linux-musl.tar.gz`
-
-Then extract and run it:
 
 ```bash
 tar xzf rustinel-<version>-x86_64-unknown-linux-musl.tar.gz
@@ -144,57 +151,41 @@ cd rustinel-<version>-x86_64-unknown-linux-musl
 sudo ./rustinel run
 ```
 
-If startup fails with `tracefs not found`, mount the tracing filesystems and retry:
-
-```bash
-mount -t tracefs tracefs /sys/kernel/tracing
-mount -t debugfs debugfs /sys/kernel/debug
-```
-
-Some minimal Linux environments, including some WSL 2 distros, may start without these filesystems mounted.
+If startup fails with `tracefs not found`, see
+[Troubleshooting](troubleshooting.md#linux-ebpf-sensor-failed-to-start).
 
 ### macOS
 
-Choose the archive that matches your Mac:
+```bash
+tar xzf rustinel-<version>-aarch64-apple-darwin.tar.gz
+cd rustinel-<version>-aarch64-apple-darwin
+sudo ./rustinel run
+```
 
-- `rustinel-<version>-aarch64-apple-darwin.tar.gz`
-- `rustinel-<version>-x86_64-apple-darwin.tar.gz`
+If startup exits with `NotPermitted`, grant Full Disk Access as described in the
+macOS install notes above. If it exits with `NotPrivileged`, re-run with `sudo`.
+See [Troubleshooting](troubleshooting.md#macos-endpoint-security-client-init-failed)
+for the macOS result-code table.
 
-macOS requires a one-time Full Disk Access approval before any Endpoint Security
-client can start, so the order matters:
+Network and DNS capture also needs access to `/dev/bpf*`. If packet capture
+cannot start, Rustinel continues with Endpoint Security process and file telemetry.
 
-1. Extract it to a stable location (not `/tmp` — macOS will not keep a Full Disk
-   Access grant for an app there):
+## Minimum Requirements
 
-   ```bash
-   tar xzf rustinel-<version>-aarch64-apple-darwin.tar.gz
-   cd rustinel-<version>-aarch64-apple-darwin
-   ```
+| Platform | Requirements |
+| --- | --- |
+| Windows | Windows 10/11 or Server 2016+, Administrator privileges |
+| Linux | Kernel 5.8+ with BTF, root or eBPF capabilities such as `CAP_BPF` or `CAP_SYS_ADMIN`, `tracefs`, and `debugfs` |
+| macOS | macOS 11+, root, signed Endpoint Security client, Full Disk Access, and `/dev/bpf*` access for network and DNS capture |
 
-2. Grant **Full Disk Access** to your **terminal app** (Terminal, iTerm, …) in
-   System Settings → Privacy & Security → Full Disk Access, then quit and reopen
-   it. Launched with `sudo` from a terminal, the permission is attributed to the
-   terminal, so `Rustinel.app` will not show up in the list itself — that is
-   normal. (You grant `Rustinel.app` directly only for a background LaunchDaemon.)
+Building from source also requires Rust 1.92+. Windows needs Visual Studio Build
+Tools, Linux eBPF rebuilds need nightly Rust plus `rust-src` and `bpf-linker`,
+and macOS needs the Xcode Command Line Tools.
 
-3. Run it as root:
+## Build From Source
 
-   ```bash
-   sudo ./rustinel run
-   ```
-
-If startup exits with `NotPermitted`, Full Disk Access is not attached yet; the
-agent opens the right Settings pane, so grant access and re-run. A
-`NotPrivileged` error means it is not running as root — re-run with `sudo`. See
-[Troubleshooting](troubleshooting.md#macos-endpoint-security-client-init-failed)
-for the full result-code table.
-
-Network and DNS capture additionally needs access to the `/dev/bpf*` device
-nodes; the agent continues with Endpoint Security only if capture cannot start.
-
-## Compile From Source
-
-Use this path if you want to build the binary yourself instead of using a published release.
+Use this path if you want to build the binary yourself instead of using a
+published release.
 
 ### Windows
 
@@ -214,6 +205,10 @@ cargo build --release
 sudo ./target/release/rustinel run
 ```
 
+On Linux, `build.rs` embeds `ebpf/rustinel-ebpf.o` when it already exists. If it
+does not exist, the build falls back to compiling the eBPF crate with nightly
+Rust.
+
 ### macOS
 
 ```bash
@@ -230,98 +225,45 @@ scripts/macos/package-app.sh \
 sudo ./target/release/Rustinel.app/Contents/MacOS/rustinel run
 ```
 
-The profile must belong to the explicit App ID approved for the project and
-authorize `com.apple.developer.endpoint-security.client`. The packaging script
-derives the bundle identifier from that profile. Grant the resulting app bundle
-Full Disk Access before starting it. See [Development](development.md) for
-profile validation, ad-hoc lab builds, and release secrets.
+The profile must belong to the explicit App ID approved for Endpoint Security
+and authorize `com.apple.developer.endpoint-security.client`. The packaging
+script derives the bundle identifier from that profile. Grant the resulting app
+bundle Full Disk Access before starting it. See [Development](development.md)
+for maintainer release-signing details and ad-hoc lab builds.
 
-Notes:
+## Optional Checks
 
-- Running `rustinel` with no subcommand is equivalent to `rustinel run`.
-- On Linux, `build.rs` embeds `ebpf/rustinel-ebpf.o` when it already exists. If it does not exist, the build falls back to compiling the eBPF crate with nightly Rust.
-- If startup fails with `tracefs not found`, mount the tracing filesystems and retry:
+### YARA Demo
 
-```bash
-mount -t tracefs tracefs /sys/kernel/tracing
-mount -t debugfs debugfs /sys/kernel/debug
-```
-
-Some minimal Linux environments, including some WSL 2 distros, may start without these filesystems mounted.
-
-## Verify First Alert
-
-### Windows Sigma Demo
-
-1. Keep Rustinel running.
-2. Execute:
-
-```powershell
-whoami /all
-```
-
-3. Confirm an alert was written to `logs\alerts.json.<date>`.
-
-The bundled rule is `rules/sigma/windows_whoami.yml`.
-
-### Linux Sigma Demo
-
-1. Keep Rustinel running.
-2. Execute:
-
-```bash
-whoami
-```
-
-3. Confirm an alert was written to `logs/alerts.json.<date>`.
-
-The bundled rule is `rules/sigma/linux_whoami.yml`.
-
-### macOS Sigma Demo
-
-1. Keep Rustinel running.
-2. Execute:
-
-```bash
-whoami
-```
-
-3. Confirm an alert was written to `logs/alerts.json.<date>`.
-
-The bundled rule is `rules/sigma/macos_whoami.yml`.
-
-### Cross-Platform YARA Demo
-
-1. Keep Rustinel running.
-2. Build the demo binary:
+Keep Rustinel running, build the demo binary, and run it:
 
 ```bash
 rustc ./examples/yara_demo.rs -o ./examples/yara_demo
+./examples/yara_demo
 ```
 
 On Windows:
 
 ```powershell
 rustc .\examples\yara_demo.rs -o .\examples\yara_demo.exe
+.\examples\yara_demo.exe
 ```
 
-3. Run the demo binary.
-4. Confirm an alert references `ExampleMarkerString` in `logs/alerts.json.<date>`.
+Confirm that an alert references `ExampleMarkerString` in
+`logs/alerts.json.<date>`.
 
-## Verify Hot Reload
+### Hot Reload
 
-1. Keep Rustinel running.
-2. Edit a Sigma, YARA, or IOC file.
-3. Wait a few seconds.
-4. Confirm the operational log reports a reload event.
+Keep Rustinel running, edit a Sigma, YARA, or IOC file, and wait a few seconds.
+The operational log should report a reload event.
 
-Example on Windows:
+Windows example:
 
 ```powershell
 Add-Content rules\sigma\windows_whoami.yml "`n# hot reload smoke test"
 ```
 
-Example on Linux:
+Linux example:
 
 ```bash
 printf '\n# hot reload smoke test\n' >> rules/sigma/linux_whoami.yml
@@ -329,7 +271,8 @@ printf '\n# hot reload smoke test\n' >> rules/sigma/linux_whoami.yml
 
 ## Next Steps
 
-- Use [Configuration](configuration.md) to move rule paths, logs, and allowlists out of the default repo layout.
-- Use [SIEM Demos](siem-demos.md) to ship first alerts to Elastic or Splunk.
-- Use [Operations and Upgrade Guide](operations.md) for installation layout and update workflows.
-- Use [CLI Reference](cli.md) for service commands and runtime examples.
+- [Configuration](configuration.md): move rule paths, logs, and allowlists out of the default layout.
+- [SIEM Demos](siem-demos.md): ship first alerts to Elastic or Splunk.
+- [Operations and Upgrade Guide](operations.md): install layouts, services, and upgrades.
+- [CLI Reference](cli.md): service commands and runtime examples.
+- [Limitations](limitations.md): current platform and detection gaps.

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,15 +12,15 @@ Rustinel is designed for blue teams, detection engineers, researchers, and anyon
 
 Visit the [official Rustinel site](https://rustinel.io/) for the main project home.
 
-## Start here
+## Start Here
 
-- [Getting Started](getting-started.md) — install and run Rustinel
-- [SIEM Demos](siem-demos.md) — ship first alerts to Elastic or Splunk
-- [Configuration](configuration.md) — configure telemetry, rules, alerts, and response
-- [Detection](detection.md) — understand Sigma, YARA, and IOC matching
-- [Architecture](architecture.md) — understand how Rustinel works internally
-- [Benchmarking](benchmarking.md) — collect repeatable performance and latency evidence
-- [Troubleshooting](troubleshooting.md) — fix common issues
+- [Getting Started](getting-started.md): install and run Rustinel
+- [SIEM Demos](siem-demos.md): ship first alerts to Elastic or Splunk
+- [Configuration](configuration.md): configure telemetry, rules, alerts, and response
+- [Detection](detection.md): understand Sigma, YARA, and IOC matching
+- [Architecture](architecture.md): understand how Rustinel works internally
+- [Benchmarking](benchmarking.md): collect repeatable performance and latency evidence
+- [Troubleshooting](troubleshooting.md): fix common issues
 
 ## Project background
 
@@ -28,7 +28,7 @@ Visit the [official Rustinel site](https://rustinel.io/) for the main project ho
 - [Limitations](limitations.md)
 - [Roadmap](roadmap.md)
 
-## What Rustinel does today
+## What Rustinel Does Today
 
 Rustinel currently provides:
 
@@ -41,7 +41,7 @@ Rustinel currently provides:
 - IOC matching for file hashes, IPs, domains, and path regexes
 - ECS NDJSON alert output
 - Hot reload for rules and indicator files
-- Optional active response with dry-run and allowlists
+- Optional active response with dry-run and allowlists on Windows and Linux
 
 macOS support is experimental while signed release packaging is validated
 across supported macOS versions.

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1,13 +1,13 @@
 # Limitations
 
 Rustinel is a transparent, rule-based endpoint detection engine. Like any
-detection system it has boundaries — and because Rustinel is open source, we
+detection system it has boundaries - and because Rustinel is open source, we
 document them in full rather than hide them.
 
 This page documents Rustinel's known limitations for the current release.
 
-> **Reading guide.** Items marked **⚠ silent** are the most important: they can
-> cause a rule to *not fire* — or match the wrong thing — with no error. Check
+> **Reading guide.** Items marked **silent risk** are the most important: they can
+> cause a rule to *not fire* - or match the wrong thing - with no error. Check
 > these before you rely on a detection.
 
 ## Highest impact: detections that can silently not fire
@@ -16,7 +16,7 @@ This page documents Rustinel's known limitations for the current release.
 | --- | --- |
 | Registry value *data* is never captured; `Details` holds the value *name* instead | Windows |
 | Process events carry no hashes (`Hashes` / `Imphash`) | Windows |
-| Command line is lost for short-lived processes | Windows · Linux |
+| Command line is lost for short-lived processes | Windows | Linux |
 | No correlation, aggregation, or temporal rules | Engine |
 | Rules are silently inert when no collector backs their logsource | Engine |
 | Telemetry is dropped under burst load (no backpressure) | Pipeline |
@@ -29,20 +29,20 @@ Rustinel collects Windows telemetry through ETW rather than a kernel driver.
 Coverage is the broadest of the three platforms, but several Sysmon-style fields
 are unavailable.
 
-- **Registry value data is not captured. ⚠ silent** Unlike Sysmon, `Details`
-  maps to the registry *value name*, not the data written to it — the
+- **Registry value data is not captured (silent risk).** Unlike Sysmon, `Details`
+  maps to the registry *value name*, not the data written to it - the
   Kernel-Registry provider doesn't emit value data. A rule matching on written
   content silently matches the value name instead.
-- **Registry `TargetObject` is a relative path. ⚠ silent** Full key paths
+- **Registry `TargetObject` is a relative path (silent risk).** Full key paths
   (e.g. `HKLM\...\Run`) aren't resolved, so `endswith`-style key matches may miss.
-- **No process or image-load hashes. ⚠ silent** There is no `Hashes`/`Imphash`
+- **No process or image-load hashes (silent risk).** There is no `Hashes`/`Imphash`
   on process or image-load events, so the many Sigma rules keyed on them can
   never fire. Hash matching exists only in the file/IOC scanner.
 - **Some process fields are always empty.** `IntegrityLevel`, `User`, `LogonId`,
   `LogonGuid`, `ParentCommandLine`, and often `CurrentDirectory` aren't populated
   by the provider; rules filtering on them won't match.
-- **Command line lost for short-lived processes. ⚠ silent** When ETW omits
-  `CommandLine`, it is back-filled by querying the live process — fast-exiting
+- **Command line lost for short-lived processes (silent risk).** When ETW omits
+  `CommandLine`, it is back-filled by querying the live process - fast-exiting
   processes are already gone, exactly when it matters most.
 - **PowerShell 7 (`pwsh`) is not covered.** Only Windows PowerShell 5.1
   script-block telemetry is collected; PowerShell Core uses a different provider.
@@ -53,16 +53,16 @@ are unavailable.
 - **DNS `QueryType` is always empty.** The DNS record type is not populated on
   Windows.
 - **No injection or driver-load visibility.** No equivalent of CreateRemoteThread,
-  ProcessAccess, named-pipe, or driver-load providers — injection-based TTPs leave
+  ProcessAccess, named-pipe, or driver-load providers - injection-based TTPs leave
   little telemetry.
 
 ## Linux (eBPF)
 
 The Linux sensor covers process, network, file, and DNS.
 
-- **Process argv isn't captured in the kernel. ⚠ silent** Command line is read
+- **Process argv isn't captured in the kernel (silent risk).** Command line is read
   from `/proc/<pid>/cmdline` in userspace, so short-lived processes yield an
-  empty command line — the dominant Linux gap, since most Linux Sigma rules match
+  empty command line - the dominant Linux gap, since most Linux Sigma rules match
   `CommandLine`.
 - **Paths are truncated.** The image path is capped at 128 bytes and `comm` at
   16, which can break `Image|endswith` matches.
@@ -78,44 +78,50 @@ The Linux sensor covers process, network, file, and DNS.
   `CAP_BPF` / `CAP_SYS_ADMIN`; older or BTF-less kernels and many restricted
   containers are unsupported.
 
-## macOS (ESF) — experimental
+## macOS (ESF) - experimental
 
 macOS support is experimental and detection-only.
 
 - **Process and file events only from Endpoint Security.** No image-load, script,
   WMI, service, or task equivalents.
+
+### macOS Network and DNS Attribution
+
 - **Network/DNS attribution is best-effort.** Telemetry comes from `/dev/bpf`
   capture, not a per-process hook: connections are matched to processes by port
   (racy), DNS events aren't attributed to a process, and capture binds to a
   single interface (default `en0`, override with `RUSTINEL_BPF_INTERFACE`).
+
+### macOS Memory Scanning
+
 - **Memory scanning is restricted.** YARA memory scanning uses `task_for_pid`,
   which generally needs root plus SIP/AMFI relaxation or an entitlement; when
   denied it returns nothing.
-- **No active response.** Process termination is unsupported on macOS —
+- **No active response.** Process termination is unsupported on macOS -
   detection only.
 
 ## Detection engine (Sigma)
 
-- **No correlation, aggregation, or temporal rules. ⚠ silent** Each event is
-  matched independently — no state, window, count, or throttle. Sigma correlation
+- **No correlation, aggregation, or temporal rules (silent risk).** Each event is
+  matched independently - no state, window, count, or throttle. Sigma correlation
   (`event_count`, `value_count`, `temporal`, `temporal_ordered`) and legacy
   aggregations (`| count() by ...`, `near`) are unsupported, so brute-force,
   beaconing, and "N events in M minutes" detections can't be expressed.
 - **Unsupported modifiers reject the whole rule.** A rule using a modifier
   outside the supported set (e.g. `|expand`, `|gzip`, `|minlength`) is dropped at
   load, not partially matched.
-- **Rules are inert without a backing collector. ⚠ silent** Rules for a
+- **Rules are inert without a backing collector (silent risk).** Rules for a
   product/category the running platform doesn't collect will load but never fire.
   On Linux/macOS a large share of a Windows-oriented ruleset is effectively dead
-  weight — don't read rule count as coverage.
+  weight - don't read rule count as coverage.
 
 ## Pipeline & operations
 
-- **Telemetry is dropped under load. ⚠ silent** Sensor channels are bounded and
+- **Telemetry is dropped under load (silent risk).** Sensor channels are bounded and
   drop on overflow, with only a periodic warning. Under burst load you get silent
   detection gaps, not slowdown.
 - **Active response is kill-after-the-fact.** The only response is process
-  termination, fired after the event is processed — the process may already have
+  termination, fired after the event is processed - the process may already have
   done its work or exited. A PID-reuse race is narrowed by identity checks but not
   eliminated. There is no quarantine, file deletion, network isolation, or
   registry rollback.
@@ -125,7 +131,7 @@ macOS support is experimental and detection-only.
 ## Detection philosophy & posture
 
 - **Not a commercial EDR replacement.** Rustinel uses ETW on Windows rather than
-  a kernel driver — simpler and more stable, but without a driver's visibility or
+  a kernel driver - simpler and more stable, but without a driver's visibility or
   enforcement points. It is not designed to detect kernel-mode rootkits,
   vulnerable-driver abuse, or direct telemetry tampering.
 - **IOC matching is only as good as its indicators.** It is deterministic and
@@ -139,7 +145,7 @@ macOS support is experimental and detection-only.
 
 ## How to think about Rustinel
 
-Rustinel is a transparent open-source detection engine — best for detection
+Rustinel is a transparent open-source detection engine - best for detection
 engineering, telemetry collection, rule development and testing, SIEM pipeline
 validation, research, lab deployments, and blue-team experimentation. It should
 not be presented as a full commercial EDR replacement today.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -46,8 +46,9 @@ C:\Rustinel\
 
 macOS support is experimental. Release archives contain a signed and notarized
 app-like daemon bundle (`Rustinel.app`) plus a `rustinel` symlink into it. The
-bundled `com.rustinel.agent.plist` LaunchDaemon expects this `/usr/local/var/rustinel`
-layout. See [Getting Started](getting-started.md) and [Development](development.md).
+bundled `com.rustinel.agent.plist` LaunchDaemon expects this
+`/usr/local/var/rustinel` layout. See [Getting Started](getting-started.md) for
+Full Disk Access setup and [Development](development.md) for signing details.
 
 Use absolute paths in `config.toml` once you move beyond the default repo layout.
 
@@ -126,13 +127,18 @@ Because `config.toml` is loaded from `WorkingDirectory`, use absolute paths for 
 
 ## macOS Runtime Model
 
-macOS support is experimental and detection-only (no active response). Rustinel does not ship macOS service-management commands yet (those are Windows-only); run it in the foreground as root:
+macOS support is experimental and detection-only. Active response is not
+supported on macOS. Rustinel does not ship macOS service-management commands
+yet; run it in the foreground as root:
 
 ```bash
 sudo /usr/local/var/rustinel/rustinel run
 ```
 
-For background execution, install the release package under `/usr/local/var/rustinel` and load the bundled `com.rustinel.agent.plist` as a `launchd` LaunchDaemon — the plist contains the exact `launchctl bootstrap` command and expects that path.
+For background execution, install the release package under
+`/usr/local/var/rustinel` and load the bundled `com.rustinel.agent.plist` as a
+`launchd` LaunchDaemon. The plist contains the exact `launchctl bootstrap`
+command and expects that path.
 
 The app bundle must be signed with the
 `com.apple.developer.endpoint-security.client` entitlement, contain the

--- a/docs/output.md
+++ b/docs/output.md
@@ -107,7 +107,7 @@ Format:
   "host.os.type": "windows",
   "host.os.family": "windows",
   "process.executable": "C:\\Windows\\System32\\whoami.exe",
-  "process.command_line": "whoami /all"
+  "process.command_line": "whoami"
 }
 ```
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -8,28 +8,29 @@ It is not a strict release commitment.
 
 ### Linux
 
-- **DNS response enrichment** — Linux DNS query names are extracted in userspace from raw eBPF payload events. Future work should parse DNS responses for `QueryResults` and DNS answer-to-network correlation.
-- **Expanded file telemetry** — cover `chmod`, `chown`, `truncate`, and `link` syscalls to close gaps in file-integrity coverage.
-- **Container context** — enrich process events with cgroup, namespace, and container runtime metadata so rules can scope to specific workloads.
+- **DNS response enrichment:** Linux DNS query names are extracted in userspace from raw eBPF payload events. Future work should parse DNS responses for `QueryResults` and DNS answer-to-network correlation.
+- **Expanded file telemetry:** cover `chmod`, `chown`, `truncate`, and `link` syscalls to close gaps in file-integrity coverage.
+- **Container context:** enrich process events with cgroup, namespace, and container runtime metadata so rules can scope to specific workloads.
 
 ### Windows
 
-- **ETW integrity checks** — detect ETW session tampering and provider blinding that could suppress telemetry.
-- **Deep inspection via stack walking** — identify shellcode and "floating code" executing outside mapped image regions.
+- **ETW integrity checks:** detect ETW session tampering and provider blinding that could suppress telemetry.
+- **Deep inspection via stack walking:** identify shellcode and "floating code" executing outside mapped image regions.
 
 ### macOS
 
 macOS support collects process and file telemetry through Endpoint Security and
-network and DNS through `/dev/bpf` capture. Future work:
+network and DNS through `/dev/bpf` capture. Active response is not supported on
+macOS today. Future work:
 
-- **NetworkExtension flow source** — replace `/dev/bpf` capture with a Network Extension that carries the owning PID per flow, removing the best-effort socket-to-PID scan and its direction ambiguity.
-- **Interface selection** — capture across all active interfaces instead of the single `RUSTINEL_BPF_INTERFACE` (default `en0`).
-- **DNS response enrichment** — parse DNS answers for `QueryResults`, matching the Linux gap.
-- **AUTH-mode prevention** — block process execution before it happens via `ES_EVENT_TYPE_AUTH_EXEC`, beyond the current kill-after-the-fact response.
+- **NetworkExtension flow source:** replace `/dev/bpf` capture with a Network Extension that carries the owning PID per flow, removing the best-effort socket-to-PID scan and its direction ambiguity.
+- **Interface selection:** capture across all active interfaces instead of the single `RUSTINEL_BPF_INTERFACE` default of `en0`.
+- **DNS response enrichment:** parse DNS answers for `QueryResults`, matching the Linux gap.
+- **AUTH-mode prevention:** explore macOS prevention by blocking process execution with `ES_EVENT_TYPE_AUTH_EXEC`.
 
 ### Cross-Platform
 
-- **Periodic YARA sweeps** — scheduled background scans of running processes independent of creation events.
+- **Periodic YARA sweeps:** scheduled background scans of running processes independent of creation events.
 
 ## Detection
 

--- a/docs/siem-demos.md
+++ b/docs/siem-demos.md
@@ -20,7 +20,7 @@ Start Rustinel from an extracted release package:
 
     ```powershell
     .\rustinel.exe run
-    whoami /all
+    whoami
     Get-Content .\logs\alerts.json.*
     ```
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -12,7 +12,7 @@ Before changing config or rules, check these first:
   - Linux: `sudo ./rustinel run --log-level debug`
   - macOS: `sudo ./rustinel run --log-level debug`
 - Trigger a known bundled demo rule:
-  - Windows: `whoami /all`
+  - Windows: `whoami`
   - Linux: `whoami`
   - macOS: `whoami`
 - Confirm you are using the expected working directory and rule paths
@@ -93,7 +93,7 @@ mount -t debugfs debugfs /sys/kernel/debug
 Typical symptom in logs:
 
 ```text
-eBPF object load failed — ensure BTF is available and kernel is 5.8+
+eBPF object load failed - ensure BTF is available and kernel is 5.8+
 ```
 
 ### Linux source build fails on the first build
@@ -114,7 +114,7 @@ end of the error tells you exactly which requirement is missing:
 | Result code | Cause | Fix |
 | --- | --- | --- |
 | `NotPrivileged` | Not running as root. | Re-run with `sudo`. |
-| `NotPermitted` | Running as root with the entitlement, but macOS has not granted the client Endpoint Security access (TCC). | For an interactive `sudo` run from a terminal, grant **Full Disk Access to that terminal app** (Terminal/iTerm/…) and reopen it — macOS attributes the permission to the terminal, so Rustinel itself will not appear in the list. For a background LaunchDaemon, grant `Rustinel.app` directly (or use an MDM PPPC profile). |
+| `NotPermitted` | Running as root with the entitlement, but macOS has not granted the client Endpoint Security access (TCC). | For an interactive `sudo` run from a terminal, grant **Full Disk Access to that terminal app** (Terminal, iTerm, Ghostty, or similar) and reopen it. macOS attributes the permission to the terminal, so Rustinel itself will not appear in the list. For a background LaunchDaemon, grant `Rustinel.app` directly, or use an MDM PPPC profile. |
 | `NotEntitled` | The binary is not signed with `com.apple.developer.endpoint-security.client`, or its provisioning profile does not authorize the entitlement. | Run a signed `Rustinel.app` from a release, or repackage with `scripts/macos/package-app.sh` (see [Development](development.md)). |
 
 On a fresh machine the first run typically reports `NotPermitted`: signing and

--- a/scripts/bench/windows.ps1
+++ b/scripts/bench/windows.ps1
@@ -323,7 +323,7 @@ function Measure-AlertLatency {
 
     $before = Get-AlertLineCount -RuleName $AlertRuleName
     $sw = [System.Diagnostics.Stopwatch]::StartNew()
-    & whoami /all | Out-Null
+    & whoami | Out-Null
     while ($sw.Elapsed.TotalSeconds -lt 15) {
         Start-Sleep -Milliseconds 100
         $after = Get-AlertLineCount -RuleName $AlertRuleName

--- a/scripts/install/install.ps1
+++ b/scripts/install/install.ps1
@@ -88,7 +88,7 @@ try {
     Write-Host "Try the bundled demo rule from an elevated PowerShell:"
     Write-Host "  Set-Location `"$InstallDir`""
     Write-Host "  .\rustinel.exe run"
-    Write-Host "  whoami /all"
+    Write-Host "  whoami"
     Write-Host "  Get-Content .\logs\alerts.json.*"
     Write-Host ""
 

--- a/zensical.toml
+++ b/zensical.toml
@@ -17,7 +17,7 @@ site_name = "Rustinel"
 # meaningful description of the site content for use by search engines.
 #
 # Read more: https://zensical.org/docs/setup/basics/#site_description
-site_description = "Open-source endpoint detection for Windows and Linux using ETW, eBPF, Sigma, YARA, IOCs, and Rust"
+site_description = "Open-source endpoint detection for Windows, Linux, and macOS using ETW, eBPF, Endpoint Security, Sigma, YARA, IOCs, and Rust"
 
 # The site_author attribute. This is used in the HTML head element.
 #


### PR DESCRIPTION
## Summary

- Rewrite Getting Started into a shorter release-first guide with clearer macOS setup.
- Update README, release notes, FAQ, troubleshooting, operations, and related docs for consistent platform wording.
- Standardize the Windows demo command to `whoami` in docs, installer output, and benchmark latency checks.
- Clarify that macOS is detection-only today and update docs metadata to include macOS.

## Validation

- `zensical build --clean`
- `git diff --check`
- Repository scan for stale `whoami /all` references and forbidden dash punctuation