### PR TITLE
docs: finish onboarding and operations guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,21 +30,34 @@
 
 ---
 
-## Get Your First Alert
+## Quick Start
 
 Rustinel ships release archives with a binary, default config, demo rules, and a
 `logs/` directory.
 
-**Windows** - from an elevated PowerShell:
+**Windows** - test from PowerShell:
 
 ```powershell
 irm https://raw.githubusercontent.com/Karib0u/rustinel/main/scripts/install/install.ps1 | iex
 ```
 
-**Linux**
+Then deploy from an elevated PowerShell and diagnose the managed installation:
+
+```powershell
+rustinel setup --yes
+rustinel doctor
+```
+
+The Windows release binary requires the x64 Microsoft Visual C++ Redistributable.
+See [Getting Started](https://docs.rustinel.io/getting-started/#windows) if the
+process exits before printing output.
+
+**Linux** - test, deploy, and diagnose:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/Karib0u/rustinel/main/scripts/install/install.sh | sh -s -- --run
+sudo rustinel setup --yes
+rustinel doctor
 ```
 
 **macOS** (experimental)
@@ -60,6 +73,13 @@ macOS notes before using it beyond a first test.
 
 ```bash
 sudo ./rustinel run
+```
+
+After Full Disk Access is granted, deploy and diagnose the managed installation:
+
+```bash
+sudo ./rustinel setup --yes
+./rustinel doctor
 ```
 
 With the agent running, trigger the bundled demo rule:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -140,7 +140,7 @@ Behavior:
 - `--yes` accepts defaults and skips the prompt.
 - `--no-start` registers the native service without starting it.
 - `--force` replaces an existing managed configuration. Without `--force`, existing configuration is preserved and validated before setup continues.
-- The current executable is copied to the managed service binary path before service registration.
+- The current executable is copied to the managed service binary path before service registration. On macOS, setup copies the complete signed `Rustinel.app` bundle so its signature, entitlements, and provisioning profile remain intact.
 - Rules pack downloads use the same catalog validation, SHA-256 verification, ZIP safety checks, and atomic activation as `rules install`.
 - If a rules download or validation fails, setup preserves existing active rules and continues only when an existing active pack is valid.
 - If service installation or startup fails, setup leaves configuration and rules in place and prints the exact recovery command.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -16,6 +16,16 @@ Invoke-WebRequest https://raw.githubusercontent.com/Karib0u/rustinel/main/script
 powershell -ExecutionPolicy Bypass -File .\install-rustinel.ps1 -Run
 ```
 
+Official Windows binaries use the MSVC runtime. Install the current x64
+[Microsoft Visual C++ Redistributable](https://aka.ms/vc14/vc_redist.x64.exe)
+if Rustinel exits before printing output. Exit code `-1073741515`
+(`0xC0000135`) normally means a required runtime DLL is missing:
+
+```powershell
+Invoke-WebRequest https://aka.ms/vc14/vc_redist.x64.exe -OutFile "$env:TEMP\vc_redist.x64.exe"
+Start-Process "$env:TEMP\vc_redist.x64.exe" -ArgumentList "/install", "/quiet", "/norestart" -Wait -Verb RunAs
+```
+
 ### Linux
 
 ```bash
@@ -172,11 +182,45 @@ for the macOS result-code table.
 Network and DNS capture also needs access to `/dev/bpf*`. If packet capture
 cannot start, Rustinel continues with Endpoint Security process and file telemetry.
 
+## Keep Rustinel Running
+
+After the portable test succeeds, install the managed layout and native service:
+
+=== "Windows"
+
+    ```powershell
+    rustinel setup --yes
+    rustinel service status
+    rustinel doctor
+    ```
+
+=== "Linux"
+
+    ```bash
+    sudo rustinel setup --yes
+    rustinel service status
+    rustinel doctor
+    ```
+
+=== "macOS"
+
+    Grant Full Disk Access to `Rustinel.app` before starting the LaunchDaemon.
+
+    ```bash
+    sudo ./rustinel setup --yes
+    ./rustinel service status
+    ./rustinel doctor
+    ```
+
+`setup` installs an Essential rules pack by default, registers the platform's
+native service, starts it, and runs health checks. Use `--pack advanced` to
+select the larger pack or `--no-start` to register without starting.
+
 ## Minimum Requirements
 
 | Platform | Requirements |
 | --- | --- |
-| Windows | Windows 10/11 or Server 2016+, Administrator privileges |
+| Windows | Windows 10/11 or Server 2016+, x64 Visual C++ Redistributable, Administrator privileges for telemetry and service management |
 | Linux | Kernel 5.8+ with BTF, root or eBPF capabilities such as `CAP_BPF`, `CAP_PERFMON`, and `CAP_NET_ADMIN`, or `CAP_SYS_ADMIN`, `tracefs`, and `debugfs` |
 | macOS | macOS 11+, root, signed Endpoint Security client, Full Disk Access, and `/dev/bpf*` access for network and DNS capture |
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -71,6 +71,10 @@ the service binary path, registers the native service, starts it unless
 service status. Existing managed configuration is preserved unless `--force` is
 supplied.
 
+On macOS, `setup` copies the complete signed `Rustinel.app` bundle into the
+managed layout. Do not replace only `Contents/MacOS/rustinel`: doing so can
+invalidate the signing context required by Endpoint Security.
+
 Pack selection:
 
 ```bash
@@ -82,6 +86,17 @@ Without `--pack`, an interactive terminal prompts for Essential or Advanced.
 Non-interactive setup defaults to Essential. If rules download or verification
 fails, setup preserves existing active rules and continues only when the active
 pack is valid.
+
+## Rules And Hot Reload
+
+Install a released pack with `rustinel rules install <PACK>`. Managed packs are
+activated atomically under the platform rules directory. Local edits to active
+Sigma, YARA, and IOC files are watched when `reload.enabled = true` (the
+default), with rapid changes grouped by `reload.debounce_ms`.
+
+After editing a rule, check the operational log for a successful reload and
+trigger a known event. A rejected reload leaves the last valid in-memory rules
+active. Run `rustinel doctor` to validate the on-disk configuration and rules.
 
 ## Working Directory Rules
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -6,6 +6,10 @@ Use this page when Rustinel starts but does not behave the way you expect, or wh
 
 Before changing config or rules, check these first:
 
+- Run `rustinel doctor` (use `sudo rustinel doctor` when validating privileged
+  platform prerequisites). Address `fail` results first; warnings return exit
+  code `1` and failures return exit code `2`. Use `rustinel doctor --json` for
+  automation.
 - Read the current operational log: `logs/rustinel.log.<date>`
 - Run in the foreground with a higher log level:
   - Windows: `.\rustinel.exe run --log-level debug`
@@ -29,6 +33,17 @@ Before changing config or rules, check these first:
 | Logs mention dropped events or full queues | sensor backpressure, YARA/IOC/response queues saturated |
 
 ## Startup Failures
+
+### Windows exits without printing output
+
+Official Windows binaries require the x64 Microsoft Visual C++ Redistributable.
+If PowerShell reports `$LASTEXITCODE` as `-1073741515` (`0xC0000135`), install
+the runtime and retry:
+
+```powershell
+Invoke-WebRequest https://aka.ms/vc14/vc_redist.x64.exe -OutFile "$env:TEMP\vc_redist.x64.exe"
+Start-Process "$env:TEMP\vc_redist.x64.exe" -ArgumentList "/install", "/quiet", "/norestart" -Wait -Verb RunAs
+```
 
 ### `Failed to load configuration`
 


### PR DESCRIPTION
Closes #110

## What changed

- Reframe the README around portable test, managed setup, and doctor.
- Document CLI, service operations, rules, and hot reload behavior.
- Lead troubleshooting with doctor and add Windows loader guidance.
- Document the x64 Visual C++ runtime and platform permission requirements.
- Clarify that macOS managed setup preserves the complete signed app bundle.

## Validation

- zensical build --clean
- git diff --check
