### PR TITLE
feat(rules): install released rules packs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,6 +141,9 @@ name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "arc-swap"
@@ -218,6 +221,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -436,6 +445,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -601,6 +627,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -866,7 +902,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -977,6 +1013,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "derive_pod"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1076,7 +1123,7 @@ dependencies = [
  "hkdf",
  "pem-rfc7468",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -1185,7 +1232,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "once_cell",
- "rand",
+ "rand 0.8.6",
  "widestring",
  "windows 0.57.0",
  "zerocopy 0.7.35",
@@ -1197,7 +1244,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1231,6 +1278,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "fsevent-sys"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1246,10 +1302,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -1264,7 +1342,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-io",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -1312,8 +1393,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1376,7 +1460,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1467,12 +1551,110 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
  "typenum",
+]
+
+[[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1500,6 +1682,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1510,6 +1774,27 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "ignore"
@@ -1741,6 +2026,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1779,6 +2070,12 @@ checksum = "605d9697bcd5ef3a42d38efc51541aa3d6a4a25f7ab6d1ed0da5ac632a26b470"
 dependencies = [
  "logos-codegen",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mach2"
@@ -1996,7 +2293,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -2135,6 +2432,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "ordered-multimap"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2211,6 +2514,12 @@ checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
 dependencies = [
  "base64ct",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
@@ -2320,6 +2629,15 @@ dependencies = [
  "embedded-io 0.4.0",
  "embedded-io 0.6.1",
  "serde",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -2445,6 +2763,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.3",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring",
+ "rustc-hash 2.1.3",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2479,7 +2853,18 @@ checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2489,7 +2874,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2499,6 +2884,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2565,6 +2965,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2572,6 +3012,20 @@ checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
  "hmac",
  "subtle",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2622,7 +3076,7 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "signature",
  "spki",
  "subtle",
@@ -2735,8 +3189,10 @@ dependencies = [
  "notify",
  "pelite",
  "regex",
+ "reqwest",
  "rsigma-eval",
  "rsigma-parser",
+ "semver",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -2748,9 +3204,11 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "url",
  "windows 0.62.2",
  "windows-service",
  "yara-x",
+ "zip 2.4.2",
 ]
 
 [[package]]
@@ -2780,6 +3238,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2801,6 +3306,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2818,6 +3332,29 @@ dependencies = [
  "pkcs8",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -2895,6 +3432,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -2992,7 +3541,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3126,6 +3675,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
 ]
 
 [[package]]
@@ -3268,6 +3826,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3276,6 +3844,21 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tinyzip"
@@ -3289,6 +3872,7 @@ version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
+ "bytes",
  "libc",
  "mio",
  "pin-project-lite",
@@ -3307,6 +3891,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -3339,6 +3933,51 @@ checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags 2.13.0",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -3467,6 +4106,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typed-path"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3515,10 +4160,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "unty"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -3593,6 +4262,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3618,6 +4296,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3860,6 +4548,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "which"
 version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4075,6 +4773,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
@@ -4254,6 +4961,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4406,7 +5119,7 @@ dependencies = [
  "yara-x-macros",
  "yara-x-parser",
  "yara-x-proto",
- "zip",
+ "zip 8.6.0",
 ]
 
 [[package]]
@@ -4454,6 +5167,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4495,10 +5231,81 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "thiserror 2.0.18",
+ "zopfli",
+]
 
 [[package]]
 name = "zip"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
 chrono = { version = "0.4", features = ["clock"] }
+semver = "1.0"
 
 # Utilities
 anyhow = "1.0"
@@ -58,6 +59,9 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "fmt"]
 tracing-appender = "0.2"
 clap = { version = "4.4", features = ["derive"] }
 arc-swap = "1.7"
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls-native-roots"] }
+url = "2.5"
+zip = { version = "2.4", default-features = false, features = ["deflate"] }
 
 # Configuration
 config = "0.15.23"

--- a/config.toml
+++ b/config.toml
@@ -4,9 +4,9 @@
 # 1. Feature Toggles & Rules
 [scanner]
 sigma_enabled = true
-sigma_rules_path = "rules/sigma"
+sigma_rules_path = "rules/current/sigma"
 yara_enabled = true
-yara_rules_path = "rules/yara"
+yara_rules_path = "rules/current/yara"
 
 [reload]
 enabled = true
@@ -77,9 +77,9 @@ channel_capacity = 128
 # 5. Atomic IOC Detection (Hashes, IPs, Domains, Path Regex)
 [ioc]
 enabled = true
-hashes_path = "rules/ioc/hashes.txt"
-ips_path = "rules/ioc/ips.txt"
-domains_path = "rules/ioc/domains.txt"
-paths_regex_path = "rules/ioc/paths_regex.txt"
+hashes_path = "rules/current/ioc/hashes.txt"
+ips_path = "rules/current/ioc/ips.txt"
+domains_path = "rules/current/ioc/domains.txt"
+paths_regex_path = "rules/current/ioc/paths_regex.txt"
 default_severity = "high"
 max_file_size_mb = 50

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -63,8 +63,8 @@
                                                │ atomic swap
                                   ┌────────────┴────────────┐
                                   │ Reload poller + worker  │
-                                  │ rules/sigma rules/yara  │
-                                  │ rules/ioc/*             │
+                                  │ rules/current/{sigma,yara} │
+                                  │ rules/current/ioc/*        │
                                   └─────────────────────────┘
 ```
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -48,6 +48,41 @@ Notes:
 - `--sigma-engine <builtin|rsigma>` selects the Sigma matching backend, overriding `scanner.sigma_engine`. `rsigma` requires a build with the `rsigma-engine` feature (included in the official release binaries). See [Detection](detection.md#detection-engine).
 - Linux foreground execution is the normal runtime model unless you wrap the binary in a service manager.
 
+### `rules`
+
+Discover and install released rules packs.
+
+```text
+rustinel rules list [--catalog-url <URL>] [--rules-dir <PATH>]
+rustinel rules install <PACK> [--catalog-url <URL>] [--rules-dir <PATH>]
+```
+
+Examples:
+
+```bash
+rustinel rules list
+sudo rustinel rules install linux-essential
+```
+
+The default catalog is the latest released `index.json` from
+`Karib0u/rustinel-rules`. `rules list` filters packs to the current platform and
+marks the active pack from `rules/state.json`. `rules install` downloads the pack
+artifact into `rules/staging`, verifies its SHA-256 checksum, rejects unsafe ZIP
+paths, validates `pack.yml`, then atomically replaces `rules/current`.
+
+Managed active rules layout:
+
+```text
+rules/
++-- current/
+|   +-- pack.yml
+|   +-- sigma/
+|   +-- yara/
+|   +-- ioc/
++-- staging/
++-- state.json
+```
+
 ### `service`
 
 Manage native service installation and lifecycle.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,8 +25,8 @@ the executable-directory file takes precedence.
 
 Relative paths in `config.toml` are resolved relative to the directory that
 contains that config file. For example, a portable archive extracted to
-`/opt/rustinel` can use `rules/sigma` in `/opt/rustinel/config.toml`, and it
-will resolve to `/opt/rustinel/rules/sigma` even if Rustinel is launched from a
+`/opt/rustinel` can use `rules/current/sigma` in `/opt/rustinel/config.toml`, and it
+will resolve to `/opt/rustinel/rules/current/sigma` even if Rustinel is launched from a
 different directory.
 
 Production note:
@@ -50,10 +50,10 @@ Production note:
 ```toml
 [scanner]
 sigma_enabled = true
-sigma_rules_path = "rules/sigma"
+sigma_rules_path = "rules/current/sigma"
 sigma_engine = "builtin"
 yara_enabled = true
-yara_rules_path = "rules/yara"
+yara_rules_path = "rules/current/yara"
 
 # Memory scanning is off by default.
 # yara_memory_enabled = false
@@ -98,10 +98,10 @@ aggregation_interval_buffer_size = 50
 
 [ioc]
 enabled = true
-hashes_path = "rules/ioc/hashes.txt"
-ips_path = "rules/ioc/ips.txt"
-domains_path = "rules/ioc/domains.txt"
-paths_regex_path = "rules/ioc/paths_regex.txt"
+hashes_path = "rules/current/ioc/hashes.txt"
+ips_path = "rules/current/ioc/ips.txt"
+domains_path = "rules/current/ioc/domains.txt"
+paths_regex_path = "rules/current/ioc/paths_regex.txt"
 default_severity = "high"
 max_file_size_mb = 50
 ```
@@ -115,10 +115,10 @@ Use Windows path prefixes on Windows and Unix path prefixes on Linux.
 | Option | Default |
 | --- | --- |
 | `scanner.sigma_enabled` | `true` |
-| `scanner.sigma_rules_path` | `rules/sigma` |
+| `scanner.sigma_rules_path` | `rules/current/sigma` |
 | `scanner.sigma_engine` | `builtin` |
 | `scanner.yara_enabled` | `true` |
-| `scanner.yara_rules_path` | `rules/yara` |
+| `scanner.yara_rules_path` | `rules/current/yara` |
 | `reload.enabled` | `true` |
 | `reload.debounce_ms` | `2000` |
 | `logging.level` | `info` |
@@ -178,10 +178,10 @@ These defaults feed `allowlist.paths`, which then propagate to active response, 
 | Option | Default | Description |
 | --- | --- | --- |
 | `sigma_enabled` | `true` | Enable Sigma rule evaluation |
-| `sigma_rules_path` | `rules/sigma` | Sigma rules directory |
+| `sigma_rules_path` | `rules/current/sigma` | Sigma rules directory |
 | `sigma_engine` | `builtin` | Sigma matching backend: `builtin` or `rsigma` (the latter needs the `rsigma-engine` build feature) |
 | `yara_enabled` | `true` | Enable YARA scanning |
-| `yara_rules_path` | `rules/yara` | YARA rules directory |
+| `yara_rules_path` | `rules/current/yara` | YARA rules directory |
 | `yara_allowlist_paths` | inherits `allowlist.paths` | Prefix paths skipped by YARA queueing and scanning |
 | `yara_memory_enabled` | `false` | Enable YARA memory scanning (requires `yara_enabled = true`) |
 | `yara_memory_queue_capacity` | `64` | Maximum pending memory scan jobs before new ones are dropped |
@@ -284,10 +284,10 @@ See [Active Response](active-response.md) for platform behavior and safe testing
 | Option | Default | Description |
 | --- | --- | --- |
 | `enabled` | `true` | Enable IOC detection |
-| `hashes_path` | `rules/ioc/hashes.txt` | Hash IOC file |
-| `ips_path` | `rules/ioc/ips.txt` | IP and CIDR IOC file |
-| `domains_path` | `rules/ioc/domains.txt` | Domain IOC file |
-| `paths_regex_path` | `rules/ioc/paths_regex.txt` | Path regex IOC file |
+| `hashes_path` | `rules/current/ioc/hashes.txt` | Hash IOC file |
+| `ips_path` | `rules/current/ioc/ips.txt` | IP and CIDR IOC file |
+| `domains_path` | `rules/current/ioc/domains.txt` | Domain IOC file |
+| `paths_regex_path` | `rules/current/ioc/paths_regex.txt` | Path regex IOC file |
 | `default_severity` | `high` | Severity assigned to IOC alerts |
 | `max_file_size_mb` | `50` | Skip hashing files larger than this limit |
 | `hash_allowlist_paths` | inherits `allowlist.paths` | Prefix paths skipped during hashing |
@@ -309,7 +309,7 @@ $env:EDR__ALLOWLIST__PATHS='["C:\\Windows\\","C:\\Program Files\\"]'
 
 ```bash
 export EDR__LOGGING__LEVEL=debug
-export EDR__SCANNER__SIGMA_RULES_PATH=/opt/rustinel/rules/sigma
+export EDR__SCANNER__SIGMA_RULES_PATH=/opt/rustinel/rules/current/sigma
 export EDR__ALLOWLIST__PATHS='["/usr/bin/","/usr/sbin/"]'
 sudo /opt/rustinel/rustinel run
 ```
@@ -343,8 +343,8 @@ directory = "C:\\Rustinel\\logs"
 
 ```toml
 [scanner]
-sigma_rules_path = "/opt/rustinel/rules/sigma"
-yara_rules_path = "/opt/rustinel/rules/yara"
+sigma_rules_path = "/opt/rustinel/rules/current/sigma"
+yara_rules_path = "/opt/rustinel/rules/current/yara"
 
 [logging]
 directory = "/opt/rustinel/logs"

--- a/docs/detection.md
+++ b/docs/detection.md
@@ -217,10 +217,10 @@ The IOC engine hot reloads indicator files and splits work between inline event 
 
 | Indicator Type | Source File | Checked Against | Execution Path |
 | --- | --- | --- | --- |
-| Hashes | `rules/ioc/hashes.txt` | Process-start executable path | Background worker |
-| IPs / CIDRs | `rules/ioc/ips.txt` | Network source and destination IPs, plus IPs parsed from DNS answers | Inline |
-| Domains | `rules/ioc/domains.txt` | DNS `QueryName`, network `DestinationHostname`, WMI `DestinationHostname` | Inline |
-| Path regexes | `rules/ioc/paths_regex.txt` | `ProcessCreation.Image`, `ProcessCreation.TargetImage`, `FileEvent.TargetFilename`, `ImageLoad.ImageLoaded`, `PowerShellScript.Path`, `ServiceCreation.ServiceFileName` | Inline |
+| Hashes | `rules/current/ioc/hashes.txt` | Process-start executable path | Background worker |
+| IPs / CIDRs | `rules/current/ioc/ips.txt` | Network source and destination IPs, plus IPs parsed from DNS answers | Inline |
+| Domains | `rules/current/ioc/domains.txt` | DNS `QueryName`, network `DestinationHostname`, WMI `DestinationHostname` | Inline |
+| Path regexes | `rules/current/ioc/paths_regex.txt` | `ProcessCreation.Image`, `ProcessCreation.TargetImage`, `FileEvent.TargetFilename`, `ImageLoad.ImageLoaded`, `PowerShellScript.Path`, `ServiceCreation.ServiceFileName` | Inline |
 
 ### Runtime Notes
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -91,6 +91,8 @@ Bundled demo rules:
 | Linux | `rules/sigma/linux_whoami.yml` |
 | macOS | `rules/sigma/macos_whoami.yml` |
 
+Installed release packs become active under `rules/current`.
+
 ## Install Options
 
 Install to a specific directory:
@@ -260,13 +262,15 @@ The operational log should report a reload event.
 Windows example:
 
 ```powershell
-Add-Content rules\sigma\windows_whoami.yml "`n# hot reload smoke test"
+$rule = Get-ChildItem rules\current\sigma -Filter *.yml | Select-Object -First 1
+Add-Content $rule.FullName "`n# hot reload smoke test"
 ```
 
 Linux example:
 
 ```bash
-printf '\n# hot reload smoke test\n' >> rules/sigma/linux_whoami.yml
+rule=$(find rules/current/sigma -name '*.yml' -print -quit)
+printf '\n# hot reload smoke test\n' >> "$rule"
 ```
 
 ## Next Steps

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -120,6 +120,11 @@ macOS support is experimental and detection-only.
 - **Telemetry is dropped under load (silent risk).** Sensor channels are bounded and
   drop on overflow, with only a periodic warning. Under burst load you get silent
   detection gaps, not slowdown.
+- **Rules catalog trust is release-bound in Phase 1.** `rustinel rules install`
+  trusts HTTPS GitHub release assets from `Karib0u/rustinel-rules` and requires
+  the artifact SHA-256 from the released catalog to match before activation. The
+  catalog is not separately signed in this phase, so protect release publishing
+  credentials and review release assets before promoting them.
 - **Active response is kill-after-the-fact.** The only response is process
   termination, fired after the event is processed - the process may already have
   done its work or exited. A PID-reuse race is narrowed by identity checks but not

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -68,6 +68,11 @@ pub enum Commands {
         #[command(subcommand)]
         action: ServiceAction,
     },
+    /// Rules catalog and active pack management
+    Rules {
+        #[command(subcommand)]
+        action: RulesAction,
+    },
 }
 
 #[derive(clap::Subcommand, Copy, Clone)]
@@ -78,6 +83,30 @@ pub enum ServiceAction {
     Stop,
     Restart,
     Status,
+}
+
+#[derive(clap::Subcommand, Clone)]
+pub enum RulesAction {
+    /// List rules packs available for this platform
+    List {
+        /// Rules catalog index URL
+        #[arg(long, default_value = crate::rules::DEFAULT_CATALOG_URL)]
+        catalog_url: String,
+        /// Rules root directory, containing current, staging, and state.json
+        #[arg(long, value_name = "PATH")]
+        rules_dir: Option<std::path::PathBuf>,
+    },
+    /// Install a rules pack and make it active
+    Install {
+        /// Pack ID from `rustinel rules list`
+        pack: String,
+        /// Rules catalog index URL
+        #[arg(long, default_value = crate::rules::DEFAULT_CATALOG_URL)]
+        catalog_url: String,
+        /// Rules root directory, containing current, staging, and state.json
+        #[arg(long, value_name = "PATH")]
+        rules_dir: Option<std::path::PathBuf>,
+    },
 }
 
 #[cfg(test)]
@@ -213,6 +242,42 @@ mod tests {
                 assert!(matches!(action, ServiceAction::Status));
             }
             _ => panic!("expected service command"),
+        }
+    }
+
+    #[test]
+    fn rules_list_accepts_catalog_url() {
+        let cli = Cli::try_parse_from([
+            "rustinel",
+            "rules",
+            "list",
+            "--catalog-url",
+            "https://github.com/Karib0u/rustinel-rules/releases/download/v0.2.0/index.json",
+        ])
+        .expect("rules list should parse");
+
+        match cli.command {
+            Some(Commands::Rules {
+                action: RulesAction::List { catalog_url, .. },
+            }) => {
+                assert!(catalog_url.ends_with("/index.json"));
+            }
+            _ => panic!("expected rules list command"),
+        }
+    }
+
+    #[test]
+    fn rules_install_requires_pack() {
+        let cli = Cli::try_parse_from(["rustinel", "rules", "install", "linux-essential"])
+            .expect("rules install should parse");
+
+        match cli.command {
+            Some(Commands::Rules {
+                action: RulesAction::Install { pack, .. },
+            }) => {
+                assert_eq!(pack, "linux-essential");
+            }
+            _ => panic!("expected rules install command"),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -62,9 +62,9 @@ impl InstallLayout {
                 platform,
                 config_file: PathBuf::from(r"C:\ProgramData\Rustinel\config.toml"),
                 rules_dir: PathBuf::from(r"C:\ProgramData\Rustinel\rules"),
-                sigma_rules_dir: PathBuf::from(r"C:\ProgramData\Rustinel\rules\sigma"),
-                yara_rules_dir: PathBuf::from(r"C:\ProgramData\Rustinel\rules\yara"),
-                ioc_dir: PathBuf::from(r"C:\ProgramData\Rustinel\rules\ioc"),
+                sigma_rules_dir: PathBuf::from(r"C:\ProgramData\Rustinel\rules\current\sigma"),
+                yara_rules_dir: PathBuf::from(r"C:\ProgramData\Rustinel\rules\current\yara"),
+                ioc_dir: PathBuf::from(r"C:\ProgramData\Rustinel\rules\current\ioc"),
                 logs_dir: PathBuf::from(r"C:\ProgramData\Rustinel\logs"),
                 alerts_dir: PathBuf::from(r"C:\ProgramData\Rustinel\logs"),
             },
@@ -116,13 +116,14 @@ impl InstallLayout {
         rules_dir: PathBuf,
         logs_dir: PathBuf,
     ) -> Self {
-        let ioc_dir = layout_join(platform, &rules_dir, "ioc");
+        let current_dir = layout_join(platform, &rules_dir, "current");
+        let ioc_dir = layout_join(platform, &current_dir, "ioc");
         Self {
             platform,
             config_file,
             rules_dir: rules_dir.clone(),
-            sigma_rules_dir: layout_join(platform, &rules_dir, "sigma"),
-            yara_rules_dir: layout_join(platform, &rules_dir, "yara"),
+            sigma_rules_dir: layout_join(platform, &current_dir, "sigma"),
+            yara_rules_dir: layout_join(platform, &current_dir, "yara"),
             ioc_dir,
             alerts_dir: logs_dir.clone(),
             logs_dir,
@@ -406,10 +407,10 @@ impl AppConfig {
             // --- Defaults ---
             // Scanner
             .set_default("scanner.sigma_enabled", true)?
-            .set_default("scanner.sigma_rules_path", "rules/sigma")?
+            .set_default("scanner.sigma_rules_path", "rules/current/sigma")?
             .set_default("scanner.sigma_engine", "builtin")?
             .set_default("scanner.yara_enabled", true)?
-            .set_default("scanner.yara_rules_path", "rules/yara")?
+            .set_default("scanner.yara_rules_path", "rules/current/yara")?
             .set_default("scanner.yara_allowlist_paths", Vec::<String>::new())?
             .set_default("scanner.yara_memory_enabled", false)?
             .set_default("scanner.yara_memory_queue_capacity", 64i64)?
@@ -445,10 +446,10 @@ impl AppConfig {
             .set_default("network.aggregation_interval_buffer_size", 50)?
             // IOC
             .set_default("ioc.enabled", true)?
-            .set_default("ioc.hashes_path", "rules/ioc/hashes.txt")?
-            .set_default("ioc.ips_path", "rules/ioc/ips.txt")?
-            .set_default("ioc.domains_path", "rules/ioc/domains.txt")?
-            .set_default("ioc.paths_regex_path", "rules/ioc/paths_regex.txt")?
+            .set_default("ioc.hashes_path", "rules/current/ioc/hashes.txt")?
+            .set_default("ioc.ips_path", "rules/current/ioc/ips.txt")?
+            .set_default("ioc.domains_path", "rules/current/ioc/domains.txt")?
+            .set_default("ioc.paths_regex_path", "rules/current/ioc/paths_regex.txt")?
             .set_default("ioc.default_severity", "high")?
             .set_default("ioc.max_file_size_mb", 50)?
             .set_default("ioc.hash_allowlist_paths", Vec::<String>::new())?
@@ -574,10 +575,10 @@ impl Default for AppConfig {
         let mut cfg = Self {
             scanner: ScannerConfig {
                 sigma_enabled: true,
-                sigma_rules_path: PathBuf::from("rules/sigma"),
+                sigma_rules_path: PathBuf::from("rules/current/sigma"),
                 sigma_engine: "builtin".to_string(),
                 yara_enabled: true,
-                yara_rules_path: PathBuf::from("rules/yara"),
+                yara_rules_path: PathBuf::from("rules/current/yara"),
                 yara_allowlist_paths: Vec::new(),
                 yara_memory_enabled: false,
                 yara_memory_queue_capacity: 64,
@@ -618,10 +619,10 @@ impl Default for AppConfig {
             },
             ioc: IocConfig {
                 enabled: true,
-                hashes_path: PathBuf::from("rules/ioc/hashes.txt"),
-                ips_path: PathBuf::from("rules/ioc/ips.txt"),
-                domains_path: PathBuf::from("rules/ioc/domains.txt"),
-                paths_regex_path: PathBuf::from("rules/ioc/paths_regex.txt"),
+                hashes_path: PathBuf::from("rules/current/ioc/hashes.txt"),
+                ips_path: PathBuf::from("rules/current/ioc/ips.txt"),
+                domains_path: PathBuf::from("rules/current/ioc/domains.txt"),
+                paths_regex_path: PathBuf::from("rules/current/ioc/paths_regex.txt"),
                 default_severity: "high".to_string(),
                 max_file_size_mb: 50,
                 hash_allowlist_paths: Vec::new(),
@@ -679,21 +680,33 @@ mod tests {
     fn test_config_paths() {
         let cfg = AppConfig::new().unwrap();
         let cwd = std::env::current_dir().expect("current dir");
-        assert_eq!(cfg.scanner.sigma_rules_path, cwd.join("rules/sigma"));
-        assert_eq!(cfg.scanner.yara_rules_path, cwd.join("rules/yara"));
-        assert_eq!(cfg.ioc.hashes_path, cwd.join("rules/ioc/hashes.txt"));
-        assert_eq!(cfg.ioc.ips_path, cwd.join("rules/ioc/ips.txt"));
+        assert_eq!(
+            cfg.scanner.sigma_rules_path,
+            cwd.join("rules/current/sigma")
+        );
+        assert_eq!(cfg.scanner.yara_rules_path, cwd.join("rules/current/yara"));
+        assert_eq!(
+            cfg.ioc.hashes_path,
+            cwd.join("rules/current/ioc/hashes.txt")
+        );
+        assert_eq!(cfg.ioc.ips_path, cwd.join("rules/current/ioc/ips.txt"));
         assert_eq!(
             cfg.ioc.paths_regex_path,
-            cwd.join("rules/ioc/paths_regex.txt")
+            cwd.join("rules/current/ioc/paths_regex.txt")
         );
     }
 
     #[test]
     fn default_config_paths_remain_portable() {
         let cfg = AppConfig::default();
-        assert_eq!(cfg.scanner.sigma_rules_path, PathBuf::from("rules/sigma"));
-        assert_eq!(cfg.scanner.yara_rules_path, PathBuf::from("rules/yara"));
+        assert_eq!(
+            cfg.scanner.sigma_rules_path,
+            PathBuf::from("rules/current/sigma")
+        );
+        assert_eq!(
+            cfg.scanner.yara_rules_path,
+            PathBuf::from("rules/current/yara")
+        );
         assert_eq!(cfg.logging.directory, PathBuf::from("logs"));
     }
 
@@ -826,7 +839,7 @@ paths_regex_path = "explicit-ioc/paths_regex.txt"
         );
         assert_eq!(
             windows.sigma_rules_dir.to_string_lossy(),
-            r"C:\ProgramData\Rustinel\rules\sigma"
+            r"C:\ProgramData\Rustinel\rules\current\sigma"
         );
 
         let linux = InstallLayout::managed(InstallPlatform::Linux);
@@ -836,7 +849,7 @@ paths_regex_path = "explicit-ioc/paths_regex.txt"
         );
         assert_eq!(
             linux.sigma_rules_dir,
-            PathBuf::from("/var/lib/rustinel/rules/sigma")
+            PathBuf::from("/var/lib/rustinel/rules/current/sigma")
         );
         assert_eq!(
             linux.managed_config().logging.directory.to_string_lossy(),
@@ -855,7 +868,7 @@ paths_regex_path = "explicit-ioc/paths_regex.txt"
                 .scanner
                 .yara_rules_path
                 .to_string_lossy(),
-            "/Library/Application Support/Rustinel/rules/yara"
+            "/Library/Application Support/Rustinel/rules/current/yara"
         );
     }
 
@@ -865,7 +878,10 @@ paths_regex_path = "explicit-ioc/paths_regex.txt"
         let layout = InstallLayout::portable(&root);
 
         assert_eq!(layout.config_file, root.join("config.toml"));
-        assert_eq!(layout.sigma_rules_dir, root.join("rules").join("sigma"));
+        assert_eq!(
+            layout.sigma_rules_dir,
+            root.join("rules").join("current").join("sigma")
+        );
         assert_eq!(layout.logs_dir, root.join("logs"));
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod normalizer;
 pub mod platform;
 pub mod reload;
 pub mod response;
+pub mod rules;
 pub mod runtime;
 pub mod scanner;
 pub mod sensor;

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -1,0 +1,835 @@
+use std::{
+    fs,
+    io::Read,
+    path::{Component, Path, PathBuf},
+};
+
+use anyhow::{bail, Context, Result};
+use chrono::{SecondsFormat, Utc};
+use semver::{Version, VersionReq};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use url::Url;
+use zip::ZipArchive;
+
+use crate::config::AppConfig;
+
+pub const DEFAULT_CATALOG_URL: &str =
+    "https://github.com/Karib0u/rustinel-rules/releases/latest/download/index.json";
+const INDEX_SCHEMA: &str = "rustinel-rules/index@1";
+const SUPPORTED_PACK_SCHEMA_VERSIONS: &[u32] = &[1, 2];
+const MAX_CATALOG_BYTES: u64 = 2 * 1024 * 1024;
+const MAX_ARTIFACT_BYTES: u64 = 50 * 1024 * 1024;
+const MAX_EXTRACTED_BYTES: u64 = 250 * 1024 * 1024;
+
+#[derive(Debug, Deserialize)]
+pub struct Catalog {
+    schema: String,
+    release_version: String,
+    packs: Vec<CatalogPack>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CatalogPack {
+    pub id: String,
+    pub name: String,
+    pub os: String,
+    pub level: String,
+    pub version: String,
+    #[serde(default)]
+    pub default: bool,
+    pub requires_rustinel: String,
+    pub status: String,
+    #[serde(default)]
+    pub rule_count: u32,
+    #[serde(default)]
+    pub ioc_count: u32,
+    pub artifact: String,
+    pub sha256: String,
+    #[serde(default)]
+    engine: Option<CatalogEngine>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct CatalogEngine {
+    sigma_rules_path: String,
+    yara_rules_path: String,
+    hashes_path: String,
+    ips_path: String,
+    domains_path: String,
+    paths_regex_path: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct PackManifest {
+    name: String,
+    id: String,
+    description: String,
+    os: String,
+    level: String,
+    pack_schema_version: u32,
+    requires_rustinel: String,
+    default: bool,
+    status: String,
+    extends: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RulesState {
+    pub pack_id: String,
+    pub version: String,
+    pub sha256: String,
+    pub installed_at: String,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct InstallOutcome {
+    pub pack_id: String,
+    pub version: String,
+    pub current_dir: PathBuf,
+}
+
+impl Catalog {
+    pub fn from_slice(bytes: &[u8]) -> Result<Self> {
+        let catalog: Self = serde_json::from_slice(bytes).context("parse rules catalog")?;
+        catalog.validate()?;
+        Ok(catalog)
+    }
+
+    pub fn compatible_packs(&self) -> Vec<&CatalogPack> {
+        let os = current_os();
+        self.packs
+            .iter()
+            .filter(|pack| pack.os == os)
+            .collect::<Vec<_>>()
+    }
+
+    fn find_pack(&self, pack_id: &str) -> Option<&CatalogPack> {
+        self.packs.iter().find(|pack| pack.id == pack_id)
+    }
+
+    fn validate(&self) -> Result<()> {
+        if self.schema != INDEX_SCHEMA {
+            bail!("unsupported catalog schema {}", self.schema);
+        }
+        if self.release_version.trim().is_empty() {
+            bail!("catalog release_version is empty");
+        }
+        if self.packs.is_empty() {
+            bail!("catalog has no packs");
+        }
+        for pack in &self.packs {
+            validate_catalog_pack(pack)?;
+        }
+        Ok(())
+    }
+}
+
+pub fn run_cli(command: crate::cli::RulesAction, config_path: Option<PathBuf>) -> Result<()> {
+    match command {
+        crate::cli::RulesAction::List {
+            catalog_url,
+            rules_dir,
+        } => {
+            let catalog_url = parse_release_url(&catalog_url)?;
+            let catalog = fetch_catalog(&catalog_url)?;
+            let rules_dir = resolve_rules_dir(config_path, rules_dir)?;
+            print_pack_list(&catalog, &rules_dir);
+            Ok(())
+        }
+        crate::cli::RulesAction::Install {
+            pack,
+            catalog_url,
+            rules_dir,
+        } => {
+            let catalog_url = parse_release_url(&catalog_url)?;
+            let catalog = fetch_catalog(&catalog_url)?;
+            let selected = catalog
+                .find_pack(&pack)
+                .with_context(|| format!("pack {pack} was not found in the catalog"))?;
+            validate_pack_installable(selected)?;
+            let artifact_url = resolve_artifact_url(&catalog_url, selected)?;
+            validate_release_url(&artifact_url)?;
+            let archive = fetch_url_bytes(&artifact_url, MAX_ARTIFACT_BYTES)
+                .with_context(|| format!("download {}", selected.artifact))?;
+            let rules_dir = resolve_rules_dir(config_path, rules_dir)?;
+            let outcome = install_pack_archive_bytes(&catalog, &pack, &rules_dir, &archive)?;
+            println!(
+                "Installed {} {} into {}",
+                outcome.pack_id,
+                outcome.version,
+                outcome.current_dir.display()
+            );
+            Ok(())
+        }
+    }
+}
+
+pub fn install_pack_archive_bytes(
+    catalog: &Catalog,
+    pack_id: &str,
+    rules_dir: &Path,
+    archive: &[u8],
+) -> Result<InstallOutcome> {
+    if archive.len() as u64 > MAX_ARTIFACT_BYTES {
+        bail!("artifact exceeds maximum download size");
+    }
+
+    let pack = catalog
+        .find_pack(pack_id)
+        .with_context(|| format!("pack {pack_id} was not found in the catalog"))?
+        .clone();
+    validate_pack_installable(&pack)?;
+    verify_sha256(archive, &pack.sha256)?;
+
+    fs::create_dir_all(rules_dir)
+        .with_context(|| format!("create rules directory {}", rules_dir.display()))?;
+    let staging_dir = rules_dir.join("staging");
+    fs::create_dir_all(&staging_dir)
+        .with_context(|| format!("create staging directory {}", staging_dir.display()))?;
+    let work_dir = staging_dir.join(format!(
+        "install-{}-{}",
+        std::process::id(),
+        Utc::now().timestamp_nanos_opt().unwrap_or_default()
+    ));
+    recreate_dir(&work_dir)?;
+    let _cleanup = WorkDirCleanup(work_dir.clone());
+
+    let archive_path = work_dir.join("artifact.zip");
+    fs::write(&archive_path, archive)
+        .with_context(|| format!("write staged artifact {}", archive_path.display()))?;
+
+    let extracted_dir = work_dir.join("extracted");
+    fs::create_dir_all(&extracted_dir)?;
+    extract_zip_safely(&archive_path, &extracted_dir)?;
+    validate_extracted_pack(&extracted_dir, &pack)?;
+
+    let next_current = work_dir.join("current-next");
+    prepare_current_dir(&extracted_dir, &next_current)?;
+
+    let state = RulesState {
+        pack_id: pack.id.clone(),
+        version: pack.version.clone(),
+        sha256: pack.sha256.clone(),
+        installed_at: Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true),
+    };
+    let state_next = work_dir.join("state-next.json");
+    let state_json = serde_json::to_vec_pretty(&state)?;
+    fs::write(&state_next, state_json)?;
+
+    let current_dir = rules_dir.join("current");
+    atomic_replace_active(rules_dir, &staging_dir, &next_current, &state_next)?;
+    Ok(InstallOutcome {
+        pack_id: pack.id,
+        version: pack.version,
+        current_dir,
+    })
+}
+
+pub fn read_state(rules_dir: &Path) -> Option<RulesState> {
+    let state_path = rules_dir.join("state.json");
+    let bytes = fs::read(state_path).ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+fn fetch_catalog(catalog_url: &Url) -> Result<Catalog> {
+    let bytes = fetch_url_bytes(catalog_url, MAX_CATALOG_BYTES)
+        .with_context(|| format!("download catalog {catalog_url}"))?;
+    Catalog::from_slice(&bytes)
+}
+
+fn fetch_url_bytes(url: &Url, max_bytes: u64) -> Result<Vec<u8>> {
+    let response = reqwest::blocking::get(url.as_str())?.error_for_status()?;
+    if let Some(length) = response.content_length() {
+        if length > max_bytes {
+            bail!("download is too large: {length} bytes");
+        }
+    }
+
+    let mut limited = response.take(max_bytes + 1);
+    let mut bytes = Vec::new();
+    limited.read_to_end(&mut bytes)?;
+    if bytes.len() as u64 > max_bytes {
+        bail!("download exceeds maximum size");
+    }
+    Ok(bytes)
+}
+
+fn print_pack_list(catalog: &Catalog, rules_dir: &Path) {
+    let active = read_state(rules_dir).map(|state| state.pack_id);
+    println!("Available rules packs for {}:", current_os());
+    println!(
+        "{:<22} {:<10} {:<10} {:>5} {:>5} {:<14} ACTIVE",
+        "ID", "VERSION", "LEVEL", "RULES", "IOC", "STATUS"
+    );
+    for pack in catalog.compatible_packs() {
+        let marker = if active.as_deref() == Some(pack.id.as_str()) {
+            "*"
+        } else {
+            ""
+        };
+        println!(
+            "{:<22} {:<10} {:<10} {:>5} {:>5} {:<14} {}",
+            pack.id, pack.version, pack.level, pack.rule_count, pack.ioc_count, pack.status, marker
+        );
+    }
+}
+
+fn resolve_rules_dir(
+    config_path: Option<PathBuf>,
+    override_dir: Option<PathBuf>,
+) -> Result<PathBuf> {
+    if let Some(path) = override_dir {
+        return Ok(path);
+    }
+
+    let cfg = AppConfig::from_config_path(config_path).context("load configuration")?;
+    Ok(infer_rules_dir(&cfg))
+}
+
+fn infer_rules_dir(cfg: &AppConfig) -> PathBuf {
+    let sigma = &cfg.scanner.sigma_rules_path;
+    if sigma.file_name().and_then(|name| name.to_str()) == Some("sigma") {
+        if let Some(parent) = sigma.parent() {
+            if parent.file_name().and_then(|name| name.to_str()) == Some("current") {
+                if let Some(root) = parent.parent() {
+                    return root.to_path_buf();
+                }
+            }
+            return parent.to_path_buf();
+        }
+    }
+    PathBuf::from("rules")
+}
+
+fn validate_catalog_pack(pack: &CatalogPack) -> Result<()> {
+    if pack.id.trim().is_empty() {
+        bail!("catalog pack has empty id");
+    }
+    if pack.name.trim().is_empty() {
+        bail!("catalog pack {} has empty name", pack.id);
+    }
+    match pack.os.as_str() {
+        "windows" | "linux" | "macos" => {}
+        _ => bail!("catalog pack {} has unsupported os {}", pack.id, pack.os),
+    }
+    if pack.artifact.trim().is_empty() {
+        bail!("catalog pack {} has empty artifact", pack.id);
+    }
+    parse_sha256(&pack.sha256)
+        .with_context(|| format!("catalog pack {} has invalid sha256", pack.id))?;
+    VersionReq::parse(&pack.requires_rustinel)
+        .with_context(|| format!("catalog pack {} has invalid requires_rustinel", pack.id))?;
+    if let Some(engine) = &pack.engine {
+        validate_engine_paths(&pack.id, engine)?;
+    }
+    Ok(())
+}
+
+fn validate_engine_paths(pack_id: &str, engine: &CatalogEngine) -> Result<()> {
+    for (value, suffix) in [
+        (&engine.sigma_rules_path, "rules/sigma"),
+        (&engine.yara_rules_path, "rules/yara"),
+        (&engine.hashes_path, "rules/ioc/hashes.txt"),
+        (&engine.ips_path, "rules/ioc/ips.txt"),
+        (&engine.domains_path, "rules/ioc/domains.txt"),
+        (&engine.paths_regex_path, "rules/ioc/paths_regex.txt"),
+    ] {
+        let path = safe_catalog_path(value)
+            .with_context(|| format!("catalog pack {pack_id} has unsafe engine path {value}"))?;
+        let normalized = path.to_string_lossy().replace('\\', "/");
+        if !normalized.ends_with(suffix) {
+            bail!("catalog pack {pack_id} engine path {value} does not end with {suffix}");
+        }
+    }
+    Ok(())
+}
+
+fn safe_catalog_path(value: &str) -> Result<PathBuf> {
+    if value.is_empty() || value.contains('\\') {
+        bail!("unsafe path");
+    }
+    let path = Path::new(value);
+    let mut safe = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Normal(value) => safe.push(value),
+            _ => bail!("unsafe path"),
+        }
+    }
+    if safe.as_os_str().is_empty() {
+        bail!("unsafe path");
+    }
+    Ok(safe)
+}
+
+fn validate_pack_installable(pack: &CatalogPack) -> Result<()> {
+    if pack.os != current_os() {
+        bail!(
+            "pack {} targets {}, but this binary runs on {}",
+            pack.id,
+            pack.os,
+            current_os()
+        );
+    }
+
+    let req = VersionReq::parse(&pack.requires_rustinel)?;
+    let current = Version::parse(env!("CARGO_PKG_VERSION").trim_start_matches('v'))?;
+    if !req.matches(&current) {
+        bail!(
+            "pack {} requires Rustinel {}, but this binary is {}",
+            pack.id,
+            pack.requires_rustinel,
+            current
+        );
+    }
+    Ok(())
+}
+
+fn verify_sha256(bytes: &[u8], expected: &str) -> Result<()> {
+    let expected = parse_sha256(expected)?;
+    let actual = Sha256::digest(bytes);
+    if expected.as_slice() != actual.as_slice() {
+        bail!("artifact SHA-256 mismatch");
+    }
+    Ok(())
+}
+
+fn parse_sha256(value: &str) -> Result<Vec<u8>> {
+    let bytes = hex::decode(value)?;
+    if bytes.len() != 32 {
+        bail!("SHA-256 must be 32 bytes");
+    }
+    Ok(bytes)
+}
+
+fn extract_zip_safely(archive_path: &Path, destination: &Path) -> Result<()> {
+    let file = fs::File::open(archive_path)
+        .with_context(|| format!("open artifact {}", archive_path.display()))?;
+    let mut archive = ZipArchive::new(file).context("read artifact zip")?;
+    let mut total_size = 0u64;
+
+    for index in 0..archive.len() {
+        let mut file = archive.by_index(index)?;
+        let relative = safe_zip_path(file.name())?;
+        if is_symlink_entry(file.unix_mode()) {
+            bail!("zip entry {} is a symlink", file.name());
+        }
+        total_size = total_size
+            .checked_add(file.size())
+            .context("zip extracted size overflow")?;
+        if total_size > MAX_EXTRACTED_BYTES {
+            bail!("zip exceeds maximum extracted size");
+        }
+
+        let output_path = destination.join(relative);
+        if file.is_dir() {
+            fs::create_dir_all(&output_path)?;
+            continue;
+        }
+
+        if let Some(parent) = output_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let mut output = fs::File::create(&output_path)?;
+        std::io::copy(&mut file, &mut output)?;
+    }
+    Ok(())
+}
+
+fn safe_zip_path(name: &str) -> Result<PathBuf> {
+    if name.is_empty() || name.contains('\\') {
+        bail!("unsafe zip entry {}", name);
+    }
+    let path = Path::new(name);
+    let mut safe = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Normal(value) => safe.push(value),
+            _ => bail!("unsafe zip entry {}", name),
+        }
+    }
+    if safe.as_os_str().is_empty() {
+        bail!("unsafe zip entry {}", name);
+    }
+    Ok(safe)
+}
+
+fn is_symlink_entry(mode: Option<u32>) -> bool {
+    mode.map(|mode| mode & 0o170000 == 0o120000)
+        .unwrap_or(false)
+}
+
+fn validate_extracted_pack(extracted_dir: &Path, pack: &CatalogPack) -> Result<()> {
+    let manifest_path = extracted_dir.join("pack.yml");
+    let manifest_bytes = fs::read(&manifest_path)
+        .with_context(|| format!("read manifest {}", manifest_path.display()))?;
+    let manifest: PackManifest =
+        serde_yaml::from_slice(&manifest_bytes).context("parse pack manifest")?;
+    validate_manifest(&manifest, pack)?;
+
+    for path in [
+        extracted_dir.join("rules").join("sigma"),
+        extracted_dir.join("rules").join("yara"),
+        extracted_dir.join("rules").join("ioc"),
+    ] {
+        if !path.is_dir() {
+            bail!("pack is missing expected directory {}", path.display());
+        }
+    }
+
+    for file in ["hashes.txt", "ips.txt", "domains.txt", "paths_regex.txt"] {
+        let path = extracted_dir.join("rules").join("ioc").join(file);
+        if !path.is_file() {
+            bail!("pack is missing expected IOC file {}", path.display());
+        }
+    }
+    Ok(())
+}
+
+fn validate_manifest(manifest: &PackManifest, pack: &CatalogPack) -> Result<()> {
+    if !SUPPORTED_PACK_SCHEMA_VERSIONS.contains(&manifest.pack_schema_version) {
+        bail!(
+            "unsupported pack manifest schema {}",
+            manifest.pack_schema_version
+        );
+    }
+    if manifest.id != pack.id {
+        bail!(
+            "manifest id {} does not match catalog id {}",
+            manifest.id,
+            pack.id
+        );
+    }
+    if manifest.os != pack.os {
+        bail!(
+            "manifest os {} does not match catalog os {}",
+            manifest.os,
+            pack.os
+        );
+    }
+    if manifest.requires_rustinel != pack.requires_rustinel {
+        bail!("manifest requires_rustinel does not match catalog");
+    }
+    if manifest.name.trim().is_empty()
+        || manifest.description.trim().is_empty()
+        || manifest.level.trim().is_empty()
+        || manifest.status.trim().is_empty()
+    {
+        bail!("manifest has empty required fields");
+    }
+    let _ = manifest.default;
+    let _ = &manifest.extends;
+    Ok(())
+}
+
+struct WorkDirCleanup(PathBuf);
+
+impl Drop for WorkDirCleanup {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+fn prepare_current_dir(extracted_dir: &Path, next_current: &Path) -> Result<()> {
+    recreate_dir(next_current)?;
+    fs::copy(
+        extracted_dir.join("pack.yml"),
+        next_current.join("pack.yml"),
+    )?;
+    for dir in ["sigma", "yara", "ioc"] {
+        fs::rename(
+            extracted_dir.join("rules").join(dir),
+            next_current.join(dir),
+        )?;
+    }
+    Ok(())
+}
+
+fn atomic_replace_active(
+    rules_dir: &Path,
+    staging_dir: &Path,
+    next_current: &Path,
+    next_state: &Path,
+) -> Result<()> {
+    let current = rules_dir.join("current");
+    let state = rules_dir.join("state.json");
+    let previous_current = staging_dir.join("previous-current");
+    let previous_state = staging_dir.join("previous-state.json");
+    let _ = fs::remove_dir_all(&previous_current);
+    let _ = fs::remove_file(&previous_state);
+
+    if current.exists() {
+        fs::rename(&current, &previous_current)
+            .with_context(|| format!("move current rules {}", current.display()))?;
+    }
+    if state.exists() {
+        fs::rename(&state, &previous_state)
+            .with_context(|| format!("move current state {}", state.display()))?;
+    }
+
+    if let Err(err) = fs::rename(next_current, &current) {
+        restore_previous(&current, &state, &previous_current, &previous_state);
+        return Err(err).context("activate staged rules");
+    }
+
+    if let Err(err) = fs::rename(next_state, &state) {
+        let _ = fs::remove_dir_all(&current);
+        restore_previous(&current, &state, &previous_current, &previous_state);
+        return Err(err).context("activate rules state");
+    }
+
+    let _ = fs::remove_dir_all(previous_current);
+    let _ = fs::remove_file(previous_state);
+    Ok(())
+}
+
+fn restore_previous(current: &Path, state: &Path, previous_current: &Path, previous_state: &Path) {
+    if previous_current.exists() {
+        let _ = fs::rename(previous_current, current);
+    }
+    if previous_state.exists() {
+        let _ = fs::rename(previous_state, state);
+    }
+}
+
+fn recreate_dir(path: &Path) -> Result<()> {
+    if path.exists() {
+        fs::remove_dir_all(path)?;
+    }
+    fs::create_dir_all(path)?;
+    Ok(())
+}
+
+fn parse_release_url(value: &str) -> Result<Url> {
+    let url = Url::parse(value).with_context(|| format!("parse URL {value}"))?;
+    validate_release_url(&url)?;
+    Ok(url)
+}
+
+fn validate_release_url(url: &Url) -> Result<()> {
+    if url.scheme() != "https" {
+        bail!("rules catalog trust model requires HTTPS release URLs");
+    }
+    if url.host_str() != Some("github.com") {
+        bail!("rules catalog trust model requires github.com release URLs");
+    }
+    if !url.path().contains("/releases/") {
+        bail!("rules catalog trust model requires GitHub release assets");
+    }
+    Ok(())
+}
+
+fn resolve_artifact_url(catalog_url: &Url, pack: &CatalogPack) -> Result<Url> {
+    catalog_url
+        .join(&pack.artifact)
+        .with_context(|| format!("resolve artifact URL {}", pack.artifact))
+}
+
+fn current_os() -> &'static str {
+    if cfg!(windows) {
+        "windows"
+    } else if cfg!(target_os = "macos") {
+        "macos"
+    } else {
+        "linux"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Cursor, Write};
+
+    use zip::{write::SimpleFileOptions, ZipWriter};
+
+    #[test]
+    fn install_pack_replaces_current_and_writes_state() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let archive = pack_zip(current_os(), "demo-pack");
+        let catalog = catalog_for("demo-pack", current_os(), &archive);
+
+        let outcome =
+            install_pack_archive_bytes(&catalog, "demo-pack", temp.path(), &archive).unwrap();
+
+        assert_eq!(outcome.pack_id, "demo-pack");
+        assert!(temp.path().join("current").join("pack.yml").is_file());
+        assert!(temp
+            .path()
+            .join("current")
+            .join("sigma")
+            .join("demo.yml")
+            .is_file());
+        let state = read_state(temp.path()).expect("state");
+        assert_eq!(state.pack_id, "demo-pack");
+    }
+
+    #[test]
+    fn install_rejects_wrong_os() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let wrong_os = if current_os() == "linux" {
+            "windows"
+        } else {
+            "linux"
+        };
+        let archive = pack_zip(wrong_os, "wrong-pack");
+        let catalog = catalog_for("wrong-pack", wrong_os, &archive);
+
+        let err = install_pack_archive_bytes(&catalog, "wrong-pack", temp.path(), &archive)
+            .expect_err("wrong os should fail");
+
+        assert!(err.to_string().contains("targets"));
+    }
+
+    #[test]
+    fn install_accepts_released_schema_v1_manifest() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let archive = pack_zip_with_schema(current_os(), "schema-one-pack", 1);
+        let catalog = catalog_for("schema-one-pack", current_os(), &archive);
+
+        let outcome =
+            install_pack_archive_bytes(&catalog, "schema-one-pack", temp.path(), &archive)
+                .expect("schema v1 should install");
+
+        assert_eq!(outcome.pack_id, "schema-one-pack");
+    }
+
+    #[test]
+    fn unsafe_zip_entry_is_rejected_before_current_is_replaced() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        fs::create_dir_all(temp.path().join("current").join("sigma")).unwrap();
+        fs::write(
+            temp.path().join("current").join("pack.yml"),
+            b"previous: true\n",
+        )
+        .unwrap();
+        let archive = unsafe_pack_zip();
+        let catalog = catalog_for("demo-pack", current_os(), &archive);
+
+        let err = install_pack_archive_bytes(&catalog, "demo-pack", temp.path(), &archive)
+            .expect_err("unsafe zip should fail");
+
+        assert!(err.to_string().contains("unsafe zip entry"));
+        assert_eq!(
+            fs::read(temp.path().join("current").join("pack.yml")).unwrap(),
+            b"previous: true\n"
+        );
+    }
+
+    #[test]
+    fn catalog_filters_compatible_packs() {
+        let archive = pack_zip(current_os(), "demo-pack");
+        let mut catalog = catalog_for("demo-pack", current_os(), &archive);
+        catalog.packs.push(CatalogPack {
+            os: if current_os() == "linux" {
+                "windows".to_string()
+            } else {
+                "linux".to_string()
+            },
+            id: "other-pack".to_string(),
+            name: "Other Pack".to_string(),
+            level: "essential".to_string(),
+            version: "0.1.0".to_string(),
+            default: false,
+            requires_rustinel: ">=1.0.0".to_string(),
+            status: "test".to_string(),
+            rule_count: 1,
+            ioc_count: 0,
+            artifact: "other.zip".to_string(),
+            sha256: sha256_hex(&archive),
+            engine: None,
+        });
+
+        let packs = catalog.compatible_packs();
+
+        assert_eq!(packs.len(), 1);
+        assert_eq!(packs[0].id, "demo-pack");
+    }
+
+    fn catalog_for(id: &str, os: &str, archive: &[u8]) -> Catalog {
+        Catalog {
+            schema: INDEX_SCHEMA.to_string(),
+            release_version: "0.1.0".to_string(),
+            packs: vec![CatalogPack {
+                id: id.to_string(),
+                name: "Demo Pack".to_string(),
+                os: os.to_string(),
+                level: "essential".to_string(),
+                version: "0.1.0".to_string(),
+                default: true,
+                requires_rustinel: ">=1.0.0".to_string(),
+                status: "test".to_string(),
+                rule_count: 1,
+                ioc_count: 4,
+                artifact: "demo.zip".to_string(),
+                sha256: sha256_hex(archive),
+                engine: Some(CatalogEngine {
+                    sigma_rules_path: format!("{id}/rules/sigma"),
+                    yara_rules_path: format!("{id}/rules/yara"),
+                    hashes_path: format!("{id}/rules/ioc/hashes.txt"),
+                    ips_path: format!("{id}/rules/ioc/ips.txt"),
+                    domains_path: format!("{id}/rules/ioc/domains.txt"),
+                    paths_regex_path: format!("{id}/rules/ioc/paths_regex.txt"),
+                }),
+            }],
+        }
+    }
+
+    fn pack_zip(os: &str, id: &str) -> Vec<u8> {
+        pack_zip_with_schema(os, id, 2)
+    }
+
+    fn pack_zip_with_schema(os: &str, id: &str, schema_version: u32) -> Vec<u8> {
+        let mut cursor = Cursor::new(Vec::new());
+        {
+            let mut zip = ZipWriter::new(&mut cursor);
+            let options = SimpleFileOptions::default();
+            zip.start_file("pack.yml", options).unwrap();
+            zip.write_all(manifest(os, id, schema_version).as_bytes())
+                .unwrap();
+            zip.start_file("rules/sigma/demo.yml", options).unwrap();
+            zip.write_all(b"title: Demo\n").unwrap();
+            zip.start_file("rules/yara/demo.yar", options).unwrap();
+            zip.write_all(b"rule demo { condition: true }\n").unwrap();
+            for file in ["hashes.txt", "ips.txt", "domains.txt", "paths_regex.txt"] {
+                zip.start_file(format!("rules/ioc/{file}"), options)
+                    .unwrap();
+                zip.write_all(b"\n").unwrap();
+            }
+            zip.finish().unwrap();
+        }
+        cursor.into_inner()
+    }
+
+    fn unsafe_pack_zip() -> Vec<u8> {
+        let mut cursor = Cursor::new(Vec::new());
+        {
+            let mut zip = ZipWriter::new(&mut cursor);
+            let options = SimpleFileOptions::default();
+            zip.start_file("../pack.yml", options).unwrap();
+            zip.write_all(b"bad: true\n").unwrap();
+            zip.finish().unwrap();
+        }
+        cursor.into_inner()
+    }
+
+    fn manifest(os: &str, id: &str, schema_version: u32) -> String {
+        format!(
+            r#"name: Demo Pack
+id: {id}
+description: Demo rules
+os: {os}
+level: essential
+pack_schema_version: {schema_version}
+requires_rustinel: ">=1.0.0"
+default: true
+status: test
+extends: []
+"#
+        )
+    }
+
+    fn sha256_hex(bytes: &[u8]) -> String {
+        hex::encode(Sha256::digest(bytes))
+    }
+}

--- a/src/runtime/orchestration.rs
+++ b/src/runtime/orchestration.rs
@@ -32,6 +32,7 @@ pub fn run() -> anyhow::Result<()> {
         None => crate::runtime::windows::run_console(true, cli.log_level, cli.config, None),
         Some(Commands::Doctor { .. }) => unreachable!("doctor is handled before service dispatch"),
         Some(Commands::Service { action }) => crate::platform::handle_service_command(action),
+        Some(Commands::Rules { action }) => crate::rules::run_cli(action, cli.config),
     }
 }
 
@@ -45,6 +46,7 @@ pub fn run() -> anyhow::Result<()> {
             let code = crate::doctor::run_cli(cli.config, json)?;
             std::process::exit(code);
         }
+        Some(Commands::Rules { action }) => crate::rules::run_cli(action, cli.config),
         Some(Commands::Run {
             no_console,
             sigma_engine,
@@ -69,6 +71,7 @@ pub fn run() -> anyhow::Result<()> {
             let code = crate::doctor::run_cli(cli.config, json)?;
             std::process::exit(code);
         }
+        Some(Commands::Rules { action }) => crate::rules::run_cli(action, cli.config),
         Some(Commands::Run {
             no_console,
             sigma_engine,


### PR DESCRIPTION
## Summary

- Add `rustinel rules list` and `rustinel rules install <PACK>` for released rules packs.
- Validate catalog schema, platform, version requirements, engine paths, checksums, ZIP entries, extracted size, and pack layout before activation.
- Move default managed rule paths to `rules/current` and document the Phase 1 release asset trust model.

Closes #107

## Validation

- `cargo fmt --all -- --check`
- `cargo test --locked`
- `cargo clippy --locked --all-targets -- -D clippy::all`
- `cargo deny --locked check`
- Live smoke: `rules list` and `rules install macos-essential` against the released catalog using a temp rules directory

Note: `cargo deny --locked check` still reports the existing yanked `num-bigint` warning, but exits successfully.