### PR TITLE
Gate installer setup promotion by version

### DIFF
--- a/scripts/install/install.ps1
+++ b/scripts/install/install.ps1
@@ -28,8 +28,30 @@ function Test-TruthyEnv {
 function Show-PromotionCommand {
     param([string]$Path)
 
+    if (-not (Test-SetupSupportedVersion $Version)) {
+        Write-Host "Permanent deployment:"
+        Write-Host "  rustinel setup is available in Rustinel 1.2.0 and later."
+        Write-Host "  This installer resolved version $Version, so no setup command is printed."
+        return
+    }
+
     Write-Host "Permanent deployment command:"
     Write-Host "  Set-Location `"$Path`"; .\rustinel.exe setup --yes"
+}
+
+function Test-SetupSupportedVersion {
+    param([string]$ReleaseVersion)
+
+    $normalized = $ReleaseVersion.TrimStart("v")
+    $match = [regex]::Match($normalized, "^(\d+)\.(\d+)\.")
+    if (-not $match.Success) {
+        return $false
+    }
+
+    $major = [int]$match.Groups[1].Value
+    $minor = [int]$match.Groups[2].Value
+
+    return ($major -gt 1) -or ($major -eq 1 -and $minor -ge 2)
 }
 
 function Show-PortableEvaluation {
@@ -175,6 +197,9 @@ try {
             $runStatus = 0
         }
         Write-Host ""
+        if ($runStatus -ne 0) {
+            Write-Host "Rustinel exited with status: $runStatus"
+        }
         Show-PromotionCommand -Path $InstallDir
         if ($runStatus -ne 0 -and -not $InvokedFromStream) {
             exit $runStatus

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -71,10 +71,36 @@ need() {
 }
 
 print_promotion_command() {
+  if ! version_supports_setup "$version"; then
+    cat <<EOF
+Permanent deployment:
+  rustinel setup is available in Rustinel 1.2.0 and later.
+  This installer resolved version $version, so no setup command is printed.
+EOF
+    return
+  fi
+
   cat <<EOF
 Permanent deployment command:
   cd "$install_dir" && sudo ./rustinel setup --yes
 EOF
+}
+
+version_supports_setup() {
+  value="${1#v}"
+  major="$(printf '%s\n' "$value" | sed -n 's/^\([0-9][0-9]*\)\..*/\1/p')"
+  minor="$(printf '%s\n' "$value" | sed -n 's/^[0-9][0-9]*\.\([0-9][0-9]*\)\..*/\1/p')"
+
+  if [ -z "$major" ] || [ -z "$minor" ]; then
+    return 1
+  fi
+  if [ "$major" -gt 1 ]; then
+    return 0
+  fi
+  if [ "$major" -eq 1 ] && [ "$minor" -ge 2 ]; then
+    return 0
+  fi
+  return 1
 }
 
 print_portable_evaluation() {
@@ -239,6 +265,9 @@ if [ "$run_after_install" -eq 1 ]; then
     fi
   fi
   echo ""
+  if [ "$run_status" -ne 0 ]; then
+    echo "Rustinel exited with status: $run_status" >&2
+  fi
   print_promotion_command
   exit "$run_status"
 fi


### PR DESCRIPTION
## Summary

- Gate the installer promotion command so `setup --yes` is only printed for Rustinel 1.2.0 and later.
- For older stable versions resolved through `latest`, print a compatibility note instead of a command the binary does not support.
- Print the foreground run exit status when portable evaluation exits non-zero.

## Why

Before 1.2.0 is final, users can stream the installer from `main` while the installer downloads latest stable `1.1.4`. That mixed a 1.2-only promotion command with a 1.1.4 binary. This keeps the `main` installer safe for users who hit it before final 1.2 promotion.

## Validation

- sh -n scripts/install/install.sh
- ./scripts/install/install.sh --help
- scanned touched files for repository wording constraints

## Not run

- PowerShell parse or Windows execution, because PowerShell is not installed locally.
