### PR TITLE
Fix Docs Pages deployment reruns

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,16 +12,11 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  deploy:
-    name: Deploy Docs
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+  build:
+    name: Build Docs
     runs-on: ubuntu-latest
     permissions:
       contents: read # checkout
-      pages: write # publish to GitHub Pages
-      id-token: write # OIDC token consumed by deploy-pages
     steps:
       - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -35,5 +30,17 @@ jobs:
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: site
+
+  deploy:
+    name: Deploy Docs
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      pages: write # publish to GitHub Pages
+      id-token: write # OIDC token consumed by deploy-pages
+    steps:
       - uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5
         id: deployment


### PR DESCRIPTION
## Summary

- Split the Docs workflow into separate build and deploy jobs.
- Keep artifact upload in `Build Docs` and Pages publication in `Deploy Docs`.
- Prevent failed deploy reruns from uploading duplicate `github-pages` artifacts in the same workflow run.

## Why

The docs build and artifact upload succeeded, but `actions/deploy-pages` failed. Rerunning the failed single-job workflow uploaded a second artifact named `github-pages`, which then caused `deploy-pages` to fail with `Multiple artifacts named "github-pages" were unexpectedly found for this workflow run`.

With separate jobs, a failed deploy rerun only reruns the deploy job and reuses the existing artifact.

## Validation

- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/docs.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/docs.yml"); puts "ok .github/workflows/docs.yml"'`
- `python3 -m venv` with `zensical build --clean`
- `git diff --check`