### PR TITLE
Mark prerelease tags as prereleases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -360,7 +360,8 @@ jobs:
             rustinel-${{ steps.version.outputs.version }}-checksums-sha256.txt
           generate_release_notes: true
           draft: false
-          prerelease: false
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          make_latest: ${{ contains(github.ref_name, '-') && 'false' || 'true' }}
           name: Rustinel ${{ github.ref_name }}
           body: |
             ## Downloads


### PR DESCRIPTION
## Summary

- Mark hyphenated release tags, such as `v1.1.5-rc.1`, as GitHub prereleases.
- Prevent prerelease tags from becoming the latest release.
- Keep plain tags, such as `v1.1.5`, as official latest releases.

## Validation

- `git diff --check -- .github/workflows/release.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release workflow YAML parses"'`