### PR TITLE
Feat: Improved IO handling for YARA and hot-reload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1152,6 +1152,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1414,6 +1423,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "533e68a5842e734946fe159fb03fc9bbbb254f590dd0d8ad321ae5ff7beca2c1"
+dependencies = [
+ "bitflags 2.11.1",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "intaglio"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1489,6 +1518,26 @@ dependencies = [
  "pest",
  "pest_derive",
  "serde",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
 ]
 
 [[package]]
@@ -1706,6 +1755,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -1733,6 +1783,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.11.1",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -2415,6 +2492,7 @@ dependencies = [
  "mach2 0.6.0",
  "md-5 0.11.0",
  "memmap2",
+ "notify",
  "pelite",
  "regex",
  "serde",
@@ -3539,7 +3617,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
 dependencies = [
  "windows-core 0.57.0",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3572,7 +3650,7 @@ dependencies = [
  "windows-implement 0.57.0",
  "windows-interface 0.57.0",
  "windows-result 0.1.2",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3665,7 +3743,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3703,7 +3781,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -3721,14 +3808,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -3747,10 +3851,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3759,10 +3875,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3771,10 +3899,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3783,10 +3923,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ arc-swap = "1.7"
 
 # Configuration
 config = "0.15.23"
+notify = "8.2.0"
 
 # Linux-specific
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/config.toml
+++ b/config.toml
@@ -10,7 +10,7 @@ yara_rules_path = "rules/yara"
 
 [reload]
 enabled = true
-debounce_ms = 2000          # poll cadence is max(debounce_ms, 2000)
+debounce_ms = 2000          # debounces real-time filesystem events; fallback polling is 60s
 
 # Shared allowlist applied to:
 # - response.allowlist_paths

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -167,8 +167,8 @@ Live detector instances sit behind `DetectorStore`:
 
 If hot reload is enabled:
 
-- The poller fingerprints Sigma, YARA, and IOC files on disk
-- The worker debounces changes and rebuilds only the affected detector set
+- The watcher monitors filesystem events on Sigma, YARA, and IOC folders (falling back to a 60-second polling cadence if watcher setup fails)
+- The worker debounces/coalesces changes and rebuilds only the affected detector set
 - Successful rebuilds are swapped in atomically
 - Failed rebuilds keep the previous live detector instances
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -172,12 +172,14 @@ These defaults feed `allowlist.paths`, which then propagate to active response, 
 | Option | Default | Description |
 | --- | --- | --- |
 | `enabled` | `true` | Enable local file-based hot reload for Sigma, YARA, and IOC files |
-| `debounce_ms` | `2000` | Debounce window before rebuilding detectors |
+| `debounce_ms` | `2000` | Coalescing/debounce delay in milliseconds before rebuilding detectors |
 
 Reload notes:
 
-- Poll cadence is `max(reload.debounce_ms, 2000ms)`.
-- Empty rebuild results are rejected to keep the last good detector set live.
+- The reload mechanism uses event-based filesystem watching (such as `inotify` on Linux) to monitor directories/files and trigger reloads near-instantly when changes occur.
+- `reload.debounce_ms` is the coalescing window used to group multiple rapid write operations into a single reload event.
+- If the event-based watcher cannot be initialized, the agent automatically falls back to a 60-second polling cycle (logging the warning `"inotify is not available for the rules directory"`).
+- For Sigma and YARA, empty rulesets/scanners are allowed and will be swapped in (effectively disabling detections if no rules exist). For IOCs, empty indicator sets are rejected to keep the last known good set live.
 
 ### Global Allowlist
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -153,7 +153,7 @@ See [Configuration](configuration.md).
 
 ### Does hot reload require a restart?
 
-No. If `reload.enabled = true`, Rustinel polls Sigma, YARA, and IOC files and reloads them automatically.
+No. If `reload.enabled = true`, Rustinel watches Sigma, YARA, and IOC directories/files for changes and reloads them automatically (falling back to a 60-second polling check if the watcher setup fails).
 
 A restart is still useful when you change deployment layout, supervisor configuration, privileges, or the binary itself.
 
@@ -163,7 +163,7 @@ A restart is still useful when you change deployment layout, supervisor configur
 - top-level YARA rule files under `scanner.yara_rules_path`
 - IOC files configured in `ioc.hashes_path`, `ioc.ips_path`, `ioc.domains_path`, and `ioc.paths_regex_path`
 
-If a rebuild produces an empty detector set, Rustinel keeps the last known good one instead of swapping in an empty configuration.
+If a rebuild produces an empty detector set, Sigma and YARA will swap in the empty set (effectively disabling those detectors), whereas IOCs will reject the empty reload and keep the last known good indicator set active.
 
 ### Do Sigma and YARA load subdirectories the same way?
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -163,7 +163,7 @@ A restart is still useful when you change deployment layout, supervisor configur
 - top-level YARA rule files under `scanner.yara_rules_path`
 - IOC files configured in `ioc.hashes_path`, `ioc.ips_path`, `ioc.domains_path`, and `ioc.paths_regex_path`
 
-If a rebuild produces an empty detector set, Sigma and YARA will swap in the empty set (effectively disabling those detectors), whereas IOCs will reject the empty reload and keep the last known good indicator set active.
+If a rebuild produces an empty detector set (i.e. no rule files are present in the directory), Sigma and YARA will swap in the empty set (effectively disabling those detectors). However, if there are files found but any of them are broken (failed to compile/parse), the reload will be refused (with a warning logged) and the previous valid rules will remain active. IOCs will reject an empty reload and keep the last known good indicator set active.
 
 ### Do Sigma and YARA load subdirectories the same way?
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -298,9 +298,9 @@ Rejected IOC reload: indicator set is empty
 
 Remember:
 
-- reload polling is local file based
-- the poll cadence is effectively `max(reload.debounce_ms, 2000ms)`
-- empty rebuild results are rejected on purpose
+- reload watching is local filesystem event-based (falling back to a 60-second poll cadence on setup failure)
+- changes are debounced using `reload.debounce_ms` (defaults to 2000ms) to coalesce multiple rapid writes
+- empty IOC rebuild results are rejected on purpose (keeping the last known good IOCs active), while empty Sigma/YARA rulesets are allowed and will clear the active rules.
 
 If in doubt, make a tiny valid change to a known-good file and watch the operational log.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -292,6 +292,8 @@ Typical reload failure messages:
 Sigma reload failed; keeping previous engine
 YARA reload failed; keeping previous scanner
 Rejected IOC reload: indicator set is empty
+Rejected Sigma reload: one or more rules failed to compile
+Rejected YARA reload: one or more rules failed to compile
 ```
 
 ### I changed a file but nothing reloaded
@@ -300,7 +302,8 @@ Remember:
 
 - reload watching is local filesystem event-based (falling back to a 60-second poll cadence on setup failure)
 - changes are debounced using `reload.debounce_ms` (defaults to 2000ms) to coalesce multiple rapid writes
-- empty IOC rebuild results are rejected on purpose (keeping the last known good IOCs active), while empty Sigma/YARA rulesets are allowed and will clear the active rules.
+- empty IOC rebuild results are rejected on purpose (keeping the last known good IOCs active)
+- empty Sigma/YARA rulesets are allowed (clearing the active rules) ONLY if no rule files were found. If any rule files are found but they are broken (syntax/compile errors), the reload is rejected entirely, keeping the previous valid configuration active.
 
 If in doubt, make a tiny valid change to a known-good file and watch the operational log.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -180,6 +180,7 @@ pub struct IocConfig {
 pub struct ReloadConfig {
     pub enabled: bool,
     pub debounce_ms: u64,
+    pub fallback_poll_interval_ms: u64,
 }
 
 /// Alert deduplication / aggregation configuration
@@ -248,6 +249,7 @@ impl AppConfig {
             // Hot Reload
             .set_default("reload.enabled", true)?
             .set_default("reload.debounce_ms", 2000)?
+            .set_default("reload.fallback_poll_interval_ms", 60000i64)?
             // Alert deduplication
             .set_default("dedup.enabled", true)?
             .set_default("dedup.window_secs", 60i64)?
@@ -347,6 +349,7 @@ impl Default for AppConfig {
             reload: ReloadConfig {
                 enabled: true,
                 debounce_ms: 2000,
+                fallback_poll_interval_ms: 60000,
             },
             dedup: DedupConfig {
                 enabled: true,

--- a/src/engine/loader.rs
+++ b/src/engine/loader.rs
@@ -30,6 +30,10 @@ impl Engine {
             self.inactive_collector_rules
         );
 
+        if self.rule_files_found > 0 && self.rule_count == 0 {
+            warn!("Sigma rules found but none compiled successfully");
+        }
+
         Ok(())
     }
 
@@ -49,6 +53,7 @@ impl Engine {
             } else if let Some(ext) = path.extension() {
                 // Only process .yml and .yaml files
                 if ext == "yml" || ext == "yaml" {
+                    self.rule_files_found += 1;
                     match self.load_rule(&path) {
                         Ok(()) => {
                             debug!("Loaded rule: {:?}", path);

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -53,6 +53,9 @@ pub struct Engine {
     /// Total number of loaded rules
     rule_count: usize,
 
+    /// Total number of rule files found
+    rule_files_found: usize,
+
     /// Failed rule paths and error messages (for diagnostics)
     failed_rules: Vec<(String, String)>,
 
@@ -143,6 +146,7 @@ impl Engine {
             platform,
             rules_by_logsource: HashMap::new(),
             rule_count: 0,
+            rule_files_found: 0,
             failed_rules: Vec::new(),
             skipped_product_rules: 0,
             skipped_deferred_rules: 0,

--- a/src/engine/stats.rs
+++ b/src/engine/stats.rs
@@ -13,6 +13,7 @@ impl Engine {
 
         EngineStats {
             total_rules: self.rule_count,
+            rule_files_found: self.rule_files_found,
             rules_by_category,
             rules_by_logsource: self
                 .rules_by_logsource
@@ -40,6 +41,7 @@ impl Engine {
 
 pub struct EngineStats {
     pub total_rules: usize,
+    pub rule_files_found: usize,
     #[allow(dead_code)] // Used by companion binaries outside the library crate.
     pub rules_by_category: HashMap<String, usize>,
     pub rules_by_logsource: HashMap<String, usize>,

--- a/src/reload/mod.rs
+++ b/src/reload/mod.rs
@@ -263,13 +263,16 @@ pub fn spawn_reload_poller(
     reload_cfg: ReloadConfig,
     reload_tx: mpsc::UnboundedSender<ReloadTarget>,
 ) -> tokio::task::JoinHandle<()> {
+    use notify::Watcher;
+
     tokio::spawn(async move {
         if !reload_cfg.enabled {
             return;
         }
 
-        let poll_ms = reload_cfg.debounce_ms.max(2000);
-        let interval = Duration::from_millis(poll_ms);
+        let mut watcher_setup_ok = true;
+        let (tx, mut rx) = mpsc::channel::<()>(100);
+        let mut watcher = None;
 
         let mut sigma_fp = scanner_cfg
             .sigma_enabled
@@ -279,14 +282,93 @@ pub fn spawn_reload_poller(
             .then(|| fingerprint_dir(&scanner_cfg.yara_rules_path, &["yar", "yara"]));
         let mut ioc_fp = ioc_cfg.enabled.then(|| fingerprint_ioc_files(&ioc_cfg));
 
+        match notify::recommended_watcher(move |res: Result<notify::Event, notify::Error>| {
+            if res.is_ok() {
+                let _ = tx.blocking_send(());
+            }
+        }) {
+            Ok(mut w) => {
+                let mut watch_targets = Vec::new();
+                if scanner_cfg.sigma_enabled {
+                    watch_targets.push((
+                        &scanner_cfg.sigma_rules_path,
+                        notify::RecursiveMode::Recursive,
+                    ));
+                }
+                if scanner_cfg.yara_enabled {
+                    watch_targets.push((
+                        &scanner_cfg.yara_rules_path,
+                        notify::RecursiveMode::Recursive,
+                    ));
+                }
+                if ioc_cfg.enabled {
+                    watch_targets.push((&ioc_cfg.hashes_path, notify::RecursiveMode::NonRecursive));
+                    watch_targets.push((&ioc_cfg.ips_path, notify::RecursiveMode::NonRecursive));
+                    watch_targets
+                        .push((&ioc_cfg.domains_path, notify::RecursiveMode::NonRecursive));
+                    watch_targets.push((
+                        &ioc_cfg.paths_regex_path,
+                        notify::RecursiveMode::NonRecursive,
+                    ));
+                }
+
+                for (path, mode) in watch_targets {
+                    if let Err(e) = w.watch(path, mode) {
+                        warn!(
+                            target: "reload",
+                            path = ?path,
+                            error = %e,
+                            "Failed to watch path, inotify/watcher setup failed"
+                        );
+                        watcher_setup_ok = false;
+                        break;
+                    }
+                }
+                if watcher_setup_ok {
+                    watcher = Some(w);
+                }
+            }
+            Err(e) => {
+                warn!(
+                    target: "reload",
+                    error = %e,
+                    "Failed to initialize recommended watcher"
+                );
+                watcher_setup_ok = false;
+            }
+        }
+
+        if !watcher_setup_ok {
+            warn!(target: "reload", "inotify is not available for the rules directory");
+        }
+
+        let debounce_interval = Duration::from_millis(reload_cfg.debounce_ms);
+        let poll_interval = if reload_cfg.debounce_ms < 2000 {
+            Duration::from_millis(reload_cfg.debounce_ms.max(50))
+        } else {
+            Duration::from_secs(60)
+        };
+
         info!(
             target: "reload",
-            poll_ms = poll_ms,
-            "Hot-reload poller started"
+            watcher_active = watcher_setup_ok,
+            "Hot-reload poller/watcher started"
         );
 
         loop {
-            tokio::time::sleep(interval).await;
+            if watcher_setup_ok {
+                // Wait for filesystem event
+                if rx.recv().await.is_none() {
+                    break; // channel closed
+                }
+                // Debounce: sleep to let multiple events coalesce
+                tokio::time::sleep(debounce_interval).await;
+                // Drain extra events
+                while rx.try_recv().is_ok() {}
+            } else {
+                // Fallback: poll every 60 seconds
+                tokio::time::sleep(poll_interval).await;
+            }
 
             if scanner_cfg.sigma_enabled {
                 let next = fingerprint_dir(&scanner_cfg.sigma_rules_path, &["yml", "yaml"]);
@@ -319,6 +401,7 @@ pub fn spawn_reload_poller(
             }
         }
 
+        drop(watcher);
         info!(target: "reload", "Hot-reload poller shutting down");
     })
 }

--- a/src/reload/mod.rs
+++ b/src/reload/mod.rs
@@ -141,6 +141,23 @@ pub fn spawn_reload_worker(
                         match engine.load_rules(&scanner_cfg.sigma_rules_path) {
                             Ok(()) => {
                                 let stats = engine.stats();
+                                if stats.rule_files_found > 0 && stats.total_rules == 0 {
+                                    warn!(
+                                        target: "reload",
+                                        path = ?scanner_cfg.sigma_rules_path,
+                                        errors = ?stats.failed_rules,
+                                        "Rejected Sigma reload: all found rule files are broken"
+                                    );
+                                    continue;
+                                }
+                                if !stats.failed_rules.is_empty() {
+                                    warn!(
+                                        target: "reload",
+                                        path = ?scanner_cfg.sigma_rules_path,
+                                        errors = ?stats.failed_rules,
+                                        "Some Sigma rules failed to compile, but loading the working rules"
+                                    );
+                                }
                                 store.swap_sigma(Arc::new(engine));
                                 info!(
                                     target: "reload",
@@ -170,6 +187,22 @@ pub fn spawn_reload_worker(
                         match scanner::Scanner::new(&scanner_cfg.yara_rules_path) {
                             Ok(compiled) => {
                                 let compiled_files = compiled.compiled_files();
+                                if compiled.files_found() > 0 && compiled_files == 0 {
+                                    warn!(
+                                        target: "reload",
+                                        path = ?scanner_cfg.yara_rules_path,
+                                        "Rejected YARA reload: all found rule files are broken"
+                                    );
+                                    continue;
+                                }
+                                if compiled.failed_files() > 0 {
+                                    warn!(
+                                        target: "reload",
+                                        path = ?scanner_cfg.yara_rules_path,
+                                        failed = compiled.failed_files(),
+                                        "Some YARA rules failed to compile, but loading the working rules"
+                                    );
+                                }
                                 store.swap_yara(Arc::new(compiled));
                                 info!(
                                     target: "reload",
@@ -273,29 +306,36 @@ pub fn spawn_reload_poller(
                 let mut watch_targets = Vec::new();
                 if scanner_cfg.sigma_enabled {
                     watch_targets.push((
-                        &scanner_cfg.sigma_rules_path,
+                        scanner_cfg.sigma_rules_path.clone(),
                         notify::RecursiveMode::Recursive,
                     ));
                 }
                 if scanner_cfg.yara_enabled {
                     watch_targets.push((
-                        &scanner_cfg.yara_rules_path,
+                        scanner_cfg.yara_rules_path.clone(),
                         notify::RecursiveMode::Recursive,
                     ));
                 }
                 if ioc_cfg.enabled {
-                    watch_targets.push((&ioc_cfg.hashes_path, notify::RecursiveMode::NonRecursive));
-                    watch_targets.push((&ioc_cfg.ips_path, notify::RecursiveMode::NonRecursive));
-                    watch_targets
-                        .push((&ioc_cfg.domains_path, notify::RecursiveMode::NonRecursive));
-                    watch_targets.push((
+                    let mut parents = HashSet::new();
+                    for path in [
+                        &ioc_cfg.hashes_path,
+                        &ioc_cfg.ips_path,
+                        &ioc_cfg.domains_path,
                         &ioc_cfg.paths_regex_path,
-                        notify::RecursiveMode::NonRecursive,
-                    ));
+                    ] {
+                        let normalized = normalize_path(path);
+                        if let Some(parent) = normalized.parent() {
+                            parents.insert(parent.to_path_buf());
+                        }
+                    }
+                    for parent in parents {
+                        watch_targets.push((parent, notify::RecursiveMode::NonRecursive));
+                    }
                 }
 
-                for (path, mode) in watch_targets {
-                    if let Err(e) = w.watch(path, mode) {
+                for (path, mode) in &watch_targets {
+                    if let Err(e) = w.watch(path, *mode) {
                         warn!(
                             target: "reload",
                             path = ?path,
@@ -325,11 +365,7 @@ pub fn spawn_reload_poller(
         }
 
         let debounce_interval = Duration::from_millis(reload_cfg.debounce_ms);
-        let poll_interval = if reload_cfg.debounce_ms < 2000 {
-            Duration::from_millis(reload_cfg.debounce_ms.max(50))
-        } else {
-            Duration::from_secs(60)
-        };
+        let poll_interval = Duration::from_millis(reload_cfg.fallback_poll_interval_ms);
 
         info!(
             target: "reload",

--- a/src/reload/mod.rs
+++ b/src/reload/mod.rs
@@ -141,15 +141,6 @@ pub fn spawn_reload_worker(
                         match engine.load_rules(&scanner_cfg.sigma_rules_path) {
                             Ok(()) => {
                                 let stats = engine.stats();
-                                if stats.total_rules == 0 {
-                                    warn!(
-                                        target: "reload",
-                                        path = ?scanner_cfg.sigma_rules_path,
-                                        "Rejected Sigma reload: compiled ruleset is empty"
-                                    );
-                                    continue;
-                                }
-
                                 store.swap_sigma(Arc::new(engine));
                                 info!(
                                     target: "reload",
@@ -179,15 +170,6 @@ pub fn spawn_reload_worker(
                         match scanner::Scanner::new(&scanner_cfg.yara_rules_path) {
                             Ok(compiled) => {
                                 let compiled_files = compiled.compiled_files();
-                                if compiled_files == 0 {
-                                    warn!(
-                                        target: "reload",
-                                        path = ?scanner_cfg.yara_rules_path,
-                                        "Rejected YARA reload: compiled file count is zero"
-                                    );
-                                    continue;
-                                }
-
                                 store.swap_yara(Arc::new(compiled));
                                 info!(
                                     target: "reload",

--- a/src/runtime/linux.rs
+++ b/src/runtime/linux.rs
@@ -159,7 +159,22 @@ async fn run_linux_edr(
     }
 
     // 9. YARA background worker
-    let (yara_tx, yara_rx) = mpsc::channel::<(String, u32)>(1000);
+    let (yara_tx, yara_worker_handle) = if cfg.scanner.yara_enabled {
+        let (tx, rx) = mpsc::channel::<(String, u32)>(1000);
+        let handle = runtime_yara::spawn_yara_file_worker(
+            Arc::clone(&detectors),
+            alert_sink.clone(),
+            response_engine.clone(),
+            cfg.alerts.match_debug,
+            rx,
+            yara_allowlist_paths.clone(),
+            Platform::Linux,
+            "ebpf",
+        );
+        (Some(tx), Some(handle))
+    } else {
+        (None, None)
+    };
 
     let (yara_memory_tx, yara_memory_rx) =
         if cfg.scanner.yara_enabled && cfg.scanner.yara_memory_enabled {
@@ -169,16 +184,6 @@ async fn run_linux_edr(
         } else {
             (None, None)
         };
-    let yara_worker_handle = runtime_yara::spawn_yara_file_worker(
-        Arc::clone(&detectors),
-        alert_sink.clone(),
-        response_engine.clone(),
-        cfg.alerts.match_debug,
-        yara_rx,
-        yara_allowlist_paths.clone(),
-        Platform::Linux,
-        "ebpf",
-    );
 
     // Spawn optional YARA memory scanning worker (Linux).
     let yara_memory_worker_handle = if let Some(mem_rx) = yara_memory_rx {
@@ -237,14 +242,23 @@ async fn run_linux_edr(
         alert_sink: alert_sink.clone(),
         response_engine: response_engine.clone(),
     };
-    let yara_handler = YaraEventHandler {
-        tx: yara_tx,
-        memory_tx: yara_memory_tx,
-        allowlist_paths: yara_allowlist_paths,
+
+    let yara_handler = if cfg.scanner.yara_enabled {
+        let yara_handler = YaraEventHandler {
+            tx: yara_tx.expect("yara_tx exists when enabled"),
+            memory_tx: yara_memory_tx,
+            allowlist_paths: yara_allowlist_paths,
+        };
+        Some(yara_handler)
+    } else {
+        None
     };
+
     let mut router_inner = SensorEventRouter::new();
     router_inner.register_handler(Box::new(sigma_handler));
-    router_inner.register_handler(Box::new(yara_handler));
+    if let Some(yh) = yara_handler {
+        router_inner.register_handler(Box::new(yh));
+    }
     let router = Arc::new(router_inner);
 
     // 13. eBPF sensor
@@ -278,7 +292,9 @@ async fn run_linux_edr(
     drop(router);
     drop(response_engine);
     let _ = sensor_worker_handle.await;
-    let _ = yara_worker_handle.await;
+    if let Some(h) = yara_worker_handle {
+        let _ = h.await;
+    }
     if let Some(h) = yara_memory_worker_handle {
         let _ = h.await;
     }

--- a/src/runtime/macos.rs
+++ b/src/runtime/macos.rs
@@ -159,7 +159,22 @@ async fn run_macos_edr(
     }
 
     // 9. YARA background worker
-    let (yara_tx, yara_rx) = mpsc::channel::<(String, u32)>(1000);
+    let (yara_tx, yara_worker_handle) = if cfg.scanner.yara_enabled {
+        let (tx, rx) = mpsc::channel::<(String, u32)>(1000);
+        let handle = runtime_yara::spawn_yara_file_worker(
+            Arc::clone(&detectors),
+            alert_sink.clone(),
+            response_engine.clone(),
+            cfg.alerts.match_debug,
+            rx,
+            yara_allowlist_paths.clone(),
+            Platform::MacOS,
+            "esf",
+        );
+        (Some(tx), Some(handle))
+    } else {
+        (None, None)
+    };
 
     let (yara_memory_tx, yara_memory_rx) =
         if cfg.scanner.yara_enabled && cfg.scanner.yara_memory_enabled {
@@ -169,16 +184,6 @@ async fn run_macos_edr(
         } else {
             (None, None)
         };
-    let yara_worker_handle = runtime_yara::spawn_yara_file_worker(
-        Arc::clone(&detectors),
-        alert_sink.clone(),
-        response_engine.clone(),
-        cfg.alerts.match_debug,
-        yara_rx,
-        yara_allowlist_paths.clone(),
-        Platform::MacOS,
-        "esf",
-    );
 
     // Spawn optional YARA memory scanning worker (macOS).
     let yara_memory_worker_handle = if let Some(mem_rx) = yara_memory_rx {
@@ -237,14 +242,23 @@ async fn run_macos_edr(
         alert_sink: alert_sink.clone(),
         response_engine: response_engine.clone(),
     };
-    let yara_handler = YaraEventHandler {
-        tx: yara_tx,
-        memory_tx: yara_memory_tx,
-        allowlist_paths: yara_allowlist_paths,
+
+    let yara_handler = if cfg.scanner.yara_enabled {
+        let yara_handler = YaraEventHandler {
+            tx: yara_tx.expect("yara_tx exists when enabled"),
+            memory_tx: yara_memory_tx,
+            allowlist_paths: yara_allowlist_paths,
+        };
+        Some(yara_handler)
+    } else {
+        None
     };
+
     let mut router_inner = SensorEventRouter::new();
     router_inner.register_handler(Box::new(sigma_handler));
-    router_inner.register_handler(Box::new(yara_handler));
+    if let Some(yh) = yara_handler {
+        router_inner.register_handler(Box::new(yh));
+    }
     let router = Arc::new(router_inner);
 
     // 13. macOS sensors: Endpoint Security (process/file) and bpf (network/DNS)
@@ -290,7 +304,9 @@ async fn run_macos_edr(
     drop(router);
     drop(response_engine);
     let _ = sensor_worker_handle.await;
-    let _ = yara_worker_handle.await;
+    if let Some(h) = yara_worker_handle {
+        let _ = h.await;
+    }
     if let Some(h) = yara_memory_worker_handle {
         let _ = h.await;
     }

--- a/src/runtime/windows.rs
+++ b/src/runtime/windows.rs
@@ -360,7 +360,22 @@ async fn run_edr(
 
     // Create background worker channel for YARA scanning
     // Buffer = 1000 items. If 1000 processes start instantly, we drop events rather than blocking.
-    let (tx, rx) = mpsc::channel::<(String, u32)>(1000);
+    let (yara_tx, yara_worker_handle) = if cfg.scanner.yara_enabled {
+        let (tx, rx) = mpsc::channel::<(String, u32)>(1000);
+        let handle = runtime_yara::spawn_yara_file_worker(
+            Arc::clone(&detectors),
+            alert_sink.clone(),
+            response_engine.clone(),
+            cfg.alerts.match_debug,
+            rx,
+            yara_allowlist_paths.clone(),
+            Platform::Windows,
+            "etw",
+        );
+        (Some(tx), Some(handle))
+    } else {
+        (None, None)
+    };
 
     // Create optional YARA memory scanning channel.
     let (yara_memory_tx, yara_memory_rx) =
@@ -424,17 +439,6 @@ async fn run_edr(
     } else {
         info!(target: "reload", "Hot-reload disabled by configuration");
     }
-
-    let yara_worker_handle = runtime_yara::spawn_yara_file_worker(
-        Arc::clone(&detectors),
-        alert_sink.clone(),
-        response_engine.clone(),
-        cfg.alerts.match_debug,
-        rx,
-        yara_allowlist_paths.clone(),
-        Platform::Windows,
-        "etw",
-    );
 
     // Spawn optional YARA memory scanning worker.
     let yara_memory_worker_handle = if let Some(mem_rx) = yara_memory_rx {
@@ -501,16 +505,23 @@ async fn run_edr(
     };
 
     // Create YARA event handler
-    let yara_handler = YaraEventHandler {
-        tx,
-        memory_tx: yara_memory_tx,
-        allowlist_paths: yara_allowlist_paths,
+    let yara_handler = if cfg.scanner.yara_enabled {
+        let yara_handler = YaraEventHandler {
+            tx: yara_tx.expect("yara_tx exists when enabled"),
+            memory_tx: yara_memory_tx,
+            allowlist_paths: yara_allowlist_paths,
+        };
+        Some(yara_handler)
+    } else {
+        None
     };
 
     // Setup shared SensorEventRouter (mutable)
     let mut router_inner = SensorEventRouter::new();
     router_inner.register_handler(Box::new(sigma_handler));
-    router_inner.register_handler(Box::new(yara_handler));
+    if let Some(yh) = yara_handler {
+        router_inner.register_handler(Box::new(yh));
+    }
 
     // Freeze router (immutable/shared)
     let router = Arc::new(router_inner);
@@ -601,11 +612,12 @@ async fn run_edr(
 
     drop(router);
     drop(response_engine);
-    info!("Signaling YARA worker to shut down...");
-
-    match yara_worker_handle.await {
-        Ok(_) => info!("YARA worker thread finished"),
-        Err(e) => error!("Failed to join YARA worker thread: {}", e),
+    if let Some(handle) = yara_worker_handle {
+        info!("Signaling YARA worker to shut down...");
+        match handle.await {
+            Ok(_) => info!("YARA worker thread finished"),
+            Err(e) => error!("Failed to join YARA worker thread: {}", e),
+        }
     }
 
     if let Some(handle) = yara_memory_worker_handle {

--- a/src/runtime/windows.rs
+++ b/src/runtime/windows.rs
@@ -358,6 +358,32 @@ async fn run_edr(
         );
     }
 
+    // Initialize IOC engine
+    let ioc_engine = Arc::new(IocEngine::load(&cfg.ioc));
+    if ioc_engine.is_enabled() {
+        let stats = ioc_engine.stats();
+        info!(
+            target: "rustinel",
+            md5 = stats.md5,
+            sha1 = stats.sha1,
+            sha256 = stats.sha256,
+            ip = stats.ip,
+            cidr = stats.cidr,
+            domain_exact = stats.domain_exact,
+            domain_suffix = stats.domain_suffix,
+            path_regex = stats.path_regex,
+            "IOC engine initialized"
+        );
+    } else {
+        info!(target: "rustinel", "IOC detection disabled by configuration");
+    }
+
+    let detectors = DetectorStore::new(
+        Arc::clone(&sigma_engine),
+        Arc::clone(&yara_scanner),
+        Arc::clone(&ioc_engine),
+    );
+
     // Create background worker channel for YARA scanning
     // Buffer = 1000 items. If 1000 processes start instantly, we drop events rather than blocking.
     let (yara_tx, yara_worker_handle) = if cfg.scanner.yara_enabled {
@@ -386,32 +412,6 @@ async fn run_edr(
         } else {
             (None, None)
         };
-
-    // Initialize IOC engine
-    let ioc_engine = Arc::new(IocEngine::load(&cfg.ioc));
-    if ioc_engine.is_enabled() {
-        let stats = ioc_engine.stats();
-        info!(
-            target: "rustinel",
-            md5 = stats.md5,
-            sha1 = stats.sha1,
-            sha256 = stats.sha256,
-            ip = stats.ip,
-            cidr = stats.cidr,
-            domain_exact = stats.domain_exact,
-            domain_suffix = stats.domain_suffix,
-            path_regex = stats.path_regex,
-            "IOC engine initialized"
-        );
-    } else {
-        info!(target: "rustinel", "IOC detection disabled by configuration");
-    }
-
-    let detectors = DetectorStore::new(
-        Arc::clone(&sigma_engine),
-        Arc::clone(&yara_scanner),
-        Arc::clone(&ioc_engine),
-    );
 
     let mut reload_poller_handle = None;
     let mut reload_worker_handle = None;

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -285,6 +285,10 @@ impl Scanner {
         path: &str,
         match_debug: MatchDebugLevel,
     ) -> Result<Vec<YaraRuleMatch>> {
+        if self.compiled_files == 0 {
+            return Ok(Vec::new());
+        }
+
         let path = normalize_yara_path(path);
         let path = path.as_str();
         let identity = yara_file_identity(path, match_debug);
@@ -339,6 +343,10 @@ impl Scanner {
         data: &[u8],
         match_debug: MatchDebugLevel,
     ) -> Result<Vec<YaraRuleMatch>> {
+        if self.compiled_files == 0 {
+            return Ok(Vec::new());
+        }
+
         let mut scanner = XScanner::new(&self.rules);
         match scanner.scan(data) {
             Ok(scan_results) => Ok(collect_yara_matches(scan_results, match_debug)),

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -213,6 +213,8 @@ pub struct YaraMemoryJob {
 pub struct Scanner {
     rules: Rules,
     compiled_files: usize,
+    files_found: usize,
+    failed_files: usize,
     cache: Mutex<YaraScanCache>,
 }
 
@@ -223,6 +225,7 @@ impl Scanner {
         let mut compiler = Compiler::new();
         let mut files_found = 0;
         let mut files_compiled = 0;
+        let mut files_failed = 0;
 
         info!("Loading YARA rules from: {:?} (recursive)", rules_dir);
 
@@ -249,6 +252,7 @@ impl Scanner {
                                     debug!("✓ Compiled YARA rule: {:?}", path);
                                 }
                                 Err(e) => {
+                                    files_failed += 1;
                                     warn!("✗ Failed to compile {:?}: {}", path, e);
                                 }
                             }
@@ -263,6 +267,10 @@ impl Scanner {
             );
         }
 
+        if files_found > 0 && files_compiled == 0 {
+            warn!("YARA rules found but none compiled successfully");
+        }
+
         let rules = compiler.build();
         info!(
             "YARA Scanner: Found {} rule files, compiled {} successfully",
@@ -271,12 +279,22 @@ impl Scanner {
         Ok(Self {
             rules,
             compiled_files: files_compiled,
+            files_found,
+            failed_files: files_failed,
             cache: Mutex::new(YaraScanCache::new()),
         })
     }
 
     pub fn compiled_files(&self) -> usize {
         self.compiled_files
+    }
+
+    pub fn files_found(&self) -> usize {
+        self.files_found
+    }
+
+    pub fn failed_files(&self) -> usize {
+        self.failed_files
     }
 
     /// Scan a file path and return matching rule details

--- a/tests/reload.rs
+++ b/tests/reload.rs
@@ -92,6 +92,7 @@ level: high
         ReloadConfig {
             enabled: true,
             debounce_ms: 100,
+            fallback_poll_interval_ms: 60000,
         },
         "info".to_string(),
         MatchDebugLevel::Off,
@@ -146,6 +147,7 @@ async fn yara_reload_swaps_valid_rules_and_allows_empty_rules() {
         ReloadConfig {
             enabled: true,
             debounce_ms: 100,
+            fallback_poll_interval_ms: 60000,
         },
         "info".to_string(),
         MatchDebugLevel::Off,
@@ -201,6 +203,7 @@ async fn ioc_reload_swaps_valid_indicators_and_rejects_empty_set() {
         ReloadConfig {
             enabled: true,
             debounce_ms: 100,
+            fallback_poll_interval_ms: 60000,
         },
         "info".to_string(),
         MatchDebugLevel::Off,
@@ -262,6 +265,7 @@ async fn test_reload_poller_fallback_polling() {
     let reload_cfg = ReloadConfig {
         enabled: true,
         debounce_ms: 10,
+        fallback_poll_interval_ms: 100,
     };
 
     let (reload_tx, mut reload_rx) = mpsc::unbounded_channel();
@@ -299,5 +303,146 @@ level: high
 
     assert_eq!(event, ReloadTarget::Sigma);
 
+    handle.abort();
+}
+
+#[tokio::test]
+async fn test_reload_rejects_invalid_rules_but_keeps_previous_rules() {
+    let sigma = SigmaFixture::new();
+    let platform = host_platform();
+    sigma.write_process_rule(platform);
+    let yara = YaraFixture::new();
+    yara.write_default_rule();
+    let ioc = common::IocFixture::new();
+
+    let mut engine = Engine::new_for_platform(platform);
+    engine
+        .load_rules(sigma.rules_dir())
+        .expect("load initial sigma");
+    let store = DetectorStore::new(
+        Arc::new(engine),
+        Arc::new(Scanner::new(yara.rules_dir()).expect("load yara")),
+        Arc::new(IocEngine::load(&ioc.config())),
+    );
+
+    let (tx, rx) = mpsc::unbounded_channel();
+    let handle = spawn_reload_worker(
+        Arc::clone(&store),
+        scanner_cfg(&sigma, &yara),
+        ioc.config(),
+        ReloadConfig {
+            enabled: true,
+            debounce_ms: 100,
+            fallback_poll_interval_ms: 60000,
+        },
+        "info".to_string(),
+        MatchDebugLevel::Off,
+        rx,
+    );
+
+    // Delete the original valid Sigma rule file and write a completely invalid rule file
+    std::fs::remove_file(sigma.rules_dir().join("process.yml")).expect("remove valid sigma rule");
+    sigma.write_rule("invalid_rule.yml", "invalid: yaml: syntax: [error");
+
+    tx.send(ReloadTarget::Sigma).expect("send reload");
+    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+
+    // The reload should have been rejected (keeping the previous rules active in memory).
+    // Let's verify that the original process rules (no longer on disk) are still working.
+    let proc_event = TestNormalizer::new(false)
+        .normalizer
+        .normalize(&process_start_event(platform))
+        .unwrap();
+    assert!(store.sigma().check_event(&proc_event).is_some());
+
+    // Delete the original valid YARA rule file and write an invalid YARA rule
+    std::fs::remove_file(yara.rules_dir().join("marker.yar")).expect("remove valid yara rule");
+    std::fs::write(
+        yara.rules_dir().join("invalid_rule.yar"),
+        "rule invalid { syntax_error }",
+    )
+    .unwrap();
+    tx.send(ReloadTarget::Yara).expect("send reload");
+    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+
+    // YARA reload should also be rejected, keeping the default YARA rule (no longer on disk) active
+    assert_eq!(
+        store
+            .yara()
+            .scan_bytes(b"RUSTINEL_TEST_MARKER", MatchDebugLevel::Off)
+            .unwrap()
+            .len(),
+        1
+    );
+
+    drop(tx);
+    handle.abort();
+}
+
+#[tokio::test]
+async fn test_reload_accepts_partially_invalid_rules() {
+    let sigma = SigmaFixture::new();
+    let platform = host_platform();
+    let yara = YaraFixture::new();
+    let ioc = common::IocFixture::new();
+
+    let engine = Engine::new_for_platform(platform);
+    // Start with empty rules
+    let store = DetectorStore::new(
+        Arc::new(engine),
+        Arc::new(Scanner::new(yara.rules_dir()).expect("load yara")),
+        Arc::new(IocEngine::load(&ioc.config())),
+    );
+
+    let (tx, rx) = mpsc::unbounded_channel();
+    let handle = spawn_reload_worker(
+        Arc::clone(&store),
+        scanner_cfg(&sigma, &yara),
+        ioc.config(),
+        ReloadConfig {
+            enabled: true,
+            debounce_ms: 100,
+            fallback_poll_interval_ms: 60000,
+        },
+        "info".to_string(),
+        MatchDebugLevel::Off,
+        rx,
+    );
+
+    // Write one valid and one invalid Sigma rule file
+    sigma.write_process_rule(platform);
+    sigma.write_rule("invalid_rule.yml", "invalid: yaml: syntax: [error");
+
+    tx.send(ReloadTarget::Sigma).expect("send reload");
+    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+
+    // The reload should have succeeded (loading the valid rule)
+    let proc_event = TestNormalizer::new(false)
+        .normalizer
+        .normalize(&process_start_event(platform))
+        .unwrap();
+    assert!(store.sigma().check_event(&proc_event).is_some());
+
+    // Write one valid and one invalid YARA rule file
+    yara.write_default_rule();
+    std::fs::write(
+        yara.rules_dir().join("invalid_rule.yar"),
+        "rule invalid { syntax_error }",
+    )
+    .unwrap();
+    tx.send(ReloadTarget::Yara).expect("send reload");
+    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+
+    // The reload should have succeeded (loading the valid rule)
+    assert_eq!(
+        store
+            .yara()
+            .scan_bytes(b"RUSTINEL_TEST_MARKER", MatchDebugLevel::Off)
+            .unwrap()
+            .len(),
+        1
+    );
+
+    drop(tx);
     handle.abort();
 }

--- a/tests/reload.rs
+++ b/tests/reload.rs
@@ -165,13 +165,11 @@ async fn yara_reload_swaps_valid_rules_and_allows_empty_rules() {
     std::fs::remove_file(yara.rules_dir().join("b.yar")).expect("remove rule B");
     tx.send(ReloadTarget::Yara).expect("send empty reload");
     tokio::time::sleep(std::time::Duration::from_millis(250)).await;
-    assert!(
-        store
-            .yara()
-            .scan_bytes(b"BBB_RELOAD_MARKER", MatchDebugLevel::Off)
-            .unwrap()
-            .is_empty()
-    );
+    assert!(store
+        .yara()
+        .scan_bytes(b"BBB_RELOAD_MARKER", MatchDebugLevel::Off)
+        .unwrap()
+        .is_empty());
     drop(tx);
     handle.abort();
 }

--- a/tests/reload.rs
+++ b/tests/reload.rs
@@ -44,7 +44,7 @@ fn scanner_cfg(sigma: &SigmaFixture, yara: &YaraFixture) -> ScannerConfig {
 }
 
 #[tokio::test]
-async fn sigma_reload_swaps_valid_rules_and_rejects_empty_rules() {
+async fn sigma_reload_swaps_valid_rules_and_allows_empty_rules() {
     let sigma = SigmaFixture::new();
     let platform = host_platform();
     sigma.write_process_rule(platform);
@@ -115,13 +115,13 @@ level: high
     std::fs::remove_file(sigma.rules_dir().join("network.yml")).expect("remove rule B");
     tx.send(ReloadTarget::Sigma).expect("send empty reload");
     tokio::time::sleep(std::time::Duration::from_millis(250)).await;
-    assert!(store.sigma().check_event(&network).is_some());
+    assert!(store.sigma().check_event(&network).is_none());
     drop(tx);
     handle.abort();
 }
 
 #[tokio::test]
-async fn yara_reload_swaps_valid_rules_and_rejects_empty_rules() {
+async fn yara_reload_swaps_valid_rules_and_allows_empty_rules() {
     let sigma = SigmaFixture::new();
     let platform = host_platform();
     sigma.write_process_rule(platform);
@@ -170,8 +170,7 @@ async fn yara_reload_swaps_valid_rules_and_rejects_empty_rules() {
             .yara()
             .scan_bytes(b"BBB_RELOAD_MARKER", MatchDebugLevel::Off)
             .unwrap()
-            .len()
-            == 1
+            .is_empty()
     );
     drop(tx);
     handle.abort();

--- a/tests/reload.rs
+++ b/tests/reload.rs
@@ -224,3 +224,83 @@ async fn ioc_reload_swaps_valid_indicators_and_rejects_empty_set() {
     drop(tx);
     handle.abort();
 }
+
+#[tokio::test]
+async fn test_reload_poller_fallback_polling() {
+    use rustinel::config::IocConfig;
+    use rustinel::reload::spawn_reload_poller;
+    use std::path::PathBuf;
+    use std::time::Duration;
+
+    let tempdir = tempfile::tempdir().expect("create tempdir");
+    let non_existent_dir = tempdir.path().join("non_existent_sigma_rules");
+
+    let scanner_cfg = ScannerConfig {
+        sigma_enabled: true,
+        sigma_rules_path: non_existent_dir.clone(),
+        yara_enabled: false,
+        yara_rules_path: PathBuf::from(""),
+        yara_allowlist_paths: Vec::new(),
+        yara_memory_enabled: false,
+        yara_memory_queue_capacity: 0,
+        yara_memory_delay_ms: 0,
+        yara_memory_max_process_mb: 0,
+        yara_memory_max_region_mb: 0,
+        yara_memory_include_private: false,
+        yara_memory_include_image: false,
+        yara_memory_include_mapped: false,
+    };
+
+    let ioc_cfg = IocConfig {
+        enabled: false,
+        hashes_path: PathBuf::from(""),
+        ips_path: PathBuf::from(""),
+        domains_path: PathBuf::from(""),
+        paths_regex_path: PathBuf::from(""),
+        default_severity: "high".to_string(),
+        max_file_size_mb: 0,
+        hash_allowlist_paths: Vec::new(),
+    };
+
+    let reload_cfg = ReloadConfig {
+        enabled: true,
+        debounce_ms: 10,
+    };
+
+    let (reload_tx, mut reload_rx) = mpsc::unbounded_channel();
+
+    // Spawning the poller with a non-existent path will trigger the watcher failure
+    // and cause it to fall back to the 100ms polling loop (in test configuration)
+    let handle = spawn_reload_poller(scanner_cfg, ioc_cfg, reload_cfg, reload_tx);
+
+    // Give it a moment to initialize and fail watcher setup
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // Now, create the directory and add a rules file to trigger a fingerprint change
+    std::fs::create_dir_all(&non_existent_dir).expect("create dir");
+    std::fs::write(
+        non_existent_dir.join("rule.yml"),
+        r#"title: Test Rule
+logsource:
+  product: windows
+  category: process_creation
+detection:
+  selection:
+    Image: "test.exe"
+  condition: selection
+level: high
+"#,
+    )
+    .expect("write rule");
+
+    // The polling loop (running at 100ms interval in test mode) should pick this up
+    // and send a ReloadTarget::Sigma event to the channel.
+    let event = tokio::time::timeout(Duration::from_millis(1500), reload_rx.recv())
+        .await
+        .expect("Timeout waiting for reload event")
+        .expect("Channel closed unexpectedly");
+
+    assert_eq!(event, ReloadTarget::Sigma);
+
+    handle.abort();
+}


### PR DESCRIPTION
## Summary

This PR addresses unnecessary IO load when running on slower HDDs. It performs thee changes:

- it disables YARA matching if no YARA rules are loaded, lowering the IO load
- it allows having empty YARA/Sigma rules folder (currently when a folder was empty, the reload was denied), which allows for the YARA rules to be empty once at least one rule was present
- it changes from polling the FS every 2 seconds for rules change into FS watch that fires on change (and fallbacks to 60 seconds poll if setting up watches fails), which allows the HDD to go to sleep if there are no changes

## Type of change
<!-- Add the matching label to this PR before merging -->
- [x] `feat` / `enhancement` - new feature
- [ ] `bug` - bug fix
- [ ] `refactor` - refactoring, no behaviour change
- [ ] `documentation` - docs only
- [ ] `ci` - CI/CD changes
- [ ] `dependencies` - dependency update

## Test plan
- [x] Tested on Windows
- [x] Tested on Linux
- [x] Existing tests pass (`cargo test`)
- [x] New tests added (if applicable)

## Checklist
- [ ] Label added to this PR
- [ ] Docs updated (if behaviour changed)
