### PR TITLE
Standardize OS ordering in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ A transparent endpoint detection engine you can read, run, test, and extend.
 - **Detection formats:** Sigma for behavior, YARA for files and memory, IOC matching for hashes, IPs, domains, and path regexes.
 - **Rule reuse:** bring existing Sigma and YARA rules instead of rewriting them into a proprietary format.
 - **SIEM output:** ECS 9.4.0 NDJSON alerts for Elastic, Splunk, and other log pipelines.
-- **Operations:** hot reload for rules and IOCs, optional active response on Windows and Linux, Windows service support, and launchd packaging notes.
+- **Operations:** hot reload for rules and IOCs, optional active response on Windows and Linux only; macOS is detection-only today. Includes Windows service support and launchd packaging notes.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -35,17 +35,17 @@
 Rustinel ships release archives with a binary, default config, demo rules, and a
 `logs/` directory.
 
-**Linux**
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/Karib0u/rustinel/main/scripts/install/install.sh | sh -s -- --run
-```
-
 **Windows** - from an elevated PowerShell:
 
 ```powershell
 Invoke-WebRequest https://raw.githubusercontent.com/Karib0u/rustinel/main/scripts/install/install.ps1 -OutFile install-rustinel.ps1
 powershell -ExecutionPolicy Bypass -File .\install-rustinel.ps1 -Run
+```
+
+**Linux**
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Karib0u/rustinel/main/scripts/install/install.sh | sh -s -- --run
 ```
 
 **macOS** (experimental)

--- a/config.toml
+++ b/config.toml
@@ -17,13 +17,13 @@ debounce_ms = 2000          # poll cadence is max(debounce_ms, 2000)
 # - ioc.hash_allowlist_paths
 # - scanner.yara_allowlist_paths
 #
-# Platform defaults are compiled in — only set this to override them.
+# Platform defaults are compiled in - only set this to override them.
 #
+# Windows defaults:
+#   C:\Windows\, C:\Program Files\, C:\Program Files (x86)\
 # Linux defaults:
 #   /usr/bin/, /usr/sbin/, /usr/lib/, /usr/lib64/, /usr/libexec/,
 #   /bin/, /sbin/, /lib/, /lib64/
-# Windows defaults:
-#   C:\Windows\, C:\Program Files\, C:\Program Files (x86)\
 #
 # [allowlist]
 # paths = [
@@ -52,7 +52,7 @@ match_debug = "off"         # off | summary | full (attach match details to aler
 # 3a. Alert Deduplication
 #   Collapses repeated identical alerts within a sliding window into a single
 #   rollup alert carrying event.count.  The first occurrence always emits
-#   immediately — there is no detection latency penalty.
+#   immediately - there is no detection latency penalty.
 #
 #   Disable for high-fidelity environments where every individual event matters.
 [dedup]
@@ -69,8 +69,8 @@ channel_capacity = 128
 # Processes that will never be terminated, matched by image basename or full path.
 # Complement the compiled-in path allowlist above for named system processes.
 #
-# Linux examples:  systemd, systemd-journald, sshd, dbus-daemon, auditd
 # Windows examples: smss.exe, csrss.exe, wininit.exe, lsass.exe, svchost.exe
+# Linux examples:  systemd, systemd-journald, sshd, dbus-daemon, auditd
 #
 # allowlist_images = []
 

--- a/docs/active-response.md
+++ b/docs/active-response.md
@@ -4,8 +4,8 @@ Rustinel includes an optional response engine that can terminate processes when
 an alert reaches the configured minimum severity. It is disabled by default and
 should be tested in dry-run mode first.
 
-Active response currently runs on **Windows and Linux only**. macOS support is
-detection-only.
+Active response currently runs on **Windows and Linux only**; macOS is
+detection-only today.
 
 ## Modes
 
@@ -19,7 +19,7 @@ detection-only.
 | --- | --- |
 | Windows | Uses process termination APIs |
 | Linux | Sends `SIGKILL` |
-| macOS | Not supported; detection only |
+| macOS | Not supported; detection-only today |
 
 ## Severity Handling
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -6,7 +6,7 @@ This page answers the questions that come up most often when running, deploying,
 
 ### What does Rustinel do?
 
-Rustinel is a cross-platform endpoint detection engine. It collects telemetry from ETW on Windows, eBPF on Linux, and Endpoint Security plus `/dev/bpf` on macOS, normalizes events into a shared model, evaluates Sigma, YARA, and IOC detections, writes ECS NDJSON alerts, and can optionally terminate offending processes (Windows and Linux only).
+Rustinel is a cross-platform endpoint detection engine. It collects telemetry from ETW on Windows, eBPF on Linux, and Endpoint Security plus `/dev/bpf` on macOS, normalizes events into a shared model, evaluates Sigma, YARA, and IOC detections, writes ECS NDJSON alerts, and can optionally terminate offending processes on Windows and Linux only; macOS is detection-only today.
 
 See [Architecture](architecture.md) and [Detection](detection.md) for the detailed runtime flow.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -7,6 +7,15 @@ This guide gets Rustinel installed, running, and producing its first alert.
 Use the install scripts when you want a published binary, bundled demo rules,
 `config.toml`, and the default `logs/` layout.
 
+### Windows
+
+Run from an elevated PowerShell:
+
+```powershell
+Invoke-WebRequest https://raw.githubusercontent.com/Karib0u/rustinel/main/scripts/install/install.ps1 -OutFile install-rustinel.ps1
+powershell -ExecutionPolicy Bypass -File .\install-rustinel.ps1 -Run
+```
+
 ### Linux
 
 ```bash
@@ -19,15 +28,6 @@ To inspect the script first:
 curl -fsSLO https://raw.githubusercontent.com/Karib0u/rustinel/main/scripts/install/install.sh
 less install.sh
 sh install.sh --run
-```
-
-### Windows
-
-Run from an elevated PowerShell:
-
-```powershell
-Invoke-WebRequest https://raw.githubusercontent.com/Karib0u/rustinel/main/scripts/install/install.ps1 -OutFile install-rustinel.ps1
-powershell -ExecutionPolicy Bypass -File .\install-rustinel.ps1 -Run
 ```
 
 ### macOS
@@ -65,16 +65,16 @@ whoami
 
 Confirm that an alert was written:
 
-=== "Linux"
-
-    ```bash
-    cat logs/alerts.json.*
-    ```
-
 === "Windows"
 
     ```powershell
     Get-Content .\logs\alerts.json.*
+    ```
+
+=== "Linux"
+
+    ```bash
+    cat logs/alerts.json.*
     ```
 
 === "macOS"

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,7 +41,7 @@ Rustinel currently provides:
 - IOC matching for file hashes, IPs, domains, and path regexes
 - ECS NDJSON alert output
 - Hot reload for rules and indicator files
-- Optional active response with dry-run and allowlists on Windows and Linux
+- Optional active response with dry-run and allowlists on Windows and Linux only; macOS is detection-only today
 
 macOS support is experimental while signed release packaging is validated
 across supported macOS versions.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -127,7 +127,7 @@ Because `config.toml` is loaded from `WorkingDirectory`, use absolute paths for 
 
 ## macOS Runtime Model
 
-macOS support is experimental and detection-only. Active response is not
+macOS support is experimental and detection-only today. Active response is not
 supported on macOS. Rustinel does not ship macOS service-management commands
 yet; run it in the foreground as root:
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -62,6 +62,30 @@ Format:
 | `edr.rule.engine` | `Sigma`, `Yara`, or `Ioc` |
 | `event.count` | *(rollup only)* Total occurrences of this alert within the dedup window (present only on aggregate rollup alerts, not on the first live emission) |
 
+### Windows Process Alert Example
+
+```json
+{
+  "@timestamp": "<date>T21:00:05Z",
+  "ecs.version": "9.4.0",
+  "event.kind": "alert",
+  "event.category": ["process"],
+  "event.type": ["start"],
+  "event.action": "process-start",
+  "event.code": "1",
+  "event.module": "edr",
+  "event.dataset": "edr.process",
+  "event.provider": "etw",
+  "rule.name": "Example - Whoami Execution (CommandLine + Image)",
+  "edr.rule.severity": "Low",
+  "edr.rule.engine": "Sigma",
+  "host.os.type": "windows",
+  "host.os.family": "windows",
+  "process.executable": "C:\\Windows\\System32\\whoami.exe",
+  "process.command_line": "whoami"
+}
+```
+
 ### Linux Process Alert Example
 
 ```json
@@ -84,30 +108,6 @@ Format:
   "process.executable": "/usr/bin/whoami",
   "process.name": "whoami",
   "user.name": "root"
-}
-```
-
-### Windows Process Alert Example
-
-```json
-{
-  "@timestamp": "<date>T21:00:05Z",
-  "ecs.version": "9.4.0",
-  "event.kind": "alert",
-  "event.category": ["process"],
-  "event.type": ["start"],
-  "event.action": "process-start",
-  "event.code": "1",
-  "event.module": "edr",
-  "event.dataset": "edr.process",
-  "event.provider": "etw",
-  "rule.name": "Example - Whoami Execution (CommandLine + Image)",
-  "edr.rule.severity": "Low",
-  "edr.rule.engine": "Sigma",
-  "host.os.type": "windows",
-  "host.os.family": "windows",
-  "process.executable": "C:\\Windows\\System32\\whoami.exe",
-  "process.command_line": "whoami"
 }
 ```
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,16 +6,16 @@ It is not a strict release commitment.
 
 ## Sensor
 
+### Windows
+
+- **ETW integrity checks:** detect ETW session tampering and provider blinding that could suppress telemetry.
+- **Deep inspection via stack walking:** identify shellcode and "floating code" executing outside mapped image regions.
+
 ### Linux
 
 - **DNS response enrichment:** Linux DNS query names are extracted in userspace from raw eBPF payload events. Future work should parse DNS responses for `QueryResults` and DNS answer-to-network correlation.
 - **Expanded file telemetry:** cover `chmod`, `chown`, `truncate`, and `link` syscalls to close gaps in file-integrity coverage.
 - **Container context:** enrich process events with cgroup, namespace, and container runtime metadata so rules can scope to specific workloads.
-
-### Windows
-
-- **ETW integrity checks:** detect ETW session tampering and provider blinding that could suppress telemetry.
-- **Deep inspection via stack walking:** identify shellcode and "floating code" executing outside mapped image regions.
 
 ### macOS
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -237,16 +237,6 @@ Check these first:
 - per-region or per-process byte caps may have prevented reading the region containing the match
 - insufficient privileges may prevent reading process memory (see below)
 
-#### Linux memory scanning privileges
-
-On Linux, reading `/proc/<pid>/mem` typically requires root or the `CAP_SYS_PTRACE` capability. You may also need to set a permissive ptrace scope:
-
-```bash
-echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
-```
-
-Without adequate privileges, region reads will fail silently (logged at `trace`).
-
 #### Windows memory scanning privileges
 
 On Windows, `OpenProcess` with `PROCESS_VM_READ` may fail for:
@@ -256,6 +246,16 @@ On Windows, `OpenProcess` with `PROCESS_VM_READ` may fail for:
 - some anti-tamper or security software
 
 These failures are logged at `trace` and do not affect other detection paths.
+
+#### Linux memory scanning privileges
+
+On Linux, reading `/proc/<pid>/mem` typically requires root or the `CAP_SYS_PTRACE` capability. You may also need to set a permissive ptrace scope:
+
+```bash
+echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
+```
+
+Without adequate privileges, region reads will fail silently (logged at `trace`).
 
 #### macOS memory scanning privileges
 


### PR DESCRIPTION
## Summary

- Standardizes human-facing platform order to Windows, Linux, and macOS in docs and sample config comments.
- Reorders quick-start sections, examples, roadmap subsections, and troubleshooting subsections where the order differed.
- Leaves implementation-specific platform ordering unchanged.

## Validation

- Ran `git diff --check` on the committed diff.
- Ran targeted searches for reversed platform ordering in docs and config.