### PR TITLE
feat(doctor): add diagnostics command

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -57,6 +57,12 @@ pub enum Commands {
         #[arg(long, value_enum, value_name = "ENGINE")]
         sigma_engine: Option<SigmaEngineArg>,
     },
+    /// Check configuration, paths, and runtime prerequisites
+    Doctor {
+        /// Emit structured JSON output
+        #[arg(long)]
+        json: bool,
+    },
     /// Service management commands
     Service {
         #[command(subcommand)]
@@ -170,5 +176,15 @@ mod tests {
             cli.config,
             Some(std::path::PathBuf::from("/tmp/rustinel.toml"))
         );
+    }
+
+    #[test]
+    fn doctor_accepts_json_flag() {
+        let cli = Cli::try_parse_from(["rustinel", "doctor", "--json"]).expect("valid CLI");
+
+        match cli.command {
+            Some(Commands::Doctor { json }) => assert!(json),
+            _ => panic!("expected doctor command"),
+        }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -149,6 +149,21 @@ pub struct ConfigLoadOptions {
     pub cwd_config: PathBuf,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfigSource {
+    Explicit,
+    Environment,
+    Managed,
+    Executable,
+    CurrentDirectory,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SelectedConfig {
+    pub source: ConfigSource,
+    pub path: PathBuf,
+}
+
 impl ConfigLoadOptions {
     pub fn from_runtime(explicit_config: Option<PathBuf>) -> Self {
         Self {
@@ -160,27 +175,42 @@ impl ConfigLoadOptions {
         }
     }
 
-    fn selected_config(&self) -> Option<PathBuf> {
+    pub fn selected_config(&self) -> Option<SelectedConfig> {
         if let Some(path) = &self.explicit_config {
-            return Some(path.clone());
+            return Some(SelectedConfig {
+                source: ConfigSource::Explicit,
+                path: path.clone(),
+            });
         }
 
         if let Some(path) = &self.env_config {
-            return Some(path.clone());
+            return Some(SelectedConfig {
+                source: ConfigSource::Environment,
+                path: path.clone(),
+            });
         }
 
         if self.managed_config.exists() {
-            return Some(self.managed_config.clone());
+            return Some(SelectedConfig {
+                source: ConfigSource::Managed,
+                path: self.managed_config.clone(),
+            });
         }
 
         if let Some(path) = &self.exe_config {
             if path.exists() {
-                return Some(path.clone());
+                return Some(SelectedConfig {
+                    source: ConfigSource::Executable,
+                    path: path.clone(),
+                });
             }
         }
 
         if self.cwd_config.exists() {
-            return Some(self.cwd_config.clone());
+            return Some(SelectedConfig {
+                source: ConfigSource::CurrentDirectory,
+                path: self.cwd_config.clone(),
+            });
         }
 
         None
@@ -364,7 +394,9 @@ impl AppConfig {
     }
 
     pub fn from_options(options: ConfigLoadOptions) -> Result<Self, config::ConfigError> {
-        let selected_config = options.selected_config().map(absolute_config_path);
+        let selected_config = options
+            .selected_config()
+            .map(|selected| absolute_config_path(selected.path));
         let config_dir = selected_config
             .as_deref()
             .and_then(Path::parent)

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -1,0 +1,511 @@
+use crate::config::{AppConfig, ConfigLoadOptions, ConfigSource, InstallLayout, InstallPlatform};
+use serde::Serialize;
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DiagnosticStatus {
+    Pass,
+    Warn,
+    Fail,
+}
+
+impl fmt::Display for DiagnosticStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DiagnosticStatus::Pass => f.write_str("PASS"),
+            DiagnosticStatus::Warn => f.write_str("WARN"),
+            DiagnosticStatus::Fail => f.write_str("FAIL"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum InstallMode {
+    Portable,
+    Managed,
+}
+
+impl fmt::Display for InstallMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            InstallMode::Portable => f.write_str("portable"),
+            InstallMode::Managed => f.write_str("managed"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct DiagnosticResult {
+    pub id: String,
+    pub status: DiagnosticStatus,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+}
+
+impl DiagnosticResult {
+    pub fn pass(id: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            status: DiagnosticStatus::Pass,
+            message: message.into(),
+            detail: None,
+        }
+    }
+
+    pub fn warn(
+        id: impl Into<String>,
+        message: impl Into<String>,
+        detail: impl Into<String>,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            status: DiagnosticStatus::Warn,
+            message: message.into(),
+            detail: Some(detail.into()),
+        }
+    }
+
+    pub fn fail(
+        id: impl Into<String>,
+        message: impl Into<String>,
+        detail: impl Into<String>,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            status: DiagnosticStatus::Fail,
+            message: message.into(),
+            detail: Some(detail.into()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ConfigDiagnostic {
+    pub source: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selected_path: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ResolvedPaths {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub config_file: Option<PathBuf>,
+    pub sigma_rules: PathBuf,
+    pub yara_rules: PathBuf,
+    pub ioc_hashes: PathBuf,
+    pub ioc_ips: PathBuf,
+    pub ioc_domains: PathBuf,
+    pub ioc_paths_regex: PathBuf,
+    pub logs_dir: PathBuf,
+    pub alerts_dir: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct DoctorReport {
+    pub status: DiagnosticStatus,
+    pub exit_code: i32,
+    pub platform: String,
+    pub mode: InstallMode,
+    pub config: ConfigDiagnostic,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub paths: Option<ResolvedPaths>,
+    pub results: Vec<DiagnosticResult>,
+}
+
+impl DoctorReport {
+    pub fn from_results(
+        platform: impl Into<String>,
+        mode: InstallMode,
+        config: ConfigDiagnostic,
+        paths: Option<ResolvedPaths>,
+        results: Vec<DiagnosticResult>,
+    ) -> Self {
+        let status = aggregate_status(&results);
+        Self {
+            status,
+            exit_code: status.exit_code(),
+            platform: platform.into(),
+            mode,
+            config,
+            paths,
+            results,
+        }
+    }
+}
+
+impl DiagnosticStatus {
+    pub fn exit_code(self) -> i32 {
+        match self {
+            DiagnosticStatus::Pass => 0,
+            DiagnosticStatus::Warn => 1,
+            DiagnosticStatus::Fail => 2,
+        }
+    }
+}
+
+pub fn inspect(config_path: Option<PathBuf>) -> DoctorReport {
+    inspect_with_options(ConfigLoadOptions::from_runtime(config_path))
+}
+
+pub fn inspect_with_options(options: ConfigLoadOptions) -> DoctorReport {
+    let selected = options.selected_config();
+    let selected_path = selected
+        .as_ref()
+        .map(|selected| absolute_path(selected.path.clone()));
+    let mode = detect_mode(&options, selected.as_ref().map(|selected| selected.source));
+    let config = ConfigDiagnostic {
+        source: selected
+            .as_ref()
+            .map(|selected| config_source_label(selected.source).to_string())
+            .unwrap_or_else(|| "defaults".to_string()),
+        selected_path: selected_path.clone(),
+    };
+
+    let mut results = Vec::new();
+    results.push(DiagnosticResult::pass(
+        "install_mode",
+        format!("Running in {mode} mode"),
+    ));
+    results.push(config_discovery_result(
+        selected.as_ref(),
+        selected_path.as_deref(),
+    ));
+
+    match AppConfig::from_options(options) {
+        Ok(cfg) => {
+            results.push(DiagnosticResult::pass(
+                "config_parse",
+                "Configuration parsed successfully",
+            ));
+            let paths = ResolvedPaths::from_config(&cfg, selected_path);
+            results.push(directory_check(
+                "logs_writable",
+                "Log directory",
+                &paths.logs_dir,
+            ));
+            results.push(directory_check(
+                "alerts_writable",
+                "Alert directory",
+                &paths.alerts_dir,
+            ));
+
+            DoctorReport::from_results(
+                platform_label(InstallPlatform::current()),
+                mode,
+                config,
+                Some(paths),
+                results,
+            )
+        }
+        Err(err) => {
+            results.push(DiagnosticResult::fail(
+                "config_parse",
+                "Configuration failed to parse",
+                format!("{err}"),
+            ));
+            DoctorReport::from_results(
+                platform_label(InstallPlatform::current()),
+                mode,
+                config,
+                None,
+                results,
+            )
+        }
+    }
+}
+
+pub fn run_cli(config_path: Option<PathBuf>, json: bool) -> anyhow::Result<i32> {
+    let report = inspect(config_path);
+    if json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        println!("{}", format_human(&report));
+    }
+    Ok(report.exit_code)
+}
+
+pub fn format_human(report: &DoctorReport) -> String {
+    let mut output = String::new();
+    output.push_str("Rustinel doctor\n");
+    output.push_str(&format!("Status: {}\n", report.status));
+    output.push_str(&format!("Mode: {}\n", report.mode));
+    output.push_str(&format!("Platform: {}\n", report.platform));
+
+    match &report.config.selected_path {
+        Some(path) => output.push_str(&format!(
+            "Config: {} at {}\n",
+            report.config.source,
+            path.display()
+        )),
+        None => output.push_str("Config: defaults only\n"),
+    }
+
+    if let Some(paths) = &report.paths {
+        output.push_str("\nResolved paths:\n");
+        if let Some(path) = &paths.config_file {
+            output.push_str(&format!("  config file: {}\n", path.display()));
+        }
+        output.push_str(&format!("  sigma rules: {}\n", paths.sigma_rules.display()));
+        output.push_str(&format!("  yara rules: {}\n", paths.yara_rules.display()));
+        output.push_str(&format!("  ioc hashes: {}\n", paths.ioc_hashes.display()));
+        output.push_str(&format!("  ioc ips: {}\n", paths.ioc_ips.display()));
+        output.push_str(&format!("  ioc domains: {}\n", paths.ioc_domains.display()));
+        output.push_str(&format!(
+            "  ioc paths regex: {}\n",
+            paths.ioc_paths_regex.display()
+        ));
+        output.push_str(&format!("  logs dir: {}\n", paths.logs_dir.display()));
+        output.push_str(&format!("  alerts dir: {}\n", paths.alerts_dir.display()));
+    }
+
+    output.push_str("\nChecks:\n");
+    for result in &report.results {
+        output.push_str(&format!(
+            "  [{}] {}: {}\n",
+            result.status, result.id, result.message
+        ));
+        if let Some(detail) = &result.detail {
+            output.push_str(&format!("      {detail}\n"));
+        }
+    }
+
+    output
+}
+
+fn aggregate_status(results: &[DiagnosticResult]) -> DiagnosticStatus {
+    if results
+        .iter()
+        .any(|result| result.status == DiagnosticStatus::Fail)
+    {
+        DiagnosticStatus::Fail
+    } else if results
+        .iter()
+        .any(|result| result.status == DiagnosticStatus::Warn)
+    {
+        DiagnosticStatus::Warn
+    } else {
+        DiagnosticStatus::Pass
+    }
+}
+
+fn config_discovery_result(
+    selected: Option<&crate::config::SelectedConfig>,
+    selected_path: Option<&Path>,
+) -> DiagnosticResult {
+    match (selected, selected_path) {
+        (Some(selected), Some(path)) => DiagnosticResult::pass(
+            "config_discovery",
+            format!(
+                "Selected {} config at {}",
+                config_source_label(selected.source),
+                path.display()
+            ),
+        ),
+        _ => DiagnosticResult::warn(
+            "config_discovery",
+            "No config file was discovered",
+            "Using built-in defaults and environment overrides only",
+        ),
+    }
+}
+
+fn directory_check(id: &str, label: &str, path: &Path) -> DiagnosticResult {
+    match std::fs::metadata(path) {
+        Ok(metadata) if !metadata.is_dir() => DiagnosticResult::fail(
+            id,
+            format!("{label} is not a directory"),
+            path.display().to_string(),
+        ),
+        Ok(metadata) if metadata.permissions().readonly() => DiagnosticResult::warn(
+            id,
+            format!("{label} is marked read-only"),
+            path.display().to_string(),
+        ),
+        Ok(metadata) if !owner_writable(&metadata) => DiagnosticResult::warn(
+            id,
+            format!("{label} is not owner-writable"),
+            path.display().to_string(),
+        ),
+        Ok(_) => DiagnosticResult::pass(id, format!("{label} exists and is writable")),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => DiagnosticResult::warn(
+            id,
+            format!("{label} does not exist"),
+            format!(
+                "{} could not be checked without creating it",
+                path.display()
+            ),
+        ),
+        Err(err) => DiagnosticResult::fail(
+            id,
+            format!("{label} could not be inspected"),
+            format!("{}: {err}", path.display()),
+        ),
+    }
+}
+
+#[cfg(unix)]
+fn owner_writable(metadata: &std::fs::Metadata) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    metadata.permissions().mode() & 0o200 != 0
+}
+
+#[cfg(not(unix))]
+fn owner_writable(_metadata: &std::fs::Metadata) -> bool {
+    true
+}
+
+fn detect_mode(options: &ConfigLoadOptions, source: Option<ConfigSource>) -> InstallMode {
+    if source == Some(ConfigSource::Managed) {
+        return InstallMode::Managed;
+    }
+
+    let managed = absolute_path(options.managed_config.clone());
+    let selected = options
+        .selected_config()
+        .map(|selected| absolute_path(selected.path));
+    if selected.as_ref() == Some(&managed) {
+        InstallMode::Managed
+    } else {
+        InstallMode::Portable
+    }
+}
+
+fn config_source_label(source: ConfigSource) -> &'static str {
+    match source {
+        ConfigSource::Explicit => "explicit",
+        ConfigSource::Environment => "environment",
+        ConfigSource::Managed => "managed",
+        ConfigSource::Executable => "executable",
+        ConfigSource::CurrentDirectory => "current-directory",
+    }
+}
+
+fn platform_label(platform: InstallPlatform) -> String {
+    match platform {
+        InstallPlatform::Windows => "windows",
+        InstallPlatform::Linux => "linux",
+        InstallPlatform::Macos => "macos",
+    }
+    .to_string()
+}
+
+fn absolute_path(path: PathBuf) -> PathBuf {
+    if path.is_absolute() {
+        return path;
+    }
+
+    match std::env::current_dir() {
+        Ok(cwd) => cwd.join(path),
+        Err(_) => path,
+    }
+}
+
+impl ResolvedPaths {
+    fn from_config(cfg: &AppConfig, config_file: Option<PathBuf>) -> Self {
+        Self {
+            config_file,
+            sigma_rules: cfg.scanner.sigma_rules_path.clone(),
+            yara_rules: cfg.scanner.yara_rules_path.clone(),
+            ioc_hashes: cfg.ioc.hashes_path.clone(),
+            ioc_ips: cfg.ioc.ips_path.clone(),
+            ioc_domains: cfg.ioc.domains_path.clone(),
+            ioc_paths_regex: cfg.ioc.paths_regex_path.clone(),
+            logs_dir: cfg.logging.directory.clone(),
+            alerts_dir: cfg.alerts.directory.clone(),
+        }
+    }
+
+    #[allow(dead_code)]
+    fn from_layout(layout: &InstallLayout) -> Self {
+        let cfg = layout.managed_config();
+        Self::from_config(&cfg, Some(layout.config_file.clone()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn aggregate_exit_code_is_zero_for_passes() {
+        let report = DoctorReport::from_results(
+            "linux",
+            InstallMode::Portable,
+            ConfigDiagnostic {
+                source: "defaults".to_string(),
+                selected_path: None,
+            },
+            None,
+            vec![DiagnosticResult::pass("one", "ok")],
+        );
+
+        assert_eq!(report.status, DiagnosticStatus::Pass);
+        assert_eq!(report.exit_code, 0);
+    }
+
+    #[test]
+    fn aggregate_exit_code_is_one_for_warnings() {
+        let report = DoctorReport::from_results(
+            "linux",
+            InstallMode::Portable,
+            ConfigDiagnostic {
+                source: "defaults".to_string(),
+                selected_path: None,
+            },
+            None,
+            vec![
+                DiagnosticResult::pass("one", "ok"),
+                DiagnosticResult::warn("two", "warning", "detail"),
+            ],
+        );
+
+        assert_eq!(report.status, DiagnosticStatus::Warn);
+        assert_eq!(report.exit_code, 1);
+    }
+
+    #[test]
+    fn aggregate_exit_code_is_two_for_failures() {
+        let report = DoctorReport::from_results(
+            "linux",
+            InstallMode::Portable,
+            ConfigDiagnostic {
+                source: "defaults".to_string(),
+                selected_path: None,
+            },
+            None,
+            vec![
+                DiagnosticResult::warn("one", "warning", "detail"),
+                DiagnosticResult::fail("two", "failed", "detail"),
+            ],
+        );
+
+        assert_eq!(report.status, DiagnosticStatus::Fail);
+        assert_eq!(report.exit_code, 2);
+    }
+
+    #[test]
+    fn inspect_reports_parse_failures() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let config = temp.path().join("bad.toml");
+        std::fs::write(&config, "[logging\nlevel = \"debug\"\n").expect("write config");
+
+        let report = inspect_with_options(ConfigLoadOptions {
+            explicit_config: Some(config),
+            env_config: None,
+            managed_config: temp.path().join("managed.toml"),
+            exe_config: None,
+            cwd_config: temp.path().join("cwd.toml"),
+        });
+
+        assert_eq!(report.status, DiagnosticStatus::Fail);
+        assert_eq!(report.exit_code, 2);
+        assert!(report
+            .results
+            .iter()
+            .any(|result| result.id == "config_parse" && result.status == DiagnosticStatus::Fail));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 pub mod alerts;
 pub mod cli;
 pub mod config;
+pub mod doctor;
 pub mod engine;
 pub mod ioc;
 pub mod memory;

--- a/src/runtime/orchestration.rs
+++ b/src/runtime/orchestration.rs
@@ -2,6 +2,13 @@ use crate::cli::{Cli, Commands};
 
 #[cfg(windows)]
 pub fn run() -> anyhow::Result<()> {
+    let cli = Cli::parse_args();
+
+    if let Some(Commands::Doctor { json }) = &cli.command {
+        let code = crate::doctor::run_cli(cli.config.clone(), *json)?;
+        std::process::exit(code);
+    }
+
     if windows_service::service_dispatcher::start(
         crate::platform::windows::SERVICE_NAME,
         crate::runtime::windows::ffi_service_main,
@@ -10,8 +17,6 @@ pub fn run() -> anyhow::Result<()> {
     {
         return Ok(());
     }
-
-    let cli = Cli::parse_args();
 
     match cli.command {
         Some(Commands::Run {
@@ -35,6 +40,10 @@ pub fn run() -> anyhow::Result<()> {
 
     match cli.command {
         Some(Commands::Service { action }) => crate::platform::handle_service_command(action),
+        Some(Commands::Doctor { json }) => {
+            let code = crate::doctor::run_cli(cli.config, json)?;
+            std::process::exit(code);
+        }
         Some(Commands::Run {
             no_console,
             sigma_engine,
@@ -55,6 +64,10 @@ pub fn run() -> anyhow::Result<()> {
 
     match cli.command {
         Some(Commands::Service { action }) => crate::platform::handle_service_command(action),
+        Some(Commands::Doctor { json }) => {
+            let code = crate::doctor::run_cli(cli.config, json)?;
+            std::process::exit(code);
+        }
         Some(Commands::Run {
             no_console,
             sigma_engine,

--- a/src/runtime/orchestration.rs
+++ b/src/runtime/orchestration.rs
@@ -30,6 +30,7 @@ pub fn run() -> anyhow::Result<()> {
             sigma_engine.map(|engine| engine.kind()),
         ),
         None => crate::runtime::windows::run_console(true, cli.log_level, cli.config, None),
+        Some(Commands::Doctor { .. }) => unreachable!("doctor is handled before service dispatch"),
         Some(Commands::Service { action }) => crate::platform::handle_service_command(action),
     }
 }


### PR DESCRIPTION
## Summary

- Add a reusable diagnostic report model for the doctor command.
- Add human-readable and JSON doctor output.
- Report config discovery, install mode, resolved paths, and read-only directory checks.
- Return distinct exit codes for healthy, warning, and failure states.

## Impact

`rustinel doctor` can inspect configuration and writable output directories without starting the agent runtime or sensors. Automation can use `rustinel doctor --json` for structured health checks.

Closes #104

## Validation

- `cargo fmt --check`
- `cargo check`
- `cargo run -- doctor --json`
- `cargo test`