### PR TITLE
chore(deps): align RSigma dependencies at 0.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3072,9 +3072,9 @@ dependencies = [
 
 [[package]]
 name = "rsigma-eval"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b1d3e0932eafcc59d5ebe244a6f7237ae16064fd01f7961b785dc390dc5afb"
+checksum = "ee77a2e8d23bd8bcc6b7512031b2d91bd9d7b72fa3bb1328090618a68f3d1184"
 dependencies = [
  "ahash",
  "aho-corasick",
@@ -3084,6 +3084,21 @@ dependencies = [
  "ipnet",
  "log",
  "regex",
+ "rsigma-ir",
+ "rsigma-parser",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.19",
+ "yaml_serde",
+]
+
+[[package]]
+name = "rsigma-ir"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a484c9b1992f9a5f1b56a40556b98bf9c4005665f72528681fcfb5d3700550d6"
+dependencies = [
+ "ciborium",
  "rsigma-parser",
  "serde",
  "serde_json",
@@ -3093,9 +3108,9 @@ dependencies = [
 
 [[package]]
 name = "rsigma-parser"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fcf7a62b8e584dd3dd8435abfd11f1af6b4e33e0f9cc18150e01274f5e7eba"
+checksum = "61cdf056039cc0bd824d8204ceec9f39211d61033d5fe272ebb8b94b404f6bf6"
 dependencies = [
  "globset",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ evalexpr = "11.3.1"
 
 # Optional RSigma library backend (enabled by the `rsigma-engine` feature):
 # parsing (rsigma-parser) and stateless evaluation (rsigma-eval).
-rsigma-parser = { version = "0.19", optional = true }
-rsigma-eval = { version = "0.19", optional = true }
+rsigma-parser = { version = "0.20", optional = true }
+rsigma-eval = { version = "0.20", optional = true }
 
 # Network and encoding utilities for Sigma
 ipnetwork = "0.21.1"

--- a/deny.toml
+++ b/deny.toml
@@ -2,7 +2,7 @@
 ignore = [
     { id = "RUSTSEC-2023-0071", reason = "rsa is pulled transitively by yara-x. No fixed rsa release is available, and rustinel does not use yara-x for attacker observable private key RSA operations." },
     { id = "RUSTSEC-2025-0141", reason = "bincode is pulled transitively by yara-x. This is tracked as an upstream maintenance advisory until yara-x removes or replaces it." },
-    { id = "RUSTSEC-2026-0222", reason = "yara-x creates a single Wasmtime engine, so the cross-engine type-index mix-up described by this advisory is not reachable. See https://github.com/VirusTotal/yara-x/issues/726." },
+  { id = "RUSTSEC-2026-0222", reason = "yara-x 1.19.0 creates a single Wasmtime engine, so the cross-engine type-index mix-up described by this advisory is not reachable. See https://github.com/VirusTotal/yara-x/issues/726." },
 ]
 
 [licenses]

--- a/deny.toml
+++ b/deny.toml
@@ -2,6 +2,7 @@
 ignore = [
     { id = "RUSTSEC-2023-0071", reason = "rsa is pulled transitively by yara-x. No fixed rsa release is available, and rustinel does not use yara-x for attacker observable private key RSA operations." },
     { id = "RUSTSEC-2025-0141", reason = "bincode is pulled transitively by yara-x. This is tracked as an upstream maintenance advisory until yara-x removes or replaces it." },
+    { id = "RUSTSEC-2026-0222", reason = "yara-x creates a single Wasmtime engine, so the cross-engine type-index mix-up described by this advisory is not reachable. See https://github.com/VirusTotal/yara-x/issues/726." },
 ]
 
 [licenses]


### PR DESCRIPTION
## Summary

Updates the optional `rsigma-parser` and `rsigma-eval` dependencies together to 0.20.0 and refreshes `Cargo.lock`. Keeping both crates on the same release avoids incompatible parser types in the RSigma engine builds.

This branch includes the changes from #224 as its base. Merge #224 first, then this PR will contain only the RSigma dependency alignment.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --locked --features rsigma-engine --all-targets -- -D clippy::all`
- `RUSTINEL_CONFIG="$PWD/config.toml" cargo test --locked --features rsigma-engine`