### PR TITLE
Prepare 1.2.0 rc1 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3150,7 +3150,7 @@ dependencies = [
 
 [[package]]
 name = "rustinel"
-version = "1.1.4"
+version = "1.2.0-rc.1"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustinel"
-version = "1.1.4"
+version = "1.2.0-rc.1"
 edition = "2021"
 authors = []
 description = "Open-source EDR for Windows, Linux, and macOS with Sigma, YARA, and IOC detection"

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -920,13 +920,15 @@ fn validate_pack_manifest(
     };
     let current = Version::parse(env!("CARGO_PKG_VERSION").trim_start_matches('v'));
     match current {
-        Ok(version) if req.matches(&version) => results.push(DiagnosticResult::pass(
-            "rules_pack_compatibility",
-            format!(
-                "Rules pack requirement {} matches Rustinel {}",
-                manifest.requires_rustinel, version
-            ),
-        )),
+        Ok(version) if crate::rules::rustinel_version_matches_requirement(&req, &version) => {
+            results.push(DiagnosticResult::pass(
+                "rules_pack_compatibility",
+                format!(
+                    "Rules pack requirement {} matches Rustinel {}",
+                    manifest.requires_rustinel, version
+                ),
+            ))
+        }
         Ok(version) => results.push(
             DiagnosticResult::fail(
                 "rules_pack_compatibility",

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -6,7 +6,7 @@ use std::{
 
 use anyhow::{bail, Context, Result};
 use chrono::{SecondsFormat, Utc};
-use semver::{Version, VersionReq};
+use semver::{Prerelease, Version, VersionReq};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use url::Url;
@@ -392,7 +392,7 @@ pub fn validate_pack_installable(pack: &CatalogPack) -> Result<()> {
 
     let req = VersionReq::parse(&pack.requires_rustinel)?;
     let current = Version::parse(env!("CARGO_PKG_VERSION").trim_start_matches('v'))?;
-    if !req.matches(&current) {
+    if !rustinel_version_matches_requirement(&req, &current) {
         bail!(
             "pack {} requires Rustinel {}, but this binary is {}",
             pack.id,
@@ -401,6 +401,20 @@ pub fn validate_pack_installable(pack: &CatalogPack) -> Result<()> {
         );
     }
     Ok(())
+}
+
+pub(crate) fn rustinel_version_matches_requirement(req: &VersionReq, current: &Version) -> bool {
+    if req.matches(current) {
+        return true;
+    }
+
+    if current.pre.is_empty() {
+        return false;
+    }
+
+    let mut release_version = current.clone();
+    release_version.pre = Prerelease::EMPTY;
+    req.matches(&release_version)
 }
 
 fn verify_sha256(bytes: &[u8], expected: &str) -> Result<()> {
@@ -761,6 +775,22 @@ mod tests {
 
         assert_eq!(packs.len(), 1);
         assert_eq!(packs[0].id, "demo-pack");
+    }
+
+    #[test]
+    fn prerelease_version_satisfies_release_floor_requirement() {
+        let req = VersionReq::parse(">=1.0.0").unwrap();
+        let current = Version::parse("1.2.0-rc.1").unwrap();
+
+        assert!(rustinel_version_matches_requirement(&req, &current));
+    }
+
+    #[test]
+    fn prerelease_version_rejects_future_release_requirement() {
+        let req = VersionReq::parse(">1.2.0").unwrap();
+        let current = Version::parse("1.2.0-rc.1").unwrap();
+
+        assert!(!rustinel_version_matches_requirement(&req, &current));
     }
 
     fn catalog_for(id: &str, os: &str, archive: &[u8]) -> Catalog {


### PR DESCRIPTION
## Summary

- Bump the package version to 1.2.0-rc.1 for the RC release prep.
- Update the lockfile root package version to match.
- Allow prerelease Rustinel binaries to satisfy normal rules-pack version requirements after standard semver matching fails.

## Why

This prepares the merged commit for the v1.2.0-rc.1 tag so the release workflow builds assets whose package version matches the RC tag. The compatibility helper keeps RC builds usable with existing rules packs that declare release-floor requirements such as >=1.0.0.

## Validation

- cargo check --locked
- cargo deny --locked check
- cargo fmt --all -- --check
- cargo test --locked rules::tests
- cargo test --locked --features rsigma-engine rules::tests
- cargo test --locked --lib
- cargo test --locked --features rsigma-engine --lib
- scanned staged files for repository wording constraints

## After merge

Tag the merged main commit:

```bash
git fetch origin
git checkout main
git pull --ff-only
git tag -a v1.2.0-rc.1 -m "Rustinel v1.2.0-rc.1"
git push origin v1.2.0-rc.1
```
