### PR TITLE
fix(network): preserve repeated connection detection (#164)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -74,7 +74,14 @@ channel_capacity = 128
 #
 # allowlist_images = []
 
-# 5. Atomic IOC Detection (Hashes, IPs, Domains, Path Regex)
+# 5. Network Connection Metrics
+[network]
+aggregation_enabled = true
+aggregation_max_entries = 20000
+aggregation_window_secs = 60
+aggregation_interval_buffer_size = 50
+
+# 6. Atomic IOC Detection (Hashes, IPs, Domains, Path Regex)
 [ioc]
 enabled = true
 hashes_path = "rules/ioc/hashes.txt"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -94,6 +94,7 @@ allowlist_images = []
 [network]
 aggregation_enabled = true
 aggregation_max_entries = 20000
+aggregation_window_secs = 60
 aggregation_interval_buffer_size = 50
 
 [ioc]
@@ -275,9 +276,19 @@ See [Active Response](active-response.md) for platform behavior and safe testing
 
 | Option | Default | Description |
 | --- | --- | --- |
-| `aggregation_enabled` | `true` | Enable repeated-connection suppression |
+| `aggregation_enabled` | `true` | Track repeated-connection metrics without suppressing network events |
 | `aggregation_max_entries` | `20000` | Maximum unique connections tracked |
+| `aggregation_window_secs` | `60` | Start a new aggregate period after this many seconds; `0` starts a new period for every event |
 | `aggregation_interval_buffer_size` | `50` | Timing intervals retained per aggregated connection |
+
+Connection aggregation is observational. Every normalized network event is
+forwarded to Sigma and IOC evaluation, including repeated connections and
+connections from a new process using the same image. The in-memory aggregate
+tracks count, first-seen and last-seen timestamps, unique process IDs, and
+intervals for each key. The window limits how long those values are combined,
+including during continuous activity; it does not create a detection blind
+spot. Forwarding every event increases processing and storage work for high
+volume destinations, while alert deduplication remains available separately.
 
 ### IOC
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -189,13 +189,12 @@ The most common reasons are:
 - the rule depends on fields that the platform does not emit
 - the event family does not exist on that platform yet
 - the event was skipped by an allowlist
-- the event was suppressed by network aggregation
 
 Examples:
 
 - registry, image load, PowerShell, WMI, service, and task detections are Windows-only today
 - Linux DNS events populate `QueryName` for outbound plaintext DNS queries, but not `QueryResults`
-- repeated network connections may be suppressed when aggregation is enabled
+- network aggregation records connection metrics but does not suppress repeated events
 
 ### Linux DNS or IOC domain rules do not match
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -351,10 +351,12 @@ pub struct ResponseConfig {
 /// Network event aggregation configuration
 #[derive(Debug, Clone, Deserialize)]
 pub struct NetworkConfig {
-    /// Enable connection aggregation to reduce event volume
+    /// Enable connection aggregation metrics without suppressing network events
     pub aggregation_enabled: bool,
     /// Maximum number of unique connections to track
     pub aggregation_max_entries: usize,
+    /// Window in seconds before a connection starts a new aggregate period
+    pub aggregation_window_secs: u64,
     /// Number of inter-connection intervals to store for beacon detection
     pub aggregation_interval_buffer_size: usize,
 }
@@ -450,6 +452,7 @@ impl AppConfig {
             // Network
             .set_default("network.aggregation_enabled", true)?
             .set_default("network.aggregation_max_entries", 20000)?
+            .set_default("network.aggregation_window_secs", 60)?
             .set_default("network.aggregation_interval_buffer_size", 50)?
             // IOC
             .set_default("ioc.enabled", true)?
@@ -622,6 +625,7 @@ impl Default for AppConfig {
             network: NetworkConfig {
                 aggregation_enabled: true,
                 aggregation_max_entries: 20_000,
+                aggregation_window_secs: 60,
                 aggregation_interval_buffer_size: 50,
             },
             ioc: IocConfig {
@@ -681,6 +685,7 @@ mod tests {
         assert!(cfg.reload.enabled);
         assert_eq!(cfg.reload.debounce_ms, 2000);
         assert_eq!(cfg.alerts.match_debug, MatchDebugLevel::Off);
+        assert_eq!(cfg.network.aggregation_window_secs, 60);
     }
 
     #[test]

--- a/src/normalizer/mod.rs
+++ b/src/normalizer/mod.rs
@@ -12,9 +12,7 @@ use chrono::{DateTime, SecondsFormat, Utc};
 
 use crate::models::*;
 use crate::sensor::{SensorAction, SensorEvent, SensorPayload};
-use crate::state::{
-    AggregationResult, ConnectionAggregator, DnsCache, ProcessCache, Protocol, SidCache,
-};
+use crate::state::{ConnectionAggregator, DnsCache, ProcessCache, Protocol, SidCache};
 use crate::utils::{convert_nt_to_dos, query_process_command_line};
 
 /// Event normalizer that converts shared sensor events to normalized events.
@@ -233,13 +231,11 @@ impl Normalizer {
                     };
                     let pid = event_pid(event, fields.process_id.as_deref());
 
-                    let result = self
-                        .connection_aggregator
+                    // Aggregation is observational state for connection counts
+                    // and interval statistics. Every raw event remains visible
+                    // to Sigma and IOC detection.
+                    self.connection_aggregator
                         .record(image, dest_ip, dest_port, protocol, pid);
-
-                    if result == AggregationResult::Aggregated {
-                        return None;
-                    }
                 }
             }
         }
@@ -675,7 +671,7 @@ mod tests {
     }
 
     #[test]
-    fn network_aggregation_suppresses_repeated_connections() {
+    fn network_aggregation_keeps_repeated_connections_for_detection() {
         let normalizer = build_normalizer(true);
         normalizer.process_cache.add(
             7,
@@ -720,7 +716,37 @@ mod tests {
         };
 
         assert!(normalizer.normalize(&build_event()).is_some());
-        assert!(normalizer.normalize(&build_event()).is_none());
+        assert!(normalizer.normalize(&build_event()).is_some());
+
+        let mut restarted = build_event();
+        restarted.pid = Some(8);
+        if let SensorPayload::Network(fields) = &mut restarted.payload {
+            fields.process_id = Some("8".to_string());
+            fields.user = Some("bob".to_string());
+            fields.destination_hostname = Some("new.example.test".to_string());
+        }
+
+        let normalized = normalizer
+            .normalize(&restarted)
+            .expect("connection from a restarted process should remain visible");
+        assert_eq!(normalized.get_field("ProcessId"), Some("8"));
+        assert_eq!(normalized.get_field("User"), Some("bob"));
+        assert_eq!(
+            normalized.get_field("DestinationHostname"),
+            Some("new.example.test")
+        );
+
+        let meta = normalizer
+            .connection_aggregator
+            .get_meta(
+                "C:\\curl.exe",
+                "198.51.100.10".parse().unwrap(),
+                443,
+                Protocol::Tcp,
+            )
+            .expect("connection aggregate should be tracked");
+        assert_eq!(meta.connection_count, 3);
+        assert_eq!(meta.unique_pids.len(), 2);
     }
 
     #[test]

--- a/src/runtime/linux.rs
+++ b/src/runtime/linux.rs
@@ -82,9 +82,10 @@ async fn run_linux_edr(
     let process_cache = Arc::new(ProcessCache::new());
     let sid_cache = Arc::new(SidCache::new()); // no-op on Linux; kept for Normalizer compat
     let dns_cache = Arc::new(DnsCache::new());
-    let connection_aggregator = Arc::new(ConnectionAggregator::with_limits(
+    let connection_aggregator = Arc::new(ConnectionAggregator::with_limits_and_window(
         cfg.network.aggregation_max_entries,
         cfg.network.aggregation_interval_buffer_size,
+        cfg.network.aggregation_window_secs,
     ));
 
     // 4. Active response engine

--- a/src/runtime/macos.rs
+++ b/src/runtime/macos.rs
@@ -82,9 +82,10 @@ async fn run_macos_edr(
     let process_cache = Arc::new(ProcessCache::new());
     let sid_cache = Arc::new(SidCache::new()); // no-op on macOS; kept for Normalizer compat
     let dns_cache = Arc::new(DnsCache::new());
-    let connection_aggregator = Arc::new(ConnectionAggregator::with_limits(
+    let connection_aggregator = Arc::new(ConnectionAggregator::with_limits_and_window(
         cfg.network.aggregation_max_entries,
         cfg.network.aggregation_interval_buffer_size,
+        cfg.network.aggregation_window_secs,
     ));
 
     // 4. Active response engine

--- a/src/runtime/windows.rs
+++ b/src/runtime/windows.rs
@@ -261,9 +261,10 @@ async fn run_edr(
     let process_cache = Arc::new(ProcessCache::new());
     let sid_cache = Arc::new(SidCache::new());
     let dns_cache = Arc::new(DnsCache::new());
-    let connection_aggregator = Arc::new(ConnectionAggregator::with_limits(
+    let connection_aggregator = Arc::new(ConnectionAggregator::with_limits_and_window(
         cfg.network.aggregation_max_entries,
         cfg.network.aggregation_interval_buffer_size,
+        cfg.network.aggregation_window_secs,
     ));
 
     // Snapshot existing processes using Windows API (handles cold start problem)

--- a/src/state/connection.rs
+++ b/src/state/connection.rs
@@ -98,7 +98,7 @@ impl ConnectionState {
     }
 }
 
-/// Aggregation metadata for summary events
+/// Aggregation metadata for connection metrics.
 #[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct AggregationMeta {
@@ -111,22 +111,26 @@ pub struct AggregationMeta {
 /// Result of recording a connection
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AggregationResult {
-    /// First connection - emit full event
+    /// First connection in the current aggregate period.
     FirstConnection,
-    /// Subsequent connection - suppress (aggregated)
+    /// Subsequent connection in the current aggregate period.
     Aggregated,
 }
 
 /// Thread-safe cache for network connection aggregation
-/// Reduces event volume by aggregating repeated connections to same destination
+/// Tracks repeated connections to the same destination without suppressing
+/// events from the detection pipeline.
 pub struct ConnectionAggregator {
     cache: RwLock<HashMap<ConnectionKey, ConnectionState>>,
     max_entries: usize,
     interval_buffer_size: usize,
+    window_secs: u64,
     last_cleanup: AtomicU64,
 }
 
 impl ConnectionAggregator {
+    const DEFAULT_WINDOW_SECS: u64 = 60;
+
     /// Create with default limits
     pub fn new() -> Self {
         Self::with_limits(20_000, 50)
@@ -134,18 +138,32 @@ impl ConnectionAggregator {
 
     /// Create with custom limits
     pub fn with_limits(max_entries: usize, interval_buffer_size: usize) -> Self {
+        Self::with_limits_and_window(max_entries, interval_buffer_size, Self::DEFAULT_WINDOW_SECS)
+    }
+
+    /// Create with custom limits and a time window for aggregate state.
+    ///
+    /// A zero window starts a new aggregate period for every connection. The
+    /// window controls metric aggregation only. Network events are never
+    /// suppressed by the normalizer.
+    pub fn with_limits_and_window(
+        max_entries: usize,
+        interval_buffer_size: usize,
+        window_secs: u64,
+    ) -> Self {
         Self {
             cache: RwLock::new(HashMap::new()),
             max_entries,
             interval_buffer_size,
+            window_secs,
             last_cleanup: AtomicU64::new(0),
         }
     }
 
-    /// Record a connection and determine if it should be emitted
+    /// Record a connection and determine its aggregate period.
     ///
-    /// Returns `FirstConnection` if this is the first time seeing this connection key,
-    /// or `Aggregated` if it's a repeat that should be suppressed.
+    /// Returns `FirstConnection` for a new aggregate period or `Aggregated`
+    /// for a repeat within the current period.
     pub fn record(
         &self,
         process_image: &str,
@@ -154,7 +172,22 @@ impl ConnectionAggregator {
         protocol: Protocol,
         pid: u32,
     ) -> AggregationResult {
-        let now = now_secs();
+        self.record_at(now_secs(), process_image, dest_ip, dest_port, protocol, pid)
+    }
+
+    /// Record a connection at a supplied timestamp.
+    ///
+    /// This is useful for deterministic callers and tests that need to verify
+    /// aggregate-window expiration without waiting for wall-clock time.
+    pub fn record_at(
+        &self,
+        timestamp: u64,
+        process_image: &str,
+        dest_ip: IpAddr,
+        dest_port: u16,
+        protocol: Protocol,
+        pid: u32,
+    ) -> AggregationResult {
         let key = ConnectionKey {
             process_image: process_image.to_string(),
             dest_ip,
@@ -165,14 +198,19 @@ impl ConnectionAggregator {
         let mut cache = self.cache.write().unwrap();
 
         if let Some(state) = cache.get_mut(&key) {
-            state.update(now, pid);
+            if timestamp.saturating_sub(state.first_seen) >= self.window_secs {
+                *state = ConnectionState::new(timestamp, pid, self.interval_buffer_size);
+                return AggregationResult::FirstConnection;
+            }
+
+            state.update(timestamp, pid);
             return AggregationResult::Aggregated;
         }
 
-        // First connection - insert and emit
+        // First connection in this aggregate period - insert and emit.
         cache.insert(
             key,
-            ConnectionState::new(now, pid, self.interval_buffer_size),
+            ConnectionState::new(timestamp, pid, self.interval_buffer_size),
         );
 
         // Trim if over capacity
@@ -183,7 +221,7 @@ impl ConnectionAggregator {
         AggregationResult::FirstConnection
     }
 
-    /// Get aggregation metadata for a connection (for summary events)
+    /// Get aggregation metadata for a connection metric.
     #[allow(dead_code)]
     pub fn get_meta(
         &self,

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -111,6 +111,26 @@ mod tests {
     }
 
     #[test]
+    fn connection_aggregator_starts_new_period_after_window() {
+        let aggregator = ConnectionAggregator::with_limits_and_window(10, 10, 60);
+        let ip: IpAddr = "10.0.0.1".parse().unwrap();
+
+        let result1 = aggregator.record_at(100, "C:\\app.exe", ip, 443, Protocol::Tcp, 1234);
+        let result2 = aggregator.record_at(101, "C:\\app.exe", ip, 443, Protocol::Tcp, 1234);
+        let result3 = aggregator.record_at(161, "C:\\app.exe", ip, 443, Protocol::Tcp, 5678);
+
+        assert_eq!(result1, AggregationResult::FirstConnection);
+        assert_eq!(result2, AggregationResult::Aggregated);
+        assert_eq!(result3, AggregationResult::FirstConnection);
+
+        let meta = aggregator
+            .get_meta("C:\\app.exe", ip, 443, Protocol::Tcp)
+            .unwrap();
+        assert_eq!(meta.connection_count, 1);
+        assert_eq!(meta.unique_pids, vec![5678]);
+    }
+
+    #[test]
     fn connection_aggregator_different_destinations_emit() {
         let aggregator = ConnectionAggregator::new();
         let ip1: IpAddr = "10.0.0.1".parse().unwrap();

--- a/tests/pipeline_ioc.rs
+++ b/tests/pipeline_ioc.rs
@@ -42,13 +42,19 @@ fn ip_ioc_matches_network_and_dns_response_ips() {
         "{TEST_DESTINATION_IP}; exact\n198.51.100.0/24; cidr\n"
     ));
     let engine = IocEngine::load(&fixture.config());
-    let harness = TestNormalizer::new(false);
+    let harness = TestNormalizer::new(true);
 
     let network = harness
         .normalizer
         .normalize(&network_connect_event(Platform::Linux))
         .expect("network event should normalize");
     assert_eq!(engine.check_event(&network).len(), 2);
+
+    let repeated_network = harness
+        .normalizer
+        .normalize(&network_connect_event(Platform::Linux))
+        .expect("repeated network event should remain available to IOC detection");
+    assert_eq!(engine.check_event(&repeated_network).len(), 2);
 
     let dns = harness
         .normalizer

--- a/tests/pipeline_sigma.rs
+++ b/tests/pipeline_sigma.rs
@@ -97,13 +97,14 @@ fn sigma_network_detection_pipeline_enriches_aggregates_and_maps_to_ecs() {
         assert_normalized_field_eq(&first, "SourceIp", TEST_SOURCE_IP);
         assert_normalized_field_eq(&first, "Protocol", "tcp");
 
-        assert!(
-            harness
-                .normalizer
-                .normalize(&network_connect_event(platform))
-                .is_none(),
-            "repeated identical connection should be aggregated"
-        );
+        let repeated = harness
+            .normalizer
+            .normalize(&network_connect_event(platform))
+            .expect("repeated connection should remain available to detection");
+        let repeated_alert = engine
+            .check_event(&repeated)
+            .expect("repeated network connection should match Sigma");
+        assert_sigma_alert(&repeated_alert, "Test Network Destination");
 
         let alert = engine
             .check_event(&first)
@@ -118,6 +119,33 @@ fn sigma_network_detection_pipeline_enriches_aggregates_and_maps_to_ecs() {
         assert_ecs_field_eq(&ecs, "network.transport", "tcp");
         assert_ecs_field_eq(&ecs, "process.executable", image_for(platform));
     }
+}
+
+#[test]
+fn sigma_network_rule_loaded_after_first_connection_matches_repeat() {
+    let fixture = SigmaFixture::new();
+    let harness = TestNormalizer::new(true);
+
+    harness
+        .normalizer
+        .normalize(&process_start_event(Platform::Linux))
+        .expect("process start should prime process cache");
+    harness
+        .normalizer
+        .normalize(&network_connect_event(Platform::Linux))
+        .expect("first network connection should normalize");
+
+    fixture.write_network_rule(Platform::Linux);
+    let engine = load_engine(Platform::Linux, &fixture);
+    let repeated = harness
+        .normalizer
+        .normalize(&network_connect_event(Platform::Linux))
+        .expect("repeated network connection should normalize");
+
+    let alert = engine
+        .check_event(&repeated)
+        .expect("a rule loaded after the first connection should match the repeat");
+    assert_sigma_alert(&alert, "Test Network Destination");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Stop network aggregation from dropping repeated connections before Sigma and IOC evaluation.
- Add configurable 60-second aggregate windows for bounded connection metrics.
- Update the sample configuration and operational documentation.

## Root cause

The normalizer returned `None` for `AggregationResult::Aggregated`, so only the first connection for a key reached detection.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --test pipeline_sigma`
- `cargo test --test pipeline_ioc`
- Focused state and normalizer tests
- The full suite has one environment-specific configuration-path failure in `config::tests::test_config_paths`; 200 tests pass.

Fixes #164