### PR TITLE
fix(sensor): resolve exec Image from /proc/<pid>/exe

### DIFF
--- a/docs/detection.md
+++ b/docs/detection.md
@@ -111,6 +111,7 @@ macOS telemetry comes from two sources: Endpoint Security (ESF) for process and 
 Per-platform process field notes:
 
 - On Linux, the kernel exec event carries only `Image`, `ProcessId`, and `User`; `CommandLine`, `ParentImage`, `ParentProcessId`, `ParentCommandLine`, and `CurrentDirectory` are enriched from `/proc/<pid>` and may be absent for very short-lived processes.
+- `Image` is resolved from `/proc/<pid>/exe`, so it is absolute and symlink-resolved even when the binary was launched with a relative path (`./payload`). Short-lived processes that exit before enrichment fall back to the raw `execve()` argument, which may be relative and is capped at 128 bytes.
 - On macOS, ESF exec events carry `CommandLine` (argv), `ParentImage`, `ParentProcessId`, and `CurrentDirectory` natively. `ParentCommandLine` is **not** provided by ESF exec events, and `IntegrityLevel` / `LogonId` / `LogonGuid` are Windows-only.
 
 DNS field availability differs by platform:

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -65,7 +65,10 @@ The Linux sensor covers process, network, file, and DNS.
   empty command line - the dominant Linux gap, since most Linux Sigma rules match
   `CommandLine`.
 - **Paths are truncated.** The image path is capped at 128 bytes and `comm` at
-  16, which can break `Image|endswith` matches.
+  16, which can break `Image|endswith` matches. This only affects processes that
+  exit before enrichment: `Image` normally comes from `/proc/<pid>/exe`, which is
+  absolute, symlink-resolved, and untruncated. The raw kernel `execve()` argument
+  is the fallback, and it is both truncated and possibly relative.
 - **DNS is UDP port 53 only.** DNS-over-TCP, DoH (443), and DoT (853) are
   invisible; long query names are dropped, QTYPE is limited to
   A/NS/CNAME/PTR/TXT/AAAA, and answers (`QueryResults`) aren't parsed.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -18,17 +18,32 @@ configuration handling on supported platforms. It includes improvements to:
 - alert and log file permissions
 - process and network configuration
 
+Three additional issues block the final release. Each one causes Rustinel to
+report something, and to report it wrongly: a bypass that suppresses detection
+entirely, a severity that is silently lowered, and a count that is inflated.
+Shipping a stability release with any of them is the wrong trade, so they are
+pulled ahead of the v1.3.1 patch release.
+
+| Issue | Focus |
+|---|---|
+| [#226: resolve process images from `/proc/<pid>/exe`](https://github.com/Karib0u/rustinel/issues/226) | Stop relative `execve` paths from bypassing YARA scanning and path-based Sigma rules. |
+| [#183: prevent low-severity rules from hiding higher-severity matches](https://github.com/Karib0u/rustinel/issues/183) | Ensure low-severity rules cannot hide higher-severity matches. |
+| [#160: correct event.count over-counting](https://github.com/Karib0u/rustinel/issues/160) | Correct `event.count` over-counting in deduplication rollups. |
+
 ## v1.3.1: Detection correctness
 
 This patch release addresses focused correctness gaps in rule evaluation,
-severity handling, deduplication, and configuration test isolation.
+deduplication windows, and configuration test isolation.
 
 | Issue | Focus |
 |---|---|
 | [#179: report unsupported RSigma correlations and filters](https://github.com/Karib0u/rustinel/issues/179) | Report correlations and filters that RSigma parses but the runtime silently ignores. |
-| [#183: prevent low-severity rules from hiding higher-severity matches](https://github.com/Karib0u/rustinel/issues/183) | Ensure low-severity rules cannot hide higher-severity matches. |
-| [#160: correct event.count over-counting](https://github.com/Karib0u/rustinel/issues/160) | Correct `event.count` over-counting in deduplication rollups. |
+| [#170: align deduplication window behavior](https://github.com/Karib0u/rustinel/issues/170) | Align deduplication window behavior with its documented semantics. |
+| [#161: define non-ASCII Sigma matching](https://github.com/Karib0u/rustinel/issues/161) | Fix or explicitly define non-ASCII case-insensitive Sigma matching. |
 | [#171: isolate configuration tests from managed host state](https://github.com/Karib0u/rustinel/issues/171) | Keep configuration tests independent from real managed host configuration. |
+
+Deduplication work stays together: #170 follows #160 in the same subsystem, so
+the window semantics and the rollup counters are settled in one pass.
 
 ## v1.4.0: Telemetry and detection model improvements
 
@@ -38,11 +53,9 @@ diagnostics, and compatibility of detection and alerting.
 | Issue | Focus |
 |---|---|
 | [#168: preserve absolute Linux file identity](https://github.com/Karib0u/rustinel/issues/168) | Preserve absolute Linux file identity and explicitly report truncated paths. |
+| [#142: capture Linux argv in the kernel](https://github.com/Karib0u/rustinel/issues/142) | Capture Linux argv in the kernel for short-lived processes. |
 | [#162: add YARA scan timeouts and file-size controls](https://github.com/Karib0u/rustinel/issues/162) | Add YARA scan timeouts and maximum file-size controls. |
 | [#140: expose telemetry counters](https://github.com/Karib0u/rustinel/issues/140) | Expose received, dropped, and high-water telemetry counters. |
-| [#142: capture Linux argv in the kernel](https://github.com/Karib0u/rustinel/issues/142) | Capture Linux argv in the kernel for short-lived processes. |
-| [#161: define non-ASCII Sigma matching](https://github.com/Karib0u/rustinel/issues/161) | Fix or explicitly define non-ASCII case-insensitive Sigma matching. |
-| [#170: align deduplication window behavior](https://github.com/Karib0u/rustinel/issues/170) | Align deduplication window behavior with its documented semantics. |
 | [#141: report rules without backing collectors](https://github.com/Karib0u/rustinel/issues/141) | Report rules that cannot fire because no collector provides their telemetry. |
 | [#135: add a pinned SigmaHQ corpus smoke test](https://github.com/Karib0u/rustinel/issues/135) | Add a pinned SigmaHQ corpus smoke test. |
 | [#136: add backend-neutral Sigma edge-case coverage](https://github.com/Karib0u/rustinel/issues/136) | Add backend-neutral Sigma modifier and edge-case coverage. |
@@ -50,12 +63,26 @@ diagnostics, and compatibility of detection and alerting.
 | [#222: update alert output to ECS 9.5.0](https://github.com/Karib0u/rustinel/issues/222) | Move alert output to ECS 9.5.0 before the ECS model changes in #182. |
 | [#182: preserve Sigma metadata and severity](https://github.com/Karib0u/rustinel/issues/182) | Preserve Sigma metadata, ATT&CK tags, references, and severity semantics. |
 | [#138: replace unmaintained serde_yaml](https://github.com/Karib0u/rustinel/issues/138) | Replace unmaintained `serde_yaml` after the corpus baseline exists. |
+| [#221: add a generic webhook output sink](https://github.com/Karib0u/rustinel/issues/221) | Push ECS alerts to configurable HTTP endpoints with bounded queuing and retries. |
 
-## v1.5.0: RSigma transition
+Path identity comes first: #168 is the file-event form of the process-image
+defect fixed in #226, and #142 covers the same collector, so the three are
+cheapest to reason about close together.
 
-This release is intended to make RSigma the default evaluation backend while
-retaining the built-in backend as a documented fallback. The transition is
-covered by capability, debugging, documentation, and licensing work.
+The webhook sink is included here rather than later because it is the one
+backlog item with an identified external consumer waiting on it. It also
+introduces the multi-destination sink abstraction that the native sinks in
+#220 reuse.
+
+This is the largest release on the roadmap. If it needs to be cut, #136 and
+#137 move to v1.5.0 without blocking anything else.
+
+## v1.5.0: RSigma transition and telemetry capture
+
+This release makes RSigma the default evaluation backend while retaining the
+built-in backend as a documented fallback, covered by capability, debugging,
+documentation, and licensing work. It also lands the first piece of the
+telemetry capture stream.
 
 | Issue | Focus |
 |---|---|
@@ -64,61 +91,46 @@ covered by capability, debugging, documentation, and licensing work.
 | [#191: reconcile Sigma capability documentation](https://github.com/Karib0u/rustinel/issues/191) | Reconcile parser, library, and runtime capability documentation. |
 | [#149: make RSigma the default backend](https://github.com/Karib0u/rustinel/issues/149) | Make RSigma the default while retaining a documented built-in fallback. |
 | [#139: resolve the evaluator licensing strategy](https://github.com/Karib0u/rustinel/issues/139) | Resolve or close the evaluator licensing strategy based on the built-in backend decision. |
+| [#231: resolve relative argv paths in CommandLine rules](https://github.com/Karib0u/rustinel/issues/231) | Close the argv half of the relative-path evasion gap, which depends on kernel argv capture in #142. |
+| [#228: write normalized events to an NDJSON file](https://github.com/Karib0u/rustinel/issues/228) | Add a bounded, non-blocking `EventSink` capturing every normalized event, disabled by default. |
 
 The built-in backend is expected to remain available throughout the v1.x
 series. Its removal, if it becomes appropriate, is reserved for a future
 major release.
 
-## v1.6.0: Alert delivery and integration
+## v1.6.0: Alert delivery, capture workflow, and replay
 
-Rustinel currently emits alerts to a single rolling NDJSON file, so every
-integration has to discover the current file, poll it, and parse it. This
-release adds destinations beyond that file. Both items share one
-multi-destination sink abstraction: whichever lands first introduces it, and
-the NDJSON file remains the source of truth in either case.
-
-| Issue | Focus |
-|---|---|
-| [#221: add a generic webhook output sink](https://github.com/Karib0u/rustinel/issues/221) | Push ECS alerts to configurable HTTP endpoints with bounded queuing and retries. |
-| [#220: emit to native OS log sinks](https://github.com/Karib0u/rustinel/issues/220) | Route alerts and operational logs to the Windows Event Log, the systemd journal or syslog, and macOS unified logging. |
-
-The webhook sink is sequenced first: it is one implementation rather than
-three, it covers the integration use case that prompted both issues, and it
-exercises the sink abstraction that the native sinks then reuse.
-
-## v1.7.0: Telemetry capture and replay
+This release completes two threads started earlier. Alert delivery gains its
+remaining destination, and the capture stream gains the workflow and analysis
+commands built on top of #228.
 
 Rustinel normalizes every sensor event into a single model, then discards it
-unless a rule matches. The only way to see that model today is a `TRACE`
-operational log, which is filtered, interleaved with unrelated output, and has
-no format stability. This release makes normalized telemetry a product output
-in its own right: a capture stream that records every event entering the
-detection engines, whether or not anything matched.
-
-The capture point is after normalization and before detection, so the recorded
-events are exactly what Sigma, IOC, and YARA receive. The capture stream stays
-separate from the alert sinks in #221 and #220; those deliver detections, while
-capture is high-volume, host-local, and serves analysis rather than alerting.
+unless a rule matches. The capture point is after normalization and before
+detection, so recorded events are exactly what Sigma, IOC, and YARA receive.
+The capture stream stays separate from the alert sinks in #221 and #220; those
+deliver detections, while capture is high-volume, host-local, and serves
+analysis rather than alerting.
 
 | Issue | Focus |
 |---|---|
-| [#228: write normalized events to an NDJSON file](https://github.com/Karib0u/rustinel/issues/228) | Add a bounded, non-blocking `EventSink` capturing every normalized event, disabled by default. |
+| [#220: emit to native OS log sinks](https://github.com/Karib0u/rustinel/issues/220) | Route alerts and operational logs to the Windows Event Log, the systemd journal or syslog, and macOS unified logging. |
 | [#229: add a time-boxed capture command](https://github.com/Karib0u/rustinel/issues/229) | Run `rustinel capture --duration 10m` to collect events plus provenance metadata in one command. |
 | [#230: replay captured telemetry offline](https://github.com/Karib0u/rustinel/issues/230) | Re-evaluate a capture against Sigma and IOC with no sensor and no privileges. |
+| [#195: add optional all-matches mode](https://github.com/Karib0u/rustinel/issues/195) | Add an optional all-matches Sigma alert mode, unblocked once #183 ships. |
+| [#146: expand Linux file telemetry](https://github.com/Karib0u/rustinel/issues/146) | Add chmod, chown, truncate, and link telemetry, building on #168. |
 
-The items are strictly sequential. #228 is the only one that ships value on its
-own and is the one worth building first; #229 is a thin workflow wrapper over
-it, and #230 should not start before there are captures worth replaying. #230
-also owns a correctness prerequisite: `NormalizedEvent` does not round-trip
-losslessly today, so replay would silently mis-evaluate rules until that is
-fixed.
+The capture items are strictly sequential behind #228: #229 is a thin workflow
+wrapper over it, and #230 should not start before there are captures worth
+replaying. #230 also owns a correctness prerequisite: `NormalizedEvent` does
+not round-trip losslessly today, so replay would silently mis-evaluate rules
+until that is fixed.
 
 Rotation, compression, and a custom capture archive format are deliberately
 excluded. A size cap and a directory of plain NDJSON and JSON files cover the
 malware-analysis and rule-authoring workflows, and remain readable with
 ordinary tools.
 
-The counters in #140 and this capture stream reinforce each other: #140 makes
+The counters in #140 and the capture stream reinforce each other: #140 makes
 telemetry loss quantifiable, and capture makes the retained telemetry
 inspectable. Capture also gives the collector and normalization fixes in #168,
 #226, #142, and #146 a direct way to verify their output.
@@ -132,12 +144,10 @@ committed release target.
 | Issue | Focus |
 |---|---|
 | [#184: add per-rule compatibility diagnostics](https://github.com/Karib0u/rustinel/issues/184) | Build per-rule compatibility diagnostics after #141, #179, and #191. Split the epic first. |
-| [#146: expand Linux file telemetry](https://github.com/Karib0u/rustinel/issues/146) | Add chmod, chown, truncate, and link telemetry after #168. |
 | [#111: add atomic rules-pack updates](https://github.com/Karib0u/rustinel/issues/111) | Add safe atomic rules-pack updates and rollback. |
 | [#148: add Linux container and cgroup context](https://github.com/Karib0u/rustinel/issues/148) | Add container and cgroup context to Linux process events. |
 | [#147: evaluate periodic YARA memory sweeps](https://github.com/Karib0u/rustinel/issues/147) | Evaluate bounded periodic YARA memory sweeps after #162. |
 | [#143: design stateful Sigma correlation](https://github.com/Karib0u/rustinel/issues/143) | Design stateful Sigma correlation and temporal evaluation. |
-| [#195: add optional all-matches mode](https://github.com/Karib0u/rustinel/issues/195) | Add optional all-matches mode after #183 and the backend decision. |
 | [#151: evaluate cargo-nextest](https://github.com/Karib0u/rustinel/issues/151) | Adopt cargo-nextest only if CI measurements justify it. |
 | [#145: replace macOS BPF capture](https://github.com/Karib0u/rustinel/issues/145) | Replace macOS BPF capture only after resolving Apple entitlement and distribution requirements. |
 

--- a/src/sensor/linux/ebpf.rs
+++ b/src/sensor/linux/ebpf.rs
@@ -316,16 +316,31 @@ fn drain_dns_ring(rb: &mut RingBuf<MapData>, tx: &Sender<SensorEvent>) {
 
 // ── Event builders ───────────────────────────────────────────────────────────
 
+/// Pick the image path for an exec event.
+///
+/// The tracepoint carries `bprm->filename`, i.e. the literal string userspace
+/// passed to `execve()` — `./malware` stays `./malware`. Downstream consumers
+/// (YARA queueing, the allowlist, Sigma `Image` rules, IOC path regexes) all
+/// need a real path, so prefer `/proc/<pid>/exe`, which is absolute,
+/// symlink-resolved, and immune to the caller's `chdir`. The raw kernel string
+/// stays as a fallback for short-lived processes that exit before the userspace
+/// ring drain gets to `/proc`.
+fn resolve_exec_image(proc_exe: Option<&str>, raw_filename: &str) -> Option<String> {
+    proc_exe
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .or_else(|| Some(raw_filename.to_string()).filter(|value| !value.is_empty()))
+}
+
 fn build_process_event(ev: &ProcessEvent) -> Option<SensorEvent> {
     let user = resolved_linux_user(ev.uid);
     match ev.kind {
         PROCESS_EVENT_EXEC => {
             let details = query_process_details(ev.pid);
-            let image = match bytes_to_string(&ev.image) {
-                value if !value.is_empty() => Some(value),
-                _ => details.as_ref().and_then(|value| value.image.clone()),
-            };
-            let image = image?;
+            let image = resolve_exec_image(
+                details.as_ref().and_then(|value| value.image.as_deref()),
+                &bytes_to_string(&ev.image),
+            )?;
 
             let now = SystemTime::now();
             Some(SensorEvent {
@@ -727,11 +742,16 @@ mod tests {
             .expect("raw dns event should normalize")
     }
 
+    /// Never a live pid: above every possible `/proc/sys/kernel/pid_max`, so
+    /// `query_process_details` is guaranteed to come back empty and the builder
+    /// falls back to the raw tracepoint filename.
+    const DEAD_PID: u32 = u32::MAX;
+
     #[test]
     fn build_process_exec_event_emits_start() {
         let raw = ProcessEvent {
             kind: PROCESS_EVENT_EXEC,
-            pid: 42,
+            pid: DEAD_PID,
             uid: 1000,
             _pad: 0,
             comm: fixed("bash"),
@@ -746,10 +766,57 @@ mod tests {
         match event.payload {
             SensorPayload::Process(fields) => {
                 assert_eq!(fields.image.as_deref(), Some("/usr/bin/bash"));
-                assert_eq!(fields.process_id.as_deref(), Some("42"));
+                assert_eq!(
+                    fields.process_id.as_deref(),
+                    Some(DEAD_PID.to_string().as_str())
+                );
             }
             other => panic!("unexpected payload: {:?}", other),
         }
+    }
+
+    #[test]
+    fn build_process_exec_event_resolves_relative_image_from_proc() {
+        let expected = std::fs::read_link("/proc/self/exe")
+            .expect("current process should expose /proc/self/exe");
+        let raw = ProcessEvent {
+            kind: PROCESS_EVENT_EXEC,
+            pid: std::process::id(),
+            uid: 1000,
+            _pad: 0,
+            comm: fixed("rustinel"),
+            // What the kernel records when a binary is run as `./rustinel`.
+            image: fixed("./rustinel"),
+        };
+
+        let event = build_process_event(&raw).expect("process exec should build");
+        match event.payload {
+            SensorPayload::Process(fields) => {
+                assert_eq!(fields.image.as_deref(), expected.to_str());
+            }
+            other => panic!("unexpected payload: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn resolve_exec_image_prefers_proc_exe_over_raw_filename() {
+        assert_eq!(
+            resolve_exec_image(Some("/tmp/malware"), "./malware").as_deref(),
+            Some("/tmp/malware")
+        );
+    }
+
+    #[test]
+    fn resolve_exec_image_falls_back_to_raw_filename() {
+        assert_eq!(
+            resolve_exec_image(None, "./malware").as_deref(),
+            Some("./malware")
+        );
+        assert_eq!(
+            resolve_exec_image(Some(""), "/usr/bin/bash").as_deref(),
+            Some("/usr/bin/bash")
+        );
+        assert_eq!(resolve_exec_image(None, ""), None);
     }
 
     #[test]

--- a/src/utils/process.rs
+++ b/src/utils/process.rs
@@ -345,7 +345,17 @@ fn read_proc_cmdline(pid: u32) -> Option<String> {
 #[cfg(target_os = "linux")]
 fn read_proc_link(pid: u32, name: &str) -> Option<String> {
     let path = fs::read_link(format!("/proc/{pid}/{name}")).ok()?;
-    Some(path.to_string_lossy().into_owned())
+    let path = path.to_string_lossy();
+    Some(strip_deleted_suffix(&path).to_string())
+}
+
+/// Drop the ` (deleted)` marker the kernel appends to `/proc/<pid>` links when
+/// the target has been unlinked. Detections match on the path the process was
+/// started from, so keeping the marker would break `endswith` rules and hand
+/// the scanner a path it can never open.
+#[cfg(target_os = "linux")]
+fn strip_deleted_suffix(path: &str) -> &str {
+    path.strip_suffix(" (deleted)").unwrap_or(path)
 }
 
 #[cfg(target_os = "linux")]
@@ -378,6 +388,16 @@ mod tests {
         assert!(details.parent_process_id.is_some());
         assert!(details.current_directory.is_some());
         assert!(details.start_time.is_some());
+    }
+
+    #[test]
+    fn strip_deleted_suffix_only_trims_the_kernel_marker() {
+        assert_eq!(
+            strip_deleted_suffix("/tmp/malware (deleted)"),
+            "/tmp/malware"
+        );
+        assert_eq!(strip_deleted_suffix("/tmp/malware"), "/tmp/malware");
+        assert_eq!(strip_deleted_suffix("/tmp/(deleted)"), "/tmp/(deleted)");
     }
 
     #[test]


### PR DESCRIPTION
Fixes #226.

## The bypass

`build_process_event` preferred the `sched_process_exec` tracepoint's `filename` field — `bprm->filename`, the literal string userspace passed to `execve()` — over the `/proc`-enriched path, using the latter only as a fallback. A binary launched as `./malware` therefore reached every downstream consumer as a relative path:

- the YARA worker resolved it against its own cwd (`/var/lib/rustinel`), found nothing, and silently scanned nothing;
- `Image` never contained `/tmp/`, so path-based Sigma rules could not match;
- `is_path_allowlisted()` and the IOC path regexes ran against the same unusable string.

No privileges required — just `cd` to the directory first.

## The fix

Flip the preference order, exactly as scoped in the issue discussion. `query_process_details` is already called on this path and already resolves `image` from `/proc/<pid>/exe`: absolute, symlink-resolved, and immune to the caller's `chdir`. The raw kernel string stays as a fallback for short-lived processes that exit before the userspace ring drain reaches `/proc`.

The precedence is extracted into `resolve_exec_image` so it is unit-testable without a live pid.

`read_proc_link` now strips the ` (deleted)` marker the kernel appends to unlinked `/proc` links. Without it, an unlinked binary would hand the scanner a path it can never open — reproducing the silent-failure symptom of #169 — and break `endswith` rules. Applied in `read_proc_link` rather than at the call site so `ParentImage` and `CurrentDirectory` get the same treatment.

## Verified end-to-end on Linux

Ubuntu 26.04, kernel 7.0 with BTF, real eBPF object built from source with nightly + bpf-linker. Agent run as root with a stand-in `Image|startswith: '/tmp/'` Sigma rule and the bundled YARA marker rule, executing a marker-carrying binary from `/tmp` twice — once absolute, once relative:

| Build | `/tmp/marker_bin` | `./marker_bin` |
|---|---|---|
| before (42be24f) | Sigma + YARA ✅ | **no alerts** |
| after | Sigma + YARA ✅ | Sigma + YARA ✅ |

The relative-exec alert on the fixed build:

```json
{"rule.name":"Potentially Suspicious Execution From Tmp Folder",
 "process.command_line":"./marker_bin",
 "process.executable":"/tmp/marker_bin", ...}
```

`Image` resolves to the absolute path while `command_line` still shows raw argv — correct, since argv resolution is #231's scope, not this issue's.

Also green on that host: full `cargo test --locked` suite including five new tests, `cargo clippy --locked --all-targets -- -D clippy::all`, and `cargo fmt --check`.

## Scope

Process-start `Image` only, per the split agreed in the issue:

- **#231** owns Case 3/4 (`chmod +x malware`), which matches on `CommandLine` and is unaffected by resolving `Image`.
- **#168** is disjoint — file events through `build_file_event`, a different eBPF source file.
- The discarded `bpf_probe_read_kernel_str_bytes` return value in `ebpf/src/process.rs` still truncates exec paths over 127 bytes silently. Preferring `/proc/<pid>/exe` mostly moots it; the fallback path retains it.
- `/proc/<pid>/exe` resolves in the target's mount namespace, so container paths may not be openable from the host — related to #148.

## Roadmap

Second commit resequences `docs/roadmap.md`, pulling #226, #183, and #160 into v1.3.0 as release blockers and regrouping the later releases by subsystem.
