### PR TITLE
release: Rustinel 1.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3150,7 +3150,7 @@ dependencies = [
 
 [[package]]
 name = "rustinel"
-version = "1.2.0-rc.4"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustinel"
-version = "1.2.0-rc.4"
+version = "1.2.0"
 edition = "2021"
 authors = []
 description = "Open-source EDR for Windows, Linux, and macOS with Sigma, YARA, and IOC detection"

--- a/scripts/install/install.ps1
+++ b/scripts/install/install.ps1
@@ -25,9 +25,30 @@ function Test-TruthyEnv {
     return @("1", "true", "yes", "on") -contains $normalized
 }
 
+function Test-SetupSupported {
+    param([string]$Path)
+
+    # Probe the installed binary. Only releases that ship the managed-deployment
+    # workflow answer `setup --help` successfully; older/stable builds do not, so
+    # we avoid advertising a command they cannot run.
+    $exe = Join-Path $Path "rustinel.exe"
+    if (-not (Test-Path $exe)) {
+        return $false
+    }
+    try {
+        & $exe setup --help *> $null
+        return ($LASTEXITCODE -eq 0)
+    } catch {
+        return $false
+    }
+}
+
 function Show-PromotionCommand {
     param([string]$Path)
 
+    if (-not (Test-SetupSupported -Path $Path)) {
+        return
+    }
     Write-Host "Permanent deployment command:"
     Write-Host "  Set-Location `"$Path`"; .\rustinel.exe setup --yes"
 }

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -70,7 +70,18 @@ need() {
   fi
 }
 
+setup_supported() {
+  # Probe the installed binary. Only releases that ship the managed-deployment
+  # workflow answer `setup --help` successfully; older/stable builds do not, so
+  # we avoid advertising a command they cannot run.
+  [ -x "$install_dir/rustinel" ] || return 1
+  "$install_dir/rustinel" setup --help >/dev/null 2>&1
+}
+
 print_promotion_command() {
+  if ! setup_supported; then
+    return 0
+  fi
   cat <<EOF
 Permanent deployment command:
   cd "$install_dir" && sudo ./rustinel setup --yes


### PR DESCRIPTION
Umbrella PR for the final **v1.2.0** release.

## Contents

- **fix(install): feature-detect `setup` support before advertising the promotion command.** `install.sh` (`setup_supported`) and `install.ps1` (`Test-SetupSupported`) probe `rustinel setup --help` against the installed binary and print the `sudo ./rustinel setup --yes` promotion block only on success. Prevents the `main`-served installer from advertising the 1.2-only `setup` command to older/stable installs. Self-corrects across releases (no hard-coded version check).
- **chore: release 1.2.0.** Bump `Cargo.toml` + `Cargo.lock` `1.2.0-rc.4` → `1.2.0` (validated consistent under `--locked`).

## Release notes (for the GitHub release body)

test it → keep it → check it. Highlights: one-command portable evaluation, one-command managed deployment (`setup`), consistent native services, read-only `doctor` diagnostics, safe `rules` install/update, and signed/notarized macOS packages (experimental; Full Disk Access required). Full notes composed and ready to apply to the `v1.2.0` GitHub release.

## After merge (Phase 8/9)

- [ ] Merge to `main`, confirm `main` CI green.
- [ ] Tag + push `v1.2.0` → triggers the Release workflow (builds all platforms, publishes, `make_latest: true` since the tag has no `-`).
- [ ] Confirm the release is not a prerelease, is `latest`, and every asset + checksum exists.
- [ ] Apply the composed release notes to the release body.
- [ ] Merge + deploy the landing page PR (`rustinel-front-final#9`) and confirm the site shows `1.2.0`.

## Related

- #106 tracking issue reconciled and closed.
- Landing page: rustinel-front-final#9 (publish only after `v1.2.0` is `latest`).