### PR TITLE
Clean up CI workflows

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,7 @@
 - [ ] `bug` - bug fix
 - [ ] `refactor` - refactoring, no behaviour change
 - [ ] `documentation` - docs only
-- [ ] `ci` - CI/CD changes
+- [ ] `ci` - CI and release changes
 - [ ] `dependencies` - dependency update
 
 ## Test plan

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -18,7 +18,7 @@ changelog:
       labels:
         - documentation
         - docs
-    - title: CI/CD
+    - title: CI and release
       labels:
         - ci
         - ci-cd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,192 @@
+name: CI
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+    branches: [master, main]
+  workflow_call:
+
+env:
+  CARGO_TERM_COLOR: always
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
+        with:
+          components: rustfmt
+          cache: false
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+  supply-chain:
+    name: Supply Chain
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
+        with:
+          cache: false
+      - uses: taiki-e/install-action@c93ccc03e00cd0e08e494f5fd058a6c55a6a1907 # v2
+        with:
+          tool: cargo-deny
+      - name: Check root dependencies
+        run: cargo deny --locked check
+      - name: Check eBPF dependencies
+        run: cargo deny --locked --manifest-path ebpf/Cargo.toml check --config ebpf/deny.toml
+
+  ebpf-build:
+    name: Linux eBPF Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup nightly Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
+        with:
+          toolchain: nightly
+          components: rust-src
+          cache: false
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          lookup-only: true
+
+      - name: Install bpf-linker
+        run: command -v bpf-linker >/dev/null 2>&1 || cargo install bpf-linker
+
+      - name: Build eBPF object
+        run: |
+          cd ebpf
+          cargo build --release
+          cp target/bpfel-unknown-none/release/rustinel-ebpf rustinel-ebpf.o
+
+      - name: Upload eBPF artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: rustinel-ebpf-object
+          path: ebpf/rustinel-ebpf.o
+          retention-days: 1
+
+  clippy-linux:
+    name: Clippy (Linux)
+    runs-on: ubuntu-latest
+    needs: ebpf-build
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
+        with:
+          components: clippy
+          cache: false
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          lookup-only: true
+      - name: Download eBPF artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: rustinel-ebpf-object
+          path: ebpf/
+      - run: cargo clippy --locked --all-targets -- -D clippy::all
+
+  clippy-windows:
+    name: Clippy (Windows)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
+        with:
+          components: clippy
+          cache: false
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          lookup-only: true
+      - run: cargo clippy --locked --all-targets -- -D clippy::all
+
+  clippy-macos:
+    name: Clippy (macOS)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
+        with:
+          components: clippy
+          cache: false
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          lookup-only: true
+      - run: cargo clippy --locked --all-targets -- -D clippy::all
+
+  test-linux:
+    name: Tests (Linux)
+    runs-on: ubuntu-latest
+    needs: ebpf-build
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
+        with:
+          cache: false
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          lookup-only: true
+      - name: Download eBPF artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: rustinel-ebpf-object
+          path: ebpf/
+      - run: cargo test --locked --verbose
+
+  test-windows:
+    name: Tests (Windows)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
+        with:
+          cache: false
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          lookup-only: true
+      - run: cargo test --locked --verbose
+
+  test-macos:
+    name: Tests (macOS)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
+        with:
+          cache: false
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          lookup-only: true
+      - run: cargo test --locked --verbose

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,4 @@
-# CI workflow for publishing documentation via Zensical
-name: Documentation
+name: Docs
 on:
   push:
     branches:
@@ -14,7 +13,7 @@ concurrency:
 
 jobs:
   deploy:
-    name: Deploy docs
+    name: Deploy Docs
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/privileged-smoke.yml
+++ b/.github/workflows/privileged-smoke.yml
@@ -1,4 +1,4 @@
-name: Privileged Smoke Tests
+name: Privileged Smoke
 
 on:
   workflow_dispatch:
@@ -15,7 +15,7 @@ env:
 
 jobs:
   linux-privileged-smoke:
-    name: Linux Privileged Smoke
+    name: Privileged Smoke (Linux)
     runs-on: [self-hosted, linux]
     permissions:
       contents: read # checkout
@@ -33,7 +33,7 @@ jobs:
         run: cargo test --locked --test active_response -- --include-ignored
 
   windows-privileged-smoke:
-    name: Windows Privileged Smoke
+    name: Privileged Smoke (Windows)
     runs-on: [self-hosted, windows]
     permissions:
       contents: read # checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,221 +1,31 @@
-name: CI/CD
+name: Release
 
 on:
   push:
-    branches: [master, main]
     tags: ['v*']
-  pull_request:
-    branches: [master, main]
 
 env:
   CARGO_TERM_COLOR: always
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
-# Least-privilege default for every job (each checks out the repo); the release
-# job overrides with contents: write to publish the GitHub Release.
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: release-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  ci:
+    name: CI Gates
+    uses: ./.github/workflows/ci.yml
+    permissions:
+      contents: read
 
-  # ── Format ──────────────────────────────────────────────────────────────────
-  fmt:
-    name: Rustfmt
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-        with:
-          persist-credentials: false
-      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
-        with:
-          components: rustfmt
-          cache: false
-      - name: Check formatting
-        run: cargo fmt --all -- --check
-
-  supply-chain:
-    name: Supply Chain
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-        with:
-          persist-credentials: false
-      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
-        with:
-          cache: false
-      - uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2
-        with:
-          tool: cargo-deny
-      - name: Check root dependencies
-        run: cargo deny --locked check
-      - name: Check eBPF dependencies
-        run: cargo deny --locked --manifest-path ebpf/Cargo.toml check --config ebpf/deny.toml
-
-  # ── Clippy ──────────────────────────────────────────────────────────────────
-  # Run on all platforms so Linux-specific code (aya, libc), Windows-specific
-  # code (ferrisetw, windows-rs), and macOS-specific code are each linted
-  # natively.
-  clippy-linux:
-    name: Clippy (Linux)
-    runs-on: ubuntu-latest
-    needs: ebpf-build
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-        with:
-          persist-credentials: false
-      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
-        with:
-          components: clippy
-          cache: false
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          lookup-only: true
-      - name: Download eBPF artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: rustinel-ebpf-object
-          path: ebpf/
-      - run: cargo clippy --locked --all-targets -- -D clippy::all
-
-  clippy-windows:
-    name: Clippy (Windows)
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-        with:
-          persist-credentials: false
-      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
-        with:
-          components: clippy
-          cache: false
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          lookup-only: true
-      - run: cargo clippy --locked --all-targets -- -D clippy::all
-
-  clippy-macos:
-    name: Clippy (macOS)
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-        with:
-          persist-credentials: false
-      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
-        with:
-          components: clippy
-          cache: false
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          lookup-only: true
-      - run: cargo clippy --locked --all-targets -- -D clippy::all
-
-# ── eBPF Build ──────────────────────────────────────────────────────────────
-  # Produces the BPF bytecode object that is embedded into the Linux binary
-  # at compile time (build.rs looks for ebpf/rustinel-ebpf.o).
-  # The bpfel-unknown-none target is architecture-agnostic, so one artifact
-  # serves both x86_64 and arm64 Linux.
-  ebpf-build:
-    name: Linux eBPF Build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-        with:
-          persist-credentials: false
-
-      - name: Setup nightly Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
-        with:
-          toolchain: nightly
-          components: rust-src
-          cache: false
-
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          lookup-only: true
-
-      - name: Install bpf-linker
-        # This workflow publishes release artifacts, so restoring a build-tool
-        # cache here would be a cache-poisoning vector (flagged by zizmor at the
-        # pedantic level). bpf-linker is therefore not cached; install it only
-        # when it is not already present on PATH so the step stays idempotent.
-        run: command -v bpf-linker >/dev/null 2>&1 || cargo install bpf-linker
-
-      - name: Build eBPF object
-        run: |
-          cd ebpf
-          cargo build --release
-          cp target/bpfel-unknown-none/release/rustinel-ebpf rustinel-ebpf.o
-
-      - name: Upload eBPF artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: rustinel-ebpf-object
-          path: ebpf/rustinel-ebpf.o
-          retention-days: 1
-
-  # ── Tests ───────────────────────────────────────────────────────────────────
-  test-linux:
-    name: Tests (Linux)
-    runs-on: ubuntu-latest
-    needs: ebpf-build
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-        with:
-          persist-credentials: false
-      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
-        with:
-          cache: false
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          lookup-only: true
-      - name: Download eBPF artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: rustinel-ebpf-object
-          path: ebpf/
-      - run: cargo test --locked --verbose
-
-  test-windows:
-    name: Tests (Windows)
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-        with:
-          persist-credentials: false
-      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
-        with:
-          cache: false
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          lookup-only: true
-      - run: cargo test --locked --verbose
-
-  test-macos:
-    name: Tests (macOS)
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-        with:
-          persist-credentials: false
-      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
-        with:
-          cache: false
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          lookup-only: true
-      - run: cargo test --locked --verbose
-
-  # ── Release Builds ──────────────────────────────────────────────────────────
-  # Only run on version tags; each job uploads a single binary artifact.
   build-linux-x86_64:
     name: Build Linux x86_64
     runs-on: ubuntu-latest
-    needs: ebpf-build
-    if: startsWith(github.ref, 'refs/tags/v')
+    needs: ci
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
@@ -251,8 +61,7 @@ jobs:
   build-linux-arm64:
     name: Build Linux arm64
     runs-on: ubuntu-latest
-    needs: ebpf-build
-    if: startsWith(github.ref, 'refs/tags/v')
+    needs: ci
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
@@ -270,11 +79,8 @@ jobs:
           name: rustinel-ebpf-object
           path: ebpf/
 
-      # cross uses Docker (pre-installed on ubuntu-latest) to provide the
-      # aarch64-linux-musl sysroot without any manual toolchain setup.
-      # All deps are pure Rust so no extra cross-compilation wrappers are needed.
       - name: Install cross
-        uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2
+        uses: taiki-e/install-action@c93ccc03e00cd0e08e494f5fd058a6c55a6a1907 # v2
         with:
           tool: cross
 
@@ -290,7 +96,7 @@ jobs:
   build-windows:
     name: Build Windows x86_64
     runs-on: windows-latest
-    if: startsWith(github.ref, 'refs/tags/v')
+    needs: ci
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
@@ -318,14 +124,10 @@ jobs:
           path: target/release/rustinel.exe
           retention-days: 1
 
-  # macOS builds run on the arm64 runner; the x86_64 target cross-compiles
-  # there since the SDK ships both slices. Endpoint Security uses a restricted
-  # entitlement, so the daemon is packaged in an app-like bundle with its
-  # provisioning profile before signing and notarization.
   build-macos:
     name: Build macOS ${{ matrix.arch }}
     runs-on: macos-latest
-    if: startsWith(github.ref, 'refs/tags/v')
+    needs: ci
     strategy:
       matrix:
         include:
@@ -428,25 +230,16 @@ jobs:
           path: rustinel-*-${{ matrix.target }}.tar.gz
           retention-days: 1
 
-  # ── Release ─────────────────────────────────────────────────────────────────
-  release:
-    name: Create Release
+  publish:
+    name: Publish Release
     runs-on: ubuntu-latest
     needs:
-      - fmt
-      - clippy-linux
-      - clippy-windows
-      - clippy-macos
-      - test-linux
-      - test-windows
-      - test-macos
       - build-linux-x86_64
       - build-linux-arm64
       - build-windows
       - build-macos
-    if: startsWith(github.ref, 'refs/tags/v')
     permissions:
-      contents: write # create the GitHub Release and upload the release assets
+      contents: write # create the GitHub Release and upload release assets
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
@@ -488,7 +281,7 @@ jobs:
 
       - name: Package Linux x86_64
         run: |
-          PKG="rustinel-${STEPS_VERSION_OUTPUTS_VERSION}-x86_64-unknown-linux-musl"
+          PKG="rustinel-${VERSION}-x86_64-unknown-linux-musl"
           mkdir -p "$PKG/rules/sigma" "$PKG/rules/yara" "$PKG/rules/ioc" "$PKG/logs" "$PKG/scripts/install" "$PKG/examples"
           cp dist/linux-x86_64/rustinel "$PKG/"
           chmod +x "$PKG/rustinel"
@@ -502,11 +295,11 @@ jobs:
           touch "$PKG/logs/.gitkeep"
           tar czf "$PKG.tar.gz" "$PKG"
         env:
-          STEPS_VERSION_OUTPUTS_VERSION: ${{ steps.version.outputs.version }}
+          VERSION: ${{ steps.version.outputs.version }}
 
       - name: Package Linux arm64
         run: |
-          PKG="rustinel-${STEPS_VERSION_OUTPUTS_VERSION}-aarch64-unknown-linux-musl"
+          PKG="rustinel-${VERSION}-aarch64-unknown-linux-musl"
           mkdir -p "$PKG/rules/sigma" "$PKG/rules/yara" "$PKG/rules/ioc" "$PKG/logs" "$PKG/scripts/install" "$PKG/examples"
           cp dist/linux-arm64/rustinel "$PKG/"
           chmod +x "$PKG/rustinel"
@@ -520,11 +313,11 @@ jobs:
           touch "$PKG/logs/.gitkeep"
           tar czf "$PKG.tar.gz" "$PKG"
         env:
-          STEPS_VERSION_OUTPUTS_VERSION: ${{ steps.version.outputs.version }}
+          VERSION: ${{ steps.version.outputs.version }}
 
       - name: Package Windows x86_64
         run: |
-          PKG="rustinel-${STEPS_VERSION_OUTPUTS_VERSION}-x86_64-pc-windows-msvc"
+          PKG="rustinel-${VERSION}-x86_64-pc-windows-msvc"
           mkdir -p "$PKG/rules/sigma" "$PKG/rules/yara" "$PKG/rules/ioc" "$PKG/logs" "$PKG/scripts/install" "$PKG/examples"
           cp dist/windows-x86_64/rustinel.exe "$PKG/"
           cp config.toml README.md "$PKG/"
@@ -536,10 +329,8 @@ jobs:
           touch "$PKG/logs/.gitkeep"
           zip -r "$PKG.zip" "$PKG"
         env:
-          STEPS_VERSION_OUTPUTS_VERSION: ${{ steps.version.outputs.version }}
+          VERSION: ${{ steps.version.outputs.version }}
 
-      # The macOS archives are signed and packaged on the macOS runner; stage
-      # them next to the other release assets.
       - name: Stage macOS packages
         run: |
           cp dist/macos-arm64/*.tar.gz .
@@ -548,14 +339,14 @@ jobs:
       - name: Generate SHA256 checksums
         run: |
           sha256sum \
-            rustinel-${STEPS_VERSION_OUTPUTS_VERSION}-x86_64-unknown-linux-musl.tar.gz \
-            rustinel-${STEPS_VERSION_OUTPUTS_VERSION}-aarch64-unknown-linux-musl.tar.gz \
-            rustinel-${STEPS_VERSION_OUTPUTS_VERSION}-x86_64-pc-windows-msvc.zip \
-            rustinel-${STEPS_VERSION_OUTPUTS_VERSION}-aarch64-apple-darwin.tar.gz \
-            rustinel-${STEPS_VERSION_OUTPUTS_VERSION}-x86_64-apple-darwin.tar.gz \
-            > rustinel-${STEPS_VERSION_OUTPUTS_VERSION}-checksums-sha256.txt
+            rustinel-${VERSION}-x86_64-unknown-linux-musl.tar.gz \
+            rustinel-${VERSION}-aarch64-unknown-linux-musl.tar.gz \
+            rustinel-${VERSION}-x86_64-pc-windows-msvc.zip \
+            rustinel-${VERSION}-aarch64-apple-darwin.tar.gz \
+            rustinel-${VERSION}-x86_64-apple-darwin.tar.gz \
+            > rustinel-${VERSION}-checksums-sha256.txt
         env:
-          STEPS_VERSION_OUTPUTS_VERSION: ${{ steps.version.outputs.version }}
+          VERSION: ${{ steps.version.outputs.version }}
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3

--- a/.github/workflows/rsigma-engine.yml
+++ b/.github/workflows/rsigma-engine.yml
@@ -1,9 +1,9 @@
-name: RSigma Engine
+name: RSigma Engine Parity
 
 # Parity gate for the optional `rsigma-engine` backend: builds and runs the
 # full test suite with the feature enabled so the RSigma-backed engine stays in
 # lockstep with the built-in one (the default backend is covered by the main
-# CI/CD workflow). Runs on macOS and Windows, which need no eBPF object, so the
+# CI workflow). Runs on macOS and Windows, which need no eBPF object, so the
 # platform-independent Sigma engine is exercised without the Linux build.rs
 # dependency.
 on:
@@ -35,7 +35,7 @@ env:
 
 jobs:
   feature:
-    name: rsigma-engine (${{ matrix.os }})
+    name: RSigma Engine (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -51,7 +51,7 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-      - name: Clippy (rsigma-engine)
+      - name: Clippy (RSigma Engine)
         run: cargo clippy --locked --features rsigma-engine --all-targets -- -D clippy::all
-      - name: Test (rsigma-engine)
+      - name: Test (RSigma Engine)
         run: cargo test --locked --features rsigma-engine --verbose

--- a/.github/workflows/sigma-rules.yml
+++ b/.github/workflows/sigma-rules.yml
@@ -1,4 +1,4 @@
-name: Detection-as-Code
+name: Sigma Rules
 
 # Detection-as-Code gate for the bundled Sigma rules. Uses the official
 # timescale/rsigma-action, which installs a SLSA-verified rsigma release and
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   rsigma:
-    name: Lint and validate Sigma rules
+    name: Lint and Validate Sigma Rules
     runs-on: ubuntu-latest
     permissions:
       contents: read # check out the rules and download the public rsigma release

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,4 +1,4 @@
-name: Workflow security (zizmor)
+name: Workflow Security
 
 on:
   push:
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   zizmor:
-    name: zizmor
+    name: Audit Workflows
     runs-on: ubuntu-latest
     permissions:
       security-events: write # upload SARIF to code scanning

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -7,4 +7,4 @@ rules:
   # audit suggests is not worth the churn on the working release pipeline.
   superfluous-actions:
     ignore:
-      - ci-cd.yml
+      - release.yml

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/Karib0u/rustinel/actions/workflows/ci-cd.yml"><img src="https://github.com/Karib0u/rustinel/actions/workflows/ci-cd.yml/badge.svg?style=flat-square" alt="CI"></a>
+  <a href="https://github.com/Karib0u/rustinel/actions/workflows/ci.yml"><img src="https://github.com/Karib0u/rustinel/actions/workflows/ci.yml/badge.svg?style=flat-square" alt="CI"></a>
   <a href="https://github.com/Karib0u/rustinel/releases/latest"><img src="https://img.shields.io/github/v/release/Karib0u/rustinel?style=flat-square&color=ff8a3d" alt="Latest release"></a>
   <a href="https://github.com/Karib0u/rustinel/releases"><img src="https://img.shields.io/github/downloads/Karib0u/rustinel/total?style=flat-square&color=ff8a3d" alt="Downloads"></a>
   <a href="https://github.com/Karib0u/rustinel/stargazers"><img src="https://img.shields.io/github/stars/Karib0u/rustinel?style=flat-square&color=ff8a3d" alt="Stars"></a>


### PR DESCRIPTION
## Summary

- Split the combined CI and release workflow into dedicated `CI` and `Release` workflows.
- Keep release publishing tag-only while gating it through the reusable CI workflow.
- Normalize workflow and job names for the GitHub Actions UI.
- Update README and GitHub metadata references to the new workflow names.

## Validation

- `go run github.com/rhysd/actionlint/cmd/actionlint@latest`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/*.yml .github/dependabot.yml .github/zizmor.yml .github/release.yml`
- `git diff --cached --check`