### PR TITLE
docs: use rustinel.io install-script URLs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -379,13 +379,13 @@ jobs:
             **Linux**
 
             ```sh
-            curl -fsSL https://raw.githubusercontent.com/Karib0u/rustinel/main/scripts/install/install.sh | sh -s -- --version ${{ steps.version.outputs.version }} --run
+            curl -fsSL https://rustinel.io/install.sh | sh -s -- --version ${{ steps.version.outputs.version }} --run
             ```
 
             **macOS**
 
             ```sh
-            curl -fsSL https://raw.githubusercontent.com/Karib0u/rustinel/main/scripts/install/install.sh | sh -s -- --version ${{ steps.version.outputs.version }}
+            curl -fsSL https://rustinel.io/install.sh | sh -s -- --version ${{ steps.version.outputs.version }}
             cd rustinel
             ```
 
@@ -398,7 +398,7 @@ jobs:
             **Windows (PowerShell)**
 
             ```powershell
-            $env:RUSTINEL_VERSION='${{ steps.version.outputs.version }}'; irm https://raw.githubusercontent.com/Karib0u/rustinel/main/scripts/install/install.ps1 | iex; Remove-Item Env:\RUSTINEL_VERSION -ErrorAction SilentlyContinue
+            $env:RUSTINEL_VERSION='${{ steps.version.outputs.version }}'; irm https://rustinel.io/install.ps1 | iex; Remove-Item Env:\RUSTINEL_VERSION -ErrorAction SilentlyContinue
             ```
 
             Full install, configuration, and SIEM ingestion guides: https://docs.rustinel.io/getting-started/

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Rustinel ships release archives with a binary, default config, demo rules, and a
 **Windows** - test from PowerShell:
 
 ```powershell
-irm https://raw.githubusercontent.com/Karib0u/rustinel/main/scripts/install/install.ps1 | iex
+irm https://rustinel.io/install.ps1 | iex
 ```
 
 Then deploy from an elevated PowerShell and diagnose the managed installation:
@@ -55,7 +55,7 @@ process exits before printing output.
 **Linux** - test, deploy, and diagnose:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Karib0u/rustinel/main/scripts/install/install.sh | sh -s -- --run
+curl -fsSL https://rustinel.io/install.sh | sh -s -- --run
 sudo rustinel setup --yes
 rustinel doctor
 ```
@@ -63,7 +63,7 @@ rustinel doctor
 **macOS** (experimental)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Karib0u/rustinel/main/scripts/install/install.sh | sh
+curl -fsSL https://rustinel.io/install.sh | sh
 cd rustinel
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,7 +12,7 @@ Use the install scripts when you want a published binary, bundled demo rules,
 Run from an elevated PowerShell:
 
 ```powershell
-Invoke-WebRequest https://raw.githubusercontent.com/Karib0u/rustinel/main/scripts/install/install.ps1 -OutFile install-rustinel.ps1
+Invoke-WebRequest https://rustinel.io/install.ps1 -OutFile install-rustinel.ps1
 powershell -ExecutionPolicy Bypass -File .\install-rustinel.ps1 -Run
 ```
 
@@ -29,13 +29,13 @@ Start-Process "$env:TEMP\vc_redist.x64.exe" -ArgumentList "/install", "/quiet", 
 ### Linux
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Karib0u/rustinel/main/scripts/install/install.sh | sh -s -- --run
+curl -fsSL https://rustinel.io/install.sh | sh -s -- --run
 ```
 
 To inspect the script first:
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/Karib0u/rustinel/main/scripts/install/install.sh
+curl -fsSLO https://rustinel.io/install.sh
 less install.sh
 sh install.sh --run
 ```
@@ -46,7 +46,7 @@ macOS support is experimental. Install without `--run` so you can grant the
 required Full Disk Access approval before the first real start:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Karib0u/rustinel/main/scripts/install/install.sh | sh
+curl -fsSL https://rustinel.io/install.sh | sh
 cd rustinel
 ```
 


### PR DESCRIPTION
Follow-up to the 1.2 release. Now that `rustinel.io/install.sh` and `rustinel.io/install.ps1` are live 302 redirects to the raw scripts on `main` (verified end-to-end), point every advertised install command at the stable `rustinel.io` URLs instead of the long `raw.githubusercontent.com` ones.

## Changes

- `README.md` — 3 install commands (Windows `irm`, Linux + macOS `curl`).
- `docs/getting-started.md` — 4 install commands (Windows `Invoke-WebRequest`, Linux `curl` + inspect-first `curl -O`, macOS `curl`).
- `.github/workflows/release.yml` — the 3 install commands baked into every release's notes body (Linux/macOS `curl`, Windows `irm`).

The `curl -fsSLO https://rustinel.io/install.sh` inspect-first flow still saves as `install.sh` (filename derives from the request URL, not the redirect target).

## Not changed

- `public/_redirects` in the site repo — that is the redirect *definition*, whose target must stay the raw-GitHub URL.

## Verified

```
$ curl -sS -o /dev/null -w '%{http_code} %{redirect_url}' https://rustinel.io/install.sh
302 https://raw.githubusercontent.com/Karib0u/rustinel/main/scripts/install/install.sh
$ curl -fsSL https://rustinel.io/install.sh | head -1
#!/usr/bin/env sh
```