### PR TITLE
chore: prepare release 1.2.0-rc.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3150,7 +3150,7 @@ dependencies = [
 
 [[package]]
 name = "rustinel"
-version = "1.2.0-rc.3"
+version = "1.2.0-rc.4"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustinel"
-version = "1.2.0-rc.3"
+version = "1.2.0-rc.4"
 edition = "2021"
 authors = []
 description = "Open-source EDR for Windows, Linux, and macOS with Sigma, YARA, and IOC detection"


### PR DESCRIPTION
## What changed

- Bump the package and lockfile version to 1.2.0-rc.4.

## Why

RC3 exposed a release-symlink setup failure. RC4 includes the merged symlink-resolution regression fix.

## Validation

- cargo check --locked
