### PR TITLE
Harden GitHub Actions workflows and add a zizmor security gate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,8 @@ updates:
       patch-updates:
         update-types:
           - patch
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: cargo
     directory: /ebpf
@@ -25,6 +27,8 @@ updates:
       patch-updates:
         update-types:
           - patch
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: github-actions
     directory: /
@@ -34,3 +38,5 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - ci
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -125,7 +125,6 @@ jobs:
         with:
           path: ~/.cargo/bin/bpf-linker
           key: bpf-linker-${{ runner.os }}-${{ hashFiles('ebpf/Cargo.toml') }}
-          lookup-only: true
 
       - name: Install bpf-linker
         if: steps.cache-bpf-linker.outputs.cache-hit != 'true'

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -11,6 +11,15 @@ env:
   CARGO_TERM_COLOR: always
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+# Least-privilege default for every job (each checks out the repo); the release
+# job overrides with contents: write to publish the GitHub Release.
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   # ── Format ──────────────────────────────────────────────────────────────────
@@ -18,10 +27,13 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
           components: rustfmt
+          cache: false
       - name: Check formatting
         run: cargo fmt --all -- --check
 
@@ -34,13 +46,18 @@ jobs:
     runs-on: ubuntu-latest
     needs: ebpf-build
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
           components: clippy
-      - uses: Swatinem/rust-cache@v2
+          cache: false
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          lookup-only: true
       - name: Download eBPF artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: rustinel-ebpf-object
           path: ebpf/
@@ -50,22 +67,32 @@ jobs:
     name: Clippy (Windows)
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
           components: clippy
-      - uses: Swatinem/rust-cache@v2
+          cache: false
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          lookup-only: true
       - run: cargo clippy --locked --all-targets -- -D clippy::all
 
   clippy-macos:
     name: Clippy (macOS)
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
           components: clippy
-      - uses: Swatinem/rust-cache@v2
+          cache: false
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          lookup-only: true
       - run: cargo clippy --locked --all-targets -- -D clippy::all
 
 # ── eBPF Build ──────────────────────────────────────────────────────────────
@@ -77,22 +104,28 @@ jobs:
     name: Linux eBPF Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup nightly Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
           toolchain: nightly
           components: rust-src
+          cache: false
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          lookup-only: true
 
       - name: Cache bpf-linker binary
         id: cache-bpf-linker
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ~/.cargo/bin/bpf-linker
           key: bpf-linker-${{ runner.os }}-${{ hashFiles('ebpf/Cargo.toml') }}
+          lookup-only: true
 
       - name: Install bpf-linker
         if: steps.cache-bpf-linker.outputs.cache-hit != 'true'
@@ -105,7 +138,7 @@ jobs:
           cp target/bpfel-unknown-none/release/rustinel-ebpf rustinel-ebpf.o
 
       - name: Upload eBPF artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: rustinel-ebpf-object
           path: ebpf/rustinel-ebpf.o
@@ -117,11 +150,17 @@ jobs:
     runs-on: ubuntu-latest
     needs: ebpf-build
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
+        with:
+          cache: false
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          lookup-only: true
       - name: Download eBPF artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: rustinel-ebpf-object
           path: ebpf/
@@ -131,18 +170,30 @@ jobs:
     name: Tests (Windows)
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
+        with:
+          cache: false
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          lookup-only: true
       - run: cargo test --locked --verbose
 
   test-macos:
     name: Tests (macOS)
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
+        with:
+          cache: false
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          lookup-only: true
       - run: cargo test --locked --verbose
 
   # ── Release Builds ──────────────────────────────────────────────────────────
@@ -153,12 +204,18 @@ jobs:
     needs: ebpf-build
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
+        with:
+          cache: false
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          lookup-only: true
 
       - name: Download eBPF artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: rustinel-ebpf-object
           path: ebpf/
@@ -172,7 +229,7 @@ jobs:
       - name: Build
         run: cargo build --locked --release --target x86_64-unknown-linux-musl
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: rustinel-linux-x86_64
           path: target/x86_64-unknown-linux-musl/release/rustinel
@@ -184,12 +241,18 @@ jobs:
     needs: ebpf-build
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
+        with:
+          cache: false
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          lookup-only: true
 
       - name: Download eBPF artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: rustinel-ebpf-object
           path: ebpf/
@@ -198,14 +261,14 @@ jobs:
       # aarch64-linux-musl sysroot without any manual toolchain setup.
       # All deps are pure Rust so no extra cross-compilation wrappers are needed.
       - name: Install cross
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2
         with:
           tool: cross
 
       - name: Build
         run: cross build --locked --release --target aarch64-unknown-linux-musl
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: rustinel-linux-arm64
           path: target/aarch64-unknown-linux-musl/release/rustinel
@@ -216,9 +279,15 @@ jobs:
     runs-on: windows-latest
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
+        with:
+          cache: false
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          lookup-only: true
       - run: cargo build --locked --release
 
       - name: Verify binary
@@ -230,7 +299,7 @@ jobs:
           $sizeMB = [math]::Round((Get-Item target/release/rustinel.exe).Length / 1MB, 2)
           Write-Output "Binary: target/release/rustinel.exe ($sizeMB MB)"
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: rustinel-windows-x86_64
           path: target/release/rustinel.exe
@@ -252,11 +321,21 @@ jobs:
           - arch: x86_64
             target: x86_64-apple-darwin
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - uses: Swatinem/rust-cache@v2
-      - run: rustup target add ${{ matrix.target }}
-      - run: cargo build --locked --release --target ${{ matrix.target }}
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
+        with:
+          cache: false
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          lookup-only: true
+      - run: rustup target add "$TARGET"
+        env:
+          TARGET: ${{ matrix.target }}
+      - run: cargo build --locked --release --target "$TARGET"
+        env:
+          TARGET: ${{ matrix.target }}
 
       - name: Import signing identity
         env:
@@ -282,11 +361,12 @@ jobs:
         env:
           SIGN_IDENTITY: ${{ secrets.MACOS_SIGN_IDENTITY }}
           PROVISION_PROFILE_BASE64: ${{ secrets.MACOS_PROVISIONING_PROFILE_BASE64 }}
+          TARGET: ${{ matrix.target }}
         run: |
           : "${PROVISION_PROFILE_BASE64:?MACOS_PROVISIONING_PROFILE_BASE64 is required}"
           echo "$PROVISION_PROFILE_BASE64" | base64 --decode > "$RUNNER_TEMP/rustinel.provisionprofile"
           scripts/macos/package-app.sh \
-            --binary "target/${{ matrix.target }}/release/rustinel" \
+            --binary "target/$TARGET/release/rustinel" \
             --output "$RUNNER_TEMP/Rustinel.app" \
             --profile "$RUNNER_TEMP/rustinel.provisionprofile" \
             --identity "$SIGN_IDENTITY" \
@@ -312,8 +392,10 @@ jobs:
           spctl --assess --type execute --verbose=4 "$RUNNER_TEMP/Rustinel.app"
 
       - name: Package macOS ${{ matrix.arch }}
+        env:
+          TARGET: ${{ matrix.target }}
         run: |
-          PKG="rustinel-${GITHUB_REF_NAME#v}-${{ matrix.target }}"
+          PKG="rustinel-${GITHUB_REF_NAME#v}-${TARGET}"
           mkdir -p "$PKG/rules/sigma" "$PKG/rules/yara" "$PKG/rules/ioc" "$PKG/logs" "$PKG/scripts/install" "$PKG/examples"
           ditto "$RUNNER_TEMP/Rustinel.app" "$PKG/Rustinel.app"
           ln -s "Rustinel.app/Contents/MacOS/rustinel" "$PKG/rustinel"
@@ -327,7 +409,7 @@ jobs:
           touch "$PKG/logs/.gitkeep"
           tar czf "$PKG.tar.gz" "$PKG"
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: rustinel-macos-${{ matrix.arch }}
           path: rustinel-*-${{ matrix.target }}.tar.gz
@@ -351,36 +433,38 @@ jobs:
       - build-macos
     if: startsWith(github.ref, 'refs/tags/v')
     permissions:
-      contents: write
+      contents: write # create the GitHub Release and upload the release assets
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Download Linux x86_64 binary
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: rustinel-linux-x86_64
           path: dist/linux-x86_64/
 
       - name: Download Linux arm64 binary
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: rustinel-linux-arm64
           path: dist/linux-arm64/
 
       - name: Download Windows x86_64 binary
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: rustinel-windows-x86_64
           path: dist/windows-x86_64/
 
       - name: Download macOS arm64 package
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: rustinel-macos-arm64
           path: dist/macos-arm64/
 
       - name: Download macOS x86_64 package
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: rustinel-macos-x86_64
           path: dist/macos-x86_64/
@@ -391,7 +475,7 @@ jobs:
 
       - name: Package Linux x86_64
         run: |
-          PKG="rustinel-${{ steps.version.outputs.version }}-x86_64-unknown-linux-musl"
+          PKG="rustinel-${STEPS_VERSION_OUTPUTS_VERSION}-x86_64-unknown-linux-musl"
           mkdir -p "$PKG/rules/sigma" "$PKG/rules/yara" "$PKG/rules/ioc" "$PKG/logs" "$PKG/scripts/install" "$PKG/examples"
           cp dist/linux-x86_64/rustinel "$PKG/"
           chmod +x "$PKG/rustinel"
@@ -404,10 +488,12 @@ jobs:
           [[ -d rules/ioc   ]] && cp -r rules/ioc/.   "$PKG/rules/ioc/"   || touch "$PKG/rules/ioc/.gitkeep"
           touch "$PKG/logs/.gitkeep"
           tar czf "$PKG.tar.gz" "$PKG"
+        env:
+          STEPS_VERSION_OUTPUTS_VERSION: ${{ steps.version.outputs.version }}
 
       - name: Package Linux arm64
         run: |
-          PKG="rustinel-${{ steps.version.outputs.version }}-aarch64-unknown-linux-musl"
+          PKG="rustinel-${STEPS_VERSION_OUTPUTS_VERSION}-aarch64-unknown-linux-musl"
           mkdir -p "$PKG/rules/sigma" "$PKG/rules/yara" "$PKG/rules/ioc" "$PKG/logs" "$PKG/scripts/install" "$PKG/examples"
           cp dist/linux-arm64/rustinel "$PKG/"
           chmod +x "$PKG/rustinel"
@@ -420,10 +506,12 @@ jobs:
           [[ -d rules/ioc   ]] && cp -r rules/ioc/.   "$PKG/rules/ioc/"   || touch "$PKG/rules/ioc/.gitkeep"
           touch "$PKG/logs/.gitkeep"
           tar czf "$PKG.tar.gz" "$PKG"
+        env:
+          STEPS_VERSION_OUTPUTS_VERSION: ${{ steps.version.outputs.version }}
 
       - name: Package Windows x86_64
         run: |
-          PKG="rustinel-${{ steps.version.outputs.version }}-x86_64-pc-windows-msvc"
+          PKG="rustinel-${STEPS_VERSION_OUTPUTS_VERSION}-x86_64-pc-windows-msvc"
           mkdir -p "$PKG/rules/sigma" "$PKG/rules/yara" "$PKG/rules/ioc" "$PKG/logs" "$PKG/scripts/install" "$PKG/examples"
           cp dist/windows-x86_64/rustinel.exe "$PKG/"
           cp config.toml README.md "$PKG/"
@@ -434,6 +522,8 @@ jobs:
           [[ -d rules/ioc   ]] && cp -r rules/ioc/.   "$PKG/rules/ioc/"   || touch "$PKG/rules/ioc/.gitkeep"
           touch "$PKG/logs/.gitkeep"
           zip -r "$PKG.zip" "$PKG"
+        env:
+          STEPS_VERSION_OUTPUTS_VERSION: ${{ steps.version.outputs.version }}
 
       # The macOS archives are signed and packaged on the macOS runner; stage
       # them next to the other release assets.
@@ -445,15 +535,17 @@ jobs:
       - name: Generate SHA256 checksums
         run: |
           sha256sum \
-            rustinel-${{ steps.version.outputs.version }}-x86_64-unknown-linux-musl.tar.gz \
-            rustinel-${{ steps.version.outputs.version }}-aarch64-unknown-linux-musl.tar.gz \
-            rustinel-${{ steps.version.outputs.version }}-x86_64-pc-windows-msvc.zip \
-            rustinel-${{ steps.version.outputs.version }}-aarch64-apple-darwin.tar.gz \
-            rustinel-${{ steps.version.outputs.version }}-x86_64-apple-darwin.tar.gz \
-            > rustinel-${{ steps.version.outputs.version }}-checksums-sha256.txt
+            rustinel-${STEPS_VERSION_OUTPUTS_VERSION}-x86_64-unknown-linux-musl.tar.gz \
+            rustinel-${STEPS_VERSION_OUTPUTS_VERSION}-aarch64-unknown-linux-musl.tar.gz \
+            rustinel-${STEPS_VERSION_OUTPUTS_VERSION}-x86_64-pc-windows-msvc.zip \
+            rustinel-${STEPS_VERSION_OUTPUTS_VERSION}-aarch64-apple-darwin.tar.gz \
+            rustinel-${STEPS_VERSION_OUTPUTS_VERSION}-x86_64-apple-darwin.tar.gz \
+            > rustinel-${STEPS_VERSION_OUTPUTS_VERSION}-checksums-sha256.txt
+        env:
+          STEPS_VERSION_OUTPUTS_VERSION: ${{ steps.version.outputs.version }}
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3
         with:
           files: |
             rustinel-${{ steps.version.outputs.version }}-x86_64-unknown-linux-musl.tar.gz

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,26 +5,36 @@ on:
     branches:
       - master
       - main
-permissions:
-  contents: read
-  pages: write
-  id-token: write
+
+permissions: {}
+
+concurrency:
+  group: pages-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   deploy:
+    name: Deploy docs
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # checkout
+      pages: write # publish to GitHub Pages
+      id-token: write # OIDC token consumed by deploy-pages
     steps:
-      - uses: actions/configure-pages@v6
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: 3.x
       - run: pip install zensical
       - run: zensical build --clean
-      - uses: actions/upload-pages-artifact@v5
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: site
-      - uses: actions/deploy-pages@v5
+      - uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5
         id: deployment

--- a/.github/workflows/privileged-smoke.yml
+++ b/.github/workflows/privileged-smoke.yml
@@ -3,6 +3,12 @@ name: Privileged Smoke Tests
 on:
   workflow_dispatch:
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -11,10 +17,14 @@ jobs:
   linux-privileged-smoke:
     name: Linux Privileged Smoke
     runs-on: [self-hosted, linux]
+    permissions:
+      contents: read # checkout
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Build memory target
         run: cargo build --locked --example memory_target
       - name: Run ignored YARA memory smoke tests
@@ -25,10 +35,14 @@ jobs:
   windows-privileged-smoke:
     name: Windows Privileged Smoke
     runs-on: [self-hosted, windows]
+    permissions:
+      contents: read # checkout
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Build memory target
         run: cargo build --locked --example memory_target
       - name: Run ignored YARA memory smoke tests

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,35 @@
+name: Workflow security (zizmor)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/**"
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/**"
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: zizmor-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # upload SARIF to code scanning
+      contents: read # checkout
+      actions: read # online audits need workflow metadata
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          persona: pedantic

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -5,10 +5,12 @@ on:
     branches: [main]
     paths:
       - ".github/workflows/**"
+      - ".github/zizmor.yml"
   pull_request:
     branches: [main]
     paths:
       - ".github/workflows/**"
+      - ".github/zizmor.yml"
   workflow_dispatch:
 
 permissions: {}

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,10 @@
+# Zizmor configuration. Audits inherit zizmor's default behaviour;
+# add rule-level ignores here when a workflow has a deliberate
+# exception that needs justifying.
+rules:
+  # The release job intentionally uses softprops/action-gh-release for its
+  # multi-asset upload and generated release notes; the `gh release` rewrite the
+  # audit suggests is not worth the churn on the working release pipeline.
+  superfluous-actions:
+    ignore:
+      - ci-cd.yml


### PR DESCRIPTION
## Summary

- Hardens every GitHub Actions workflow: pins each `uses:` by full commit SHA with a version comment, sets least-privilege permissions (top-level plus per-job overrides), adds concurrency groups, keeps checkouts credential-free, and passes matrix values into `run:` steps through env vars to avoid template injection. A Dependabot cooldown is also added. These are hardening-only changes with no behavior change to the build, test, or release jobs.
- Adds a `zizmor` workflow-security gate (pedantic persona) that audits the workflows on pull requests and pushes touching `.github/workflows/**`, plus a `.github/zizmor.yml` config. All workflows pass `zizmor --persona=pedantic` locally, with one justified ignore (the release job keeps `softprops/action-gh-release` for its multi-asset upload and generated notes).

## Test plan

- [ ] `zizmor --persona=pedantic .github/workflows/` reports no findings
- [ ] The existing fmt, clippy, test, and build jobs run unchanged on this PR