### PR TITLE
ci: document YARA-X Wasmtime advisory exception

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -2,7 +2,7 @@
 ignore = [
     { id = "RUSTSEC-2023-0071", reason = "rsa is pulled transitively by yara-x. No fixed rsa release is available, and rustinel does not use yara-x for attacker observable private key RSA operations." },
     { id = "RUSTSEC-2025-0141", reason = "bincode is pulled transitively by yara-x. This is tracked as an upstream maintenance advisory until yara-x removes or replaces it." },
-    { id = "RUSTSEC-2026-0222", reason = "yara-x creates a single Wasmtime engine, so the cross-engine type-index mix-up described by this advisory is not reachable. See https://github.com/VirusTotal/yara-x/issues/726." },
+  { id = "RUSTSEC-2026-0222", reason = "yara-x 1.19.0 creates a single Wasmtime engine, so the cross-engine type-index mix-up described by this advisory is not reachable. See https://github.com/VirusTotal/yara-x/issues/726." },
 ]
 
 [licenses]

--- a/deny.toml
+++ b/deny.toml
@@ -2,6 +2,7 @@
 ignore = [
     { id = "RUSTSEC-2023-0071", reason = "rsa is pulled transitively by yara-x. No fixed rsa release is available, and rustinel does not use yara-x for attacker observable private key RSA operations." },
     { id = "RUSTSEC-2025-0141", reason = "bincode is pulled transitively by yara-x. This is tracked as an upstream maintenance advisory until yara-x removes or replaces it." },
+    { id = "RUSTSEC-2026-0222", reason = "yara-x creates a single Wasmtime engine, so the cross-engine type-index mix-up described by this advisory is not reachable. See https://github.com/VirusTotal/yara-x/issues/726." },
 ]
 
 [licenses]


### PR DESCRIPTION
## Summary

The Supply Chain check started failing on RUSTSEC-2026-0222 because YARA-X 1.19.0 brings in Wasmtime 43.0.2.

YARA-X maintains a single Wasmtime engine, so the cross-engine type-index mix-up described by the advisory is not reachable. This records the upstream assessment in the repository's cargo-deny configuration:

https://github.com/VirusTotal/yara-x/issues/726

## Validation

- cargo deny --locked check
- cargo deny --locked --manifest-path ebpf/Cargo.toml check --config ebpf/deny.toml
- cargo fmt --all -- --check

The yanked spin 0.9.8 dependency remains reported as a warning because it is constrained transitively by lazy_static, but the advisory check passes.