### PR TITLE
feat(service): add native service management

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -50,10 +50,10 @@ Notes:
 
 ### `service`
 
-Manage Windows service installation and lifecycle.
+Manage native service installation and lifecycle.
 
 ```text
-rustinel service <install|uninstall|start|stop>
+rustinel service <install|uninstall|start|stop|restart|status>
 ```
 
 Examples:
@@ -61,14 +61,45 @@ Examples:
 ```powershell
 rustinel service install
 rustinel service start
+rustinel service status
+rustinel service restart
 rustinel service stop
 rustinel service uninstall
 ```
 
-Platform note:
+```bash
+sudo rustinel service install
+sudo rustinel service start
+rustinel service status
+sudo rustinel service restart
+sudo rustinel service stop
+sudo rustinel service uninstall
+```
 
-- Service commands are supported on Windows only.
-- On Linux, use `systemd` or another process supervisor if you need background execution.
+Status output is normalized across platforms:
+
+```text
+not-installed
+stopped
+starting
+running
+failed
+unknown
+```
+
+Managed paths:
+
+| Platform | Native manager | Binary | Configuration |
+| --- | --- | --- | --- |
+| Windows | Service Control Manager | `C:\Program Files\Rustinel\rustinel.exe` | `C:\ProgramData\Rustinel\config.toml` |
+| Linux | systemd | `/opt/rustinel/rustinel` | `/etc/rustinel/config.toml` |
+| macOS | launchd | `/usr/local/var/rustinel/Rustinel.app/Contents/MacOS/rustinel` | `/Library/Application Support/Rustinel/config.toml` |
+
+`service install` validates that the managed binary and configuration file
+already exist. It registers the native service definition only; it does not
+download rules, copy a temporary executable, or overwrite user configuration.
+`service uninstall` unregisters the native service and preserves configuration,
+rules, logs, and state.
 
 ## Environment Variables
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -61,33 +61,50 @@ Use absolute paths in `config.toml` once you move beyond the default repo layout
   `rustinel.exe` (it will still be found) and use absolute paths for rules and logs.
 - Linux supervisors should also use absolute paths for predictable upgrades and restarts.
 
-## Windows Service Lifecycle
+## Native Service Lifecycle
 
-Rustinel includes built-in Windows service management commands:
+Rustinel includes built-in native service management commands on Windows,
+Linux, and macOS:
 
 ```powershell
 .\rustinel.exe service install
 .\rustinel.exe service start
+.\rustinel.exe service status
+.\rustinel.exe service restart
 .\rustinel.exe service stop
 .\rustinel.exe service uninstall
 ```
 
+```bash
+sudo rustinel service install
+sudo rustinel service start
+rustinel service status
+sudo rustinel service restart
+sudo rustinel service stop
+sudo rustinel service uninstall
+```
+
 Important behavior:
 
-- `service install` registers the current executable path with the Service Control Manager.
-- Replacing the binary in the same directory is fine.
-- Moving the binary to a new directory requires `service uninstall` followed by `service install`.
-- Service mode does not consume interactive CLI flags; configure it with `config.toml` and `EDR__...` environment variables.
+- `service install` registers the native service definition with managed paths.
+- The managed binary and managed configuration file must already exist.
+- `service install` does not download rules, copy a temporary executable, or overwrite user configuration.
+- `service uninstall` stops and unregisters the native service while preserving configuration, rules, logs, and state.
+- `service status` prints one normalized value: `not-installed`, `stopped`, `starting`, `running`, `failed`, or `unknown`.
+- Service mode uses the managed config file path and can still be adjusted with `EDR__...` environment variables.
+
+Managed service paths:
+
+| Platform | Native manager | Binary | Configuration |
+| --- | --- | --- | --- |
+| Windows | Service Control Manager | `C:\Program Files\Rustinel\rustinel.exe` | `C:\ProgramData\Rustinel\config.toml` |
+| Linux | systemd | `/opt/rustinel/rustinel` | `/etc/rustinel/config.toml` |
+| macOS | launchd | `/usr/local/var/rustinel/Rustinel.app/Contents/MacOS/rustinel` | `/Library/Application Support/Rustinel/config.toml` |
 
 ## Linux Runtime Model
 
-Rustinel does not currently ship Linux service-management commands. Common deployment patterns are:
-
-- Run it directly in a root shell for testing
-- Wrap it in `systemd`
-- Run it under another process supervisor
-
-The binary itself is the same foreground application in all cases:
+The binary itself remains the same foreground application. Service management
+wraps it with `systemd`:
 
 ```bash
 sudo /opt/rustinel/rustinel run
@@ -104,7 +121,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=/opt/rustinel/rustinel run
+ExecStart=/opt/rustinel/rustinel run --config /etc/rustinel/config.toml --no-console
 WorkingDirectory=/opt/rustinel
 Restart=on-failure
 RestartSec=5s
@@ -123,22 +140,23 @@ sudo systemctl start rustinel
 sudo systemctl status rustinel
 ```
 
-Because `config.toml` is loaded from `WorkingDirectory`, use absolute paths for all rules and log directories in that file when running under `systemd`.
+The built-in `service install` command writes this unit to
+`/etc/systemd/system/rustinel.service`, reloads `systemd`, and enables the unit.
 
 ## macOS Runtime Model
 
 macOS support is experimental and detection-only today. Active response is not
-supported on macOS. Rustinel does not ship macOS service-management commands
-yet; run it in the foreground as root:
+supported on macOS. You can still run it in the foreground as root:
 
 ```bash
 sudo /usr/local/var/rustinel/rustinel run
 ```
 
-For background execution, install the release package under
-`/usr/local/var/rustinel` and load the bundled `com.rustinel.agent.plist` as a
-`launchd` LaunchDaemon. The plist contains the exact `launchctl bootstrap`
-command and expects that path.
+For background execution, `service install` writes and bootstraps
+`/Library/LaunchDaemons/com.rustinel.agent.plist` as a `launchd`
+LaunchDaemon. It expects the managed app bundle at
+`/usr/local/var/rustinel/Rustinel.app` and the managed configuration file at
+`/Library/Application Support/Rustinel/config.toml`.
 
 The app bundle must be signed with the
 `com.apple.developer.endpoint-security.client` entitlement, contain the

--- a/packaging/macos/com.rustinel.agent.plist
+++ b/packaging/macos/com.rustinel.agent.plist
@@ -9,8 +9,9 @@
 
     sudo launchctl bootstrap system /Library/LaunchDaemons/com.rustinel.agent.plist
 
-  This template expects the release package to be installed under
-  /usr/local/var/rustinel.
+  This template expects the managed release package to be installed under
+  /usr/local/var/rustinel and the configuration to live in
+  /Library/Application Support/Rustinel/config.toml.
 -->
 <plist version="1.0">
 <dict>
@@ -20,6 +21,9 @@
     <array>
         <string>/usr/local/var/rustinel/Rustinel.app/Contents/MacOS/rustinel</string>
         <string>run</string>
+        <string>--config</string>
+        <string>/Library/Application Support/Rustinel/config.toml</string>
+        <string>--no-console</string>
     </array>
     <key>WorkingDirectory</key>
     <string>/usr/local/var/rustinel</string>
@@ -30,8 +34,8 @@
     <key>ProcessType</key>
     <string>Interactive</string>
     <key>StandardOutPath</key>
-    <string>/usr/local/var/log/rustinel/launchd.out.log</string>
+    <string>/Library/Logs/Rustinel/launchd.out.log</string>
     <key>StandardErrorPath</key>
-    <string>/usr/local/var/log/rustinel/launchd.err.log</string>
+    <string>/Library/Logs/Rustinel/launchd.err.log</string>
 </dict>
 </plist>

--- a/rustinel.service
+++ b/rustinel.service
@@ -4,21 +4,21 @@ Documentation=https://github.com/Karib0u/rustinel
 After=network.target
 
 [Service]
-ExecStart=/opt/rustinel/rustinel run
+Type=simple
+ExecStart=/opt/rustinel/rustinel run --config /etc/rustinel/config.toml --no-console
 WorkingDirectory=/opt/rustinel
 Restart=on-failure
-RestartSec=5
+RestartSec=5s
+User=root
 
 # Allow eBPF program loading and network observability without full root.
-# CAP_BPF          — load and attach eBPF programs
-# CAP_NET_ADMIN    — attach tc/xdp programs (future use), read socket metadata
-# CAP_SYS_RESOURCE — raise memlock limit required by eBPF maps
+# CAP_BPF loads and attaches eBPF programs.
+# CAP_NET_ADMIN attaches tc/xdp programs and reads socket metadata.
+# CAP_SYS_RESOURCE raises memlock limits required by eBPF maps.
 AmbientCapabilities=CAP_BPF CAP_NET_ADMIN CAP_SYS_RESOURCE
 CapabilityBoundingSet=CAP_BPF CAP_NET_ADMIN CAP_SYS_RESOURCE
 NoNewPrivileges=true
 
-# Logging goes to files in WorkingDirectory/logs/ via tracing-appender.
-# StandardOutput/StandardError are left as journal so startup errors are visible.
 StandardOutput=journal
 StandardError=journal
 SyslogIdentifier=rustinel

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -76,6 +76,8 @@ pub enum ServiceAction {
     Uninstall,
     Start,
     Stop,
+    Restart,
+    Status,
 }
 
 #[cfg(test)]
@@ -185,6 +187,32 @@ mod tests {
         match cli.command {
             Some(Commands::Doctor { json }) => assert!(json),
             _ => panic!("expected doctor command"),
+        }
+    }
+
+    #[test]
+    fn service_accepts_restart() {
+        let cli =
+            Cli::try_parse_from(["rustinel", "service", "restart"]).expect("restart should parse");
+
+        match cli.command {
+            Some(Commands::Service { action }) => {
+                assert!(matches!(action, ServiceAction::Restart));
+            }
+            _ => panic!("expected service command"),
+        }
+    }
+
+    #[test]
+    fn service_accepts_status() {
+        let cli =
+            Cli::try_parse_from(["rustinel", "service", "status"]).expect("status should parse");
+
+        match cli.command {
+            Some(Commands::Service { action }) => {
+                assert!(matches!(action, ServiceAction::Status));
+            }
+            _ => panic!("expected service command"),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -130,7 +130,7 @@ impl InstallLayout {
     }
 }
 
-fn layout_join(platform: InstallPlatform, base: &Path, child: &str) -> PathBuf {
+pub(crate) fn layout_join(platform: InstallPlatform, base: &Path, child: &str) -> PathBuf {
     let separator = match platform {
         InstallPlatform::Windows => r"\",
         InstallPlatform::Linux | InstallPlatform::Macos => "/",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,5 +17,6 @@ pub mod response;
 pub mod runtime;
 pub mod scanner;
 pub mod sensor;
+pub mod service;
 pub mod state;
 pub mod utils;

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -1,0 +1,117 @@
+use std::fs;
+use std::process::Command;
+
+use anyhow::{bail, Context};
+
+use crate::cli::ServiceAction;
+use crate::service::{
+    execute_backend_action, systemd_status_from_state, ManagedServicePaths, ServiceBackend,
+    ServiceStatus, SystemdDefinition, SYSTEMD_SERVICE_NAME,
+};
+
+pub fn handle_service_command(action: ServiceAction) -> anyhow::Result<()> {
+    let backend = SystemdBackend::new();
+    execute_backend_action(&backend, action)
+}
+
+struct SystemdBackend {
+    paths: ManagedServicePaths,
+}
+
+impl SystemdBackend {
+    fn new() -> Self {
+        Self {
+            paths: ManagedServicePaths::current(),
+        }
+    }
+
+    fn unit_path(&self) -> anyhow::Result<&std::path::Path> {
+        self.paths
+            .systemd_unit_path
+            .as_deref()
+            .context("missing systemd unit path")
+    }
+
+    fn command(&self, args: &[&str]) -> anyhow::Result<()> {
+        let output = Command::new("systemctl")
+            .args(args)
+            .output()
+            .with_context(|| format!("failed to run systemctl {}", args.join(" ")))?;
+
+        if output.status.success() {
+            return Ok(());
+        }
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("systemctl {} failed: {}", args.join(" "), stderr.trim());
+    }
+
+    fn command_output(&self, args: &[&str]) -> anyhow::Result<std::process::Output> {
+        Command::new("systemctl")
+            .args(args)
+            .output()
+            .with_context(|| format!("failed to run systemctl {}", args.join(" ")))
+    }
+}
+
+impl ServiceBackend for SystemdBackend {
+    fn name(&self) -> &'static str {
+        SYSTEMD_SERVICE_NAME
+    }
+
+    fn install(&self) -> anyhow::Result<()> {
+        self.paths.validate_install_inputs()?;
+
+        let unit_path = self.unit_path()?;
+        let definition = SystemdDefinition::managed(&self.paths);
+        if let Some(parent) = unit_path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create {}", parent.display()))?;
+        }
+
+        let should_write = fs::read_to_string(unit_path)
+            .map(|existing| existing != definition.contents)
+            .unwrap_or(true);
+        if should_write {
+            fs::write(unit_path, definition.contents)
+                .with_context(|| format!("failed to write {}", unit_path.display()))?;
+        }
+
+        self.command(&["daemon-reload"])?;
+        self.command(&["enable", crate::service::SYSTEMD_UNIT_NAME])?;
+        Ok(())
+    }
+
+    fn uninstall(&self) -> anyhow::Result<()> {
+        let unit_path = self.unit_path()?;
+        let installed = unit_path.exists();
+
+        if installed {
+            let _ = self.command(&["stop", crate::service::SYSTEMD_UNIT_NAME]);
+            let _ = self.command(&["disable", crate::service::SYSTEMD_UNIT_NAME]);
+            fs::remove_file(unit_path)
+                .with_context(|| format!("failed to remove {}", unit_path.display()))?;
+            self.command(&["daemon-reload"])?;
+        }
+
+        Ok(())
+    }
+
+    fn start(&self) -> anyhow::Result<()> {
+        self.command(&["start", crate::service::SYSTEMD_UNIT_NAME])
+    }
+
+    fn stop(&self) -> anyhow::Result<()> {
+        self.command(&["stop", crate::service::SYSTEMD_UNIT_NAME])
+    }
+
+    fn status(&self) -> anyhow::Result<ServiceStatus> {
+        if !self.unit_path()?.exists() {
+            return Ok(ServiceStatus::NotInstalled);
+        }
+
+        let output = self.command_output(&["is-active", crate::service::SYSTEMD_UNIT_NAME])?;
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        Ok(systemd_status_from_state(&stdout))
+    }
+}

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -1,0 +1,141 @@
+use std::fs;
+use std::process::{Command, Output};
+
+use anyhow::{bail, Context};
+
+use crate::cli::ServiceAction;
+use crate::service::{
+    execute_backend_action, launchd_status_from_output, LaunchdDefinition, ManagedServicePaths,
+    ServiceBackend, ServiceStatus, LAUNCHD_LABEL,
+};
+
+pub fn handle_service_command(action: ServiceAction) -> anyhow::Result<()> {
+    let backend = LaunchdBackend::new();
+    execute_backend_action(&backend, action)
+}
+
+struct LaunchdBackend {
+    paths: ManagedServicePaths,
+}
+
+impl LaunchdBackend {
+    fn new() -> Self {
+        Self {
+            paths: ManagedServicePaths::current(),
+        }
+    }
+
+    fn plist_path(&self) -> anyhow::Result<&std::path::Path> {
+        self.paths
+            .launchd_plist_path
+            .as_deref()
+            .context("missing launchd plist path")
+    }
+
+    fn command(&self, args: &[&str]) -> anyhow::Result<()> {
+        let output = self.command_output(args)?;
+        if output.status.success() {
+            return Ok(());
+        }
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("launchctl {} failed: {}", args.join(" "), stderr.trim());
+    }
+
+    fn command_output(&self, args: &[&str]) -> anyhow::Result<Output> {
+        Command::new("launchctl")
+            .args(args)
+            .output()
+            .with_context(|| format!("failed to run launchctl {}", args.join(" ")))
+    }
+
+    fn service_target(&self) -> String {
+        format!("system/{LAUNCHD_LABEL}")
+    }
+
+    fn print_service(&self) -> anyhow::Result<Output> {
+        self.command_output(&["print", &self.service_target()])
+    }
+}
+
+impl ServiceBackend for LaunchdBackend {
+    fn name(&self) -> &'static str {
+        LAUNCHD_LABEL
+    }
+
+    fn install(&self) -> anyhow::Result<()> {
+        self.paths.validate_install_inputs()?;
+
+        let plist_path = self.plist_path()?;
+        let definition = LaunchdDefinition::managed(&self.paths);
+        if let Some(parent) = plist_path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create {}", parent.display()))?;
+        }
+
+        let should_write = fs::read_to_string(plist_path)
+            .map(|existing| existing != definition.contents)
+            .unwrap_or(true);
+        if should_write {
+            fs::write(plist_path, definition.contents)
+                .with_context(|| format!("failed to write {}", plist_path.display()))?;
+        }
+
+        if self.print_service()?.status.success() {
+            self.command(&["enable", &self.service_target()])?;
+            return Ok(());
+        }
+
+        self.command(&["bootstrap", "system", &plist_path.to_string_lossy()])?;
+        self.command(&["enable", &self.service_target()])?;
+        Ok(())
+    }
+
+    fn uninstall(&self) -> anyhow::Result<()> {
+        let plist_path = self.plist_path()?;
+
+        if plist_path.exists() {
+            let _ = self.command(&["bootout", "system", &plist_path.to_string_lossy()]);
+            fs::remove_file(plist_path)
+                .with_context(|| format!("failed to remove {}", plist_path.display()))?;
+        }
+
+        Ok(())
+    }
+
+    fn start(&self) -> anyhow::Result<()> {
+        let plist_path = self.plist_path()?;
+        if !plist_path.exists() {
+            bail!("LaunchDaemon is not installed: {}", plist_path.display());
+        }
+
+        if !self.print_service()?.status.success() {
+            self.command(&["bootstrap", "system", &plist_path.to_string_lossy()])?;
+        }
+        self.command(&["kickstart", "-k", &self.service_target()])
+    }
+
+    fn stop(&self) -> anyhow::Result<()> {
+        let plist_path = self.plist_path()?;
+        if !plist_path.exists() {
+            return Ok(());
+        }
+
+        let _ = self.command(&["bootout", "system", &plist_path.to_string_lossy()]);
+        Ok(())
+    }
+
+    fn status(&self) -> anyhow::Result<ServiceStatus> {
+        if !self.plist_path()?.exists() {
+            return Ok(ServiceStatus::NotInstalled);
+        }
+
+        let output = self.print_service()?;
+        if !output.status.success() {
+            return Ok(ServiceStatus::Stopped);
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        Ok(launchd_status_from_output(&stdout))
+    }
+}

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -1,3 +1,9 @@
+#[cfg(target_os = "linux")]
+pub mod linux;
+
+#[cfg(target_os = "macos")]
+pub mod macos;
+
 #[cfg(windows)]
 pub mod windows;
 
@@ -6,9 +12,19 @@ pub fn handle_service_command(action: crate::cli::ServiceAction) -> anyhow::Resu
     windows::handle_service_command(action)
 }
 
-#[cfg(not(windows))]
+#[cfg(target_os = "linux")]
+pub fn handle_service_command(action: crate::cli::ServiceAction) -> anyhow::Result<()> {
+    linux::handle_service_command(action)
+}
+
+#[cfg(target_os = "macos")]
+pub fn handle_service_command(action: crate::cli::ServiceAction) -> anyhow::Result<()> {
+    macos::handle_service_command(action)
+}
+
+#[cfg(not(any(windows, target_os = "linux", target_os = "macos")))]
 pub fn handle_service_command(_action: crate::cli::ServiceAction) -> anyhow::Result<()> {
     Err(anyhow::anyhow!(
-        "Service commands are only supported on Windows"
+        "Service commands are only supported on Windows, Linux, and macOS"
     ))
 }

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -1,81 +1,163 @@
+use std::ffi::OsString;
+
 use crate::cli::ServiceAction;
+use crate::service::{
+    execute_backend_action, ManagedServicePaths, ServiceBackend, ServiceStatus,
+    SERVICE_DESCRIPTION, WINDOWS_SERVICE_DISPLAY_NAME, WINDOWS_SERVICE_NAME,
+};
 use crate::state::ProcessCache;
 
-pub const SERVICE_NAME: &str = "Rustinel";
-const SERVICE_DISPLAY_NAME: &str = "Rustinel ETW Sentinel";
-const SERVICE_DESCRIPTION: &str = "High-performance endpoint detection agent";
+pub const SERVICE_NAME: &str = WINDOWS_SERVICE_NAME;
 
 pub fn handle_service_command(action: ServiceAction) -> anyhow::Result<()> {
-    match action {
-        ServiceAction::Install => install_service(),
-        ServiceAction::Uninstall => uninstall_service(),
-        ServiceAction::Start => start_service(),
-        ServiceAction::Stop => stop_service(),
+    let backend = WindowsServiceBackend::new();
+    execute_backend_action(&backend, action)
+}
+
+struct WindowsServiceBackend {
+    paths: ManagedServicePaths,
+}
+
+impl WindowsServiceBackend {
+    fn new() -> Self {
+        Self {
+            paths: ManagedServicePaths::current(),
+        }
+    }
+
+    fn service_info(&self) -> windows_service::service::ServiceInfo {
+        use windows_service::service::{
+            ServiceErrorControl, ServiceInfo, ServiceStartType, ServiceType,
+        };
+
+        ServiceInfo {
+            name: OsString::from(SERVICE_NAME),
+            display_name: OsString::from(WINDOWS_SERVICE_DISPLAY_NAME),
+            service_type: ServiceType::OWN_PROCESS,
+            start_type: ServiceStartType::AutoStart,
+            error_control: ServiceErrorControl::Normal,
+            executable_path: self.paths.binary_path.clone(),
+            launch_arguments: vec![
+                OsString::from("run"),
+                OsString::from("--config"),
+                self.paths.config_path.as_os_str().to_os_string(),
+                OsString::from("--no-console"),
+            ],
+            dependencies: vec![],
+            account_name: None,
+            account_password: None,
+        }
+    }
+
+    fn is_not_installed(err: &windows_service::Error) -> bool {
+        match err {
+            windows_service::Error::Winapi(io_err) => io_err.raw_os_error() == Some(1060),
+            _ => false,
+        }
     }
 }
 
-fn install_service() -> anyhow::Result<()> {
-    use std::env;
-    use std::ffi::OsString;
+impl ServiceBackend for WindowsServiceBackend {
+    fn name(&self) -> &'static str {
+        SERVICE_NAME
+    }
+
+    fn install(&self) -> anyhow::Result<()> {
+        use windows_service::service::ServiceAccess;
+        use windows_service::service_manager::{ServiceManager, ServiceManagerAccess};
+
+        self.paths.validate_install_inputs()?;
+
+        let manager = ServiceManager::local_computer(
+            None::<&str>,
+            ServiceManagerAccess::CONNECT | ServiceManagerAccess::CREATE_SERVICE,
+        )?;
+        let service_info = self.service_info();
+        let access = ServiceAccess::QUERY_CONFIG | ServiceAccess::CHANGE_CONFIG;
+
+        match manager.open_service(SERVICE_NAME, access) {
+            Ok(service) => {
+                service.change_config(&service_info)?;
+                service.set_description(SERVICE_DESCRIPTION)?;
+            }
+            Err(err) if Self::is_not_installed(&err) => {
+                let service = manager.create_service(&service_info, access)?;
+                service.set_description(SERVICE_DESCRIPTION)?;
+            }
+            Err(err) => return Err(err.into()),
+        }
+
+        Ok(())
+    }
+
+    fn uninstall(&self) -> anyhow::Result<()> {
+        use windows_service::service::ServiceAccess;
+        use windows_service::service_manager::{ServiceManager, ServiceManagerAccess};
+
+        let manager = ServiceManager::local_computer(None::<&str>, ServiceManagerAccess::CONNECT)?;
+        let access = ServiceAccess::QUERY_STATUS | ServiceAccess::STOP | ServiceAccess::DELETE;
+        let service = match manager.open_service(SERVICE_NAME, access) {
+            Ok(service) => service,
+            Err(err) if Self::is_not_installed(&err) => return Ok(()),
+            Err(err) => return Err(err.into()),
+        };
+
+        let status = service.query_status()?;
+        if windows_status(status.current_state) == ServiceStatus::Running {
+            let _ = service.stop();
+        }
+        service.delete()?;
+        Ok(())
+    }
+
+    fn start(&self) -> anyhow::Result<()> {
+        use windows_service::service::ServiceAccess;
+        use windows_service::service_manager::{ServiceManager, ServiceManagerAccess};
+
+        let manager = ServiceManager::local_computer(None::<&str>, ServiceManagerAccess::CONNECT)?;
+        let service = manager.open_service(SERVICE_NAME, ServiceAccess::START)?;
+        service.start(&[] as &[OsString])?;
+        Ok(())
+    }
+
+    fn stop(&self) -> anyhow::Result<()> {
+        use windows_service::service::ServiceAccess;
+        use windows_service::service_manager::{ServiceManager, ServiceManagerAccess};
+
+        let manager = ServiceManager::local_computer(None::<&str>, ServiceManagerAccess::CONNECT)?;
+        let service = manager.open_service(SERVICE_NAME, ServiceAccess::STOP)?;
+        service.stop()?;
+        Ok(())
+    }
+
+    fn status(&self) -> anyhow::Result<ServiceStatus> {
+        use windows_service::service::ServiceAccess;
+        use windows_service::service_manager::{ServiceManager, ServiceManagerAccess};
+
+        let manager = ServiceManager::local_computer(None::<&str>, ServiceManagerAccess::CONNECT)?;
+        let service = match manager.open_service(SERVICE_NAME, ServiceAccess::QUERY_STATUS) {
+            Ok(service) => service,
+            Err(err) if Self::is_not_installed(&err) => return Ok(ServiceStatus::NotInstalled),
+            Err(err) => return Err(err.into()),
+        };
+
+        Ok(windows_status(service.query_status()?.current_state))
+    }
+}
+
+fn windows_status(state: windows_service::service::ServiceState) -> ServiceStatus {
     use windows_service::service::{
-        ServiceAccess, ServiceErrorControl, ServiceInfo, ServiceStartType, ServiceType,
-    };
-    use windows_service::service_manager::{ServiceManager, ServiceManagerAccess};
-
-    let exe_path = env::current_exe()?;
-    let manager =
-        ServiceManager::local_computer(None::<&str>, ServiceManagerAccess::CREATE_SERVICE)?;
-
-    let service_info = ServiceInfo {
-        name: OsString::from(SERVICE_NAME),
-        display_name: OsString::from(SERVICE_DISPLAY_NAME),
-        service_type: ServiceType::OWN_PROCESS,
-        start_type: ServiceStartType::AutoStart,
-        error_control: ServiceErrorControl::Normal,
-        executable_path: exe_path,
-        launch_arguments: vec![],
-        dependencies: vec![],
-        account_name: None,
-        account_password: None,
+        ServiceState::ContinuePending, ServiceState::PausePending, ServiceState::Paused,
+        ServiceState::Running, ServiceState::StartPending, ServiceState::StopPending,
+        ServiceState::Stopped,
     };
 
-    let service = manager.create_service(&service_info, ServiceAccess::CHANGE_CONFIG)?;
-    let _ = service.set_description(SERVICE_DESCRIPTION);
-    println!("Service '{}' installed.", SERVICE_NAME);
-    Ok(())
-}
-
-fn uninstall_service() -> anyhow::Result<()> {
-    use windows_service::service::ServiceAccess;
-    use windows_service::service_manager::{ServiceManager, ServiceManagerAccess};
-
-    let manager = ServiceManager::local_computer(None::<&str>, ServiceManagerAccess::CONNECT)?;
-    let service = manager.open_service(SERVICE_NAME, ServiceAccess::DELETE)?;
-    service.delete()?;
-    println!("Service '{}' uninstalled.", SERVICE_NAME);
-    Ok(())
-}
-
-fn start_service() -> anyhow::Result<()> {
-    use windows_service::service::ServiceAccess;
-    use windows_service::service_manager::{ServiceManager, ServiceManagerAccess};
-
-    let manager = ServiceManager::local_computer(None::<&str>, ServiceManagerAccess::CONNECT)?;
-    let service = manager.open_service(SERVICE_NAME, ServiceAccess::START)?;
-    service.start(&[] as &[std::ffi::OsString])?;
-    println!("Service '{}' started.", SERVICE_NAME);
-    Ok(())
-}
-
-fn stop_service() -> anyhow::Result<()> {
-    use windows_service::service::ServiceAccess;
-    use windows_service::service_manager::{ServiceManager, ServiceManagerAccess};
-
-    let manager = ServiceManager::local_computer(None::<&str>, ServiceManagerAccess::CONNECT)?;
-    let service = manager.open_service(SERVICE_NAME, ServiceAccess::STOP)?;
-    service.stop()?;
-    println!("Service '{}' stopped.", SERVICE_NAME);
-    Ok(())
+    match state {
+        Stopped | Paused => ServiceStatus::Stopped,
+        StartPending | ContinuePending => ServiceStatus::Starting,
+        Running => ServiceStatus::Running,
+        StopPending | PausePending => ServiceStatus::Stopped,
+    }
 }
 
 mod native_snapshot {

--- a/src/service.rs
+++ b/src/service.rs
@@ -53,9 +53,10 @@ pub fn launchd_status_from_output(output: &str) -> ServiceStatus {
         ServiceStatus::Running
     } else if output.contains("state = spawning") {
         ServiceStatus::Starting
-    } else if output.contains("state = waiting") || output.contains("state = exited") {
-        ServiceStatus::Stopped
-    } else if output.contains("last exit code = 0") {
+    } else if output.contains("state = waiting")
+        || output.contains("state = exited")
+        || output.contains("last exit code = 0")
+    {
         ServiceStatus::Stopped
     } else if output.contains("last exit code =") {
         ServiceStatus::Failed
@@ -185,8 +186,8 @@ pub struct LaunchdDefinition {
 
 impl LaunchdDefinition {
     pub fn managed(paths: &ManagedServicePaths) -> Self {
-        let stdout_path = paths.logs_dir.join("launchd.out.log");
-        let stderr_path = paths.logs_dir.join("launchd.err.log");
+        let stdout_path = layout_path_string(paths.platform, &paths.logs_dir, "launchd.out.log");
+        let stderr_path = layout_path_string(paths.platform, &paths.logs_dir, "launchd.err.log");
         let contents = format!(
             "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
 <!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n\
@@ -220,8 +221,8 @@ impl LaunchdDefinition {
             xml_escape(&paths.binary_path.to_string_lossy()),
             xml_escape(&paths.config_path.to_string_lossy()),
             xml_escape(&paths.working_dir.to_string_lossy()),
-            xml_escape(&stdout_path.to_string_lossy()),
-            xml_escape(&stderr_path.to_string_lossy())
+            xml_escape(&stdout_path),
+            xml_escape(&stderr_path)
         );
 
         Self {
@@ -229,6 +230,16 @@ impl LaunchdDefinition {
             contents,
         }
     }
+}
+
+fn layout_path_string(platform: InstallPlatform, base: &Path, child: &str) -> String {
+    let separator = match platform {
+        InstallPlatform::Windows => r"\",
+        InstallPlatform::Linux | InstallPlatform::Macos => "/",
+    };
+    let base = base.to_string_lossy();
+    let base = base.trim_end_matches(['/', '\\']);
+    format!("{base}{separator}{child}")
 }
 
 fn xml_escape(value: &str) -> String {

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,0 +1,503 @@
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context};
+
+use crate::cli::ServiceAction;
+use crate::config::{InstallLayout, InstallPlatform};
+
+pub const WINDOWS_SERVICE_NAME: &str = "Rustinel";
+pub const WINDOWS_SERVICE_DISPLAY_NAME: &str = "Rustinel ETW Sentinel";
+pub const SERVICE_DESCRIPTION: &str = "High-performance endpoint detection agent";
+pub const SYSTEMD_SERVICE_NAME: &str = "rustinel";
+pub const SYSTEMD_UNIT_NAME: &str = "rustinel.service";
+pub const LAUNCHD_LABEL: &str = "com.rustinel.agent";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ServiceStatus {
+    NotInstalled,
+    Stopped,
+    Starting,
+    Running,
+    Failed,
+    Unknown,
+}
+
+impl fmt::Display for ServiceStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let value = match self {
+            Self::NotInstalled => "not-installed",
+            Self::Stopped => "stopped",
+            Self::Starting => "starting",
+            Self::Running => "running",
+            Self::Failed => "failed",
+            Self::Unknown => "unknown",
+        };
+        f.write_str(value)
+    }
+}
+
+pub fn systemd_status_from_state(state: &str) -> ServiceStatus {
+    match state.trim() {
+        "active" => ServiceStatus::Running,
+        "activating" => ServiceStatus::Starting,
+        "inactive" | "deactivating" => ServiceStatus::Stopped,
+        "failed" => ServiceStatus::Failed,
+        "unknown" => ServiceStatus::Unknown,
+        _ => ServiceStatus::Unknown,
+    }
+}
+
+pub fn launchd_status_from_output(output: &str) -> ServiceStatus {
+    if output.contains("state = running") {
+        ServiceStatus::Running
+    } else if output.contains("state = spawning") {
+        ServiceStatus::Starting
+    } else if output.contains("state = waiting") || output.contains("state = exited") {
+        ServiceStatus::Stopped
+    } else if output.contains("last exit code = 0") {
+        ServiceStatus::Stopped
+    } else if output.contains("last exit code =") {
+        ServiceStatus::Failed
+    } else {
+        ServiceStatus::Unknown
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ManagedServicePaths {
+    pub platform: InstallPlatform,
+    pub binary_path: PathBuf,
+    pub config_path: PathBuf,
+    pub working_dir: PathBuf,
+    pub systemd_unit_path: Option<PathBuf>,
+    pub launchd_plist_path: Option<PathBuf>,
+    pub logs_dir: PathBuf,
+}
+
+impl ManagedServicePaths {
+    pub fn for_platform(platform: InstallPlatform) -> Self {
+        let layout = InstallLayout::managed(platform);
+        match platform {
+            InstallPlatform::Windows => Self {
+                platform,
+                binary_path: PathBuf::from(r"C:\Program Files\Rustinel\rustinel.exe"),
+                config_path: layout.config_file,
+                working_dir: PathBuf::from(r"C:\Program Files\Rustinel"),
+                systemd_unit_path: None,
+                launchd_plist_path: None,
+                logs_dir: layout.logs_dir,
+            },
+            InstallPlatform::Linux => Self {
+                platform,
+                binary_path: PathBuf::from("/opt/rustinel/rustinel"),
+                config_path: layout.config_file,
+                working_dir: PathBuf::from("/opt/rustinel"),
+                systemd_unit_path: Some(PathBuf::from("/etc/systemd/system/rustinel.service")),
+                launchd_plist_path: None,
+                logs_dir: layout.logs_dir,
+            },
+            InstallPlatform::Macos => Self {
+                platform,
+                binary_path: PathBuf::from(
+                    "/usr/local/var/rustinel/Rustinel.app/Contents/MacOS/rustinel",
+                ),
+                config_path: layout.config_file,
+                working_dir: PathBuf::from("/usr/local/var/rustinel"),
+                systemd_unit_path: None,
+                launchd_plist_path: Some(PathBuf::from(
+                    "/Library/LaunchDaemons/com.rustinel.agent.plist",
+                )),
+                logs_dir: layout.logs_dir,
+            },
+        }
+    }
+
+    pub fn current() -> Self {
+        Self::for_platform(InstallPlatform::current())
+    }
+
+    pub fn validate_install_inputs(&self) -> anyhow::Result<()> {
+        ensure_regular_file(&self.binary_path, "managed binary")?;
+        ensure_regular_file(&self.config_path, "managed configuration")?;
+        Ok(())
+    }
+}
+
+fn ensure_regular_file(path: &Path, description: &str) -> anyhow::Result<()> {
+    if !path.is_file() {
+        bail!(
+            "Required {} does not exist or is not a file: {}",
+            description,
+            path.display()
+        );
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SystemdDefinition {
+    pub unit_name: String,
+    pub contents: String,
+}
+
+impl SystemdDefinition {
+    pub fn managed(paths: &ManagedServicePaths) -> Self {
+        let contents = format!(
+            "[Unit]\n\
+Description=Rustinel endpoint detection agent\n\
+Documentation=https://github.com/Karib0u/rustinel\n\
+After=network.target\n\
+\n\
+[Service]\n\
+Type=simple\n\
+ExecStart={} run --config {} --no-console\n\
+WorkingDirectory={}\n\
+Restart=on-failure\n\
+RestartSec=5s\n\
+User=root\n\
+AmbientCapabilities=CAP_BPF CAP_NET_ADMIN CAP_SYS_RESOURCE\n\
+CapabilityBoundingSet=CAP_BPF CAP_NET_ADMIN CAP_SYS_RESOURCE\n\
+NoNewPrivileges=true\n\
+StandardOutput=journal\n\
+StandardError=journal\n\
+SyslogIdentifier=rustinel\n\
+\n\
+[Install]\n\
+WantedBy=multi-user.target\n",
+            paths.binary_path.display(),
+            paths.config_path.display(),
+            paths.working_dir.display()
+        );
+
+        Self {
+            unit_name: SYSTEMD_UNIT_NAME.to_string(),
+            contents,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LaunchdDefinition {
+    pub label: String,
+    pub contents: String,
+}
+
+impl LaunchdDefinition {
+    pub fn managed(paths: &ManagedServicePaths) -> Self {
+        let stdout_path = paths.logs_dir.join("launchd.out.log");
+        let stderr_path = paths.logs_dir.join("launchd.err.log");
+        let contents = format!(
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n\
+<plist version=\"1.0\">\n\
+<dict>\n\
+    <key>Label</key>\n\
+    <string>{}</string>\n\
+    <key>ProgramArguments</key>\n\
+    <array>\n\
+        <string>{}</string>\n\
+        <string>run</string>\n\
+        <string>--config</string>\n\
+        <string>{}</string>\n\
+        <string>--no-console</string>\n\
+    </array>\n\
+    <key>WorkingDirectory</key>\n\
+    <string>{}</string>\n\
+    <key>RunAtLoad</key>\n\
+    <true/>\n\
+    <key>KeepAlive</key>\n\
+    <true/>\n\
+    <key>ProcessType</key>\n\
+    <string>Interactive</string>\n\
+    <key>StandardOutPath</key>\n\
+    <string>{}</string>\n\
+    <key>StandardErrorPath</key>\n\
+    <string>{}</string>\n\
+</dict>\n\
+</plist>\n",
+            xml_escape(LAUNCHD_LABEL),
+            xml_escape(&paths.binary_path.to_string_lossy()),
+            xml_escape(&paths.config_path.to_string_lossy()),
+            xml_escape(&paths.working_dir.to_string_lossy()),
+            xml_escape(&stdout_path.to_string_lossy()),
+            xml_escape(&stderr_path.to_string_lossy())
+        );
+
+        Self {
+            label: LAUNCHD_LABEL.to_string(),
+            contents,
+        }
+    }
+}
+
+fn xml_escape(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&apos;")
+}
+
+pub trait ServiceBackend {
+    fn name(&self) -> &'static str;
+    fn install(&self) -> anyhow::Result<()>;
+    fn uninstall(&self) -> anyhow::Result<()>;
+    fn start(&self) -> anyhow::Result<()>;
+    fn stop(&self) -> anyhow::Result<()>;
+    fn status(&self) -> anyhow::Result<ServiceStatus>;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ServiceCommandResult {
+    NoStatus,
+    Status(ServiceStatus),
+}
+
+pub fn run_backend_action<B: ServiceBackend>(
+    backend: &B,
+    action: ServiceAction,
+) -> anyhow::Result<ServiceCommandResult> {
+    match action {
+        ServiceAction::Install => {
+            backend.install()?;
+            Ok(ServiceCommandResult::NoStatus)
+        }
+        ServiceAction::Uninstall => {
+            backend.uninstall()?;
+            Ok(ServiceCommandResult::NoStatus)
+        }
+        ServiceAction::Start => {
+            backend.start()?;
+            Ok(ServiceCommandResult::NoStatus)
+        }
+        ServiceAction::Stop => {
+            backend.stop()?;
+            Ok(ServiceCommandResult::NoStatus)
+        }
+        ServiceAction::Restart => {
+            match backend.status().unwrap_or(ServiceStatus::Unknown) {
+                ServiceStatus::NotInstalled => backend.start()?,
+                ServiceStatus::Stopped => backend.start()?,
+                ServiceStatus::Starting | ServiceStatus::Running | ServiceStatus::Failed => {
+                    backend.stop()?;
+                    backend.start()?;
+                }
+                ServiceStatus::Unknown => {
+                    backend
+                        .stop()
+                        .with_context(|| format!("failed to stop {}", backend.name()))?;
+                    backend.start()?;
+                }
+            }
+            Ok(ServiceCommandResult::NoStatus)
+        }
+        ServiceAction::Status => Ok(ServiceCommandResult::Status(backend.status()?)),
+    }
+}
+
+pub fn execute_backend_action<B: ServiceBackend>(
+    backend: &B,
+    action: ServiceAction,
+) -> anyhow::Result<()> {
+    let result = run_backend_action(backend, action)?;
+    match result {
+        ServiceCommandResult::NoStatus => {
+            println!("Service '{}' {}.", backend.name(), action_verb(action))
+        }
+        ServiceCommandResult::Status(status) => println!("{}", status),
+    }
+    Ok(())
+}
+
+fn action_verb(action: ServiceAction) -> &'static str {
+    match action {
+        ServiceAction::Install => "installed",
+        ServiceAction::Uninstall => "uninstalled",
+        ServiceAction::Start => "started",
+        ServiceAction::Stop => "stopped",
+        ServiceAction::Restart => "restarted",
+        ServiceAction::Status => "status",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::RefCell;
+
+    use super::*;
+
+    #[test]
+    fn systemd_definition_uses_managed_paths() {
+        let paths = ManagedServicePaths::for_platform(InstallPlatform::Linux);
+        let definition = SystemdDefinition::managed(&paths);
+
+        assert_eq!(definition.unit_name, "rustinel.service");
+        assert!(definition.contents.contains(
+            "ExecStart=/opt/rustinel/rustinel run --config /etc/rustinel/config.toml --no-console"
+        ));
+        assert!(definition
+            .contents
+            .contains("WorkingDirectory=/opt/rustinel"));
+        assert!(definition.contents.contains("WantedBy=multi-user.target"));
+    }
+
+    #[test]
+    fn launchd_definition_uses_managed_paths() {
+        let paths = ManagedServicePaths::for_platform(InstallPlatform::Macos);
+        let definition = LaunchdDefinition::managed(&paths);
+
+        assert_eq!(definition.label, "com.rustinel.agent");
+        assert!(definition.contents.contains(
+            "<string>/usr/local/var/rustinel/Rustinel.app/Contents/MacOS/rustinel</string>"
+        ));
+        assert!(definition
+            .contents
+            .contains("<string>/Library/Application Support/Rustinel/config.toml</string>"));
+        assert!(definition
+            .contents
+            .contains("<string>/Library/Logs/Rustinel/launchd.err.log</string>"));
+    }
+
+    #[test]
+    fn mock_backend_records_successful_restart_from_running() {
+        let backend = MockBackend::new(ServiceStatus::Running);
+
+        let result = run_backend_action(&backend, ServiceAction::Restart).expect("restart");
+
+        assert_eq!(result, ServiceCommandResult::NoStatus);
+        assert_eq!(backend.calls(), ["status", "stop", "start"]);
+    }
+
+    #[test]
+    fn mock_backend_records_successful_restart_from_stopped() {
+        let backend = MockBackend::new(ServiceStatus::Stopped);
+
+        run_backend_action(&backend, ServiceAction::Restart).expect("restart");
+
+        assert_eq!(backend.calls(), ["status", "start"]);
+    }
+
+    #[test]
+    fn mock_backend_surfaces_failures() {
+        let backend = MockBackend::new(ServiceStatus::Running).fail_on("stop");
+
+        let err = run_backend_action(&backend, ServiceAction::Restart).expect_err("failure");
+
+        assert!(err.to_string().contains("stop failed"));
+        assert_eq!(backend.calls(), ["status", "stop"]);
+    }
+
+    #[test]
+    fn mock_backend_reports_unknown_status() {
+        let backend = MockBackend::new(ServiceStatus::Unknown);
+
+        let result = run_backend_action(&backend, ServiceAction::Status).expect("status");
+
+        assert_eq!(result, ServiceCommandResult::Status(ServiceStatus::Unknown));
+        assert_eq!(backend.calls(), ["status"]);
+    }
+
+    #[test]
+    fn systemd_status_values_are_normalized() {
+        assert_eq!(systemd_status_from_state("active"), ServiceStatus::Running);
+        assert_eq!(
+            systemd_status_from_state("activating"),
+            ServiceStatus::Starting
+        );
+        assert_eq!(
+            systemd_status_from_state("inactive"),
+            ServiceStatus::Stopped
+        );
+        assert_eq!(systemd_status_from_state("failed"), ServiceStatus::Failed);
+        assert_eq!(
+            systemd_status_from_state("unexpected"),
+            ServiceStatus::Unknown
+        );
+    }
+
+    #[test]
+    fn launchd_status_values_are_normalized() {
+        assert_eq!(
+            launchd_status_from_output("state = running"),
+            ServiceStatus::Running
+        );
+        assert_eq!(
+            launchd_status_from_output("state = spawning"),
+            ServiceStatus::Starting
+        );
+        assert_eq!(
+            launchd_status_from_output("state = waiting"),
+            ServiceStatus::Stopped
+        );
+        assert_eq!(
+            launchd_status_from_output("last exit code = 17"),
+            ServiceStatus::Failed
+        );
+        assert_eq!(
+            launchd_status_from_output("pid = 0"),
+            ServiceStatus::Unknown
+        );
+    }
+
+    struct MockBackend {
+        status: ServiceStatus,
+        calls: RefCell<Vec<&'static str>>,
+        fail_on: Option<&'static str>,
+    }
+
+    impl MockBackend {
+        fn new(status: ServiceStatus) -> Self {
+            Self {
+                status,
+                calls: RefCell::new(Vec::new()),
+                fail_on: None,
+            }
+        }
+
+        fn fail_on(mut self, action: &'static str) -> Self {
+            self.fail_on = Some(action);
+            self
+        }
+
+        fn calls(&self) -> Vec<&'static str> {
+            self.calls.borrow().clone()
+        }
+
+        fn record(&self, action: &'static str) -> anyhow::Result<()> {
+            self.calls.borrow_mut().push(action);
+            if self.fail_on == Some(action) {
+                bail!("{action} failed");
+            }
+            Ok(())
+        }
+    }
+
+    impl ServiceBackend for MockBackend {
+        fn name(&self) -> &'static str {
+            "mock"
+        }
+
+        fn install(&self) -> anyhow::Result<()> {
+            self.record("install")
+        }
+
+        fn uninstall(&self) -> anyhow::Result<()> {
+            self.record("uninstall")
+        }
+
+        fn start(&self) -> anyhow::Result<()> {
+            self.record("start")
+        }
+
+        fn stop(&self) -> anyhow::Result<()> {
+            self.record("stop")
+        }
+
+        fn status(&self) -> anyhow::Result<ServiceStatus> {
+            self.record("status")?;
+            Ok(self.status)
+        }
+    }
+}

--- a/src/service.rs
+++ b/src/service.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{bail, Context};
 
 use crate::cli::ServiceAction;
-use crate::config::{InstallLayout, InstallPlatform};
+use crate::config::{layout_join, InstallLayout, InstallPlatform};
 
 pub const WINDOWS_SERVICE_NAME: &str = "Rustinel";
 pub const WINDOWS_SERVICE_DISPLAY_NAME: &str = "Rustinel ETW Sentinel";
@@ -186,8 +186,8 @@ pub struct LaunchdDefinition {
 
 impl LaunchdDefinition {
     pub fn managed(paths: &ManagedServicePaths) -> Self {
-        let stdout_path = layout_path_string(paths.platform, &paths.logs_dir, "launchd.out.log");
-        let stderr_path = layout_path_string(paths.platform, &paths.logs_dir, "launchd.err.log");
+        let stdout_path = layout_join(paths.platform, &paths.logs_dir, "launchd.out.log");
+        let stderr_path = layout_join(paths.platform, &paths.logs_dir, "launchd.err.log");
         let contents = format!(
             "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
 <!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n\
@@ -221,8 +221,8 @@ impl LaunchdDefinition {
             xml_escape(&paths.binary_path.to_string_lossy()),
             xml_escape(&paths.config_path.to_string_lossy()),
             xml_escape(&paths.working_dir.to_string_lossy()),
-            xml_escape(&stdout_path),
-            xml_escape(&stderr_path)
+            xml_escape(&stdout_path.to_string_lossy()),
+            xml_escape(&stderr_path.to_string_lossy())
         );
 
         Self {
@@ -230,16 +230,6 @@ impl LaunchdDefinition {
             contents,
         }
     }
-}
-
-fn layout_path_string(platform: InstallPlatform, base: &Path, child: &str) -> String {
-    let separator = match platform {
-        InstallPlatform::Windows => r"\",
-        InstallPlatform::Linux | InstallPlatform::Macos => "/",
-    };
-    let base = base.to_string_lossy();
-    let base = base.trim_end_matches(['/', '\\']);
-    format!("{base}{separator}{child}")
 }
 
 fn xml_escape(value: &str) -> String {


### PR DESCRIPTION
Closes #105

## Summary
- Adds a shared service backend with normalized status and restart handling.
- Adds Windows SCM, Linux systemd, and macOS launchd service backends using managed binary and configuration paths.
- Updates docs and packaged service templates for the native service lifecycle.

## Tests
- cargo check
- cargo test

## Notes
- Linux cross-target checking on this macOS host was blocked by a missing x86_64-linux-gnu-gcc toolchain, so CI should validate Linux build coverage.