### PR TITLE
Prepare v1.3.0-rc.1 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3150,7 +3150,7 @@ dependencies = [
 
 [[package]]
 name = "rustinel"
-version = "1.2.0"
+version = "1.3.0-rc.1"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustinel"
-version = "1.2.0"
+version = "1.3.0-rc.1"
 edition = "2021"
 authors = []
 description = "Open-source EDR for Windows, Linux, and macOS with Sigma, YARA, and IOC detection"


### PR DESCRIPTION
## Summary

Prepare Rustinel v1.3.0-rc.1 for release from the current main branch.

This release candidate packages the 16 commits since v1.2.0, including:

- bounded process caching
- hardened YARA and hash caches
- explicit YARA scan failure outcomes
- corrected Windows network routing
- corrected alert deduplication identity
- fixed network aggregation suppression
- Linux sendmsg and sendmmsg DNS capture
- process identity validation before memory scanning
- restricted Unix alert and log permissions
- new process and network configuration

## Release plan

1. Publish v1.3.0-rc.1.
2. Test installers, managed upgrades, services, and rustinel doctor on all platforms.
3. Publish v1.3.0 after 48 to 72 hours without a blocker.

## Changes

- Bump the crate version in Cargo.toml to 1.3.0-rc.1.
- Keep Cargo.lock aligned with the prerelease version.

## Test plan

- cargo fmt --all -- --check
- cargo metadata --locked --no-deps --format-version 1
- RUSTINEL_CONFIG="$PWD/config.toml" cargo test --locked
- RUSTINEL_CONFIG="$PWD/config.toml" cargo check --locked --features rsigma-engine

The unconfigured macOS test run is affected by an existing managed configuration on the host. Selecting the repository config makes the complete suite pass.