### PR TITLE
fix(yara): revalidate process identity before memory scan

### DIFF
--- a/docs/detection.md
+++ b/docs/detection.md
@@ -200,7 +200,9 @@ Every YARA match is emitted as a `critical` alert.
 
 YARA memory scanning is optional and disabled by default (`scanner.yara_memory_enabled = false`).
 
-When enabled, Rustinel queues process IDs from process-start events to a bounded background worker. The worker waits a configurable delay (`yara_memory_delay_ms`, default 750 ms) to allow packers or loaders to finish unpacking, then reads a limited amount of selected process memory and scans it with the active YARA ruleset.
+When enabled, Rustinel queues process identities from process-start events to a bounded background worker. The worker waits a configurable delay (`yara_memory_delay_ms`, default 750 ms) to allow packers or loaders to finish unpacking, then reads a limited amount of selected process memory and scans it with the active YARA ruleset.
+
+Before reading memory, the worker revalidates the queued PID against the process image and any available start-time and command-line metadata. If the process identity changed or cannot be queried, the worker skips the scan and logs the reason. Platforms without process identity query support fail closed.
 
 Default behavior scans private readable memory only and avoids mapped or image-backed regions to reduce overhead and false positives. Each matching YARA rule emits its own `critical` alert. The alert `provider` field is set to `yara-memory` to distinguish memory hits from file hits (`etw`, `ebpf`, or `esf`).
 

--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -5,7 +5,9 @@
 
 use crate::config::ResponseConfig;
 use crate::models::{Alert, AlertSeverity, DetectionEngine, EventFields};
-use crate::utils::{hash_command_line, query_process_identity, ProcessIdentity};
+use crate::utils::{
+    hash_command_line, normalize_path_for_comparison, validate_process_identity, ProcessIdentity,
+};
 use std::sync::atomic::{AtomicU64, Ordering};
 use tokio::sync::mpsc;
 use tracing::{error, info, warn};
@@ -482,54 +484,6 @@ fn extract_process_identity(alert: &Alert) -> Option<ProcessIdentity> {
     })
 }
 
-fn validate_process_identity(expected: &ProcessIdentity) -> Result<ProcessIdentity, String> {
-    let current = query_process_identity(expected.pid)
-        .ok_or_else(|| "process no longer exists or identity could not be queried".to_string())?;
-
-    if !same_process_image(&expected.image, &current.image) {
-        return Err(format!(
-            "image changed from '{}' to '{}'",
-            expected.image, current.image
-        ));
-    }
-
-    if let (Some(expected_start), Some(current_start)) = (expected.start_time, current.start_time) {
-        if expected_start != current_start {
-            return Err(format!(
-                "start time changed from {} to {}",
-                expected_start, current_start
-            ));
-        }
-    }
-
-    if let (Some(expected_hash), Some(current_hash)) = (
-        expected.command_line_hash.as_deref(),
-        current.command_line_hash.as_deref(),
-    ) {
-        if expected_hash != current_hash {
-            return Err("command line hash changed".to_string());
-        }
-    }
-
-    Ok(current)
-}
-
-fn same_process_image(expected: &str, current: &str) -> bool {
-    if normalize_path(expected) == normalize_path(current) {
-        return true;
-    }
-
-    let expected = std::fs::canonicalize(expected).ok();
-    let current = std::fs::canonicalize(current).ok();
-    match (expected, current) {
-        (Some(expected), Some(current)) => {
-            normalize_path(&expected.to_string_lossy())
-                == normalize_path(&current.to_string_lossy())
-        }
-        _ => false,
-    }
-}
-
 fn parse_pid(value: Option<&str>) -> Option<u32> {
     let value = value?.trim();
     if let Some(hex) = value
@@ -539,17 +493,6 @@ fn parse_pid(value: Option<&str>) -> Option<u32> {
         u32::from_str_radix(hex, 16).ok()
     } else {
         value.parse::<u32>().ok()
-    }
-}
-
-fn normalize_path(value: &str) -> String {
-    #[cfg(any(target_os = "linux", target_os = "macos"))]
-    {
-        value.trim().to_ascii_lowercase()
-    }
-    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
-    {
-        value.trim().replace('/', "\\").to_ascii_lowercase()
     }
 }
 
@@ -563,7 +506,7 @@ fn normalize_allowlist_paths(values: &[String]) -> Vec<String> {
         .iter()
         .filter(|v| !v.trim().is_empty())
         .map(|value| {
-            let mut normalized = normalize_path(value);
+            let mut normalized = normalize_path_for_comparison(value);
             if !normalized.ends_with(SEP) {
                 normalized.push(SEP);
             }
@@ -576,7 +519,7 @@ fn normalize_allowlist_images(values: &[String]) -> Vec<String> {
     values
         .iter()
         .filter(|v| !v.trim().is_empty())
-        .map(|value| normalize_path(value))
+        .map(|value| normalize_path_for_comparison(value))
         .collect()
 }
 
@@ -590,7 +533,7 @@ fn image_basename(path: &str) -> &str {
 }
 
 fn is_allowlisted(image: &str, allowlist_images: &[String], allowlist_paths: &[String]) -> bool {
-    let normalized = normalize_path(image);
+    let normalized = normalize_path_for_comparison(image);
 
     if allowlist_paths
         .iter()
@@ -706,7 +649,7 @@ mod tests {
     #[test]
     fn validate_process_identity_accepts_current_process() {
         let pid = std::process::id();
-        let identity = query_process_identity(pid).expect("current process identity");
+        let identity = crate::utils::query_process_identity(pid).expect("current process identity");
         assert!(validate_process_identity(&identity).is_ok());
     }
 
@@ -714,7 +657,8 @@ mod tests {
     #[test]
     fn validate_process_identity_rejects_image_mismatch() {
         let pid = std::process::id();
-        let mut identity = query_process_identity(pid).expect("current process identity");
+        let mut identity =
+            crate::utils::query_process_identity(pid).expect("current process identity");
         identity.image = if cfg!(windows) {
             r"C:\definitely-not-rustinel.exe".to_string()
         } else {
@@ -728,7 +672,8 @@ mod tests {
     #[test]
     fn validate_process_identity_rejects_start_time_mismatch_when_available() {
         let pid = std::process::id();
-        let mut identity = query_process_identity(pid).expect("current process identity");
+        let mut identity =
+            crate::utils::query_process_identity(pid).expect("current process identity");
         let Some(start_time) = identity.start_time else {
             return;
         };

--- a/src/runtime/yara.rs
+++ b/src/runtime/yara.rs
@@ -8,7 +8,7 @@ use crate::reload::DetectorStore;
 use crate::response::ResponseEngine;
 use crate::scanner::{self, YaraMemoryJob};
 use crate::sensor::Platform;
-use crate::utils::{self, LogRateLimiter};
+use crate::utils::{self, validate_process_identity, LogRateLimiter};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc;
@@ -291,13 +291,24 @@ pub fn spawn_yara_memory_worker(
         info!(target: "scanner", "YARA memory worker started");
         while let Some(job) = rx.blocking_recv() {
             std::thread::sleep(Duration::from_millis(cfg.delay_ms));
-            let chunks = match memory::read_process_memory_chunks(job.pid, &cfg) {
+            if let Err(reason) = validate_process_identity(&job.expected_identity) {
+                debug!(
+                    target: "scanner",
+                    pid = job.expected_identity.pid,
+                    image = %job.expected_identity.image,
+                    reason = %reason,
+                    "YARA memory scan skipped after process identity validation"
+                );
+                continue;
+            }
+
+            let chunks = match memory::read_process_memory_chunks(job.expected_identity.pid, &cfg) {
                 Ok(chunks) => chunks,
                 Err(err) => {
                     tracing::trace!(
                         target: "scanner",
-                        pid = job.pid,
-                        image = %job.image,
+                        pid = job.expected_identity.pid,
+                        image = %job.expected_identity.image,
                         error = %err,
                         "YARA memory scan skipped"
                     );
@@ -312,7 +323,7 @@ pub fn spawn_yara_memory_worker(
                     Err(err) => {
                         tracing::trace!(
                             target: "scanner",
-                            pid = job.pid,
+                            pid = job.expected_identity.pid,
                             error = %err,
                             "YARA memory chunk scan failed"
                         );
@@ -324,8 +335,8 @@ pub fn spawn_yara_memory_worker(
                     let rule_names: Vec<String> =
                         matches.iter().map(|rule| rule.rule.clone()).collect();
                     warn!(
-                        pid = job.pid,
-                        image = %job.image,
+                        pid = job.expected_identity.pid,
+                        image = %job.expected_identity.image,
                         rules = ?rule_names,
                         "YARA memory detection triggered"
                     );
@@ -336,8 +347,8 @@ pub fn spawn_yara_memory_worker(
                         let alert = build_yara_memory_alert(
                             &rule_match.rule,
                             rule_match.metadata_id.clone(),
-                            &job.image,
-                            job.pid,
+                            &job.expected_identity.image,
+                            job.expected_identity.pid,
                             details,
                             platform,
                             provider,

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -12,8 +12,9 @@ use tokio::sync::mpsc::Sender;
 use tracing::{debug, info, warn};
 use yara_x::{Compiler, Rules, Scanner as XScanner};
 
-use crate::models::{MatchDebugLevel, YaraRuleMatch, YaraStringMatch};
+use crate::models::{MatchDebugLevel, ProcessCreationFields, YaraRuleMatch, YaraStringMatch};
 use crate::sensor::{SensorAction, SensorEvent, SensorEventHandler, SensorPayload};
+use crate::utils::{hash_command_line, query_process_identity, ProcessIdentity};
 
 /// Strip NT namespace prefix and convert to a path the YARA scanner can open.
 /// On Windows raw ETW paths may arrive as `\??\C:\Windows\...`.
@@ -205,8 +206,7 @@ fn truncate_str(s: &str, max_len: usize) -> String {
 /// Job queued from a process-start event for background memory scanning.
 #[derive(Debug, Clone)]
 pub struct YaraMemoryJob {
-    pub pid: u32,
-    pub image: String,
+    pub expected_identity: ProcessIdentity,
 }
 
 /// Main Scanner struct holding compiled rules
@@ -525,10 +525,8 @@ impl SensorEventHandler for YaraEventHandler {
         }
 
         if let Some(memory_tx) = &self.memory_tx {
-            match memory_tx.try_send(YaraMemoryJob {
-                pid,
-                image: path.to_string(),
-            }) {
+            let expected_identity = capture_process_identity(event, fields, pid, path);
+            match memory_tx.try_send(YaraMemoryJob { expected_identity }) {
                 Ok(_) => tracing::trace!(
                     target: "scanner",
                     pid = pid,
@@ -544,6 +542,38 @@ impl SensorEventHandler for YaraEventHandler {
                 ),
             }
         }
+    }
+}
+
+fn capture_process_identity(
+    event: &SensorEvent,
+    fields: &ProcessCreationFields,
+    pid: u32,
+    image: &str,
+) -> ProcessIdentity {
+    let queried = query_process_identity(pid);
+    let event_start_time = event
+        .process_start_key
+        .filter(|key| key.pid == pid)
+        .map(|key| key.start_time);
+    let start_time = event_start_time
+        .or_else(|| queried.as_ref().and_then(|identity| identity.start_time))
+        .or(fields.process_start_time);
+    let command_line_hash = fields
+        .command_line
+        .as_deref()
+        .map(hash_command_line)
+        .or_else(|| {
+            queried
+                .as_ref()
+                .and_then(|identity| identity.command_line_hash.clone())
+        });
+
+    ProcessIdentity {
+        pid,
+        image: image.to_string(),
+        start_time,
+        command_line_hash,
     }
 }
 

--- a/src/sensor/windows/etw.rs
+++ b/src/sensor/windows/etw.rs
@@ -514,7 +514,7 @@ fn decode_process(
 
     let process_start_key = match action {
         SensorAction::Start => {
-            creation_time_with_fallback.map(|start_time| ProcessStartKey { pid, start_time })
+            creation_time_opt.map(|start_time| ProcessStartKey { pid, start_time })
         }
         SensorAction::Stop => {
             creation_time_opt.map(|start_time| ProcessStartKey { pid, start_time })

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -13,7 +13,7 @@ pub mod time;
 pub mod user;
 
 pub use log_rate_limiter::LogRateLimiter;
-pub use path::convert_nt_to_dos;
+pub use path::{convert_nt_to_dos, normalize_path_for_comparison};
 #[cfg(windows)]
 pub use pe::parse_metadata;
 #[cfg(target_os = "macos")]
@@ -23,7 +23,8 @@ pub use process::query_process_command_line_from_handle;
 #[cfg(target_os = "linux")]
 pub use process::query_process_details;
 pub use process::{
-    hash_command_line, query_process_command_line, query_process_identity, ProcessIdentity,
+    hash_command_line, query_process_command_line, query_process_identity,
+    validate_process_identity, ProcessIdentity,
 };
 #[cfg(target_os = "linux")]
 pub use socket::query_socket_metadata;

--- a/src/utils/path.rs
+++ b/src/utils/path.rs
@@ -113,6 +113,18 @@ pub fn convert_nt_to_dos(nt_path: &str) -> String {
     nt_path.to_string()
 }
 
+/// Normalize a path for case-insensitive process identity comparisons.
+pub fn normalize_path_for_comparison(value: &str) -> String {
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    {
+        value.trim().to_ascii_lowercase()
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        value.trim().replace('/', "\\").to_ascii_lowercase()
+    }
+}
+
 fn lookup_dos_path(drive_map: &DriveMapCache, nt_path: &str) -> Option<String> {
     let map = drive_map.map.read().ok()?;
     for (device_path, dos_drive) in map.iter() {
@@ -210,6 +222,21 @@ mod tests {
         assert_eq!(
             convert_nt_to_dos(r"\\server\share\file.txt"),
             r"\\server\share\file.txt"
+        );
+    }
+
+    #[test]
+    fn test_normalize_path_for_comparison() {
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        assert_eq!(
+            normalize_path_for_comparison(" /USR/BIN/example "),
+            "/usr/bin/example"
+        );
+
+        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+        assert_eq!(
+            normalize_path_for_comparison(" /USR/BIN/example "),
+            r"\usr\bin\example"
         );
     }
 }

--- a/src/utils/process.rs
+++ b/src/utils/process.rs
@@ -3,12 +3,50 @@
 use digest::Digest;
 use sha2::Sha256;
 
+use super::path::normalize_path_for_comparison;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProcessIdentity {
     pub pid: u32,
     pub image: String,
     pub start_time: Option<u64>,
     pub command_line_hash: Option<String>,
+}
+
+impl ProcessIdentity {
+    /// Compare two identities, allowing metadata that is unavailable on one side.
+    pub fn matches(&self, current: &Self) -> Result<(), String> {
+        if self.pid != current.pid {
+            return Err(format!("pid changed from {} to {}", self.pid, current.pid));
+        }
+
+        if !same_process_image(&self.image, &current.image) {
+            return Err(format!(
+                "image changed from '{}' to '{}'",
+                self.image, current.image
+            ));
+        }
+
+        if let (Some(expected_start), Some(current_start)) = (self.start_time, current.start_time) {
+            if expected_start != current_start {
+                return Err(format!(
+                    "start time changed from {} to {}",
+                    expected_start, current_start
+                ));
+            }
+        }
+
+        if let (Some(expected_hash), Some(current_hash)) = (
+            self.command_line_hash.as_deref(),
+            current.command_line_hash.as_deref(),
+        ) {
+            if expected_hash != current_hash {
+                return Err("command line hash changed".to_string());
+            }
+        }
+
+        Ok(())
+    }
 }
 
 #[cfg(target_os = "linux")]
@@ -258,10 +296,34 @@ pub fn query_process_identity(_pid: u32) -> Option<ProcessIdentity> {
     None
 }
 
+/// Query and validate the process currently using the expected PID.
+pub fn validate_process_identity(expected: &ProcessIdentity) -> Result<ProcessIdentity, String> {
+    let current = query_process_identity(expected.pid)
+        .ok_or_else(|| "process no longer exists or identity could not be queried".to_string())?;
+    expected.matches(&current)?;
+    Ok(current)
+}
+
 pub fn hash_command_line(command_line: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(command_line.as_bytes());
     hex::encode(hasher.finalize())
+}
+
+fn same_process_image(expected: &str, current: &str) -> bool {
+    if normalize_path_for_comparison(expected) == normalize_path_for_comparison(current) {
+        return true;
+    }
+
+    let expected = std::fs::canonicalize(expected).ok();
+    let current = std::fs::canonicalize(current).ok();
+    match (expected, current) {
+        (Some(expected), Some(current)) => {
+            normalize_path_for_comparison(&expected.to_string_lossy())
+                == normalize_path_for_comparison(&current.to_string_lossy())
+        }
+        _ => false,
+    }
 }
 
 #[cfg(target_os = "linux")]
@@ -324,5 +386,81 @@ mod tests {
         let command_line =
             query_process_command_line(pid).expect("current process command line should exist");
         assert!(!command_line.is_empty());
+    }
+}
+
+#[cfg(test)]
+mod identity_tests {
+    use super::*;
+
+    fn identity() -> ProcessIdentity {
+        ProcessIdentity {
+            pid: 42,
+            image: "/usr/bin/example".to_string(),
+            start_time: Some(100),
+            command_line_hash: Some("hash".to_string()),
+        }
+    }
+
+    #[test]
+    fn matching_identity_is_accepted() {
+        assert!(identity().matches(&identity()).is_ok());
+    }
+
+    #[test]
+    fn image_mismatch_is_rejected() {
+        let mut current = identity();
+        current.image = "/usr/bin/other".to_string();
+
+        assert_eq!(
+            identity().matches(&current),
+            Err("image changed from '/usr/bin/example' to '/usr/bin/other'".to_string())
+        );
+    }
+
+    #[test]
+    fn start_time_mismatch_is_rejected_when_both_are_available() {
+        let mut current = identity();
+        current.start_time = Some(101);
+
+        assert_eq!(
+            identity().matches(&current),
+            Err("start time changed from 100 to 101".to_string())
+        );
+    }
+
+    #[test]
+    fn command_line_hash_mismatch_is_rejected_when_both_are_available() {
+        let mut current = identity();
+        current.command_line_hash = Some("other-hash".to_string());
+
+        assert_eq!(
+            identity().matches(&current),
+            Err("command line hash changed".to_string())
+        );
+    }
+
+    #[test]
+    fn unavailable_optional_metadata_does_not_reject_identity() {
+        let mut current = identity();
+        current.start_time = None;
+        current.command_line_hash = None;
+
+        assert!(identity().matches(&current).is_ok());
+    }
+
+    #[test]
+    fn missing_current_identity_is_rejected() {
+        let expected = ProcessIdentity {
+            pid: 0,
+            image: "/usr/bin/example".to_string(),
+            start_time: None,
+            command_line_hash: None,
+        };
+
+        assert_eq!(
+            validate_process_identity(&expected),
+            Err("process no longer exists or identity could not be queried".to_string())
+        );
     }
 }

--- a/tests/router_and_handlers.rs
+++ b/tests/router_and_handlers.rs
@@ -4,6 +4,7 @@ mod common;
 use std::sync::Arc;
 
 use common::{process_start_event, SigmaFixture, TestNormalizer, TEST_PID};
+use rustinel::utils::hash_command_line;
 use rustinel::{
     alerts::AlertSink,
     config::ResponseConfig,
@@ -82,8 +83,23 @@ async fn yara_event_handler_queues_disk_and_memory_only_for_non_allowlisted_star
     assert_eq!(path, common::image_for(Platform::Linux));
     assert_eq!(pid, TEST_PID);
     let memory = memory_rx.try_recv().expect("memory job queued");
-    assert_eq!(memory.pid, TEST_PID);
-    assert_eq!(memory.image, common::image_for(Platform::Linux));
+    assert_eq!(memory.expected_identity.pid, TEST_PID);
+    assert_eq!(
+        memory.expected_identity.image,
+        common::image_for(Platform::Linux)
+    );
+    assert_eq!(
+        memory.expected_identity.start_time,
+        Some(common::TEST_PROCESS_START_TIME)
+    );
+    assert_eq!(
+        memory.expected_identity.command_line_hash,
+        Some(hash_command_line(&format!(
+            "{} https://{}",
+            common::image_for(Platform::Linux),
+            common::TEST_DOMAIN
+        )))
+    );
 
     let mut stop = process_start_event(Platform::Linux);
     stop.action = SensorAction::Stop;


### PR DESCRIPTION
## Summary

- Capture expected process identity when queueing delayed YARA memory jobs.
- Revalidate the PID, image, start time, and command-line hash before reading memory.
- Skip and log scans when the identity changes or cannot be queried.
- Share path comparison normalization between process validation and active response.
- Document fail-closed behavior on unsupported platforms.

## Root cause

The delayed memory worker previously used only the queued PID and image. If the original process exited and the operating system reused the PID, the worker could scan a different process.

## Validation

- cargo check --locked --all-targets
- cargo test --locked --lib identity_tests
- cargo test --locked --lib normalize_path_for_comparison
- cargo test --locked --test router_and_handlers
- cargo test --locked --test yara_memory
- Full library tests: 205 passed, with one unrelated environment-dependent config path failure on macOS.

Closes #35