### PR TITLE
fix(state): bound ProcessCache

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -74,14 +74,18 @@ channel_capacity = 128
 #
 # allowlist_images = []
 
-# 5. Network Connection Metrics
+# 5. Process Metadata Cache
+[process]
+max_entries = 65536 # maximum process records retained when exit events are missed
+
+# 6. Network Connection Metrics
 [network]
 aggregation_enabled = true
 aggregation_max_entries = 20000
 aggregation_window_secs = 60
 aggregation_interval_buffer_size = 50
 
-# 6. Atomic IOC Detection (Hashes, IPs, Domains, Path Regex)
+# 7. Atomic IOC Detection (Hashes, IPs, Domains, Path Regex)
 [ioc]
 enabled = true
 hashes_path = "rules/ioc/hashes.txt"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -91,6 +91,9 @@ min_severity = "critical"
 channel_capacity = 128
 allowlist_images = []
 
+[process]
+max_entries = 65536
+
 [network]
 aggregation_enabled = true
 aggregation_max_entries = 20000
@@ -276,6 +279,12 @@ dedup: suppressed_total=1420 aggregated_rollup_alerts=38 pending_keys=0
 | `allowlist_paths` | inherits `allowlist.paths` | Module-specific trusted prefixes |
 
 See [Active Response](active-response.md) for platform behavior and safe testing.
+
+### Process Cache
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `max_entries` | `65536` | Maximum process metadata records retained; oldest records are evicted when process-exit events are missed |
 
 ### Network
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -284,6 +284,7 @@ pub struct AppConfig {
     pub alerts: AlertConfig,
     pub allowlist: AllowlistConfig,
     pub response: ResponseConfig,
+    pub process: ProcessConfig,
     pub network: NetworkConfig,
     pub ioc: IocConfig,
     pub reload: ReloadConfig,
@@ -346,6 +347,13 @@ pub struct ResponseConfig {
     pub channel_capacity: usize,
     pub allowlist_images: Vec<String>,
     pub allowlist_paths: Vec<String>,
+}
+
+/// Process metadata cache configuration
+#[derive(Debug, Clone, Deserialize)]
+pub struct ProcessConfig {
+    /// Maximum number of process metadata entries retained
+    pub max_entries: usize,
 }
 
 /// Network event aggregation configuration
@@ -449,6 +457,8 @@ impl AppConfig {
             .set_default("response.channel_capacity", 128)?
             .set_default("response.allowlist_images", Vec::<String>::new())?
             .set_default("response.allowlist_paths", Vec::<String>::new())?
+            // Process cache
+            .set_default("process.max_entries", 65536i64)?
             // Network
             .set_default("network.aggregation_enabled", true)?
             .set_default("network.aggregation_max_entries", 20000)?
@@ -621,6 +631,9 @@ impl Default for AppConfig {
                 channel_capacity: 128,
                 allowlist_images: Vec::new(),
                 allowlist_paths: Vec::new(),
+            },
+            process: ProcessConfig {
+                max_entries: 65_536,
             },
             network: NetworkConfig {
                 aggregation_enabled: true,
@@ -920,6 +933,12 @@ paths_regex_path = "explicit-ioc/paths_regex.txt"
         assert!(cfg.dedup.enabled);
         assert_eq!(cfg.dedup.window_secs, 60);
         assert_eq!(cfg.dedup.max_entries, 10_000);
+    }
+
+    #[test]
+    fn test_process_cache_defaults() {
+        let cfg = AppConfig::default();
+        assert_eq!(cfg.process.max_entries, 65_536);
     }
 
     #[test]

--- a/src/runtime/linux.rs
+++ b/src/runtime/linux.rs
@@ -79,7 +79,7 @@ async fn run_linux_edr(
     log_startup_banner("Linux eBPF");
 
     // 3. Shared state
-    let process_cache = Arc::new(ProcessCache::new());
+    let process_cache = Arc::new(ProcessCache::with_max_entries(cfg.process.max_entries));
     let sid_cache = Arc::new(SidCache::new()); // no-op on Linux; kept for Normalizer compat
     let dns_cache = Arc::new(DnsCache::new());
     let connection_aggregator = Arc::new(ConnectionAggregator::with_limits_and_window(

--- a/src/runtime/macos.rs
+++ b/src/runtime/macos.rs
@@ -79,7 +79,7 @@ async fn run_macos_edr(
     log_startup_banner("macOS ESF");
 
     // 3. Shared state
-    let process_cache = Arc::new(ProcessCache::new());
+    let process_cache = Arc::new(ProcessCache::with_max_entries(cfg.process.max_entries));
     let sid_cache = Arc::new(SidCache::new()); // no-op on macOS; kept for Normalizer compat
     let dns_cache = Arc::new(DnsCache::new());
     let connection_aggregator = Arc::new(ConnectionAggregator::with_limits_and_window(

--- a/src/runtime/windows.rs
+++ b/src/runtime/windows.rs
@@ -258,7 +258,7 @@ async fn run_edr(
 
     // Initialize Process Cache and perform cold start snapshot
     info!("Initializing Process Cache...");
-    let process_cache = Arc::new(ProcessCache::new());
+    let process_cache = Arc::new(ProcessCache::with_max_entries(cfg.process.max_entries));
     let sid_cache = Arc::new(SidCache::new());
     let dns_cache = Arc::new(DnsCache::new());
     let connection_aggregator = Arc::new(ConnectionAggregator::with_limits_and_window(

--- a/src/state/process.rs
+++ b/src/state/process.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::RwLock;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -61,6 +61,9 @@ pub struct ProcessCache {
     cache: RwLock<HashMap<(u32, u64), ProcessMetadata>>,
     /// Secondary index: PID -> Latest CreationTime (for O(1) lookup from events that only have PID)
     pid_index: RwLock<HashMap<u32, u64>>,
+    /// Compound keys ordered by creation time for efficient oldest-first eviction
+    eviction_order: RwLock<BTreeSet<(u64, u32)>>,
+    max_entries: usize,
     /// Recently-dead processes retained briefly to avoid parent/child race conditions
     graveyard: RwLock<HashMap<u32, GraveyardEntry>>,
     last_graveyard_cleanup: AtomicU64,
@@ -69,9 +72,16 @@ pub struct ProcessCache {
 impl ProcessCache {
     /// Create a new empty ProcessCache
     pub fn new() -> Self {
+        Self::with_max_entries(PROCESS_CACHE_MAX_ENTRIES)
+    }
+
+    /// Create an empty ProcessCache capped at `max_entries` processes
+    pub fn with_max_entries(max_entries: usize) -> Self {
         Self {
             cache: RwLock::new(HashMap::new()),
             pid_index: RwLock::new(HashMap::new()),
+            eviction_order: RwLock::new(BTreeSet::new()),
+            max_entries,
             graveyard: RwLock::new(HashMap::new()),
             last_graveyard_cleanup: AtomicU64::new(0),
         }
@@ -114,10 +124,11 @@ impl ProcessCache {
         logon_id: Option<String>,
         logon_guid: Option<String>,
     ) {
-        // Lock order: pid_index -> cache to avoid deadlocks with readers.
+        // Lock order: pid_index -> cache -> eviction_order to avoid deadlocks with readers.
         {
             let mut pid_index = self.pid_index.write().unwrap();
             let mut cache = self.cache.write().unwrap();
+            let mut eviction_order = self.eviction_order.write().unwrap();
 
             cache.insert(
                 (pid, creation_time),
@@ -138,9 +149,21 @@ impl ProcessCache {
                     logon_guid,
                 },
             );
+            eviction_order.insert((creation_time, pid));
 
             // Update secondary index to point to the latest creation time
             pid_index.insert(pid, creation_time);
+
+            while cache.len() > self.max_entries {
+                let Some((oldest_creation_time, oldest_pid)) = eviction_order.pop_first() else {
+                    break;
+                };
+
+                cache.remove(&(oldest_pid, oldest_creation_time));
+                if pid_index.get(&oldest_pid) == Some(&oldest_creation_time) {
+                    pid_index.remove(&oldest_pid);
+                }
+            }
         }
 
         if let Ok(mut graveyard) = self.graveyard.write() {
@@ -153,12 +176,14 @@ impl ProcessCache {
     /// Remove a process from the cache (called on process exit)
     /// Removes both from primary storage and updates secondary index
     pub fn remove(&self, pid: u32, creation_time: u64) {
-        // Lock order: pid_index -> cache to avoid deadlocks with readers.
+        // Lock order: pid_index -> cache -> eviction_order to avoid deadlocks with readers.
         let removed_meta = {
             let mut pid_index = self.pid_index.write().unwrap();
             let mut cache = self.cache.write().unwrap();
+            let mut eviction_order = self.eviction_order.write().unwrap();
 
             let meta = cache.remove(&(pid, creation_time));
+            eviction_order.remove(&(creation_time, pid));
 
             // Only remove from index if this was the latest creation_time
             if let Some(&indexed_time) = pid_index.get(&pid) {
@@ -304,3 +329,65 @@ struct GraveyardEntry {
 
 const GRAVEYARD_TTL_SECS: u64 = 60;
 const GRAVEYARD_CLEANUP_INTERVAL_SECS: u64 = 10;
+const PROCESS_CACHE_MAX_ENTRIES: usize = 65_536;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn add_process(cache: &ProcessCache, pid: u32, creation_time: u64) {
+        cache.add(
+            pid,
+            creation_time,
+            format!("process-{pid}"),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
+    }
+
+    #[test]
+    fn missed_exit_events_do_not_grow_cache_past_limit() {
+        let cache = ProcessCache::with_max_entries(2);
+
+        add_process(&cache, 10, 100);
+        add_process(&cache, 20, 200);
+        add_process(&cache, 30, 300);
+
+        assert_eq!(cache.count(), 2);
+        assert!(cache.get_metadata_by_key(10, 100).is_none());
+        assert_eq!(cache.get_image(20).as_deref(), Some("process-20"));
+        assert_eq!(cache.get_image(30).as_deref(), Some("process-30"));
+    }
+
+    #[test]
+    fn eviction_keeps_pid_index_consistent() {
+        let cache = ProcessCache::with_max_entries(1);
+
+        add_process(&cache, 10, 100);
+        add_process(&cache, 10, 200);
+
+        assert_eq!(cache.get_latest_creation_time(10), Some(200));
+        assert!(cache.get_metadata_by_key(10, 100).is_none());
+        assert_eq!(cache.get_image(10).as_deref(), Some("process-10"));
+    }
+
+    #[test]
+    fn zero_entry_limit_keeps_cache_empty() {
+        let cache = ProcessCache::with_max_entries(0);
+
+        add_process(&cache, 10, 100);
+
+        assert_eq!(cache.count(), 0);
+        assert_eq!(cache.get_latest_creation_time(10), None);
+    }
+}


### PR DESCRIPTION
## Summary

- add a configurable maximum size for `ProcessCache`
- evict the oldest process records while keeping the compound-key cache and PID index consistent
- apply the configured limit on Linux, macOS, and Windows
- document the new `process.max_entries` setting

## Why

Missed process-exit events left enriched process metadata in the cache indefinitely. On hosts with high process churn, this allowed the long-lived agent process to grow memory without a bound.

## Impact

The process cache now defaults to a maximum of 65,536 entries. When the limit is exceeded, the oldest compound keys are evicted efficiently. PID reuse remains safe because eviction only removes a PID index entry when it still points to the evicted creation time.

## Validation

- `cargo test state::process::tests`
- `cargo test config::tests::test_process_cache_defaults`
- `cargo check --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #159
