### PR TITLE
fix(scanning): harden YARA and hash caches against file replacement

### DIFF
--- a/src/ioc/hash.rs
+++ b/src/ioc/hash.rs
@@ -3,10 +3,12 @@ use md5::Md5;
 use sha1::Sha1;
 use sha2::Sha256;
 use std::collections::HashMap;
-use std::fs;
+use std::fs::File;
 use std::io::Read;
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::utils::file_identity::{self, FileIdentity};
 
 const HASH_CACHE_MAX_ENTRIES: usize = 10_000;
 const HASH_CACHE_TTL_SECS: u64 = 6 * 60 * 60;
@@ -37,13 +39,6 @@ pub struct ComputedHashes {
     pub md5: Option<String>,
     pub sha1: Option<String>,
     pub sha256: Option<String>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct FileIdentity {
-    path: String,
-    size: u64,
-    mtime: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -79,27 +74,43 @@ impl HashCache {
         requirements: HashRequirements,
         buf: &mut [u8],
     ) -> anyhow::Result<ComputedHashes> {
-        let identity = file_identity(path);
+        self.get_or_compute_with(path, requirements, buf, compute_hashes)
+    }
+
+    fn get_or_compute_with<F>(
+        &mut self,
+        path: &Path,
+        requirements: HashRequirements,
+        buf: &mut [u8],
+        compute: F,
+    ) -> anyhow::Result<ComputedHashes>
+    where
+        F: FnOnce(&mut File, HashRequirements, &mut [u8]) -> anyhow::Result<ComputedHashes>,
+    {
+        let mut file = File::open(path)?;
+        let identity = file_identity::from_file(&file);
         if let Some(identity) = &identity {
             if let Some(entry) = self.entries.get(identity) {
-                if !self.is_expired(entry) {
+                if !self.is_expired(entry) && file_identity::unchanged(&file, path, identity) {
                     return Ok(entry.hashes.clone());
                 }
             }
         }
 
-        let hashes = compute_hashes(path, requirements, buf)?;
+        let hashes = compute(&mut file, requirements, buf)?;
         if let Some(identity) = identity {
-            let now = now_secs();
-            self.entries.insert(
-                identity,
-                HashCacheEntry {
-                    hashes: hashes.clone(),
-                    timestamp: now,
-                },
-            );
-            if self.entries.len() > self.max_entries {
-                self.trim();
+            if file_identity::unchanged(&file, path, &identity) {
+                let now = now_secs();
+                self.entries.insert(
+                    identity,
+                    HashCacheEntry {
+                        hashes: hashes.clone(),
+                        timestamp: now,
+                    },
+                );
+                if self.entries.len() > self.max_entries {
+                    self.trim();
+                }
             }
         }
 
@@ -131,12 +142,10 @@ impl HashCache {
 }
 
 fn compute_hashes(
-    path: &Path,
+    file: &mut File,
     requirements: HashRequirements,
     buf: &mut [u8],
 ) -> anyhow::Result<ComputedHashes> {
-    let mut file = fs::File::open(path)?;
-
     let mut md5_hasher = requirements.md5.then(Md5::new);
     let mut sha1_hasher = requirements.sha1.then(Sha1::new);
     let mut sha256_hasher = requirements.sha256.then(Sha256::new);
@@ -164,26 +173,104 @@ fn compute_hashes(
     })
 }
 
-fn file_identity(path: &Path) -> Option<FileIdentity> {
-    let metadata = fs::metadata(path).ok()?;
-    let size = metadata.len();
-    let mtime = metadata
-        .modified()
-        .ok()
-        .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
-        .map(|d| d.as_secs())
-        .unwrap_or_default();
-
-    Some(FileIdentity {
-        path: path.display().to_string(),
-        size,
-        mtime,
-    })
-}
-
 fn now_secs() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn sha256_only() -> HashRequirements {
+        HashRequirements {
+            md5: false,
+            sha1: false,
+            sha256: true,
+        }
+    }
+
+    #[test]
+    fn unchanged_file_reuses_hash_cache_entry() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let path = tempdir.path().join("sample.bin");
+        fs::write(&path, b"clean!").expect("write sample");
+        let mut cache = HashCache::new();
+        let mut buf = [0u8; 64];
+
+        let first = cache
+            .get_or_compute(&path, sha256_only(), &mut buf)
+            .expect("first hash");
+        cache
+            .entries
+            .values_mut()
+            .next()
+            .expect("cache entry")
+            .hashes
+            .sha256 = Some("cached".to_string());
+        let second = cache
+            .get_or_compute(&path, sha256_only(), &mut buf)
+            .expect("cached hash");
+
+        assert_ne!(first.sha256, second.sha256);
+        assert_eq!(second.sha256.as_deref(), Some("cached"));
+        assert_eq!(cache.entries.len(), 1);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn replacement_with_same_size_and_mtime_gets_new_hash() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let path = tempdir.path().join("sample.bin");
+        fs::write(&path, b"clean!").expect("write sample");
+        let original_mtime = fs::metadata(&path)
+            .expect("metadata")
+            .modified()
+            .expect("mtime");
+        let mut cache = HashCache::new();
+        let mut buf = [0u8; 64];
+        let clean = cache
+            .get_or_compute(&path, sha256_only(), &mut buf)
+            .expect("clean hash");
+
+        let replacement = tempdir.path().join("replacement.bin");
+        fs::write(&replacement, b"evil!!").expect("write replacement");
+        File::options()
+            .write(true)
+            .open(&replacement)
+            .expect("open replacement")
+            .set_times(fs::FileTimes::new().set_modified(original_mtime))
+            .expect("preserve mtime");
+        fs::rename(&replacement, &path).expect("replace sample");
+
+        let malicious = cache
+            .get_or_compute(&path, sha256_only(), &mut buf)
+            .expect("replacement hash");
+
+        assert_ne!(clean.sha256, malicious.sha256);
+        assert_eq!(cache.entries.len(), 2);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn file_changed_during_hashing_is_not_cached() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let path = tempdir.path().join("sample.bin");
+        fs::write(&path, b"clean!").expect("write sample");
+        let mut cache = HashCache::new();
+        let mut buf = [0u8; 64];
+
+        cache
+            .get_or_compute_with(&path, sha256_only(), &mut buf, |file, requirements, buf| {
+                let hashes = compute_hashes(file, requirements, buf)?;
+                fs::write(&path, b"evil!!").expect("mutate during hashing");
+                Ok(hashes)
+            })
+            .expect("hash mutated file");
+
+        assert!(cache.entries.is_empty());
+    }
 }

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -14,6 +14,7 @@ use yara_x::{Compiler, Rules, Scanner as XScanner};
 
 use crate::models::{MatchDebugLevel, ProcessCreationFields, YaraRuleMatch, YaraStringMatch};
 use crate::sensor::{SensorAction, SensorEvent, SensorEventHandler, SensorPayload};
+use crate::utils::file_identity::{self, FileIdentity};
 use crate::utils::{hash_command_line, query_process_identity, ProcessIdentity};
 
 /// Strip NT namespace prefix and convert to a path the YARA scanner can open.
@@ -78,9 +79,7 @@ const YARA_CACHE_TTL_SECS: u64 = 6 * 60 * 60;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct YaraFileIdentity {
-    path: String,
-    size: u64,
-    mtime_nanos: u128,
+    file: FileIdentity,
     match_debug: MatchDebugLevel,
 }
 
@@ -160,24 +159,6 @@ fn now_secs() -> u64 {
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs()
-}
-
-fn yara_file_identity(path: &str, match_debug: MatchDebugLevel) -> Option<YaraFileIdentity> {
-    let metadata = fs::metadata(path).ok()?;
-    let size = metadata.len();
-    let mtime_nanos = metadata
-        .modified()
-        .ok()
-        .and_then(|value| value.duration_since(UNIX_EPOCH).ok())
-        .map(|d| d.as_nanos())
-        .unwrap_or(0);
-
-    Some(YaraFileIdentity {
-        path: normalize_path_for_allowlist(path),
-        size,
-        mtime_nanos,
-        match_debug,
-    })
 }
 
 fn truncate_str(s: &str, max_len: usize) -> String {
@@ -322,31 +303,55 @@ impl Scanner {
         }
 
         let path = normalize_yara_path(path);
-        let path = path.as_str();
-        let identity = yara_file_identity(path, match_debug);
+        self.scan_file_cached(&path, match_debug, |path| {
+            let mut scanner = XScanner::new(&self.rules);
+            let scan_results = scanner
+                .scan_file(path)
+                .with_context(|| format!("YARA scan failed for {path}"))?;
+            Ok(collect_yara_matches(scan_results, match_debug))
+        })
+    }
+
+    fn scan_file_cached<F>(
+        &self,
+        path: &str,
+        match_debug: MatchDebugLevel,
+        scan: F,
+    ) -> Result<Vec<YaraRuleMatch>>
+    where
+        F: FnOnce(&str) -> Result<Vec<YaraRuleMatch>>,
+    {
+        let identity_guard = fs::File::open(path).ok();
+        let identity = identity_guard
+            .as_ref()
+            .and_then(file_identity::from_file)
+            .map(|file| YaraFileIdentity { file, match_debug });
         if let Some(identity) = identity.as_ref() {
             if let Ok(mut cache) = self.cache.lock() {
                 if let Some(cached_matches) = cache.get(identity) {
-                    tracing::trace!(
-                        target: "scanner",
-                        file = %path,
-                        matches = cached_matches.len(),
-                        "YARA cache hit"
-                    );
-                    return Ok(cached_matches);
+                    if let Some(identity_guard) = identity_guard.as_ref() {
+                        if file_identity::unchanged(identity_guard, Path::new(path), &identity.file)
+                        {
+                            tracing::trace!(
+                                target: "scanner",
+                                file = %path,
+                                matches = cached_matches.len(),
+                                "YARA cache hit"
+                            );
+                            return Ok(cached_matches);
+                        }
+                    }
                 }
             }
         }
 
-        let mut scanner = XScanner::new(&self.rules);
-        let scan_results = scanner
-            .scan_file(path)
-            .with_context(|| format!("YARA scan failed for {path}"))?;
-        let matches = collect_yara_matches(scan_results, match_debug);
+        let matches = scan(path)?;
 
-        if let Some(identity) = identity {
-            if let Ok(mut cache) = self.cache.lock() {
-                cache.insert(identity, matches.clone());
+        if let (Some(identity), Some(identity_guard)) = (identity, identity_guard) {
+            if file_identity::unchanged(&identity_guard, Path::new(path), &identity.file) {
+                if let Ok(mut cache) = self.cache.lock() {
+                    cache.insert(identity, matches.clone());
+                }
             }
         }
 
@@ -556,6 +561,11 @@ fn capture_process_identity(
 mod tests {
     use super::*;
 
+    fn test_file_identity() -> FileIdentity {
+        let file = tempfile::NamedTempFile::new().expect("temp file");
+        file_identity::from_file(file.as_file()).expect("stable file identity")
+    }
+
     #[test]
     fn test_scanner_creation() {
         // Test that we can create a scanner even with an empty/missing directory
@@ -634,9 +644,7 @@ mod tests {
             ttl_secs: 60,
         };
         let identity = YaraFileIdentity {
-            path: r"c:\temp\sample.exe".to_string(),
-            size: 1337,
-            mtime_nanos: 42,
+            file: test_file_identity(),
             match_debug: MatchDebugLevel::Off,
         };
         let expected = vec![YaraRuleMatch {
@@ -663,19 +671,139 @@ mod tests {
             ttl_secs: 60,
         };
         let identity = YaraFileIdentity {
-            path: r"c:\temp\sample.exe".to_string(),
-            size: 1337,
-            mtime_nanos: 42,
+            file: test_file_identity(),
             match_debug: MatchDebugLevel::Off,
         };
         let updated = YaraFileIdentity {
-            path: r"c:\temp\sample.exe".to_string(),
-            size: 2048,
-            mtime_nanos: 43,
+            file: test_file_identity(),
             match_debug: MatchDebugLevel::Off,
         };
 
         cache.insert(identity, Vec::new());
         assert!(cache.get(&updated).is_none());
+    }
+
+    #[test]
+    fn test_yara_scan_cache_hits_for_unchanged_file() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let path = tempdir.path().join("sample.bin");
+        fs::write(&path, b"clean!").expect("write sample");
+        let scanner = Scanner::empty();
+
+        scanner
+            .scan_file_cached(path.to_str().unwrap(), MatchDebugLevel::Off, |_| {
+                Ok(Vec::new())
+            })
+            .expect("initial scan");
+        scanner
+            .scan_file_cached(path.to_str().unwrap(), MatchDebugLevel::Off, |_| {
+                panic!("unchanged file should use cached result")
+            })
+            .expect("cached scan");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_yara_scan_cache_misses_after_same_metadata_replacement() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let path = tempdir.path().join("sample.bin");
+        fs::write(&path, b"clean!").expect("write sample");
+        let original_mtime = fs::metadata(&path)
+            .expect("metadata")
+            .modified()
+            .expect("mtime");
+        let scanner = Scanner::empty();
+
+        scanner
+            .scan_file_cached(path.to_str().unwrap(), MatchDebugLevel::Off, |_| {
+                Ok(Vec::new())
+            })
+            .expect("initial scan");
+
+        let replacement = tempdir.path().join("replacement.bin");
+        fs::write(&replacement, b"evil!!").expect("write replacement");
+        fs::File::options()
+            .write(true)
+            .open(&replacement)
+            .expect("open replacement")
+            .set_times(fs::FileTimes::new().set_modified(original_mtime))
+            .expect("preserve mtime");
+        fs::rename(&replacement, &path).expect("replace sample");
+
+        let matches = scanner
+            .scan_file_cached(path.to_str().unwrap(), MatchDebugLevel::Off, |_| {
+                Ok(vec![YaraRuleMatch {
+                    rule: "Malicious".to_string(),
+                    metadata_id: None,
+                    tags: Vec::new(),
+                    namespace: None,
+                    strings: Vec::new(),
+                }])
+            })
+            .expect("replacement scan");
+        assert_eq!(matches[0].rule, "Malicious");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_yara_scan_detects_same_metadata_replacement() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let rules_dir = tempdir.path().join("rules");
+        fs::create_dir(&rules_dir).expect("create rules directory");
+        fs::write(
+            rules_dir.join("malicious.yar"),
+            r#"rule Malicious { strings: $marker = "evil!!" condition: $marker }"#,
+        )
+        .expect("write rule");
+        let path = tempdir.path().join("sample.bin");
+        fs::write(&path, b"clean!").expect("write clean sample");
+        let original_mtime = fs::metadata(&path)
+            .expect("metadata")
+            .modified()
+            .expect("mtime");
+        let scanner = Scanner::new(&rules_dir).expect("compile scanner");
+
+        assert!(scanner
+            .scan_file(path.to_str().unwrap(), MatchDebugLevel::Off)
+            .expect("scan clean sample")
+            .is_empty());
+
+        let replacement = tempdir.path().join("replacement.bin");
+        fs::write(&replacement, b"evil!!").expect("write malicious replacement");
+        fs::File::options()
+            .write(true)
+            .open(&replacement)
+            .expect("open replacement")
+            .set_times(fs::FileTimes::new().set_modified(original_mtime))
+            .expect("preserve mtime");
+        fs::rename(&replacement, &path).expect("replace sample");
+
+        let matches = scanner
+            .scan_file(path.to_str().unwrap(), MatchDebugLevel::Off)
+            .expect("scan malicious replacement");
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].rule, "Malicious");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_yara_scan_does_not_cache_file_changed_during_scan() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let path = tempdir.path().join("sample.bin");
+        fs::write(&path, b"clean!").expect("write sample");
+        let scanner = Scanner::empty();
+
+        scanner
+            .scan_file_cached(
+                path.to_str().unwrap(),
+                MatchDebugLevel::Off,
+                |scanned_path| {
+                    fs::write(scanned_path, b"evil!!").expect("mutate during scan");
+                    Ok(Vec::new())
+                },
+            )
+            .expect("scan mutated file");
+
+        assert!(scanner.cache.lock().unwrap().entries.is_empty());
     }
 }

--- a/src/utils/file_identity.rs
+++ b/src/utils/file_identity.rs
@@ -1,0 +1,138 @@
+//! Stable file identity used to validate cached file-content results.
+//!
+//! Identity is derived from an open handle. On Unix it includes device and
+//! inode numbers plus size, mtime, and ctime. On Windows it includes volume
+//! and file IDs plus size, last-write time, and change time. Other platforms
+//! deliberately return no identity, which disables caching.
+
+use std::fs::File;
+use std::path::Path;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct FileIdentity {
+    platform: PlatformFileIdentity,
+    size: u64,
+    modified: i128,
+    changed: i128,
+}
+
+#[cfg(unix)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum PlatformFileIdentity {
+    Unix { device: u64, inode: u64 },
+}
+
+#[cfg(windows)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum PlatformFileIdentity {
+    Windows { volume: u32, file_id: u64 },
+}
+
+#[cfg(not(any(unix, windows)))]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum PlatformFileIdentity {}
+
+#[cfg(unix)]
+pub(crate) fn from_file(file: &File) -> Option<FileIdentity> {
+    use std::os::unix::fs::MetadataExt;
+
+    let metadata = file.metadata().ok()?;
+    Some(FileIdentity {
+        platform: PlatformFileIdentity::Unix {
+            device: metadata.dev(),
+            inode: metadata.ino(),
+        },
+        size: metadata.len(),
+        modified: timestamp(metadata.mtime(), metadata.mtime_nsec()),
+        changed: timestamp(metadata.ctime(), metadata.ctime_nsec()),
+    })
+}
+
+#[cfg(unix)]
+fn timestamp(seconds: i64, nanos: i64) -> i128 {
+    i128::from(seconds) * 1_000_000_000 + i128::from(nanos)
+}
+
+#[cfg(windows)]
+pub(crate) fn from_file(file: &File) -> Option<FileIdentity> {
+    use std::mem::size_of;
+    use std::os::windows::io::AsRawHandle;
+    use windows::Win32::Foundation::HANDLE;
+    use windows::Win32::Storage::FileSystem::{
+        FileBasicInfo, GetFileInformationByHandle, GetFileInformationByHandleEx,
+        BY_HANDLE_FILE_INFORMATION, FILE_BASIC_INFO,
+    };
+
+    let handle = HANDLE(file.as_raw_handle());
+    let mut info = BY_HANDLE_FILE_INFORMATION::default();
+    let mut basic = FILE_BASIC_INFO::default();
+    unsafe {
+        GetFileInformationByHandle(handle, &mut info).ok()?;
+        GetFileInformationByHandleEx(
+            handle,
+            FileBasicInfo,
+            (&mut basic as *mut FILE_BASIC_INFO).cast(),
+            size_of::<FILE_BASIC_INFO>() as u32,
+        )
+        .ok()?;
+    }
+
+    Some(FileIdentity {
+        platform: PlatformFileIdentity::Windows {
+            volume: info.dwVolumeSerialNumber,
+            file_id: (u64::from(info.nFileIndexHigh) << 32) | u64::from(info.nFileIndexLow),
+        },
+        size: (u64::from(info.nFileSizeHigh) << 32) | u64::from(info.nFileSizeLow),
+        modified: i128::from(basic.LastWriteTime),
+        changed: i128::from(basic.ChangeTime),
+    })
+}
+
+#[cfg(not(any(unix, windows)))]
+pub(crate) fn from_file(_file: &File) -> Option<FileIdentity> {
+    None
+}
+
+pub(crate) fn from_path(path: &Path) -> Option<FileIdentity> {
+    let file = File::open(path).ok()?;
+    from_file(&file)
+}
+
+pub(crate) fn unchanged(file: &File, path: &Path, initial: &FileIdentity) -> bool {
+    from_file(file).as_ref() == Some(initial) && from_path(path).as_ref() == Some(initial)
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn replacement_with_same_size_and_mtime_has_different_identity() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let path = tempdir.path().join("sample.bin");
+        fs::write(&path, b"clean!").expect("write clean file");
+        let original = File::open(&path).expect("open clean file");
+        let identity = from_file(&original).expect("stable identity");
+        let times = fs::FileTimes::new().set_modified(
+            original
+                .metadata()
+                .expect("metadata")
+                .modified()
+                .expect("mtime"),
+        );
+
+        let replacement = tempdir.path().join("replacement.bin");
+        fs::write(&replacement, b"evil!!").expect("write replacement");
+        File::options()
+            .write(true)
+            .open(&replacement)
+            .expect("open replacement")
+            .set_times(times)
+            .expect("preserve mtime");
+        fs::rename(&replacement, &path).expect("replace original");
+
+        assert_ne!(from_path(&path), Some(identity.clone()));
+        assert!(!unchanged(&original, &path, &identity));
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! Provides helper functions for path normalization and PE parsing.
 
+pub(crate) mod file_identity;
 pub mod log_rate_limiter;
 pub mod path;
 #[cfg(windows)]


### PR DESCRIPTION
## Summary

- derive a shared stable file identity from open handles on Unix and Windows
- validate the open handle and current path before cache hits and insertions
- avoid caching YARA or IOC hash results when a file changes during processing
- add regression coverage for unchanged cache hits, preserved-mtime replacements, malicious replacements, and mid-operation mutation

## Root cause

The YARA and IOC hash caches identified files using path, size, and modification time captured before processing. A file could be replaced with equal-size content while preserving its modification time, or changed during scanning, allowing stale results to be cached or reused.

## Impact

Cached results are now tied to stable platform file identity and change metadata. Platforms where stable identity cannot be established skip caching.

## Validation

- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --lib --all-features -- --skip config::tests::test_config_paths` (223 passed)
- isolated Windows target compile check for handle identity APIs

Closes #167