### PR TITLE
fix(scanner): stop scanning the current directory when YARA is disabled

### DIFF
--- a/src/runtime/linux.rs
+++ b/src/runtime/linux.rs
@@ -12,7 +12,6 @@ use crate::sensor::linux::EbpfSensor;
 use crate::sensor::{Platform, Sensor, SensorEvent, SensorEventRouter};
 use crate::state::{ConnectionAggregator, DnsCache, ProcessCache, SidCache};
 use crate::{config, reload, scanner};
-use std::path::Path;
 use std::sync::Arc;
 use tokio::runtime::Builder;
 use tokio::sync::mpsc;
@@ -132,11 +131,11 @@ async fn run_linux_edr(
             }
             Err(e) => {
                 warn!(error = %e, "Failed to load YARA rules; YARA scanning disabled");
-                Arc::new(scanner::Scanner::new(Path::new(".")).expect("empty YARA scanner"))
+                Arc::new(scanner::Scanner::empty())
             }
         }
     } else {
-        Arc::new(scanner::Scanner::new(Path::new(".")).expect("empty YARA scanner"))
+        Arc::new(scanner::Scanner::empty())
     };
 
     let yara_allowlist_paths =

--- a/src/runtime/macos.rs
+++ b/src/runtime/macos.rs
@@ -12,7 +12,6 @@ use crate::sensor::macos::{BpfSensor, EsfSensor};
 use crate::sensor::{Platform, Sensor, SensorEvent, SensorEventRouter};
 use crate::state::{ConnectionAggregator, DnsCache, ProcessCache, SidCache};
 use crate::{config, reload, scanner};
-use std::path::Path;
 use std::sync::Arc;
 use tokio::runtime::Builder;
 use tokio::sync::mpsc;
@@ -132,11 +131,11 @@ async fn run_macos_edr(
             }
             Err(e) => {
                 warn!(error = %e, "Failed to load YARA rules; YARA scanning disabled");
-                Arc::new(scanner::Scanner::new(Path::new(".")).expect("empty YARA scanner"))
+                Arc::new(scanner::Scanner::empty())
             }
         }
     } else {
-        Arc::new(scanner::Scanner::new(Path::new(".")).expect("empty YARA scanner"))
+        Arc::new(scanner::Scanner::empty())
     };
 
     let yara_allowlist_paths =

--- a/src/runtime/windows.rs
+++ b/src/runtime/windows.rs
@@ -12,7 +12,6 @@ use crate::sensor::windows::EtwSensor;
 use crate::sensor::{Platform, Sensor, SensorEvent, SensorEventRouter};
 use crate::state::{ConnectionAggregator, DnsCache, ProcessCache, SidCache};
 use crate::{config, reload, scanner};
-use std::path::Path;
 use std::sync::Arc;
 use tokio::runtime::Builder;
 use tokio::sync::{mpsc, watch};
@@ -348,17 +347,12 @@ async fn run_edr(
             Err(e) => {
                 warn!(target: "rustinel", error = %e, "Failed to load YARA rules. YARA scanning disabled.");
                 // Create an empty scanner so we don't crash
-                Arc::new(
-                    scanner::Scanner::new(Path::new("."))
-                        .expect("Failed to create empty YARA scanner"),
-                )
+                Arc::new(scanner::Scanner::empty())
             }
         }
     } else {
         info!(target: "rustinel", "YARA scanning disabled by configuration");
-        Arc::new(
-            scanner::Scanner::new(Path::new(".")).expect("Failed to create empty YARA scanner"),
-        )
+        Arc::new(scanner::Scanner::empty())
     };
 
     let yara_allowlist_paths =

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -285,6 +285,20 @@ impl Scanner {
         })
     }
 
+    /// Build a scanner with zero rules without touching the filesystem.
+    ///
+    /// Used when YARA scanning is disabled or rule loading fails, so the
+    /// fallback never walks a directory tree.
+    pub fn empty() -> Self {
+        Self {
+            rules: Compiler::new().build(),
+            compiled_files: 0,
+            files_found: 0,
+            failed_files: 0,
+            cache: Mutex::new(YaraScanCache::new()),
+        }
+    }
+
     pub fn compiled_files(&self) -> usize {
         self.compiled_files
     }
@@ -542,6 +556,14 @@ mod tests {
         // Test that we can create a scanner even with an empty/missing directory
         let result = Scanner::new("nonexistent_dir");
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_empty_scanner_has_no_rules() {
+        let scanner = Scanner::empty();
+        assert_eq!(scanner.compiled_files(), 0);
+        assert_eq!(scanner.files_found(), 0);
+        assert_eq!(scanner.failed_files(), 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

When `scanner.yara_enabled = false` (or when loading the configured rules fails), all three platform runtimes built the fallback "empty" scanner with `Scanner::new(Path::new("."))`. Since `Scanner::new` recursively walks the given directory looking for `.yar`/`.yara` files, the agent ended up scanning whatever its current working directory happened to be at startup — with YARA explicitly disabled.

- Add `Scanner::empty()`, which builds a zero-rule scanner without any filesystem access.
- Use it in the disabled / load-failure fallbacks in `runtime/windows.rs`, `runtime/linux.rs`, and `runtime/macos.rs` (the now-unneeded `Path` imports are removed).
- The normal rule-loading path (`Scanner::new`) is untouched.

Fixes #134

## Verification

- Unit test added: `Scanner::empty()` reports zero found/compiled/failed rule files. Full `cargo test --locked` passes on Linux and Windows.
- `cargo fmt --check` and `cargo clippy --locked --all-targets -- -D clippy::all` pass on Linux and Windows targets.

### End-to-end (Windows 11, YARA disabled, cwd = a large user-profile directory)

| | Startup (launch → ETW trace session started) | `Loading YARA rules from: "."` in log | spurious YARA compile warnings |
| --- | --- | --- | --- |
| before (`b4e0293`) | **>300 s** (timed out, sensors never started) | yes | 7 |
| after (this branch) | **1.5 s** | no | 0 |

### No-regression checks (Windows 11, on this branch)

- **YARA disabled**: the detection pipeline still works end to end — file create/write/rename/delete operations fire the corresponding Sigma rules, even when the agent is launched from the same large working directory that previously blocked startup.
- **YARA enabled**: the configured rules directory loads normally (`Found 1 rule files, compiled 1 successfully`) and a YARA alert fires as expected on a process scan. No working-directory walk happens in either mode.

Same behavior confirmed on Linux with a synthetic 40k-entry tree as the working directory: the walk and the misleading compile warnings occur only before the fix, and the YARA-enabled load path is unchanged.

**Not verified on macOS**: the macOS runtime change is the same mechanical substitution as the other two platforms, but I could not runtime-test it — coverage there is compile/test via CI (`clippy-macos`, `test-macos`) only.
