### PR TITLE
fix(windows): correct network event routing

### DIFF
--- a/src/sensor/mod.rs
+++ b/src/sensor/mod.rs
@@ -10,6 +10,8 @@ pub(crate) mod dns;
 pub mod linux;
 #[cfg(target_os = "macos")]
 pub mod macos;
+#[cfg(any(windows, test))]
+mod network_events;
 #[cfg(windows)]
 pub mod windows;
 

--- a/src/sensor/network_events.rs
+++ b/src/sensor/network_events.rs
@@ -1,0 +1,179 @@
+use std::net::Ipv4Addr;
+
+use super::SensorAction;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum NetworkProtocol {
+    Tcp,
+    Udp,
+}
+
+impl NetworkProtocol {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Tcp => "tcp",
+            Self::Udp => "udp",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum NetworkAddressFamily {
+    Ipv4,
+    Ipv6,
+    Unspecified,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum NetworkOperation {
+    Send,
+    Receive,
+    Connect,
+    Disconnect,
+    Retransmit,
+    Accept,
+    Reconnect,
+    Fail,
+    Copy,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct KernelNetworkEvent {
+    pub(crate) protocol: NetworkProtocol,
+    pub(crate) address_family: NetworkAddressFamily,
+    pub(crate) operation: NetworkOperation,
+}
+
+impl KernelNetworkEvent {
+    pub(crate) fn connection_action(self) -> Option<SensorAction> {
+        match self.operation {
+            NetworkOperation::Connect => Some(SensorAction::Connect),
+            NetworkOperation::Accept => Some(SensorAction::Accept),
+            _ => None,
+        }
+    }
+}
+
+/// Classifies Microsoft-Windows-Kernel-Network manifest event IDs.
+///
+/// TCP and UDP operations share several classic ETW type values, but the
+/// manifest provider assigns UDP its own IDs. Keep every known operation
+/// explicit so packet and lifecycle events cannot become connections through
+/// a range check.
+pub(crate) fn classify_kernel_network_event(event_id: u16) -> Option<KernelNetworkEvent> {
+    use NetworkAddressFamily::{Ipv4, Ipv6, Unspecified};
+    use NetworkOperation::{
+        Accept, Connect, Copy, Disconnect, Fail, Receive, Reconnect, Retransmit, Send,
+    };
+    use NetworkProtocol::{Tcp, Udp};
+
+    let (protocol, address_family, operation) = match event_id {
+        10 => (Tcp, Ipv4, Send),
+        11 => (Tcp, Ipv4, Receive),
+        12 => (Tcp, Ipv4, Connect),
+        13 => (Tcp, Ipv4, Disconnect),
+        14 => (Tcp, Ipv4, Retransmit),
+        15 => (Tcp, Ipv4, Accept),
+        16 => (Tcp, Ipv4, Reconnect),
+        17 => (Tcp, Unspecified, Fail),
+        18 => (Tcp, Ipv4, Copy),
+        26 => (Tcp, Ipv6, Send),
+        27 => (Tcp, Ipv6, Receive),
+        28 => (Tcp, Ipv6, Connect),
+        29 => (Tcp, Ipv6, Disconnect),
+        30 => (Tcp, Ipv6, Retransmit),
+        31 => (Tcp, Ipv6, Accept),
+        32 => (Tcp, Ipv6, Reconnect),
+        34 => (Tcp, Ipv6, Copy),
+        42 => (Udp, Ipv4, Send),
+        43 => (Udp, Ipv4, Receive),
+        49 => (Udp, Unspecified, Fail),
+        58 => (Udp, Ipv6, Send),
+        59 => (Udp, Ipv6, Receive),
+        _ => return None,
+    };
+
+    Some(KernelNetworkEvent {
+        protocol,
+        address_family,
+        operation,
+    })
+}
+
+/// ETW stores IPv4 address bytes in network order inside a UInt32 payload.
+/// TDH exposes that payload as a little-endian integer on Windows, so preserve
+/// its byte sequence instead of converting the integer to big-endian bytes.
+pub(crate) fn decode_etw_ipv4(addr: u32) -> Ipv4Addr {
+    Ipv4Addr::from(addr.to_le_bytes())
+}
+
+/// ETW port fields are encoded in network byte order.
+pub(crate) fn decode_etw_port(port: u16) -> u16 {
+    u16::from_be(port)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tcp_connect_and_accept_routes_are_explicit_for_both_address_families() {
+        for (event_id, address_family, action) in [
+            (12, NetworkAddressFamily::Ipv4, SensorAction::Connect),
+            (15, NetworkAddressFamily::Ipv4, SensorAction::Accept),
+            (28, NetworkAddressFamily::Ipv6, SensorAction::Connect),
+            (31, NetworkAddressFamily::Ipv6, SensorAction::Accept),
+        ] {
+            let event = classify_kernel_network_event(event_id).unwrap();
+            assert_eq!(event.protocol, NetworkProtocol::Tcp);
+            assert_eq!(event.protocol.as_str(), "tcp");
+            assert_eq!(event.address_family, address_family);
+            assert_eq!(event.connection_action(), Some(action));
+        }
+    }
+
+    #[test]
+    fn udp_event_ids_are_classified_without_becoming_connections() {
+        for (event_id, address_family, operation) in [
+            (42, NetworkAddressFamily::Ipv4, NetworkOperation::Send),
+            (43, NetworkAddressFamily::Ipv4, NetworkOperation::Receive),
+            (58, NetworkAddressFamily::Ipv6, NetworkOperation::Send),
+            (59, NetworkAddressFamily::Ipv6, NetworkOperation::Receive),
+        ] {
+            let event = classify_kernel_network_event(event_id).unwrap();
+            assert_eq!(event.protocol, NetworkProtocol::Udp);
+            assert_eq!(event.protocol.as_str(), "udp");
+            assert_eq!(event.address_family, address_family);
+            assert_eq!(event.operation, operation);
+            assert_eq!(event.connection_action(), None);
+        }
+    }
+
+    #[test]
+    fn packet_and_non_connection_tcp_operations_are_ignored() {
+        for event_id in [10, 11, 13, 14, 16, 17, 18, 26, 27, 29, 30, 32, 34] {
+            let event = classify_kernel_network_event(event_id).unwrap();
+            assert_eq!(event.protocol, NetworkProtocol::Tcp);
+            assert_eq!(event.connection_action(), None, "event {event_id}");
+        }
+    }
+
+    #[test]
+    fn unknown_event_ids_are_not_classified() {
+        for event_id in [0, 9, 19, 25, 33, 35, 41, 44, 60, u16::MAX] {
+            assert_eq!(classify_kernel_network_event(event_id), None);
+        }
+    }
+
+    #[test]
+    fn ipv4_payload_bytes_keep_network_order() {
+        assert_eq!(decode_etw_ipv4(0x0100_007f), Ipv4Addr::LOCALHOST);
+        assert_eq!(decode_etw_ipv4(0x0808_0808), Ipv4Addr::new(8, 8, 8, 8));
+    }
+
+    #[test]
+    fn port_payload_bytes_keep_network_order() {
+        assert_eq!(decode_etw_port(0x5000), 80);
+        assert_eq!(decode_etw_port(0xbb01), 443);
+    }
+}

--- a/src/sensor/windows/etw.rs
+++ b/src/sensor/windows/etw.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::net::{IpAddr, Ipv4Addr};
+use std::net::IpAddr;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -17,6 +17,9 @@ use crate::models::{
     DnsQueryFields, EventCategory, FileEventFields, ImageLoadFields, NetworkConnectionFields,
     PowerShellScriptFields, ProcessCreationFields, RegistryEventFields, ServiceCreationFields,
     TaskCreationFields, WmiEventFields,
+};
+use crate::sensor::network_events::{
+    classify_kernel_network_event, decode_etw_ipv4, decode_etw_port, NetworkAddressFamily,
 };
 use crate::sensor::{Platform, ProcessStartKey, Sensor, SensorAction, SensorEvent, SensorPayload};
 use crate::utils::{convert_nt_to_dos, parse_metadata, query_process_command_line};
@@ -237,14 +240,9 @@ impl EtwRouting {
 
         let category = *self.guid_to_category.get(&provider_guid)?;
         let action = match category {
-            EventCategory::Network => match record.event_id() {
-                10 | 11 => return None,
-                12 => SensorAction::Connect,
-                13 => SensorAction::Disconnect,
-                14 => SensorAction::Accept,
-                id if id >= 15 => SensorAction::Connect,
-                _ => return None,
-            },
+            EventCategory::Network => {
+                classify_kernel_network_event(record.event_id())?.connection_action()?
+            }
             EventCategory::File => kernel_file_action(record.event_id()),
             EventCategory::Registry => match record.opcode() {
                 36 => SensorAction::Create,
@@ -582,21 +580,17 @@ fn decode_registry(parser: &Parser, record: &EventRecord) -> Option<DecodedEtwEv
 
 fn decode_network(parser: &Parser, record: &EventRecord) -> Option<DecodedEtwEvent> {
     let mappings = field_maps::network_connection_mappings();
-    let transport = match record.event_id() {
-        12..=14 => Some("tcp".to_string()),
-        id if id >= 15 => Some("udp".to_string()),
-        _ => None,
-    };
+    let route = classify_kernel_network_event(record.event_id())?;
 
     let fields = NetworkConnectionFields {
-        destination_ip: try_get_ip(parser, "daddr")
-            .or_else(|| try_get_ip(parser, "DestinationAddress"))
-            .or_else(|| try_get_ip(parser, "RemoteAddress"))
-            .or_else(|| try_get_ip(parser, "dstaddr")),
-        source_ip: try_get_ip(parser, "saddr")
-            .or_else(|| try_get_ip(parser, "SourceAddress"))
-            .or_else(|| try_get_ip(parser, "LocalAddress"))
-            .or_else(|| try_get_ip(parser, "srcaddr")),
+        destination_ip: try_get_ip(parser, "daddr", route.address_family)
+            .or_else(|| try_get_ip(parser, "DestinationAddress", route.address_family))
+            .or_else(|| try_get_ip(parser, "RemoteAddress", route.address_family))
+            .or_else(|| try_get_ip(parser, "dstaddr", route.address_family)),
+        source_ip: try_get_ip(parser, "saddr", route.address_family)
+            .or_else(|| try_get_ip(parser, "SourceAddress", route.address_family))
+            .or_else(|| try_get_ip(parser, "LocalAddress", route.address_family))
+            .or_else(|| try_get_ip(parser, "srcaddr", route.address_family)),
         destination_port: try_get_port(parser, "dport")
             .or_else(|| try_get_port(parser, "DestinationPort"))
             .or_else(|| try_get_port(parser, "RemotePort"))
@@ -614,7 +608,7 @@ fn decode_network(parser: &Parser, record: &EventRecord) -> Option<DecodedEtwEve
             parser,
             mappings.get_etw_field("DestinationHostname")?,
         ),
-        protocol: transport,
+        protocol: Some(route.protocol.as_str().to_string()),
     };
 
     Some(DecodedEtwEvent {
@@ -828,21 +822,35 @@ fn try_get_uint_as_u64(parser: &Parser, property_name: &str) -> Option<u64> {
 
 fn try_get_port(parser: &Parser, property_name: &str) -> Option<String> {
     if let Ok(value) = parser.try_parse::<u16>(property_name) {
-        return Some(u16::from_be(value).to_string());
+        return Some(decode_etw_port(value).to_string());
     }
     if let Ok(value) = parser.try_parse::<u32>(property_name) {
-        return Some(u16::from_be(value as u16).to_string());
+        return Some(decode_etw_port(value as u16).to_string());
     }
     None
 }
 
-fn try_get_ip(parser: &Parser, property_name: &str) -> Option<String> {
-    if let Ok(ip) = parser.try_parse::<IpAddr>(property_name) {
-        return Some(ip.to_string());
-    }
-    if let Ok(addr) = parser.try_parse::<u32>(property_name) {
-        let ipv4 = Ipv4Addr::from(addr.to_be_bytes());
-        return Some(ipv4.to_string());
+fn try_get_ip(
+    parser: &Parser,
+    property_name: &str,
+    address_family: NetworkAddressFamily,
+) -> Option<String> {
+    match address_family {
+        NetworkAddressFamily::Ipv4 => {
+            if let Ok(addr) = parser.try_parse::<u32>(property_name) {
+                return Some(decode_etw_ipv4(addr).to_string());
+            }
+        }
+        NetworkAddressFamily::Ipv6 => {
+            if let Ok(IpAddr::V6(addr)) = parser.try_parse::<IpAddr>(property_name) {
+                return Some(addr.to_string());
+            }
+        }
+        NetworkAddressFamily::Unspecified => {
+            if let Ok(ip) = parser.try_parse::<IpAddr>(property_name) {
+                return Some(ip.to_string());
+            }
+        }
     }
     try_get_string(parser, property_name)
 }

--- a/src/sensor/windows/mapper.rs
+++ b/src/sensor/windows/mapper.rs
@@ -29,17 +29,11 @@ fn action_code_for_record(
 ) -> u8 {
     match category {
         EventCategory::Process | EventCategory::ImageLoad => record.opcode(),
-        EventCategory::Network => match record.event_id() {
-            12 => 12,
-            13 => 13,
-            14 => 14,
-            id if id >= 15 => 15,
-            _ => match action {
-                SensorAction::Disconnect => 13,
-                SensorAction::Accept => 14,
-                SensorAction::Connect => 12,
-                _ => 0,
-            },
+        EventCategory::Network => match action {
+            SensorAction::Connect => 12,
+            SensorAction::Disconnect => 13,
+            SensorAction::Accept => 15,
+            _ => 0,
         },
         // The manifest-based Kernel-File provider emits events with opcode 0,
         // so the action code comes from the routed action, not the opcode.


### PR DESCRIPTION
## Summary

- replace range-based Kernel-Network routing with explicit TCP, UDP, IPv4, and IPv6 event mappings
- emit connection telemetry only for TCP connect and accept operations
- ignore send, receive, disconnect, retransmit, reconnect, copy, and failure events as connections
- correct IPv4 address and port byte-order decoding
- add host-testable coverage for the event table and byte-order conversions

## Root cause

The Windows ETW sensor treated event IDs as broad numeric ranges. This mislabeled TCP lifecycle and packet events as UDP connections, including IPv6 send and receive traffic.

## Impact

Connection telemetry now reflects actual TCP connect and accept operations. TCP events are no longer labeled UDP, and packet or lifecycle activity no longer pollutes connection aggregation and detection fields.

## Validation

- `cargo test --lib sensor::network_events`: 6 passed
- `cargo check`: passed
- `cargo clippy --all-targets -- -D warnings`: passed
- native Windows MSVC routing tests: 6 passed
- live Windows 11 ETW capture confirmed IDs 12/15 for IPv4 TCP, 28/31 for IPv6 TCP, 42/43 for IPv4 UDP, and 58/59 for IPv6 UDP

A full local `cargo test --all-targets` run passed 233 tests and hit one unrelated environment-dependent configuration path failure because the workstation has a managed installation.

Closes #166