### PR TITLE
Simplify and refresh project documentation

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -34,56 +34,33 @@ It behaves the same as `rustinel run`.
 
 See [CLI Reference](cli.md).
 
-### Can I run Rustinel as a Windows service?
+### Can I run Rustinel as a native service?
 
-Yes. Windows supports built-in service commands:
+Yes. `rustinel setup` installs the managed layout and registers the native
+service on Windows, Linux, and macOS. The `rustinel service` commands manage its
+lifecycle through the Windows Service Control Manager, systemd, or launchd.
 
-- `rustinel service install`
-- `rustinel service start`
-- `rustinel service stop`
-- `rustinel service uninstall`
-
-The installed service points at the current executable path, so moving the binary to a new directory requires reinstalling the service.
-
-See [Operations and Upgrade Guide](operations.md).
-
-### Can I run Rustinel as a Linux service?
-
-Yes, but Rustinel does not include built-in Linux service-management commands. Run it under `systemd` or another supervisor.
-
-See [Operations and Upgrade Guide](operations.md) for the example `systemd` unit.
-
-### Can I run Rustinel as a macOS service?
-
-Yes, but like Linux it has no built-in service-management commands (those are Windows-only today). Run it in the foreground as root, or load the bundled `com.rustinel.agent.plist` as a `launchd` LaunchDaemon for background execution. Either way, the signed app bundle needs Full Disk Access.
-
-See [Operations and Upgrade Guide](operations.md) for the launchd layout.
+See [Operations and Upgrade Guide](operations.md) for managed paths, service
+behavior, and upgrades.
 
 ### Why does Rustinel look in the wrong directory for rules or logs?
 
-Because relative paths resolve from the current working directory.
+Relative paths in `config.toml` resolve from the directory containing the
+selected configuration file. Check which configuration file Rustinel selected,
+then verify its relative paths from that directory. Use `rustinel doctor` to
+inspect the resolved configuration and paths.
 
-That matters especially for:
-
-- Windows services, which often start in `C:\Windows\System32`
-- Linux supervisors, which may start outside your install directory
-
-For production deployments, use absolute paths for `config.toml`, rules, logs, and alerts.
+For production deployments, managed layouts and absolute paths remain the
+clearest choices.
 
 See [Configuration](configuration.md).
 
 ### Where does Rustinel read configuration from?
 
-Configuration precedence is:
-
-1. CLI flags where supported
-2. `EDR__...` environment variables
-3. `config.toml` in the current working directory
-4. `config.toml` in the directory containing the executable
-5. Built-in defaults
-
-This means you can keep `config.toml` next to the `rustinel` executable even when
-the working directory differs (such as `C:\Windows\System32` for a Windows service).
+Configuration values use CLI flags first, then `EDR__...` environment
+variables, the selected configuration file, and built-in defaults. The file is
+selected from `--config`, `RUSTINEL_CONFIG`, the managed platform path, the
+executable directory, or the current working directory, in that order.
 
 See [Configuration](configuration.md).
 
@@ -129,15 +106,8 @@ See [Getting Started](getting-started.md).
 
 ### Why do I see startup logs but no alerts?
 
-The most common reasons are:
-
-- the agent is running from a directory that does not contain the expected `config.toml` or rule paths
-- the relevant detector is disabled in config
-- the rule files were not loaded from the path you expected
-- the event source you are testing is not covered on that platform
-- the event was suppressed by network aggregation or skipped by an allowlist
-
-The operational log is the first place to check because it records sensor startup, rule loading, reload activity, warnings, and response decisions.
+Run `rustinel doctor`, trigger the bundled `whoami` rule, and follow the ordered
+checks in [Troubleshooting](troubleshooting.md#agent-runs-but-no-alerts).
 
 ## Detection Behavior
 
@@ -159,11 +129,10 @@ A restart is still useful when you change deployment layout, supervisor configur
 
 ### What exactly hot reloads?
 
-- Sigma rule files under `scanner.sigma_rules_path`
-- top-level YARA rule files under `scanner.yara_rules_path`
-- IOC files configured in `ioc.hashes_path`, `ioc.ips_path`, `ioc.domains_path`, and `ioc.paths_regex_path`
-
-If a rebuild produces an empty detector set (i.e. no rule files are present in the directory), Sigma and YARA will swap in the empty set (effectively disabling those detectors). However, if there are files found but any of them are broken (failed to compile/parse), the reload will be refused (with a warning logged) and the previous valid rules will remain active. IOCs will reject an empty reload and keep the last known good indicator set active.
+Sigma, YARA, and configured IOC files reload automatically. Sigma is recursive;
+YARA reads only the top-level configured directory. Invalid reloads keep the
+last valid detector active. See
+[Troubleshooting](troubleshooting.md#hot-reload-problems) for failure behavior.
 
 ### Do Sigma and YARA load subdirectories the same way?
 
@@ -176,36 +145,14 @@ See [Detection](detection.md).
 
 ### Why are my Linux DNS or domain-based detections not matching?
 
-Linux DNS coverage is still narrower than Windows, but outbound query names are supported.
-
-The eBPF DNS path observes userspace `sendto` calls for plaintext DNS traffic and parses the queried domain name in userspace. Linux DNS events can populate:
-
-- `QueryName`
-- `RecordType`
-- `Image`
-- `ProcessId`
-
-Linux DNS events do not currently populate `QueryResults` or `QueryStatus`. That means:
-
-- Sigma DNS rules that depend on `QueryName` can match on Linux
-- IOC domain matching from DNS `QueryName` works on Linux
-- IOC IP matching from DNS answers is effectively Windows-only right now
-
-Linux DNS query-name extraction covers outbound plaintext DNS queries observed on port 53. It does not cover DNS-over-HTTPS, DNS-over-TLS, cached resolver answers that do not send a packet, or response-answer parsing.
-
-See [Detection](detection.md).
+Linux captures visible plaintext DNS queries but not every resolver path or DNS
+response. See the focused checks in
+[Troubleshooting](troubleshooting.md#linux-dns-or-ioc-domain-rules-do-not-match).
 
 ### Why did YARA not scan a process I expected?
 
-The common causes are:
-
-- the event was not a process-start event
-- the executable path was under an allowlisted prefix
-- YARA is disabled
-- the rule file was not loaded from the configured directory
-- the queue was full and the job was dropped
-
-See [Detection](detection.md) and [Configuration](configuration.md).
+See the ordered checks in
+[Troubleshooting](troubleshooting.md#yara-did-not-scan-the-process-i-expected).
 
 ### How are severities assigned?
 
@@ -229,21 +176,11 @@ See [Detection](detection.md) and [Output Format](output.md).
 
 ## Active Response and Allowlists
 
-### Why didn’t active response kill the process?
+### Why didn't active response kill the process?
 
-Active response only acts when all of the following are true:
-
-- `response.enabled = true`
-- the alert severity is at or above `response.min_severity`
-- the process has a usable PID and image path
-- the PID is not protected
-- the target is not Rustinel itself
-- the image or path is not allowlisted
-- `prevention_enabled = true`
-
-If `prevention_enabled = false`, Rustinel logs what it would have done without terminating the process.
-
-See [Active Response](active-response.md).
+See the ordered checks in
+[Troubleshooting](troubleshooting.md#i-see-alerts-but-no-process-is-killed) and
+the safety model in [Active Response](active-response.md).
 
 ### Are allowlists shared across modules?
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -103,84 +103,11 @@ Bundled demo rules:
 
 Installed release packs become active under `rules/current`.
 
-## Install Options
+## Other Install Methods
 
-Install to a specific directory:
-
-```bash
-scripts/install/install.sh --dir /opt/rustinel
-```
-
-```powershell
-.\scripts\install\install.ps1 -InstallDir C:\Rustinel
-```
-
-Install a specific version:
-
-```bash
-scripts/install/install.sh --version 1.0.2
-```
-
-```powershell
-.\scripts\install\install.ps1 -Version 1.0.2
-```
-
-The install scripts only download published release binaries. They do not
-install Rust, Cargo, or build from source. If no release asset exists for your
-OS or architecture, the script exits before changing the install directory.
-
-## Manual Package Install
-
-Download the package for your platform from
-[GitHub Releases](https://github.com/Karib0u/rustinel/releases).
-
-| Platform | Package |
-| --- | --- |
-| Windows x86_64 | `rustinel-<version>-x86_64-pc-windows-msvc.zip` |
-| Linux x86_64 | `rustinel-<version>-x86_64-unknown-linux-musl.tar.gz` |
-| Linux arm64 | `rustinel-<version>-aarch64-unknown-linux-musl.tar.gz` |
-| macOS Apple Silicon | `rustinel-<version>-aarch64-apple-darwin.tar.gz` |
-| macOS Intel | `rustinel-<version>-x86_64-apple-darwin.tar.gz` |
-
-Release packages already include `config.toml`, bundled demo rules, install
-scripts, examples, and an empty `logs/` directory.
-
-### Windows
-
-1. Extract the zip archive.
-2. Open an elevated PowerShell in the extracted directory.
-3. Run:
-
-```powershell
-.\rustinel.exe run
-```
-
-### Linux
-
-```bash
-tar xzf rustinel-<version>-x86_64-unknown-linux-musl.tar.gz
-cd rustinel-<version>-x86_64-unknown-linux-musl
-sudo ./rustinel run
-```
-
-If startup fails with `tracefs not found`, see
-[Troubleshooting](troubleshooting.md#linux-ebpf-sensor-failed-to-start).
-
-### macOS
-
-```bash
-tar xzf rustinel-<version>-aarch64-apple-darwin.tar.gz
-cd rustinel-<version>-aarch64-apple-darwin
-sudo ./rustinel run
-```
-
-If startup exits with `NotPermitted`, grant Full Disk Access as described in the
-macOS install notes above. If it exits with `NotPrivileged`, re-run with `sudo`.
-See [Troubleshooting](troubleshooting.md#macos-endpoint-security-client-init-failed)
-for the macOS result-code table.
-
-Network and DNS capture also needs access to `/dev/bpf*`. If packet capture
-cannot start, Rustinel continues with Endpoint Security process and file telemetry.
+The scripts only download published release binaries. For version selection,
+custom installation directories, manual archives, and upgrade procedures, see
+[Operations and Upgrade Guide](operations.md).
 
 ## Keep Rustinel Running
 
@@ -224,98 +151,8 @@ select the larger pack or `--no-start` to register without starting.
 | Linux | Kernel 5.8+ with BTF, root or eBPF capabilities such as `CAP_BPF`, `CAP_PERFMON`, and `CAP_NET_ADMIN`, or `CAP_SYS_ADMIN`, `tracefs`, and `debugfs` |
 | macOS | macOS 11+, root, signed Endpoint Security client, Full Disk Access, and `/dev/bpf*` access for network and DNS capture |
 
-Building from source also requires Rust 1.92+. Windows needs Visual Studio Build
-Tools, Linux eBPF rebuilds need nightly Rust plus `rust-src` and `bpf-linker`,
-and macOS needs the Xcode Command Line Tools.
-
-## Build From Source
-
-Use this path if you want to build the binary yourself instead of using a
-published release.
-
-### Windows
-
-```powershell
-git clone https://github.com/Karib0u/rustinel.git
-cd rustinel
-cargo build --release
-.\target\release\rustinel.exe run
-```
-
-### Linux
-
-```bash
-git clone https://github.com/Karib0u/rustinel.git
-cd rustinel
-cargo build --release
-sudo ./target/release/rustinel run
-```
-
-On Linux, `build.rs` embeds `ebpf/rustinel-ebpf.o` when it already exists. If it
-does not exist, the build falls back to compiling the eBPF crate with nightly
-Rust.
-
-### macOS
-
-```bash
-git clone https://github.com/Karib0u/rustinel.git
-cd rustinel
-cargo build --release
-
-scripts/macos/package-app.sh \
-  --binary target/release/rustinel \
-  --output target/release/Rustinel.app \
-  --profile "$HOME/Downloads/rustinel.provisionprofile" \
-  --identity "Developer ID Application: Example (TEAMID)"
-
-sudo ./target/release/Rustinel.app/Contents/MacOS/rustinel run
-```
-
-The profile must belong to the explicit App ID approved for Endpoint Security
-and authorize `com.apple.developer.endpoint-security.client`. The packaging
-script derives the bundle identifier from that profile. Grant the resulting app
-bundle Full Disk Access before starting it. See [Development](development.md)
-for maintainer release-signing details and ad-hoc lab builds.
-
-## Optional Checks
-
-### YARA Demo
-
-Keep Rustinel running, build the demo binary, and run it:
-
-```bash
-rustc ./examples/yara_demo.rs -o ./examples/yara_demo
-./examples/yara_demo
-```
-
-On Windows:
-
-```powershell
-rustc .\examples\yara_demo.rs -o .\examples\yara_demo.exe
-.\examples\yara_demo.exe
-```
-
-Confirm that an alert references `ExampleMarkerString` in
-`logs/alerts.json.<date>`.
-
-### Hot Reload
-
-Keep Rustinel running, edit a Sigma, YARA, or IOC file, and wait a few seconds.
-The operational log should report a reload event.
-
-Windows example:
-
-```powershell
-$rule = Get-ChildItem rules\current\sigma -Filter *.yml | Select-Object -First 1
-Add-Content $rule.FullName "`n# hot reload smoke test"
-```
-
-Linux example:
-
-```bash
-rule=$(find rules/current/sigma -name '*.yml' -print -quit)
-printf '\n# hot reload smoke test\n' >> "$rule"
-```
+Source builds require Rust 1.92 and platform build tools. See
+[Development](development.md) for build, signing, eBPF, and test instructions.
 
 ## Next Steps
 
@@ -323,4 +160,5 @@ printf '\n# hot reload smoke test\n' >> "$rule"
 - [SIEM Demos](siem-demos.md): ship first alerts to Elastic or Splunk.
 - [Operations and Upgrade Guide](operations.md): install layouts, services, and upgrades.
 - [CLI Reference](cli.md): service commands and runtime examples.
+- [Development](development.md): build and test from source.
 - [Limitations](limitations.md): current platform and detection gaps.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -87,6 +87,29 @@ Non-interactive setup defaults to Essential. If rules download or verification
 fails, setup preserves existing active rules and continues only when the active
 pack is valid.
 
+## Installer And Archive Options
+
+The install scripts accept a target directory and published version:
+
+=== "Linux and macOS"
+
+    ```bash
+    scripts/install/install.sh --dir /opt/rustinel --version 1.2.0
+    ```
+
+=== "Windows"
+
+    ```powershell
+    .\scripts\install\install.ps1 -InstallDir C:\Rustinel -Version 1.2.0
+    ```
+
+The scripts download published binaries only. They do not install Rust or build
+from source. Manual packages are available from
+[GitHub Releases](https://github.com/Karib0u/rustinel/releases) for Windows
+x86_64, Linux x86_64 and arm64, and macOS Intel and Apple Silicon. Each archive
+contains the binary, `config.toml`, demo rules, install scripts, examples, and
+an empty `logs/` directory.
+
 ## Rules And Hot Reload
 
 Install a released pack with `rustinel rules install <PACK>`. Managed packs are
@@ -100,12 +123,14 @@ active. Run `rustinel doctor` to validate the on-disk configuration and rules.
 
 ## Working Directory Rules
 
-- `config.toml` is loaded from the current working directory, falling back to the
-  directory containing the executable (the working-directory copy wins on conflicts).
-- Relative rule and log paths resolve from the current working directory.
-- Windows services often start in `C:\Windows\System32`; keep `config.toml` next to
-  `rustinel.exe` (it will still be found) and use absolute paths for rules and logs.
-- Linux supervisors should also use absolute paths for predictable upgrades and restarts.
+- Configuration files are selected from `--config`, `RUSTINEL_CONFIG`, the
+  managed platform path, the executable directory, and the current working
+  directory, in that order.
+- Relative paths resolve from the directory containing the selected
+  configuration file.
+- `rustinel doctor` reports the selected configuration and resolved paths.
+- Use the managed platform configuration path for native services.
+- Prefer absolute paths for custom service layouts and supervisors.
 
 ## Native Service Lifecycle
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,121 +1,53 @@
 # Roadmap
 
-This roadmap describes planned areas of work.
+This page summarizes the active GitHub backlog. Priorities may change, and an
+open issue is not a release commitment. Follow the linked issue for current
+scope, discussion, and acceptance criteria.
 
-It is not a strict release commitment.
+## Immediate Correctness
 
-## Sensor
+- [#164: stop connection aggregation from permanently suppressing detection](https://github.com/Karib0u/rustinel/issues/164)
+- [#35: revalidate process identity before YARA memory scans](https://github.com/Karib0u/rustinel/issues/35)
+- [#32: capture `sendmsg` and `sendmmsg` DNS queries on Linux](https://github.com/Karib0u/rustinel/issues/32)
 
-### Windows
+## Telemetry Fidelity
 
-- **ETW integrity checks:** detect ETW session tampering and provider blinding that could suppress telemetry.
-- **Deep inspection via stack walking:** identify shellcode and "floating code" executing outside mapped image regions.
+- [#166: route Windows Kernel-Network events by operation and protocol](https://github.com/Karib0u/rustinel/issues/166)
+- [#168: preserve absolute Linux file paths and report truncation](https://github.com/Karib0u/rustinel/issues/168)
+- [#142: capture Linux process arguments in the kernel](https://github.com/Karib0u/rustinel/issues/142)
+- [#140: add telemetry drop counters and backpressure visibility](https://github.com/Karib0u/rustinel/issues/140)
+- [#141: report rules that have no active backing collector](https://github.com/Karib0u/rustinel/issues/141)
 
-### Linux
+## Detection Reliability
 
-- **DNS response enrichment:** Linux DNS query names are extracted in userspace from raw eBPF payload events. Future work should parse DNS responses for `QueryResults` and DNS answer-to-network correlation.
-- **Expanded file telemetry:** cover `chmod`, `chown`, `truncate`, and `link` syscalls to close gaps in file-integrity coverage.
-- **Container context:** enrich process events with cgroup, namespace, and container runtime metadata so rules can scope to specific workloads.
+- [#165: prevent distinct event subjects from sharing a deduplication key](https://github.com/Karib0u/rustinel/issues/165)
+- [#160: correct deduplication rollup counts](https://github.com/Karib0u/rustinel/issues/160)
+- [#170: align deduplication window behavior with its documented semantics](https://github.com/Karib0u/rustinel/issues/170)
+- [#167: harden YARA and IOC caches against file replacement](https://github.com/Karib0u/rustinel/issues/167)
+- [#169: distinguish YARA scan failures from clean results](https://github.com/Karib0u/rustinel/issues/169)
+- [#161: close the Unicode case-insensitive Sigma matching gap](https://github.com/Karib0u/rustinel/issues/161)
+- [#162: add YARA scan timeouts and file-size limits](https://github.com/Karib0u/rustinel/issues/162)
 
-### macOS
+## Engineering Quality
 
-macOS support collects process and file telemetry through Endpoint Security and
-network and DNS through `/dev/bpf` capture. Active response is not supported on
-macOS today. Future work:
+- [#159: bound the process cache](https://github.com/Karib0u/rustinel/issues/159)
+- [#163: restrict alert and log file permissions](https://github.com/Karib0u/rustinel/issues/163)
+- [#135: add a SigmaHQ corpus smoke test in CI](https://github.com/Karib0u/rustinel/issues/135)
+- [#136: expand direct matcher edge-case tests](https://github.com/Karib0u/rustinel/issues/136)
+- [#137: cover alert construction and field-mapping degradation](https://github.com/Karib0u/rustinel/issues/137)
+- [#138: migrate away from unmaintained `serde_yaml`](https://github.com/Karib0u/rustinel/issues/138)
+- [#139: avoid AGPL `evalexpr` releases](https://github.com/Karib0u/rustinel/issues/139)
+- [#171: isolate configuration tests from managed host state](https://github.com/Karib0u/rustinel/issues/171)
 
-- **NetworkExtension flow source:** replace `/dev/bpf` capture with a Network Extension that carries the owning PID per flow, removing the best-effort socket-to-PID scan and its direction ambiguity.
-- **Interface selection:** capture across all active interfaces instead of the single `RUSTINEL_BPF_INTERFACE` default of `en0`.
-- **DNS response enrichment:** parse DNS answers for `QueryResults`, matching the Linux gap.
-- **AUTH-mode prevention:** explore macOS prevention by blocking process execution with `ES_EVENT_TYPE_AUTH_EXEC`.
+## Longer-Term Direction
 
-### Cross-Platform
+- [#143: design correlation and temporal rule support](https://github.com/Karib0u/rustinel/issues/143)
+- [#145: replace macOS `/dev/bpf` capture with NetworkExtension](https://github.com/Karib0u/rustinel/issues/145)
+- [#146: expand Linux file telemetry](https://github.com/Karib0u/rustinel/issues/146)
+- [#147: add periodic YARA memory sweeps](https://github.com/Karib0u/rustinel/issues/147)
+- [#148: add Linux container context](https://github.com/Karib0u/rustinel/issues/148)
+- [#149: make RSigma the default backend and stage built-in removal](https://github.com/Karib0u/rustinel/issues/149)
+- [#111: add safe atomic rules pack updates](https://github.com/Karib0u/rustinel/issues/111)
 
-- **Periodic YARA sweeps:** scheduled background scans of running processes independent of creation events.
-
-## Detection
-
-### YARA memory scanning enhancements
-
-YARA memory scanning is available as an optional detector for process memory.
-Future work is focused on improving coverage and operator control:
-
-- Periodic process sweeps independent of process creation events
-- Better memory-region selection
-- Optional executable-only private-region scanning
-- Richer memory match metadata in alerts
-
-Memory scanning remains privilege-dependent and platform behavior differs between
-Windows process-memory APIs and Linux `/proc/<pid>/mem` access.
-
-### More Sigma examples
-
-More example Sigma rules are planned for common detection scenarios, including:
-
-- Suspicious PowerShell
-- WMI abuse
-- Service creation
-- Scheduled task creation
-- Suspicious Linux process execution
-- Suspicious network activity
-
-### Better IOC examples
-
-More IOC examples are planned for:
-
-- Hash matching
-- Domain matching
-- IP matching
-- Path regex matching
-
-## Telemetry
-
-### Expanded Linux eBPF coverage
-
-Linux support currently focuses on process, network, file, and DNS telemetry.
-
-Future work may expand Linux coverage depending on stability, portability, and usefulness.
-
-### Better normalization documentation
-
-More documentation is planned around how raw ETW and eBPF events are normalized into Rustinel’s shared event model.
-
-## Operations
-
-### SIEM integration examples
-
-Rustinel writes ECS NDJSON alerts.
-
-Future documentation should include examples for ingesting those alerts into common SIEM and log platforms.
-
-### Deployment examples
-
-More deployment examples are planned for:
-
-- Windows service mode
-- Linux supervisor-based deployment
-- Lab environments
-- Detection engineering environments
-
-### Hardening guidance
-
-Optional hardening guidance is planned for users who want to make Rustinel harder to stop or identify.
-
-This may include recommendations around:
-
-- Installation paths
-- Service names
-- File permissions
-- Logging locations
-- Operational monitoring
-
-## Community
-
-Useful community contributions include:
-
-- Testing on different Windows, Linux, and macOS versions
-- Reporting telemetry gaps
-- Improving documentation
-- Adding Sigma examples
-- Adding YARA examples
-- Adding safe demo scenarios
-- Testing SIEM ingestion
+The complete backlog is available in
+[GitHub Issues](https://github.com/Karib0u/rustinel/issues).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -49,16 +49,15 @@ Start-Process "$env:TEMP\vc_redist.x64.exe" -ArgumentList "/install", "/quiet", 
 
 This usually means one of these:
 
-- `config.toml` is not in the current working directory or next to the executable
+- no configuration exists in the explicit, managed, executable, or working-directory locations
 - the TOML syntax is invalid
 - an `EDR__...` environment override has the wrong shape or type
-- a relative path assumes a different working directory than the one Rustinel is using
+- a relative path is wrong for the directory containing the selected configuration
 
 What to do:
 
-- verify where you launched Rustinel from
+- run `rustinel doctor` to see the selected configuration and resolved paths
 - prefer absolute paths for production deployments
-- temporarily move to the install directory and start again
 - remove recent environment overrides and retry
 
 See [Configuration](configuration.md).
@@ -386,7 +385,7 @@ If the problem is persistent, capture the relevant log excerpt before tuning.
 Check these first:
 
 - `logging.directory` points to a writable location
-- the current working directory is what you expect
+- relative log paths resolve correctly from the selected configuration directory
 - the service or supervisor account can write there
 
 Rustinel may fall back to a temp directory if file logging cannot be initialized. If that also fails, it falls back to a sink writer and you may lose file-based operational logs.

--- a/planning/release-1.2-plan.md
+++ b/planning/release-1.2-plan.md
@@ -1,0 +1,218 @@
+# Rustinel 1.2 Release Plan
+
+Status: **release candidate green** — `v1.2.0-rc.4` published; only close-out work remains
+Target: Rustinel 1.2.0
+Tracking issue: https://github.com/Karib0u/rustinel/issues/106
+Last updated: 2026-07-11
+
+All engineering fixes and RC validation are done. What remains is documentation
+close-out, the landing page, and the final `v1.2.0` promotion.
+
+## Goal
+
+Ship Rustinel 1.2 with a simple, trustworthy path: `test it -> keep it -> check it`.
+
+Final user-facing flow (live only after `v1.2.0` + website install URLs):
+
+```bash
+# Linux and macOS
+curl -fsSL https://rustinel.io/install.sh | sh -s -- --run
+sudo rustinel setup --yes
+rustinel doctor
+```
+
+```powershell
+# Windows PowerShell
+irm https://rustinel.io/install.ps1 | iex
+rustinel setup --yes
+rustinel doctor
+```
+
+## Where we are
+
+- `Cargo.toml` is at `1.2.0-rc.4`. RCs 1–4 are published as GitHub prereleases;
+  `latest`/stable remains `v1.1.4` (intended — no RC took `latest`).
+- CI on `main` HEAD is green (CI, Docs, RSigma Engine Parity).
+- **Full RC smoke matrix is green:** Linux and Windows portable+managed passed on
+  official RC2; macOS portable+managed passed on official RC4. RC3/RC4 only
+  changed macOS setup and docs, so the Linux/Windows binaries are functionally
+  unchanged.
+- **Official RC4 macOS validation passed (2026-07-11):** archive checksum and
+  version, deep managed-app signature, Apple notarization, the exact
+  `./rustinel setup --yes --force` flow, launchd reaching `running`, `doctor`
+  clean (expected Full Disk Access detectability warning only), restart/stop/start
+  lifecycle, and manual Sigma hot reload from the official asset.
+
+### RC history (brief)
+
+- RC1: first prerelease. Found portable rule-path and managed catalog-path
+  defects incompatible with the published package layout.
+- RC2: fixed portable/managed paths, catalog validation, and Linux `CAP_PERFMON`.
+  Linux and Windows passed; macOS managed failed (setup copied only the
+  executable, producing an invalid app bundle).
+- RC3: macOS bundle-copy fix (PR #154). Still failed via the documented
+  `./rustinel` symlink path, which resolved to copying only the executable.
+- RC4: macOS symlink-resolution fix (PR #157) + onboarding/operations docs
+  (PR #156, closed #110) + release prep (PR #158). **Viable release candidate.**
+
+## Issue status
+
+- #109 (installer UX) — CLOSED.
+- #110 (onboarding docs) — CLOSED via PR #156.
+- #130 (Windows VC++ runtime docs) — CLOSED; documented in PR #156.
+- #106 (tracking, p0) — OPEN. Remaining criteria to confirm and check off:
+  one-command promotion, cross-platform managed consistency, doctor
+  diagnosability, README simplification. Close after `v1.2.0` ships.
+- Everything else open (#135–#151, #32, #35, PR #153, etc.) is post-1.2 backlog,
+  not a release blocker.
+
+## Remaining work to ship v1.2.0
+
+1. [x] **Installer output: feature-detect the promotion command (decided).**
+   In `scripts/install/install.sh` and `install.ps1`, only print the
+   `sudo ./rustinel setup --yes` promotion block when the installed binary
+   actually supports `setup` (probe `./rustinel setup --help` and print the
+   block only on success). This is the clean fix for the `main`-served installer
+   advertising the 1.2-only `setup` command to older/stable `--version`
+   installs. Chosen over a hard-coded version check so it self-corrects across
+   releases. Land before the website points at these scripts.
+   Done: `setup_supported()` in `install.sh` and `Test-SetupSupported` in
+   `install.ps1` gate the promotion block on a successful `setup --help` probe.
+2. [ ] **Landing page (Phase 6).** Publish only after final assets exist.
+   Code is written and build-verified (redirects + `QuickStart.astro` rewrite);
+   publish is still gated on `v1.2.0` being `latest`.
+3. [x] **Reconcile and close #106.** Confirmed all acceptance criteria and
+   closed the tracking issue with a reconciliation comment
+   (comment 4950069426).
+4. [x] **Write `v1.2.0` release notes** covering installer, setup, doctor,
+   service, rules, and macOS status. Composed; to be applied to the GitHub
+   release body after the tag publishes (workflow auto-generates Downloads +
+   Installer + PR list, highlights prepended on top).
+5. [ ] **Cut and promote `v1.2.0` (Phase 8).** Version bump `1.2.0-rc.4` ->
+   `1.2.0` committed to `release/1.2.0` (PR #172, ready). Remaining: merge to
+   `main`, then tag + push `v1.2.0` (irreversible — awaiting go-ahead).
+6. [ ] **Post-release close-out (Phase 9).**
+7. [ ] *(Optional, low risk)* Re-confirm Linux/Windows portable+managed on the
+   RC4 asset — binaries are unchanged, so this is belt-and-suspenders.
+
+## Release decision rule
+
+Ship `v1.2.0` only when:
+
+- #106, #109, #110 user-visible acceptance criteria pass. *(#109/#110 done.)*
+- At least one clean Linux VM passes portable and managed flows. *(done, RC2)*
+- Windows passes portable and managed flows. *(done, RC2)*
+- macOS passes portable evaluation and has documented managed status. *(done, RC4)*
+- Release assets install from GitHub without local build dependencies. *(done)*
+- Website install URLs work for the stable release path. *(pending — Phase 6)*
+
+## Phase 6: Landing page
+
+Repo: `/Users/theo/src/rustinel-front-final` (Astro + Cloudflare Workers static
+assets, `trailingSlash: 'always'`). Publish only after `v1.2.0` is `latest`.
+
+Site facts that shape this work:
+
+- Version is read from GitHub `/releases/latest` (`src/lib/github.ts`,
+  `getGitHubMeta`), which ignores prereleases. The site therefore cannot display
+  an RC version — no gating change is needed, just confirm it flips to `1.2.0`
+  once `v1.2.0` is `latest`.
+- `public/_redirects` already serves Cloudflare redirects (trailing-slash 301s);
+  add the install-script routes there.
+- `src/components/QuickStart.astro` currently shows a download-extract-run flow
+  with `releases/latest/download/...` archive URLs and no `setup` step. This is
+  the component to rewrite for the `test it / keep it / check it` story.
+
+Tasks:
+
+- [x] Add install-script routes to `public/_redirects`:
+
+```text
+/install.sh   https://raw.githubusercontent.com/Karib0u/rustinel/main/scripts/install/install.sh   302
+/install.ps1  https://raw.githubusercontent.com/Karib0u/rustinel/main/scripts/install/install.ps1  302
+```
+
+- [x] Rewrite `QuickStart.astro` to lead with the three-command flow per
+  platform tab, keeping the existing tab switcher and `__VERSION__` token:
+  - Linux/macOS: `curl -fsSL https://rustinel.io/install.sh | sh -s -- --run`,
+    then `sudo rustinel setup --yes`, then `rustinel doctor`.
+  - Windows: `irm https://rustinel.io/install.ps1 | iex`, then
+    `rustinel setup --yes`, then `rustinel doctor`.
+  - Keep the macOS experimental note and Full Disk Access callout.
+- [x] Keep direct release-archive downloads and build-from-source as secondary
+  (demote the current archive steps rather than delete them). Archive steps now
+  live in a collapsed `<details>` disclosure below the three-command tabs.
+- [ ] Confirm the displayed version resolves to `1.2.0` after promotion.
+
+Test locally before promoting:
+
+```bash
+cd /Users/theo/src/rustinel-front-final && pnpm install && pnpm build && pnpm dev
+```
+
+Pass criteria: `curl -fsSL https://rustinel.io/install.sh` and the `install.ps1`
+URL return the installer scripts (302 to raw `main`), Quick Start leads with the
+three-command flow and references no RC, the displayed version is `1.2.0`, and
+mobile/desktop layouts remain readable.
+
+## Phase 8: Final 1.2.0 release
+
+Only after the landing page is ready and the release notes are written.
+
+- [ ] Bump version `1.2.0-rc.4` -> `1.2.0`, commit, merge to `main`.
+- [ ] Tag and push the final release:
+
+```bash
+git fetch origin && git checkout main && git pull --ff-only
+git tag -a v1.2.0 -m "Rustinel v1.2.0"
+git push origin v1.2.0
+```
+
+- [ ] Confirm the release is not a prerelease and is marked `latest`.
+- [ ] Confirm every asset and checksum exists.
+- [ ] Run installer smoke with `--version 1.2.0`, then with the stable
+  `https://rustinel.io/install.sh` and `install.ps1` URLs. Verify the Windows
+  VC++ runtime prerequisite or that the installer gives a clear diagnostic.
+
+## Phase 9: Post-release
+
+- [x] Confirm `releases/latest` resolves to `v1.2.0` and the frontend shows it.
+  `releases/latest` -> `v1.2.0`; `/api/github-meta` returns `1.2.0`
+  (`isFallback: false`); site renders "Download v1.2.0".
+- [x] Confirm website install commands use stable URLs. `rustinel.io/install.sh`
+  and `install.ps1` 302 -> raw `main` and deliver the scripts; QuickStart leads
+  with the `rustinel.io` three-command flow. README + docs migrated to
+  `rustinel.io` URLs in PR #173 (follow-up).
+- [x] Close #106 with links. Closed with a reconciliation comment referencing
+  #109/#110 and the close-out work.
+- [x] `v1.2.0` release notes / changelog written and applied to the release body
+  (curated highlights + full change list from `v1.1.4`).
+- [ ] File follow-up issues for anything deferred. Deferred items already
+  tracked (#111 Phase 2, backlog). Optional new follow-up: migrate the Release
+  workflow body install commands to `rustinel.io` (flagged in PR #173).
+- [ ] Remove RC test directories and managed test installs on local hosts.
+  (Local machine task — run the cleanup block below manually.)
+
+Cleanup:
+
+```bash
+# Linux / macOS
+sudo ./rustinel service uninstall || true
+sudo rm -rf /opt/rustinel /etc/rustinel /var/lib/rustinel /var/log/rustinel   # Linux
+sudo rm -rf /usr/local/var/rustinel "/Library/Application Support/Rustinel"    # macOS
+rm -rf ~/rustinel ~/rustinel-rc-test
+```
+
+```powershell
+# Windows
+.\rustinel.exe service uninstall
+Remove-Item -Recurse -Force "C:\Program Files\Rustinel" -ErrorAction SilentlyContinue
+Remove-Item -Recurse -Force "C:\ProgramData\Rustinel" -ErrorAction SilentlyContinue
+Remove-Item -Recurse -Force "$env:USERPROFILE\rustinel-rc-test" -ErrorAction SilentlyContinue
+```
+
+## Non-goals for 1.2
+
+No package-manager integration, no fleet management, no rules-catalog trust-model
+change, no RC as the default website download, no docs that make unreleased
+commands look stable.


### PR DESCRIPTION
## Summary

- correct service, configuration precedence, and relative-path guidance
- shorten Getting Started and move operational detail to its authoritative pages
- replace the stale roadmap with a priority-oriented view of current GitHub issues
- reduce duplicated troubleshooting content in the FAQ
- preserve the completed 1.2 release plan outside the published documentation tree

## Why

The documentation had accumulated stale operational guidance, repeated troubleshooting sections, and roadmap entries for work that was already complete. This made first-use workflows harder to scan and allowed related pages to drift apart.

## Impact

Users get a shorter onboarding path, consistent configuration and service guidance, and a roadmap tied directly to the active backlog. Maintainers have clearer ownership boundaries between FAQ, troubleshooting, operations, and development content.

## Validation

- `zensical build`
- `git diff --check`
