### PR TITLE
Ignore evalexpr 12 Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - dependencies
+    ignore:
+      - dependency-name: evalexpr
+        versions:
+          - ">= 12"
     groups:
       patch-updates:
         update-types:


### PR DESCRIPTION
## Summary
- configure Dependabot to ignore evalexpr updates at version 12 and above

## Context
- evalexpr needs to stay on the current major version because newer releases changed licensing in a way that is rejected by cargo-deny
- keeping Dependabot from opening evalexpr 12+ updates avoids recurring dependency PRs that cannot pass the supply-chain policy

## Validation
- git diff --check