### PR TITLE
feat(cli): add managed setup command

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -83,6 +83,40 @@ rules/
 +-- state.json
 ```
 
+### `setup`
+
+Install Rustinel into the managed platform layout, install a rules pack,
+register the native service, optionally start it, and run health checks.
+
+```text
+rustinel setup [--pack <essential|advanced>] [--yes] [--no-start] [--force]
+```
+
+Examples:
+
+```powershell
+rustinel setup --yes
+rustinel setup --pack advanced --no-start
+```
+
+```bash
+sudo rustinel setup --yes
+sudo rustinel setup --pack advanced --no-start
+```
+
+Behavior:
+
+- `setup` creates the managed configuration, rules, log, alert, and binary directories before writing files.
+- `--pack` chooses the Essential or Advanced rules pack. Without `--pack`, interactive terminals prompt for a pack and non-interactive runs use Essential.
+- `--yes` accepts defaults and skips the prompt.
+- `--no-start` registers the native service without starting it.
+- `--force` replaces an existing managed configuration. Without `--force`, existing configuration is preserved and validated before setup continues.
+- The current executable is copied to the managed service binary path before service registration.
+- Rules pack downloads use the same catalog validation, SHA-256 verification, ZIP safety checks, and atomic activation as `rules install`.
+- If a rules download or validation fails, setup preserves existing active rules and continues only when an existing active pack is valid.
+- If service installation or startup fails, setup leaves configuration and rules in place and prints the exact recovery command.
+- The final summary prints configuration, rules, logs, alerts, service binary, active pack, and service status.
+
 ### `service`
 
 Manage native service installation and lifecycle.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -52,6 +52,37 @@ Full Disk Access setup and [Development](development.md) for signing details.
 
 Use absolute paths in `config.toml` once you move beyond the default repo layout.
 
+## Managed Setup
+
+For a persistent endpoint installation, use the managed setup command:
+
+```powershell
+rustinel setup --yes
+```
+
+```bash
+sudo rustinel setup --yes
+```
+
+`setup` prepares the managed layout, writes a managed configuration when needed,
+downloads and verifies the selected rules pack, copies the current executable to
+the service binary path, registers the native service, starts it unless
+`--no-start` is supplied, runs health checks, and prints the final paths and
+service status. Existing managed configuration is preserved unless `--force` is
+supplied.
+
+Pack selection:
+
+```bash
+sudo rustinel setup --pack essential
+sudo rustinel setup --pack advanced --no-start
+```
+
+Without `--pack`, an interactive terminal prompts for Essential or Advanced.
+Non-interactive setup defaults to Essential. If rules download or verification
+fails, setup preserves existing active rules and continues only when the active
+pack is valid.
+
 ## Working Directory Rules
 
 - `config.toml` is loaded from the current working directory, falling back to the

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -44,6 +44,24 @@ impl SigmaEngineArg {
 
 #[derive(clap::Subcommand)]
 pub enum Commands {
+    /// Install Rustinel into the managed platform layout
+    Setup {
+        /// Rules pack level to install
+        #[arg(long, value_enum, value_name = "PACK")]
+        pack: Option<SetupPack>,
+        /// Accept defaults and do not prompt
+        #[arg(long)]
+        yes: bool,
+        /// Register the service but do not start it
+        #[arg(long)]
+        no_start: bool,
+        /// Replace existing managed configuration
+        #[arg(long)]
+        force: bool,
+        /// Rules catalog index URL
+        #[arg(long, default_value = crate::rules::DEFAULT_CATALOG_URL)]
+        catalog_url: String,
+    },
     /// Run in the foreground with console output
     Run {
         /// Compatibility alias; console output is enabled by default
@@ -73,6 +91,21 @@ pub enum Commands {
         #[command(subcommand)]
         action: RulesAction,
     },
+}
+
+#[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SetupPack {
+    Essential,
+    Advanced,
+}
+
+impl SetupPack {
+    pub fn level(self) -> &'static str {
+        match self {
+            Self::Essential => "essential",
+            Self::Advanced => "advanced",
+        }
+    }
 }
 
 #[derive(clap::Subcommand, Copy, Clone)]
@@ -207,6 +240,37 @@ mod tests {
             cli.config,
             Some(std::path::PathBuf::from("/tmp/rustinel.toml"))
         );
+    }
+
+    #[test]
+    fn setup_accepts_managed_install_flags() {
+        let cli = Cli::try_parse_from([
+            "rustinel",
+            "setup",
+            "--pack",
+            "advanced",
+            "--yes",
+            "--no-start",
+            "--force",
+        ])
+        .expect("setup should parse");
+
+        match cli.command {
+            Some(Commands::Setup {
+                pack,
+                yes,
+                no_start,
+                force,
+                catalog_url,
+            }) => {
+                assert_eq!(pack, Some(SetupPack::Advanced));
+                assert!(yes);
+                assert!(no_start);
+                assert!(force);
+                assert!(catalog_url.ends_with("/index.json"));
+            }
+            _ => panic!("expected setup command"),
+        }
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,5 +19,6 @@ pub mod runtime;
 pub mod scanner;
 pub mod sensor;
 pub mod service;
+pub mod setup;
 pub mod state;
 pub mod utils;

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -5,13 +5,18 @@ use anyhow::{bail, Context};
 
 use crate::cli::ServiceAction;
 use crate::service::{
-    execute_backend_action, systemd_status_from_state, ManagedServicePaths, ServiceBackend,
-    ServiceStatus, SystemdDefinition, SYSTEMD_SERVICE_NAME,
+    execute_backend_action, run_backend_action, systemd_status_from_state, ManagedServicePaths,
+    ServiceBackend, ServiceCommandResult, ServiceStatus, SystemdDefinition, SYSTEMD_SERVICE_NAME,
 };
 
 pub fn handle_service_command(action: ServiceAction) -> anyhow::Result<()> {
     let backend = SystemdBackend::new();
     execute_backend_action(&backend, action)
+}
+
+pub fn run_service_action(action: ServiceAction) -> anyhow::Result<ServiceCommandResult> {
+    let backend = SystemdBackend::new();
+    run_backend_action(&backend, action)
 }
 
 struct SystemdBackend {

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -5,13 +5,18 @@ use anyhow::{bail, Context};
 
 use crate::cli::ServiceAction;
 use crate::service::{
-    execute_backend_action, launchd_status_from_output, LaunchdDefinition, ManagedServicePaths,
-    ServiceBackend, ServiceStatus, LAUNCHD_LABEL,
+    execute_backend_action, launchd_status_from_output, run_backend_action, LaunchdDefinition,
+    ManagedServicePaths, ServiceBackend, ServiceCommandResult, ServiceStatus, LAUNCHD_LABEL,
 };
 
 pub fn handle_service_command(action: ServiceAction) -> anyhow::Result<()> {
     let backend = LaunchdBackend::new();
     execute_backend_action(&backend, action)
+}
+
+pub fn run_service_action(action: ServiceAction) -> anyhow::Result<ServiceCommandResult> {
+    let backend = LaunchdBackend::new();
+    run_backend_action(&backend, action)
 }
 
 struct LaunchdBackend {

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -12,9 +12,23 @@ pub fn handle_service_command(action: crate::cli::ServiceAction) -> anyhow::Resu
     windows::handle_service_command(action)
 }
 
+#[cfg(windows)]
+pub fn run_service_action(
+    action: crate::cli::ServiceAction,
+) -> anyhow::Result<crate::service::ServiceCommandResult> {
+    windows::run_service_action(action)
+}
+
 #[cfg(target_os = "linux")]
 pub fn handle_service_command(action: crate::cli::ServiceAction) -> anyhow::Result<()> {
     linux::handle_service_command(action)
+}
+
+#[cfg(target_os = "linux")]
+pub fn run_service_action(
+    action: crate::cli::ServiceAction,
+) -> anyhow::Result<crate::service::ServiceCommandResult> {
+    linux::run_service_action(action)
 }
 
 #[cfg(target_os = "macos")]
@@ -22,8 +36,24 @@ pub fn handle_service_command(action: crate::cli::ServiceAction) -> anyhow::Resu
     macos::handle_service_command(action)
 }
 
+#[cfg(target_os = "macos")]
+pub fn run_service_action(
+    action: crate::cli::ServiceAction,
+) -> anyhow::Result<crate::service::ServiceCommandResult> {
+    macos::run_service_action(action)
+}
+
 #[cfg(not(any(windows, target_os = "linux", target_os = "macos")))]
 pub fn handle_service_command(_action: crate::cli::ServiceAction) -> anyhow::Result<()> {
+    Err(anyhow::anyhow!(
+        "Service commands are only supported on Windows, Linux, and macOS"
+    ))
+}
+
+#[cfg(not(any(windows, target_os = "linux", target_os = "macos")))]
+pub fn run_service_action(
+    _action: crate::cli::ServiceAction,
+) -> anyhow::Result<crate::service::ServiceCommandResult> {
     Err(anyhow::anyhow!(
         "Service commands are only supported on Windows, Linux, and macOS"
     ))

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -2,8 +2,9 @@ use std::ffi::OsString;
 
 use crate::cli::ServiceAction;
 use crate::service::{
-    execute_backend_action, ManagedServicePaths, ServiceBackend, ServiceStatus,
-    SERVICE_DESCRIPTION, WINDOWS_SERVICE_DISPLAY_NAME, WINDOWS_SERVICE_NAME,
+    execute_backend_action, run_backend_action, ManagedServicePaths, ServiceBackend,
+    ServiceCommandResult, ServiceStatus, SERVICE_DESCRIPTION, WINDOWS_SERVICE_DISPLAY_NAME,
+    WINDOWS_SERVICE_NAME,
 };
 use crate::state::ProcessCache;
 
@@ -12,6 +13,11 @@ pub const SERVICE_NAME: &str = WINDOWS_SERVICE_NAME;
 pub fn handle_service_command(action: ServiceAction) -> anyhow::Result<()> {
     let backend = WindowsServiceBackend::new();
     execute_backend_action(&backend, action)
+}
+
+pub fn run_service_action(action: ServiceAction) -> anyhow::Result<ServiceCommandResult> {
+    let backend = WindowsServiceBackend::new();
+    run_backend_action(&backend, action)
 }
 
 struct WindowsServiceBackend {

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -104,7 +104,7 @@ impl Catalog {
             .collect::<Vec<_>>()
     }
 
-    fn find_pack(&self, pack_id: &str) -> Option<&CatalogPack> {
+    pub fn find_pack(&self, pack_id: &str) -> Option<&CatalogPack> {
         self.packs.iter().find(|pack| pack.id == pack_id)
     }
 
@@ -226,19 +226,36 @@ pub fn install_pack_archive_bytes(
     })
 }
 
+pub fn download_and_install_pack(
+    catalog_url: &Url,
+    catalog: &Catalog,
+    pack_id: &str,
+    rules_dir: &Path,
+) -> Result<InstallOutcome> {
+    let selected = catalog
+        .find_pack(pack_id)
+        .with_context(|| format!("pack {pack_id} was not found in the catalog"))?;
+    validate_pack_installable(selected)?;
+    let artifact_url = resolve_artifact_url(catalog_url, selected)?;
+    validate_release_url(&artifact_url)?;
+    let archive = fetch_url_bytes(&artifact_url, MAX_ARTIFACT_BYTES)
+        .with_context(|| format!("download {}", selected.artifact))?;
+    install_pack_archive_bytes(catalog, pack_id, rules_dir, &archive)
+}
+
 pub fn read_state(rules_dir: &Path) -> Option<RulesState> {
     let state_path = rules_dir.join("state.json");
     let bytes = fs::read(state_path).ok()?;
     serde_json::from_slice(&bytes).ok()
 }
 
-fn fetch_catalog(catalog_url: &Url) -> Result<Catalog> {
+pub fn fetch_catalog(catalog_url: &Url) -> Result<Catalog> {
     let bytes = fetch_url_bytes(catalog_url, MAX_CATALOG_BYTES)
         .with_context(|| format!("download catalog {catalog_url}"))?;
     Catalog::from_slice(&bytes)
 }
 
-fn fetch_url_bytes(url: &Url, max_bytes: u64) -> Result<Vec<u8>> {
+pub fn fetch_url_bytes(url: &Url, max_bytes: u64) -> Result<Vec<u8>> {
     let response = reqwest::blocking::get(url.as_str())?.error_for_status()?;
     if let Some(length) = response.content_length() {
         if length > max_bytes {
@@ -363,7 +380,7 @@ fn safe_catalog_path(value: &str) -> Result<PathBuf> {
     Ok(safe)
 }
 
-fn validate_pack_installable(pack: &CatalogPack) -> Result<()> {
+pub fn validate_pack_installable(pack: &CatalogPack) -> Result<()> {
     if pack.os != current_os() {
         bail!(
             "pack {} targets {}, but this binary runs on {}",
@@ -601,7 +618,7 @@ fn recreate_dir(path: &Path) -> Result<()> {
     Ok(())
 }
 
-fn parse_release_url(value: &str) -> Result<Url> {
+pub fn parse_release_url(value: &str) -> Result<Url> {
     let url = Url::parse(value).with_context(|| format!("parse URL {value}"))?;
     validate_release_url(&url)?;
     Ok(url)
@@ -620,7 +637,7 @@ fn validate_release_url(url: &Url) -> Result<()> {
     Ok(())
 }
 
-fn resolve_artifact_url(catalog_url: &Url, pack: &CatalogPack) -> Result<Url> {
+pub fn resolve_artifact_url(catalog_url: &Url, pack: &CatalogPack) -> Result<Url> {
     catalog_url
         .join(&pack.artifact)
         .with_context(|| format!("resolve artifact URL {}", pack.artifact))

--- a/src/runtime/orchestration.rs
+++ b/src/runtime/orchestration.rs
@@ -33,6 +33,19 @@ pub fn run() -> anyhow::Result<()> {
         Some(Commands::Doctor { .. }) => unreachable!("doctor is handled before service dispatch"),
         Some(Commands::Service { action }) => crate::platform::handle_service_command(action),
         Some(Commands::Rules { action }) => crate::rules::run_cli(action, cli.config),
+        Some(Commands::Setup {
+            pack,
+            yes,
+            no_start,
+            force,
+            catalog_url,
+        }) => crate::setup::run_cli(crate::setup::SetupOptions {
+            pack,
+            yes,
+            no_start,
+            force,
+            catalog_url,
+        }),
     }
 }
 
@@ -47,6 +60,19 @@ pub fn run() -> anyhow::Result<()> {
             std::process::exit(code);
         }
         Some(Commands::Rules { action }) => crate::rules::run_cli(action, cli.config),
+        Some(Commands::Setup {
+            pack,
+            yes,
+            no_start,
+            force,
+            catalog_url,
+        }) => crate::setup::run_cli(crate::setup::SetupOptions {
+            pack,
+            yes,
+            no_start,
+            force,
+            catalog_url,
+        }),
         Some(Commands::Run {
             no_console,
             sigma_engine,
@@ -72,6 +98,19 @@ pub fn run() -> anyhow::Result<()> {
             std::process::exit(code);
         }
         Some(Commands::Rules { action }) => crate::rules::run_cli(action, cli.config),
+        Some(Commands::Setup {
+            pack,
+            yes,
+            no_start,
+            force,
+            catalog_url,
+        }) => crate::setup::run_cli(crate::setup::SetupOptions {
+            pack,
+            yes,
+            no_start,
+            force,
+            catalog_url,
+        }),
         Some(Commands::Run {
             no_console,
             sigma_engine,

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1,0 +1,455 @@
+use std::fs;
+use std::io::{self, IsTerminal, Write};
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context, Result};
+
+use crate::cli::{ServiceAction, SetupPack};
+use crate::config::{ConfigLoadOptions, InstallLayout, InstallPlatform};
+use crate::doctor::{self, DiagnosticStatus};
+use crate::rules::{self, Catalog, CatalogPack, InstallOutcome};
+use crate::service::{ManagedServicePaths, ServiceCommandResult, ServiceStatus};
+
+pub struct SetupOptions {
+    pub pack: Option<SetupPack>,
+    pub yes: bool,
+    pub no_start: bool,
+    pub force: bool,
+    pub catalog_url: String,
+}
+
+pub fn run_cli(options: SetupOptions) -> Result<()> {
+    let layout = InstallLayout::managed_current();
+    let service_paths = ManagedServicePaths::current();
+
+    println!("Preparing managed setup for Rustinel.");
+    create_managed_directories(&layout, &service_paths)?;
+    prepare_config(&layout, options.force)?;
+
+    let catalog_url = rules::parse_release_url(&options.catalog_url)?;
+    let catalog = rules::fetch_catalog(&catalog_url)?;
+    let pack = select_pack(&catalog, options.pack, options.yes)?;
+    let rules_outcome =
+        install_rules_with_recovery(&catalog_url, &catalog, &layout.rules_dir, pack)?;
+
+    install_binary(&service_paths.binary_path)?;
+    install_service(&layout, &service_paths)?;
+
+    let service_status = if options.no_start {
+        status_or_unknown()
+    } else {
+        start_service(&layout, &service_paths)?
+    };
+
+    let health_status = run_health_checks(&layout)?;
+    print_summary(
+        &layout,
+        &service_paths,
+        rules_outcome.as_ref(),
+        service_status,
+    );
+    print_macos_privacy_warning(layout.platform);
+
+    if health_status == DiagnosticStatus::Fail {
+        bail!("setup completed, but health checks failed");
+    }
+
+    Ok(())
+}
+
+fn create_managed_directories(
+    layout: &InstallLayout,
+    service_paths: &ManagedServicePaths,
+) -> Result<()> {
+    for path in managed_directories(layout, service_paths) {
+        fs::create_dir_all(&path)
+            .with_context(|| format!("create managed directory {}", path.display()))?;
+    }
+    Ok(())
+}
+
+fn managed_directories(
+    layout: &InstallLayout,
+    service_paths: &ManagedServicePaths,
+) -> Vec<PathBuf> {
+    let mut dirs = vec![
+        layout.rules_dir.clone(),
+        layout.logs_dir.clone(),
+        layout.alerts_dir.clone(),
+        service_paths.working_dir.clone(),
+    ];
+    if let Some(parent) = layout.config_file.parent() {
+        dirs.push(parent.to_path_buf());
+    }
+    if let Some(parent) = service_paths.binary_path.parent() {
+        dirs.push(parent.to_path_buf());
+    }
+    dirs
+}
+
+fn prepare_config(layout: &InstallLayout, force: bool) -> Result<()> {
+    if layout.config_file.exists() && !force {
+        validate_existing_config(&layout.config_file)?;
+        println!(
+            "Preserved existing configuration at {}",
+            layout.config_file.display()
+        );
+        return Ok(());
+    }
+
+    let contents = managed_config_toml(layout);
+    fs::write(&layout.config_file, contents).with_context(|| {
+        format!(
+            "write managed configuration {}",
+            layout.config_file.display()
+        )
+    })?;
+    println!(
+        "Wrote managed configuration to {}",
+        layout.config_file.display()
+    );
+    Ok(())
+}
+
+fn validate_existing_config(config_file: &Path) -> Result<()> {
+    crate::config::AppConfig::from_options(ConfigLoadOptions {
+        explicit_config: Some(config_file.to_path_buf()),
+        env_config: None,
+        managed_config: config_file.to_path_buf(),
+        exe_config: None,
+        cwd_config: PathBuf::from("config.toml"),
+    })
+    .with_context(|| {
+        format!(
+            "existing configuration at {} is not valid enough for setup; rerun with --force to replace it",
+            config_file.display()
+        )
+    })?;
+    Ok(())
+}
+
+fn managed_config_toml(layout: &InstallLayout) -> String {
+    let cfg = layout.managed_config();
+    format!(
+        "[scanner]\n\
+sigma_rules_path = {}\n\
+yara_rules_path = {}\n\
+\n\
+[logging]\n\
+directory = {}\n\
+\n\
+[alerts]\n\
+directory = {}\n\
+\n\
+[ioc]\n\
+hashes_path = {}\n\
+ips_path = {}\n\
+domains_path = {}\n\
+paths_regex_path = {}\n",
+        toml_string(&cfg.scanner.sigma_rules_path),
+        toml_string(&cfg.scanner.yara_rules_path),
+        toml_string(&cfg.logging.directory),
+        toml_string(&cfg.alerts.directory),
+        toml_string(&cfg.ioc.hashes_path),
+        toml_string(&cfg.ioc.ips_path),
+        toml_string(&cfg.ioc.domains_path),
+        toml_string(&cfg.ioc.paths_regex_path),
+    )
+}
+
+fn toml_string(path: &Path) -> String {
+    let value = path.to_string_lossy();
+    let escaped = value.replace('\\', "\\\\").replace('"', "\\\"");
+    format!("\"{escaped}\"")
+}
+
+fn select_pack(catalog: &Catalog, requested: Option<SetupPack>, yes: bool) -> Result<CatalogPack> {
+    let choice = match requested {
+        Some(pack) => pack,
+        None if yes || !io::stdin().is_terminal() => SetupPack::Essential,
+        None => prompt_pack_choice()?,
+    };
+
+    select_pack_by_level(catalog, choice)
+}
+
+fn prompt_pack_choice() -> Result<SetupPack> {
+    print!("Select rules pack [1] Essential [2] Advanced (default 1): ");
+    io::stdout().flush().context("flush setup prompt")?;
+    let mut input = String::new();
+    io::stdin()
+        .read_line(&mut input)
+        .context("read setup prompt")?;
+
+    match input.trim().to_ascii_lowercase().as_str() {
+        "" | "1" | "essential" | "e" => Ok(SetupPack::Essential),
+        "2" | "advanced" | "a" => Ok(SetupPack::Advanced),
+        other => bail!("unknown pack selection {other}"),
+    }
+}
+
+fn select_pack_by_level(catalog: &Catalog, choice: SetupPack) -> Result<CatalogPack> {
+    let level = choice.level();
+    let mut candidates = catalog
+        .compatible_packs()
+        .into_iter()
+        .filter(|pack| pack.level.eq_ignore_ascii_case(level))
+        .collect::<Vec<_>>();
+    candidates.sort_by_key(|pack| (!pack.default, pack.id.clone()));
+    candidates
+        .into_iter()
+        .next()
+        .cloned()
+        .with_context(|| format!("catalog has no compatible {level} pack for this platform"))
+}
+
+fn install_rules_with_recovery(
+    catalog_url: &url::Url,
+    catalog: &Catalog,
+    rules_dir: &Path,
+    pack: CatalogPack,
+) -> Result<Option<InstallOutcome>> {
+    match rules::download_and_install_pack(catalog_url, catalog, &pack.id, rules_dir) {
+        Ok(outcome) => {
+            println!(
+                "Installed rules pack {} {} into {}",
+                outcome.pack_id,
+                outcome.version,
+                outcome.current_dir.display()
+            );
+            Ok(Some(outcome))
+        }
+        Err(err) if active_rules_are_valid(rules_dir) => {
+            println!(
+                "Warning: could not install rules pack {}: {err}. Preserving existing active rules.",
+                pack.id
+            );
+            Ok(None)
+        }
+        Err(err) => Err(err).with_context(|| {
+            format!(
+                "install rules pack {}; no valid active rules were available to preserve",
+                pack.id
+            )
+        }),
+    }
+}
+
+fn active_rules_are_valid(rules_dir: &Path) -> bool {
+    let current = rules_dir.join("current");
+    rules::read_state(rules_dir).is_some()
+        && current.join("pack.yml").is_file()
+        && current.join("sigma").is_dir()
+        && current.join("yara").is_dir()
+        && current.join("ioc").is_dir()
+        && ["hashes.txt", "ips.txt", "domains.txt", "paths_regex.txt"]
+            .into_iter()
+            .all(|file| current.join("ioc").join(file).is_file())
+}
+
+fn install_binary(binary_path: &Path) -> Result<()> {
+    let current_exe = std::env::current_exe().context("locate current executable")?;
+    if same_file_best_effort(&current_exe, binary_path) {
+        println!("Managed binary already points to {}", binary_path.display());
+        return Ok(());
+    }
+
+    fs::copy(&current_exe, binary_path).with_context(|| {
+        format!(
+            "copy executable from {} to {}",
+            current_exe.display(),
+            binary_path.display()
+        )
+    })?;
+    set_executable_permissions(binary_path)?;
+    println!("Installed managed binary to {}", binary_path.display());
+    Ok(())
+}
+
+fn same_file_best_effort(left: &Path, right: &Path) -> bool {
+    match (left.canonicalize(), right.canonicalize()) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => false,
+    }
+}
+
+#[cfg(unix)]
+fn set_executable_permissions(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mut permissions = fs::metadata(path)?.permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions)?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn set_executable_permissions(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
+fn install_service(layout: &InstallLayout, service_paths: &ManagedServicePaths) -> Result<()> {
+    crate::platform::run_service_action(ServiceAction::Install).map_err(|err| {
+        print_service_install_recovery(layout, service_paths, &err);
+        err
+    })?;
+    println!("Registered native service.");
+    Ok(())
+}
+
+fn start_service(
+    layout: &InstallLayout,
+    service_paths: &ManagedServicePaths,
+) -> Result<ServiceStatus> {
+    if let Err(err) = crate::platform::run_service_action(ServiceAction::Start) {
+        let status = status_or_unknown();
+        print_service_start_recovery(layout, service_paths, status, &err);
+        return Err(err);
+    }
+
+    let status = status_or_unknown();
+    println!("Started native service with status {status}.");
+    Ok(status)
+}
+
+fn status_or_unknown() -> ServiceStatus {
+    match crate::platform::run_service_action(ServiceAction::Status) {
+        Ok(ServiceCommandResult::Status(status)) => status,
+        _ => ServiceStatus::Unknown,
+    }
+}
+
+fn run_health_checks(layout: &InstallLayout) -> Result<DiagnosticStatus> {
+    let report = doctor::inspect(Some(layout.config_file.clone()));
+    println!("Health checks: {}", report.status);
+    for result in &report.results {
+        println!("  [{}] {}: {}", result.status, result.id, result.message);
+        if let Some(detail) = &result.detail {
+            println!("      {detail}");
+        }
+    }
+    Ok(report.status)
+}
+
+fn print_service_install_recovery(
+    layout: &InstallLayout,
+    service_paths: &ManagedServicePaths,
+    err: &anyhow::Error,
+) {
+    println!("Service install failed: {err}");
+    println!("Configuration and rules were left in place.");
+    println!(
+        "Recovery: {}",
+        recovery_command(
+            layout.platform,
+            &service_paths.binary_path,
+            "service install"
+        )
+    );
+}
+
+fn print_service_start_recovery(
+    layout: &InstallLayout,
+    service_paths: &ManagedServicePaths,
+    status: ServiceStatus,
+    err: &anyhow::Error,
+) {
+    println!("Service start failed: {err}");
+    println!("Service status: {status}");
+    println!(
+        "Diagnostics: {}",
+        recovery_command(layout.platform, &service_paths.binary_path, "doctor")
+    );
+    println!(
+        "Restart: {}",
+        recovery_command(
+            layout.platform,
+            &service_paths.binary_path,
+            "service restart"
+        )
+    );
+}
+
+fn recovery_command(platform: InstallPlatform, binary: &Path, args: &str) -> String {
+    match platform {
+        InstallPlatform::Windows => format!("\"{}\" {args}", binary.display()),
+        InstallPlatform::Linux | InstallPlatform::Macos => {
+            format!("sudo \"{}\" {args}", binary.display())
+        }
+    }
+}
+
+fn print_summary(
+    layout: &InstallLayout,
+    service_paths: &ManagedServicePaths,
+    rules_outcome: Option<&InstallOutcome>,
+    service_status: ServiceStatus,
+) {
+    println!("Setup summary:");
+    println!("  configuration: {}", layout.config_file.display());
+    println!("  rules: {}", layout.rules_dir.display());
+    if let Some(outcome) = rules_outcome {
+        println!("  active pack: {} {}", outcome.pack_id, outcome.version);
+    } else {
+        println!("  active pack: existing");
+    }
+    println!("  logs: {}", layout.logs_dir.display());
+    println!("  alerts: {}", layout.alerts_dir.display());
+    println!("  service binary: {}", service_paths.binary_path.display());
+    println!("  service status: {service_status}");
+}
+
+fn print_macos_privacy_warning(platform: InstallPlatform) {
+    if platform == InstallPlatform::Macos {
+        println!(
+            "Warning: macOS may still require Full Disk Access and Endpoint Security approval for Rustinel.app."
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn managed_config_contains_managed_paths() {
+        let layout = InstallLayout::managed(InstallPlatform::Linux);
+        let contents = managed_config_toml(&layout);
+
+        assert!(contents.contains("sigma_rules_path = \"/var/lib/rustinel/rules/current/sigma\""));
+        assert!(contents.contains("directory = \"/var/log/rustinel\""));
+        assert!(
+            contents.contains("hashes_path = \"/var/lib/rustinel/rules/current/ioc/hashes.txt\"")
+        );
+    }
+
+    #[test]
+    fn toml_string_escapes_windows_paths() {
+        let value = toml_string(Path::new(r#"C:\ProgramData\Rustinel\config "main".toml"#));
+
+        assert_eq!(
+            value,
+            r#""C:\\ProgramData\\Rustinel\\config \"main\".toml""#
+        );
+    }
+
+    #[test]
+    fn active_rules_require_state_and_expected_files() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let current = temp.path().join("current");
+        fs::create_dir_all(current.join("sigma")).expect("sigma");
+        fs::create_dir_all(current.join("yara")).expect("yara");
+        fs::create_dir_all(current.join("ioc")).expect("ioc");
+        fs::write(current.join("pack.yml"), "name: test\n").expect("pack");
+        for file in ["hashes.txt", "ips.txt", "domains.txt", "paths_regex.txt"] {
+            fs::write(current.join("ioc").join(file), "\n").expect("ioc file");
+        }
+        fs::write(
+            temp.path().join("state.json"),
+            r#"{"pack_id":"linux-essential","version":"1","sha256":"00","installed_at":"now"}"#,
+        )
+        .expect("state");
+
+        assert!(active_rules_are_valid(temp.path()));
+    }
+}

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -289,9 +289,8 @@ fn set_executable_permissions(_path: &Path) -> Result<()> {
 }
 
 fn install_service(layout: &InstallLayout, service_paths: &ManagedServicePaths) -> Result<()> {
-    crate::platform::run_service_action(ServiceAction::Install).map_err(|err| {
-        print_service_install_recovery(layout, service_paths, &err);
-        err
+    crate::platform::run_service_action(ServiceAction::Install).inspect_err(|err| {
+        print_service_install_recovery(layout, service_paths, err);
     })?;
     println!("Registered native service.");
     Ok(())


### PR DESCRIPTION
## Summary

- Add `rustinel setup` for managed deployment with Essential and Advanced pack selection, `--yes`, `--no-start`, and `--force`.
- Compose managed directory creation, config preservation or replacement, rules installation with existing active rules recovery, binary installation, native service registration, optional startup, and health checks.
- Document setup behavior in CLI and operations docs.

## Validation

- `cargo fmt --check`
- `cargo test --lib`
- `cargo test --all-targets`
- `cargo check --all-targets`
- `target/debug/rustinel setup --help`

Fixes #108