### PR TITLE
fix(logging): restrict Unix log permissions

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -108,6 +108,11 @@ max_file_size_mb = 50
 
 Use Windows path prefixes on Windows and Unix path prefixes on Linux.
 
+On Unix, Rustinel restricts configured log and alert directories to mode `0700`
+and their rolling files to `0600`. This prevents other local users from reading
+operational context or alert details. Windows continues to use the owning
+account's configured ACLs.
+
 ## Platform-Aware Defaults
 
 ### Shared Defaults

--- a/src/runtime/logging.rs
+++ b/src/runtime/logging.rs
@@ -20,7 +20,8 @@ struct RestrictedFileAppender {
 impl Write for RestrictedFileAppender {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         let written = self.inner.write(buf)?;
-        let current_date = chrono::Local::now().date_naive();
+        // RollingFileAppender's daily rotation boundary is UTC.
+        let current_date = chrono::Utc::now().date_naive();
         if current_date != self.permission_date {
             restrict_log_file_permissions(&self.directory, &self.filename_prefix)?;
             self.permission_date = current_date;
@@ -233,7 +234,7 @@ fn try_build_daily_writer(
                 inner: appender,
                 directory: directory.to_path_buf(),
                 filename_prefix: filename.to_owned(),
-                permission_date: chrono::Local::now().date_naive(),
+                permission_date: chrono::Utc::now().date_naive(),
             }))
         }
         Err(err) => {
@@ -297,6 +298,7 @@ mod permission_tests {
         let unrelated_file = directory.join("other.log");
         fs::write(&log_file, b"alert").unwrap();
         fs::write(&unrelated_file, b"other").unwrap();
+        fs::set_permissions(&unrelated_file, fs::Permissions::from_mode(0o644)).unwrap();
 
         restrict_log_directory_permissions(&directory).unwrap();
         restrict_log_file_permissions(&directory, "alerts.json").unwrap();
@@ -309,9 +311,9 @@ mod permission_tests {
             fs::metadata(&log_file).unwrap().permissions().mode() & 0o777,
             0o600
         );
-        assert_ne!(
+        assert_eq!(
             fs::metadata(&unrelated_file).unwrap().permissions().mode() & 0o777,
-            0o600
+            0o644
         );
     }
 }

--- a/src/runtime/logging.rs
+++ b/src/runtime/logging.rs
@@ -1,13 +1,37 @@
 use crate::alerts::AlertSink;
 use crate::config;
 use std::fs;
-use std::path::Path;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
 use tracing::info;
 use tracing_appender::rolling;
 use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer};
 
 const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
 const STARTUP_BANNER_INNER_WIDTH: usize = 49;
+
+struct RestrictedFileAppender {
+    inner: rolling::RollingFileAppender,
+    directory: PathBuf,
+    filename_prefix: String,
+    permission_date: chrono::NaiveDate,
+}
+
+impl Write for RestrictedFileAppender {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let written = self.inner.write(buf)?;
+        let current_date = chrono::Local::now().date_naive();
+        if current_date != self.permission_date {
+            restrict_log_file_permissions(&self.directory, &self.filename_prefix)?;
+            self.permission_date = current_date;
+        }
+        Ok(written)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+}
 
 /// Build an `EnvFilter` from the logging configuration, with fallback to `info`.
 pub fn build_log_filter(logging: &config::LogConfig) -> EnvFilter {
@@ -184,12 +208,34 @@ fn try_build_daily_writer(
         return None;
     }
 
+    if let Err(err) = restrict_log_directory_permissions(directory) {
+        eprintln!(
+            "Unable to restrict {} log directory permissions for {:?}: {}",
+            label, directory, err
+        );
+        return None;
+    }
+
     match rolling::RollingFileAppender::builder()
         .rotation(rolling::Rotation::DAILY)
         .filename_prefix(filename)
         .build(directory)
     {
-        Ok(appender) => Some(tracing_appender::non_blocking(appender)),
+        Ok(appender) => {
+            if let Err(err) = restrict_log_file_permissions(directory, filename) {
+                eprintln!(
+                    "Unable to restrict {} log file permissions in {:?}: {}",
+                    label, directory, err
+                );
+                return None;
+            }
+            Some(tracing_appender::non_blocking(RestrictedFileAppender {
+                inner: appender,
+                directory: directory.to_path_buf(),
+                filename_prefix: filename.to_owned(),
+                permission_date: chrono::Local::now().date_naive(),
+            }))
+        }
         Err(err) => {
             eprintln!(
                 "Unable to initialize {} rolling log appender in {:?}: {}",
@@ -197,5 +243,75 @@ fn try_build_daily_writer(
             );
             None
         }
+    }
+}
+
+#[cfg(unix)]
+fn restrict_log_directory_permissions(directory: &Path) -> io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    fs::set_permissions(directory, fs::Permissions::from_mode(0o700))
+}
+
+#[cfg(not(unix))]
+fn restrict_log_directory_permissions(_directory: &Path) -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn restrict_log_file_permissions(directory: &Path, filename_prefix: &str) -> io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let expected_prefix = format!("{filename_prefix}.");
+    for entry in fs::read_dir(directory)? {
+        let entry = entry?;
+        if entry.file_type()?.is_file()
+            && entry
+                .file_name()
+                .to_string_lossy()
+                .starts_with(&expected_prefix)
+        {
+            fs::set_permissions(entry.path(), fs::Permissions::from_mode(0o600))?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn restrict_log_file_permissions(_directory: &Path, _filename_prefix: &str) -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(all(test, unix))]
+mod permission_tests {
+    use super::{restrict_log_directory_permissions, restrict_log_file_permissions};
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    #[test]
+    fn restricts_log_directory_and_matching_files() {
+        let temp = tempfile::tempdir().unwrap();
+        let directory = temp.path().join("logs");
+        fs::create_dir(&directory).unwrap();
+        let log_file = directory.join("alerts.json.2026-07-12");
+        let unrelated_file = directory.join("other.log");
+        fs::write(&log_file, b"alert").unwrap();
+        fs::write(&unrelated_file, b"other").unwrap();
+
+        restrict_log_directory_permissions(&directory).unwrap();
+        restrict_log_file_permissions(&directory, "alerts.json").unwrap();
+
+        assert_eq!(
+            fs::metadata(&directory).unwrap().permissions().mode() & 0o777,
+            0o700
+        );
+        assert_eq!(
+            fs::metadata(&log_file).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+        assert_ne!(
+            fs::metadata(&unrelated_file).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
     }
 }


### PR DESCRIPTION
## Summary

- restrict Unix log and alert directories to `0700`
- restrict current and newly rolled operational/alert files to `0600`
- document the Unix permission model and add regression coverage

## Type of change

- [ ] `feat` / `enhancement` - new feature
- [x] `bug` - bug fix
- [ ] `refactor` - refactoring, no behaviour change
- [x] `documentation` - docs only
- [ ] `ci` - CI and release changes
- [ ] `dependencies` - dependency update

## Test plan

- [ ] Tested on Windows
- [x] Tested on Linux
- [x] Existing tests pass (`cargo test --locked --lib`: 194 passed)
- [x] New tests added (if applicable)
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`

`cargo clippy --locked --all-targets -- -D clippy::all` was attempted, but the local eBPF build failed before project linting because the installed stable compiler and freshly downloaded nightly `rust-src` were incompatible. The full Linux library test suite passes; Windows/macOS behavior remains the existing ACL-based no-op and is left to CI.

## Checklist

- [ ] Label added to this PR (requires repository triage permission)
- [x] Docs updated (if behaviour changed)

Fixes #163
