### PR TITLE
Improve portable evaluation installers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -398,7 +398,7 @@ jobs:
             **Windows (PowerShell)**
 
             ```powershell
-            iwr https://raw.githubusercontent.com/Karib0u/rustinel/main/scripts/install/install.ps1 -OutFile install-rustinel.ps1; powershell -ExecutionPolicy Bypass -File .\install-rustinel.ps1 -Version ${{ steps.version.outputs.version }} -Run
+            $env:RUSTINEL_VERSION='${{ steps.version.outputs.version }}'; irm https://raw.githubusercontent.com/Karib0u/rustinel/main/scripts/install/install.ps1 | iex; Remove-Item Env:\RUSTINEL_VERSION -ErrorAction SilentlyContinue
             ```
 
             Full install, configuration, and SIEM ingestion guides: https://docs.rustinel.io/getting-started/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -873,9 +873,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2260,9 +2260,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c863e9ab5e7bf9c99ba75e1050f1e4d624ae87ed3532d6238ffbdc7b585dbbe6"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",

--- a/README.md
+++ b/README.md
@@ -38,8 +38,7 @@ Rustinel ships release archives with a binary, default config, demo rules, and a
 **Windows** - from an elevated PowerShell:
 
 ```powershell
-Invoke-WebRequest https://raw.githubusercontent.com/Karib0u/rustinel/main/scripts/install/install.ps1 -OutFile install-rustinel.ps1
-powershell -ExecutionPolicy Bypass -File .\install-rustinel.ps1 -Run
+irm https://raw.githubusercontent.com/Karib0u/rustinel/main/scripts/install/install.ps1 | iex
 ```
 
 **Linux**

--- a/scripts/install/install.ps1
+++ b/scripts/install/install.ps1
@@ -14,6 +14,86 @@ function Show-InstallScope {
     Write-Host "Source build guide: https://docs.rustinel.io/getting-started/#compile-from-source"
 }
 
+function Test-TruthyEnv {
+    param([string]$Value)
+
+    if ([string]::IsNullOrWhiteSpace($Value)) {
+        return $false
+    }
+
+    $normalized = $Value.Trim().ToLowerInvariant()
+    return @("1", "true", "yes", "on") -contains $normalized
+}
+
+function Show-PromotionCommand {
+    param([string]$Path)
+
+    Write-Host "Permanent deployment command:"
+    Write-Host "  Set-Location `"$Path`"; .\rustinel.exe setup --yes"
+}
+
+function Show-PortableEvaluation {
+    param(
+        [string]$Path,
+        [string]$ReleaseVersion
+    )
+
+    $demoRulesPath = Join-Path $Path "rules\sigma"
+    $demoRulesStatus = "not found"
+    $demoRule = Get-ChildItem -Path $demoRulesPath -Filter "*whoami*.yml" -File -ErrorAction SilentlyContinue |
+        Select-Object -First 1
+    if ($demoRule) {
+        $demoRulesStatus = "present"
+    }
+
+    Write-Host ""
+    Write-Host "Rustinel $ReleaseVersion installed to:"
+    Write-Host "  $Path"
+    Write-Host ""
+    Write-Host "Portable evaluation mode:"
+    Write-Host "  Package: $Path"
+    Write-Host "  Config: $(Join-Path $Path 'config.toml')"
+    Write-Host "  Demo rules: $demoRulesPath ($demoRulesStatus)"
+    Write-Host "  Alerts: $(Join-Path $Path 'logs\alerts.json.*')"
+    Write-Host "  Active response: disabled in bundled config"
+    Write-Host ""
+    Write-Host "Start monitoring from an elevated PowerShell:"
+    Write-Host "  Set-Location `"$Path`""
+    Write-Host "  .\rustinel.exe run"
+    Write-Host ""
+    Write-Host "Demo trigger from another PowerShell:"
+    Write-Host "  whoami"
+    Write-Host ""
+    Write-Host "Show the alert:"
+    Write-Host "  Get-Content `"$Path\logs\alerts.json.*`""
+    Write-Host ""
+    Show-PromotionCommand -Path $Path
+}
+
+$InvokedFromStream = [string]::IsNullOrEmpty($PSCommandPath)
+
+if (-not $PSBoundParameters.ContainsKey("Repo") -and -not [string]::IsNullOrWhiteSpace($env:RUSTINEL_REPO)) {
+    $Repo = $env:RUSTINEL_REPO
+}
+
+if (-not $PSBoundParameters.ContainsKey("Version") -and -not [string]::IsNullOrWhiteSpace($env:RUSTINEL_VERSION)) {
+    $Version = $env:RUSTINEL_VERSION
+}
+
+if (-not $PSBoundParameters.ContainsKey("InstallDir") -and -not [string]::IsNullOrWhiteSpace($env:RUSTINEL_INSTALL_DIR)) {
+    $InstallDir = $env:RUSTINEL_INSTALL_DIR
+}
+
+if (-not $PSBoundParameters.ContainsKey("Run") -and (Test-TruthyEnv $env:RUSTINEL_RUN)) {
+    $Run = $true
+}
+
+if (-not $PSBoundParameters.ContainsKey("Force") -and (Test-TruthyEnv $env:RUSTINEL_FORCE)) {
+    $Force = $true
+}
+
+$RunEvaluation = [bool]$Run -or $InvokedFromStream
+
 if (-not [Environment]::Is64BitOperatingSystem) {
     throw "Only 64-bit Windows is supported by the published release archive."
 }
@@ -81,20 +161,24 @@ try {
     New-Item -ItemType Directory -Path $InstallDir | Out-Null
     Copy-Item -Path (Join-Path $packageDir "*") -Destination $InstallDir -Recurse -Force
 
-    Write-Host ""
-    Write-Host "Rustinel $Version installed to:"
-    Write-Host "  $InstallDir"
-    Write-Host ""
-    Write-Host "Try the bundled demo rule from an elevated PowerShell:"
-    Write-Host "  Set-Location `"$InstallDir`""
-    Write-Host "  .\rustinel.exe run"
-    Write-Host "  whoami"
-    Write-Host "  Get-Content .\logs\alerts.json.*"
-    Write-Host ""
+    Show-PortableEvaluation -Path $InstallDir -ReleaseVersion $Version
 
-    if ($Run) {
+    if ($RunEvaluation) {
         Set-Location $InstallDir
+        Write-Host ""
+        Write-Host "Starting portable evaluation. Trigger detection with: whoami"
+        Write-Host "Alerts are written to: $(Join-Path $InstallDir 'logs\alerts.json.*')"
+        Write-Host ""
         & .\rustinel.exe run
+        $runStatus = $LASTEXITCODE
+        if ($null -eq $runStatus) {
+            $runStatus = 0
+        }
+        Write-Host ""
+        Show-PromotionCommand -Path $InstallDir
+        if ($runStatus -ne 0 -and -not $InvokedFromStream) {
+            exit $runStatus
+        }
     }
 }
 finally {

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -70,6 +70,61 @@ need() {
   fi
 }
 
+print_promotion_command() {
+  cat <<EOF
+Permanent deployment command:
+  cd "$install_dir" && sudo ./rustinel setup --yes
+EOF
+}
+
+print_portable_evaluation() {
+  run_command="sudo ./rustinel run"
+  if [ "$os" = "Darwin" ]; then
+    run_command="sudo ./rustinel run"
+  fi
+  demo_rules_status="not found"
+  if find "$install_dir/rules/sigma" -type f -name '*whoami*.yml' | grep -q .; then
+    demo_rules_status="present"
+  fi
+
+  cat <<EOF
+
+Rustinel $version installed to:
+  $install_dir
+
+Portable evaluation mode:
+  Package: $install_dir
+  Config: $install_dir/config.toml
+  Demo rules: $install_dir/rules/sigma ($demo_rules_status)
+  Alerts: $install_dir/logs/alerts.json.*
+  Active response: disabled in bundled config
+
+Start monitoring:
+  cd "$install_dir"
+  $run_command
+
+Demo trigger from another terminal:
+  whoami
+
+Show the alert:
+  cat "$install_dir/logs/alerts.json."*
+
+EOF
+
+  if [ "$os" = "Darwin" ]; then
+    cat <<EOF
+macOS note:
+  Grant Full Disk Access to $install_dir/Rustinel.app before the first
+  successful Endpoint Security run. If the first run exits with NotPermitted,
+  grant access in System Settings > Privacy & Security > Full Disk Access and
+  run the command again.
+
+EOF
+  fi
+
+  print_promotion_command
+}
+
 need curl
 need tar
 
@@ -157,37 +212,7 @@ mkdir -p "$(dirname "$install_dir")"
 mkdir -p "$install_dir"
 cp -R "$package_dir/." "$install_dir/"
 
-if [ "$os" = "Darwin" ]; then
-  cat <<EOF
-
-Rustinel $version installed to:
-  $install_dir
-
-macOS requires a one-time approval before Endpoint Security can start:
-  1. Grant Full Disk Access to:  $install_dir/Rustinel.app
-     (System Settings > Privacy & Security > Full Disk Access)
-  2. cd "$install_dir" && sudo ./rustinel run
-  3. Trigger the demo in another terminal:  whoami
-  4. Read the alert:  cat logs/alerts.json.*
-
-Before approval the agent exits with a NotPermitted error and opens the Full
-Disk Access pane for you; grant access, then run it again.
-
-EOF
-else
-  cat <<EOF
-
-Rustinel $version installed to:
-  $install_dir
-
-Try the bundled demo rule:
-  cd "$install_dir"
-  sudo ./rustinel run
-  whoami
-  cat logs/alerts.json.*
-
-EOF
-fi
+print_portable_evaluation
 
 if [ "$run_after_install" -eq 1 ]; then
   cd "$install_dir"
@@ -196,9 +221,24 @@ if [ "$run_after_install" -eq 1 ]; then
     echo "$install_dir/Rustinel.app; if it exits with NotPermitted, grant access" >&2
     echo "in System Settings > Privacy & Security > Full Disk Access, then re-run." >&2
   fi
+  echo ""
+  echo "Starting portable evaluation. Trigger detection with: whoami"
+  echo "Alerts are written to: $install_dir/logs/alerts.json.*"
+  echo ""
   if [ "$(id -u)" -eq 0 ]; then
-    exec ./rustinel run
+    if ./rustinel run; then
+      run_status=0
+    else
+      run_status=$?
+    fi
   else
-    exec sudo ./rustinel run
+    if sudo ./rustinel run; then
+      run_status=0
+    else
+      run_status=$?
+    fi
   fi
+  echo ""
+  print_promotion_command
+  exit "$run_status"
 fi


### PR DESCRIPTION
## Summary

- Add clearer portable evaluation output to the Unix installer, including config path, demo rule status, alert path, trigger command, and promotion command.
- Make streamed PowerShell installs run portable evaluation by default and accept environment overrides for stream-safe options.
- Update the README and generated release notes command to use the streamed PowerShell path.
- Refresh supply-chain lockfile entries for transitive advisory and yanked-crate findings.

## Validation

- cargo deny --locked check
- sh -n scripts/install/install.sh
- ./scripts/install/install.sh --help
- cargo test --locked config::tests::test_config_loads_defaults
- staged content scans for repository wording constraints

## Not run

- PowerShell parse or Windows execution, because PowerShell is not installed locally.
- Lab host smoke checks from the release plan.
