### PR TITLE
fix(linux-dns): capture sendmsg and sendmmsg DNS queries

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -106,7 +106,7 @@ The Linux sensor loads eBPF programs with Aya and currently covers:
 - Process execution and exit
 - Network connect activity
 - File create, delete, change, and rename flows
-- DNS queries observed from userspace sends. The eBPF program emits a bounded raw DNS payload and userspace parses `QueryName`, keeping string parsing out of the verifier-sensitive in-kernel path. Linux DNS response answers are not parsed yet, so `QueryResults` remains unavailable on Linux.
+- DNS queries observed from userspace `sendto`, `sendmsg`, and `sendmmsg` calls. The eBPF program emits a bounded raw DNS payload and userspace parses `QueryName`, keeping string parsing out of the verifier-sensitive in-kernel path. Linux DNS response answers are not parsed yet, so `QueryResults` remains unavailable on Linux.
 
 The current loader attaches a mix of tracepoints and kprobes, including:
 
@@ -122,6 +122,8 @@ The current loader attaches a mix of tracepoints and kprobes, including:
 - `syscalls:sys_enter_renameat2`
 - `syscalls:sys_exit_renameat2`
 - `syscalls:sys_enter_sendto`
+- `syscalls:sys_enter_sendmsg`
+- `syscalls:sys_enter_sendmmsg`
 - `kprobe:vfs_create`
 
 Requirements for the Linux sensor are kernel 5.8+, BTF, and eBPF privileges.

--- a/docs/detection.md
+++ b/docs/detection.md
@@ -124,7 +124,7 @@ DNS field availability differs by platform:
 | `Image` | Yes | Yes | No |
 | `ProcessId` | Yes | Yes | No |
 
-On Linux, `QueryName` is extracted in userspace from the bounded raw DNS payload emitted by the eBPF `sendto` path. This covers outbound plaintext DNS queries observed on port 53. It does not cover DNS-over-HTTPS, DNS-over-TLS, cached resolver answers that do not send a packet, or DNS response answers. `QueryResults` and `QueryStatus` remain Windows-only today.
+On Linux, `QueryName` is extracted in userspace from the bounded raw DNS payload emitted by the eBPF `sendto`, `sendmsg`, or `sendmmsg` paths. Each message uses the first iovec, capped at 256 bytes, and each `sendmmsg` call is capped at four messages. This covers outbound plaintext DNS queries observed on port 53. It does not cover DNS-over-HTTPS, DNS-over-TLS, cached resolver answers that do not send a packet, or DNS response answers. `QueryResults` and `QueryStatus` remain Windows-only today.
 
 On macOS, `QueryName` and `RecordType` are parsed from `/dev/bpf` packet capture of outbound port-53 traffic, so the same plaintext-only limitations apply. Because capture is packet-based rather than per-process, macOS DNS events are **not** attributed to a process; `Image` and `ProcessId` are empty. Likewise, macOS `network_connection` events do not populate `DestinationHostname`, and their process attribution is best-effort. See [Limitations](limitations.md#macos-network-and-dns-attribution).
 

--- a/ebpf/src/dns.rs
+++ b/ebpf/src/dns.rs
@@ -1,10 +1,10 @@
 //! DNS syscall telemetry eBPF programs.
 //!
-//! Emits outbound DNS query telemetry from `sendto(2)` payloads, capturing
-//! PID/UID/FD and the DNS record type (QTYPE).  The domain name is **not**
-//! extracted in eBPF — doing so exceeded the BPF verifier's 1 M-instruction
-//! complexity limit.  Callers should enrich the event with the domain in
-//! userspace via `/proc/<pid>/net/` or application-layer tracing.
+//! Emits outbound DNS query telemetry from `sendto(2)`, `sendmsg(2)`, and
+//! `sendmmsg(2)` payloads, capturing PID/UID/FD and the DNS record type
+//! (QTYPE). The domain name is not extracted in eBPF because doing so
+//! exceeded the BPF verifier's 1 M-instruction complexity limit. Callers
+//! should enrich the event with the domain in userspace via the raw payload.
 
 use aya_ebpf::{
     helpers::{
@@ -31,6 +31,15 @@ const DNS_TYPE_AAAA: u16 = 28;
 /// Maximum bytes of DNS payload we copy in one probe read.
 const MAX_DNS_PAYLOAD: usize = 256;
 
+/// Maximum iovec segments copied from one sendmsg-style message.
+///
+/// DNS libraries normally pass one contiguous payload iovec. Keeping this at
+/// one gives the verifier a statically bounded destination range.
+const MAX_IOVEC_SEGMENTS: usize = 1;
+
+/// Maximum messages inspected from one sendmmsg call.
+const MAX_SENDMMSG_MESSAGES: usize = 4;
+
 const AF_INET: u16 = 2;
 const AF_INET6: u16 = 10;
 
@@ -53,6 +62,41 @@ struct SockAddrIn6 {
     scope_id: u32,
 }
 
+/// 64-bit Linux userspace `struct msghdr` layout.
+///
+/// The syscall tracepoints expose userspace pointers, so this layout is read
+/// with `bpf_probe_read_user` instead of dereferenced directly.
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct UserMsghdr {
+    msg_name: u64,
+    msg_namelen: u32,
+    _pad0: u32,
+    msg_iov: u64,
+    msg_iovlen: u64,
+    msg_control: u64,
+    msg_controllen: u64,
+    msg_flags: u32,
+    _pad1: u32,
+}
+
+/// 64-bit Linux userspace `struct iovec` layout.
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct UserIovec {
+    iov_base: u64,
+    iov_len: u64,
+}
+
+/// 64-bit Linux userspace `struct mmsghdr` layout.
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct UserMmsghdr {
+    msg_hdr: UserMsghdr,
+    msg_len: u32,
+    _pad0: u32,
+}
+
 /// Ring buffer shared with the userspace loader for DNS events.
 #[map]
 pub static DNS_RING: RingBuf = RingBuf::with_byte_size(256 * 1024, 0);
@@ -64,6 +108,16 @@ static DNS_SCRATCH: PerCpuArray<DnsEvent> = PerCpuArray::with_max_entries(1, 0);
 #[tracepoint]
 pub fn handle_sendto(ctx: TracePointContext) -> u32 {
     unsafe { try_handle_sendto(&ctx) }.unwrap_or(1)
+}
+
+#[tracepoint]
+pub fn handle_sendmsg(ctx: TracePointContext) -> u32 {
+    unsafe { try_handle_sendmsg(&ctx) }.unwrap_or(1)
+}
+
+#[tracepoint]
+pub fn handle_sendmmsg(ctx: TracePointContext) -> u32 {
+    unsafe { try_handle_sendmmsg(&ctx) }.unwrap_or(1)
 }
 
 #[inline(always)]
@@ -82,8 +136,6 @@ unsafe fn try_handle_sendto(ctx: &TracePointContext) -> Result<u32, i64> {
         return Ok(0);
     }
 
-    // ── Stage 1: one probe read ──────────────────────────────────────────────
-
     let scratch = match DNS_SCRATCH.get_ptr_mut(0) {
         Some(p) => p,
         None => return Ok(0),
@@ -99,13 +151,126 @@ unsafe fn try_handle_sendto(ctx: &TracePointContext) -> Result<u32, i64> {
         return Ok(0);
     }
 
-    // ── Stage 2: parse (kernel memory only) ─────────────────────────────────
+    emit_dns_query(scratch, pid, uid, fd, read_len);
+
+    Ok(0)
+}
+
+#[inline(always)]
+unsafe fn try_handle_sendmsg(ctx: &TracePointContext) -> Result<u32, i64> {
+    let pid = (bpf_get_current_pid_tgid() >> 32) as u32;
+    let uid = bpf_get_current_uid_gid() as u32;
+    let fd = ctx.read_at::<i64>(16)? as i32;
+    let msg_ptr = ctx.read_at::<u64>(24)?;
+
+    if msg_ptr == 0 {
+        return Ok(0);
+    }
+
+    let msg = match bpf_probe_read_user::<UserMsghdr>(msg_ptr as *const _) {
+        Ok(value) => value,
+        Err(_) => return Ok(0),
+    };
+    if msg.msg_name != 0 && !sockaddr_points_to_dns_port(msg.msg_name)? {
+        return Ok(0);
+    }
+
+    let scratch = match DNS_SCRATCH.get_ptr_mut(0) {
+        Some(p) => p,
+        None => return Ok(0),
+    };
+    let read_len = match read_iovec_payload(&msg, &mut (*scratch).payload) {
+        Some(value) => value,
+        None => return Ok(0),
+    };
+
+    emit_dns_query(scratch, pid, uid, fd, read_len);
+
+    Ok(0)
+}
+
+#[inline(always)]
+unsafe fn try_handle_sendmmsg(ctx: &TracePointContext) -> Result<u32, i64> {
+    let pid = (bpf_get_current_pid_tgid() >> 32) as u32;
+    let uid = bpf_get_current_uid_gid() as u32;
+    let fd = ctx.read_at::<i64>(16)? as i32;
+    let msgvec_ptr = ctx.read_at::<u64>(24)?;
+    let message_count = ctx.read_at::<u64>(32)? as usize;
+
+    if msgvec_ptr == 0 || message_count == 0 {
+        return Ok(0);
+    }
+
+    let mut index = 0usize;
+    while index < MAX_SENDMMSG_MESSAGES {
+        if index >= message_count {
+            break;
+        }
+
+        let offset = index * core::mem::size_of::<UserMmsghdr>();
+        let msg_ptr = msgvec_ptr.wrapping_add(offset as u64);
+        let msg = match bpf_probe_read_user::<UserMsghdr>(msg_ptr as *const _) {
+            Ok(value) => value,
+            Err(_) => break,
+        };
+        if msg.msg_name != 0 && !sockaddr_points_to_dns_port(msg.msg_name)? {
+            index += 1;
+            continue;
+        }
+
+        let scratch = match DNS_SCRATCH.get_ptr_mut(0) {
+            Some(p) => p,
+            None => return Ok(0),
+        };
+        let read_len = match read_iovec_payload(&msg, &mut (*scratch).payload) {
+            Some(value) => value,
+            None => {
+                index += 1;
+                continue;
+            }
+        };
+
+        emit_dns_query(scratch, pid, uid, fd, read_len);
+        index += 1;
+    }
+
+    Ok(0)
+}
+
+#[inline(always)]
+unsafe fn read_iovec_payload(msg: &UserMsghdr, payload: &mut [u8; MAX_DNS_PAYLOAD]) -> Option<usize> {
+    if msg.msg_iov == 0 || msg.msg_iovlen < MAX_IOVEC_SEGMENTS as u64 {
+        return None;
+    }
+
+    *payload = [0u8; MAX_DNS_PAYLOAD];
+    let iovec = match bpf_probe_read_user::<UserIovec>(msg.msg_iov as *const _) {
+        Ok(value) => value,
+        Err(_) => return None,
+    };
+    if iovec.iov_base == 0 || iovec.iov_len < DNS_HEADER_LEN as u64 {
+        return None;
+    }
+
+    let read_len = (iovec.iov_len as usize).min(MAX_DNS_PAYLOAD);
+    if bpf_probe_read_user_buf(iovec.iov_base as *const u8, &mut payload[..read_len]).is_err() {
+        return None;
+    }
+
+    Some(read_len)
+}
+
+#[inline(always)]
+unsafe fn emit_dns_query(scratch: *mut DnsEvent, pid: u32, uid: u32, fd: i32, read_len: usize) {
+    if read_len < DNS_HEADER_LEN || read_len > MAX_DNS_PAYLOAD {
+        return;
+    }
 
     // Validate DNS header: must be a query (QR=0) with at least one question.
     let flags = (((*scratch).payload[2] as u16) << 8) | ((*scratch).payload[3] as u16);
     let qdcount = (((*scratch).payload[4] as u16) << 8) | ((*scratch).payload[5] as u16);
     if flags & 0x8000 != 0 || qdcount == 0 {
-        return Ok(0);
+        return;
     }
 
     // Locate QTYPE: scan past the name (null-terminated labels) to the QTYPE
@@ -116,7 +281,7 @@ unsafe fn try_handle_sendto(ctx: &TracePointContext) -> Result<u32, i64> {
     let mut i = 0usize;
     while i < MAX_DNS_PAYLOAD {
         if pos >= read_len {
-            return Ok(0);
+            return;
         }
         let b = (*scratch).payload[pos & (MAX_DNS_PAYLOAD - 1)];
         if b == 0 {
@@ -128,7 +293,7 @@ unsafe fn try_handle_sendto(ctx: &TracePointContext) -> Result<u32, i64> {
     }
     // pos points at the null byte; QTYPE is the two bytes that follow.
     if pos + 3 > read_len {
-        return Ok(0);
+        return;
     }
     let qtype = (((*scratch).payload[(pos + 1) & (MAX_DNS_PAYLOAD - 1)] as u16) << 8)
         | ((*scratch).payload[(pos + 2) & (MAX_DNS_PAYLOAD - 1)] as u16);
@@ -150,8 +315,6 @@ unsafe fn try_handle_sendto(ctx: &TracePointContext) -> Result<u32, i64> {
         entry.write(*scratch);
         entry.submit(0);
     }
-
-    Ok(0)
 }
 
 #[inline(always)]

--- a/ebpf/src/main.rs
+++ b/ebpf/src/main.rs
@@ -19,6 +19,8 @@
 //! | `handle_renameat2`    | `syscalls/sys_enter_renameat2`| queue rename |
 //! | `handle_renameat2_exit`| `syscalls/sys_exit_renameat2`| emit rename |
 //! | `handle_sendto`       | `syscalls/sys_enter_sendto`  | emit DNS query |
+//! | `handle_sendmsg`      | `syscalls/sys_enter_sendmsg` | emit DNS query |
+//! | `handle_sendmmsg`     | `syscalls/sys_enter_sendmmsg`| emit DNS query |
 //!
 //! Requirements: Linux 5.8+ with BTF enabled (CO-RE / ring-buffer support).
 

--- a/src/sensor/linux/ebpf.rs
+++ b/src/sensor/linux/ebpf.rs
@@ -144,6 +144,13 @@ impl Sensor for EbpfSensor {
             "sys_exit_renameat2",
         )?;
         attach_tracepoint(&mut bpf, "handle_sendto", "syscalls", "sys_enter_sendto")?;
+        attach_tracepoint(&mut bpf, "handle_sendmsg", "syscalls", "sys_enter_sendmsg")?;
+        attach_tracepoint(
+            &mut bpf,
+            "handle_sendmmsg",
+            "syscalls",
+            "sys_enter_sendmmsg",
+        )?;
 
         info!("eBPF tracepoints attached");
 


### PR DESCRIPTION
Fixes #32

## Summary

- Attach Linux eBPF tracepoints for `sys_enter_sendmsg` and `sys_enter_sendmmsg`.
- Read the first bounded DNS iovec safely from userspace and preserve the existing `DnsEvent` ABI and userspace parsing path.
- Inspect up to four messages per `sendmmsg` call and drop malformed or truncated payloads safely.
- Update Linux architecture and detection documentation for the expanded hook coverage.

## Root cause

The Linux loader attached only `sys_enter_sendto`, so DNS queries sent through `sendmsg` and `sendmmsg` never reached the DNS ring buffer or downstream Sigma and IOC detection.

## Validation

- `cargo fmt --all -- --check`
- `RUSTINEL_CONFIG=$PWD/config.toml cargo test --locked`
- `RUSTINEL_CONFIG=$PWD/config.toml cargo clippy --locked --all-targets -- -D warnings`
- Built the eBPF object and userspace binary on Ubuntu 26.04.
- Loaded the programs successfully on the lab's Ubuntu 7.0 kernel.
- Confirmed live Sigma and domain IOC alerts for `sendto`, `sendmsg`, and both messages in a `sendmmsg` call.
- Confirmed `dig example.com A @8.8.8.8` succeeds on the lab.