### PR TITLE
fix(dedup): count only suppressed repeats in rollup event.count

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -54,6 +54,10 @@ match_debug = "off"         # off | summary | full (attach match details to aler
 #   rollup alert carrying event.count.  The first occurrence always emits
 #   immediately - there is no detection latency penalty.
 #
+#   event.count on the rollup is the number of *suppressed* repeats (the first
+#   occurrence is already its own line, which carries no event.count).  Summing
+#   event.count across lines - absent meaning 1 - gives the true event volume.
+#
 #   Disable for high-fidelity environments where every individual event matters.
 [dedup]
 enabled = true

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -250,7 +250,9 @@ Propagation behavior:
 
 Alert deduplication collapses repeated identical alerts within a sliding window into a single rollup alert. The **first occurrence always emits immediately** - there is no added detection latency for novel alerts. Only repeats of the same alert within the window are suppressed.
 
-A rollup alert is written at window close carrying `event.count` with the total number of occurrences (including the first).
+A rollup alert is written at window close carrying `event.count` with the number of **suppressed repeats** — that is, the occurrences that were *not* written as their own line. This follows the ECS definition of `event.count` (the number of events a document represents): the live first-occurrence line represents exactly one event and carries no `event.count` at all, so summing `event.count` across every emitted line — counting a missing field as `1`, as SIEMs do — yields the true event volume.
+
+A burst of 5 identical alerts therefore produces 2 lines: the live alert (no `event.count`, implicitly 1) and a rollup with `event.count = 4`, totalling 5.
 
 The dedup key is `(engine, rule_name, process.executable, process.parent.executable, user.name)`.
 
@@ -262,7 +264,7 @@ The dedup key is `(engine, rule_name, process.executable, process.parent.executa
 
 Set `enabled = false` for high-fidelity environments where every individual alert event matters.
 
-**Dedup metrics** are written to the operational log at shutdown:
+**Dedup metrics** are written to the operational log every 5 minutes while dedup activity is happening, and once more at shutdown:
 
 ```
 dedup: suppressed_total=1420 aggregated_rollup_alerts=38 pending_keys=0

--- a/docs/output.md
+++ b/docs/output.md
@@ -61,7 +61,7 @@ Format:
 | `rule.id`           | Optional detection rule identifier, unique amongs the rustinel rules. Formatted as: `sigma::<uuid>` for Sigma, `yara::<id>` for YARA (if metadata ID is defined), or `ioc::<type>::<value>` for IOCs. |
 | `edr.rule.severity` | Low, Medium, High, or Critical                                                                                                                                                                        |
 | `edr.rule.engine`   | `Sigma`, `Yara`, or `Ioc`                                                                                                                                                                             |
-| `event.count`       | *(rollup only)* Total occurrences of this alert within the dedup window (present only on aggregate rollup alerts, not on the first live emission)                                                     |
+| `event.count`       | *(rollup only)* Number of suppressed repeats this rollup represents, i.e. occurrences within the dedup window excluding the first. Absent on the live first emission, which represents a single event. Summing `event.count` across lines (absent = 1) gives the true event volume. |
 
 ### Windows Process Alert Example
 

--- a/src/alerts/dedup.rs
+++ b/src/alerts/dedup.rs
@@ -4,6 +4,14 @@
 //! and emits a single rollup alert with `event.count` at window close.  The first
 //! occurrence always emits immediately, so there is zero added latency for novel alerts.
 //!
+//! # Counting semantics
+//! `event.count` follows ECS: it is the number of events the *document* represents.
+//! The live first-occurrence line represents exactly one event and therefore carries
+//! no `event.count` (absent means 1).  The rollup represents only the repeats that
+//! were suppressed, so it carries `count - 1`.  Summing `event.count` across every
+//! emitted line (treating a missing field as 1) yields the true number of matching
+//! events — a burst of N identical alerts totals N, not N + 1.
+//!
 //! # Identity
 //! Every key contains the detection engine, rule ID (or rule name fallback), event
 //! dataset/action/code, and a canonical subject fingerprint. The fingerprint includes
@@ -22,6 +30,10 @@
 //! Each key starts a *tumbling* window anchored to the first emission.  Once
 //! `now - first_seen >= window` the entry is expired during the next flush tick,
 //! at which point a rollup alert is written (if count > 1) and the slot is freed.
+//!
+//! # Metrics
+//! Counters are logged periodically by the flush worker (and once more at shutdown)
+//! so dedup activity stays observable on a long-running agent.
 
 use crate::models::ecs::EcsAlert;
 use crate::models::Alert;
@@ -225,8 +237,9 @@ impl Deduplicator {
         true
     }
 
-    /// Flush entries whose window has expired.  Emits a rollup alert with
-    /// `event.count` for any entry that had more than one occurrence.
+    /// Flush entries whose window has expired.  Emits a rollup alert carrying the
+    /// number of suppressed repeats in `event.count` for any entry that had more
+    /// than one occurrence.
     pub fn flush_expired(&self, sink: &super::AlertSink) {
         let now = Instant::now();
         let expired = self.drain_expired(now);
@@ -261,12 +274,9 @@ impl Deduplicator {
 
     fn emit_rollups(&self, entries: Vec<DedupEntry>, sink: &super::AlertSink) {
         for entry in entries {
-            if entry.count <= 1 {
-                // Already emitted on first occurrence, so nothing more to do.
+            let Some(ecs) = rollup_alert(&entry) else {
                 continue;
-            }
-            let mut ecs = EcsAlert::from(&entry.sample);
-            ecs.event_count = Some(entry.count);
+            };
             self.counters
                 .aggregated_total
                 .fetch_add(1, Ordering::Relaxed);
@@ -274,10 +284,17 @@ impl Deduplicator {
         }
     }
 
+    /// Cumulative `(suppressed_total, aggregated_total)` counters.
+    fn totals(&self) -> (u64, u64) {
+        (
+            self.counters.suppressed_total.load(Ordering::Relaxed),
+            self.counters.aggregated_total.load(Ordering::Relaxed),
+        )
+    }
+
     /// Log current metrics to the operational log.
     pub fn log_metrics(&self) {
-        let suppressed = self.counters.suppressed_total.load(Ordering::Relaxed);
-        let aggregated = self.counters.aggregated_total.load(Ordering::Relaxed);
+        let (suppressed, aggregated) = self.totals();
         let pending = self.table.lock().unwrap().len();
         info!(
             target: "dedup",
@@ -289,9 +306,27 @@ impl Deduplicator {
     }
 }
 
-/// Spawn a background task that ticks every `tick_interval` and flushes expired
-/// dedup entries.  The returned handle should be aborted on shutdown, after which
-/// the caller should call `flush_all` directly.
+/// How often the flush worker logs dedup counters while the agent is running.
+const METRICS_LOG_INTERVAL: Duration = Duration::from_secs(300);
+
+/// Build the rollup alert for an expired entry.
+///
+/// `event.count` is the number of *suppressed* repeats (`count - 1`): the first
+/// occurrence was already written as its own line and must not be counted twice.
+/// Returns `None` for a single occurrence, which needs no rollup at all.
+fn rollup_alert(entry: &DedupEntry) -> Option<EcsAlert> {
+    let suppressed = entry.count.saturating_sub(1);
+    if suppressed == 0 {
+        return None;
+    }
+    let mut ecs = EcsAlert::from(&entry.sample);
+    ecs.event_count = Some(suppressed);
+    Some(ecs)
+}
+
+/// Spawn a background task that ticks every `tick_interval`, flushes expired
+/// dedup entries, and periodically logs dedup metrics.  The returned handle should
+/// be aborted on shutdown, after which the caller should call `flush_all` directly.
 pub fn spawn_flush_worker(
     dedup: std::sync::Arc<Deduplicator>,
     sink: super::AlertSink,
@@ -301,9 +336,22 @@ pub fn spawn_flush_worker(
         let mut interval = tokio::time::interval(tick_interval);
         // The first tick fires immediately; skip it to avoid an early no-op flush.
         interval.tick().await;
+        let mut last_metrics = Instant::now();
+        let mut last_totals = dedup.totals();
         loop {
             interval.tick().await;
             dedup.flush_expired(&sink);
+            // Metrics are otherwise only visible at shutdown, which hides dedup
+            // activity for the whole life of a long-running agent.  Stay quiet
+            // while nothing is being deduplicated.
+            if last_metrics.elapsed() >= METRICS_LOG_INTERVAL {
+                last_metrics = Instant::now();
+                let totals = dedup.totals();
+                if totals != last_totals {
+                    dedup.log_metrics();
+                    last_totals = totals;
+                }
+            }
         }
     })
 }
@@ -487,14 +535,51 @@ mod tests {
         assert_eq!(dedup.counters.suppressed_total.load(Ordering::Relaxed), 2);
 
         // With a 0-second window the entry is already expired.
-        let sink = null_sink();
         std::thread::sleep(Duration::from_millis(10)); // ensure duration_since > 0
-        dedup.flush_expired(&sink);
+        let expired = dedup.drain_expired(Instant::now());
+        assert_eq!(expired.len(), 1, "the single key must have expired");
+        let rollup = rollup_alert(&expired[0]).expect("rollup for a repeated alert");
+        assert_eq!(
+            rollup.event_count,
+            Some(2),
+            "rollup counts the suppressed repeats only; the first occurrence \
+             was already emitted as its own line"
+        );
 
+        let sink = null_sink();
+        dedup.emit_rollups(expired, &sink);
         assert_eq!(
             dedup.counters.aggregated_total.load(Ordering::Relaxed),
             1,
             "one rollup alert should have been emitted"
+        );
+    }
+
+    #[test]
+    fn rollup_count_plus_live_alert_equals_real_event_count() {
+        let dedup = Deduplicator::new(0, 1000);
+        let alert = make_alert("Rule A", "/usr/bin/curl");
+        let ecs = EcsAlert::from(&alert);
+
+        const BURST: u64 = 7;
+        let mut emitted_live = 0u64;
+        for _ in 0..BURST {
+            if dedup.record(&ecs, &alert) {
+                emitted_live += 1;
+            }
+        }
+
+        std::thread::sleep(Duration::from_millis(10));
+        let expired = dedup.drain_expired(Instant::now());
+        let rolled_up: u64 = expired
+            .iter()
+            .filter_map(|entry| rollup_alert(entry)?.event_count)
+            .sum();
+
+        assert_eq!(
+            emitted_live + rolled_up,
+            BURST,
+            "summed event.count across emitted lines must equal the real event count"
         );
     }
 
@@ -509,6 +594,19 @@ mod tests {
 
         assert_eq!(dedup.table.lock().unwrap().len(), 2);
 
+        // Rule A saw 2 occurrences → rollup carrying the 1 suppressed repeat;
+        // Rule B saw 1 → no rollup at all.
+        let counts: Vec<Option<u64>> = {
+            let table = dedup.table.lock().unwrap();
+            let mut counts: Vec<Option<u64>> = table
+                .values()
+                .map(|entry| rollup_alert(entry).and_then(|ecs| ecs.event_count))
+                .collect();
+            counts.sort_unstable();
+            counts
+        };
+        assert_eq!(counts, vec![None, Some(1)]);
+
         let sink = null_sink();
         dedup.flush_all(&sink);
 
@@ -517,7 +615,7 @@ mod tests {
             0,
             "table must be empty after flush_all"
         );
-        // Rule A had count=2 → rollup emitted; Rule B had count=1 → no rollup
+        // Only Rule A produced a rollup.
         assert_eq!(dedup.counters.aggregated_total.load(Ordering::Relaxed), 1);
     }
 

--- a/src/alerts/mod.rs
+++ b/src/alerts/mod.rs
@@ -2,7 +2,8 @@
 //!
 //! Writes ECS alerts as one JSON object per line, with optional sliding-window
 //! deduplication that collapses repeated identical alerts into a single rollup
-//! carrying `event.count`.
+//! carrying `event.count` — the number of repeats it suppressed, so that the live
+//! first occurrence is not counted twice.  See [`dedup`] for the full semantics.
 
 pub mod dedup;
 

--- a/tests/dedup_integration.rs
+++ b/tests/dedup_integration.rs
@@ -71,6 +71,15 @@ fn setup(
     (sink, dedup, guard)
 }
 
+/// Total event volume the emitted lines represent, the way a SIEM would sum it:
+/// `event.count` when present, 1 otherwise.
+fn total_event_count(lines: &[Value]) -> u64 {
+    lines
+        .iter()
+        .map(|line| line.get("event.count").and_then(Value::as_u64).unwrap_or(1))
+        .sum()
+}
+
 fn read_json_lines(path: &std::path::Path) -> Vec<Value> {
     let contents = std::fs::read_to_string(path).expect("read output");
     contents
@@ -129,18 +138,23 @@ fn repeated_alerts_suppressed_and_rollup_emitted_on_flush() {
         lines.len()
     );
 
-    // Line 0: the live alert (no event.count)
+    // Line 0: the live alert (no event.count — an absent count means 1)
     assert!(
         lines[0].get("event.count").is_none(),
         "live alert must not carry event.count"
     );
 
-    // Line 1: the rollup
+    // Line 1: the rollup, covering only the suppressed repeats.
     assert_eq!(
-        lines[1]["event.count"], 5,
-        "rollup must carry event.count = 5 (all occurrences)"
+        lines[1]["event.count"], 4,
+        "rollup must carry event.count = 4 (the suppressed repeats only)"
     );
     assert_eq!(lines[1]["rule.name"], "Suspicious Shell");
+    assert_eq!(
+        total_event_count(&lines),
+        5,
+        "summed event.count must equal the 5 real events, not 6"
+    );
 }
 
 #[test]
@@ -171,8 +185,16 @@ fn distinct_rules_tracked_and_flushed_independently() {
         .collect();
     assert_eq!(rollups.len(), 2, "two rollup lines (one per rule)");
     for rollup in rollups {
-        assert_eq!(rollup["event.count"], 2, "each rollup has count=2");
+        assert_eq!(
+            rollup["event.count"], 1,
+            "each rollup covers the single suppressed repeat"
+        );
     }
+    assert_eq!(
+        total_event_count(&lines),
+        4,
+        "two occurrences per rule, four events in total"
+    );
 }
 
 #[test]
@@ -221,10 +243,44 @@ fn distinct_process_subjects_keep_independent_rollups() {
     assert_eq!(
         rollup_subjects,
         vec![
-            ("curl https://first.example", 2),
-            ("curl https://second.example", 2),
+            ("curl https://first.example", 1),
+            ("curl https://second.example", 1),
         ],
         "each rollup must retain the subject of its suppressed event"
+    );
+}
+
+#[test]
+fn summed_event_count_matches_real_volume_across_windows() {
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let out = dir.path().join("alerts.ndjson");
+    // 0-second window: every flush closes the current window immediately.
+    let (sink, dedup, _guard) = setup(&out, 0);
+
+    let alert = make_alert("Suspicious Shell", "/usr/bin/bash");
+    const BURSTS: usize = 3;
+    const PER_BURST: usize = 4;
+    for _ in 0..BURSTS {
+        for _ in 0..PER_BURST {
+            sink.write_alert(&alert);
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        dedup.flush_expired(&sink);
+    }
+
+    drop(sink);
+    drop(_guard);
+
+    let lines = read_json_lines(&out);
+    assert_eq!(
+        lines.len(),
+        BURSTS * 2,
+        "each window emits one live alert and one rollup"
+    );
+    assert_eq!(
+        total_event_count(&lines),
+        (BURSTS * PER_BURST) as u64,
+        "summed event.count must equal the real event volume across all windows"
     );
 }
 


### PR DESCRIPTION
## Problem

The sliding-window deduplicator emits the first occurrence of an alert immediately, then writes a rollup at window close whose `event.count` **still includes that already-emitted occurrence**. A burst of N identical alerts produced two lines — the live alert (implicitly 1) plus a rollup with `event.count = N` — so a SIEM summing `event.count` (missing field meaning 1) totalled `N + 1` for N real events. Every window inflated alert-volume dashboards and any count-based threshold by one.

## Fix

The rollup now carries `count - 1`: the number of repeats that were actually **suppressed**.

This is the ECS reading of `event.count` — the number of events the document represents. The live line already represents the first occurrence and carries no count of its own, so summing across emitted lines now yields the real event volume:

| | before | after |
|---|---|---|
| live alert | *(absent → 1)* | *(absent → 1)* |
| rollup | `event.count = 5` | `event.count = 4` |
| **sum for 5 real events** | **6** | **5** |

I did not take the alternative "suppress the immediate emit and only write rollups" option: it would add up to a full window of detection latency for novel alerts, which the dedup design deliberately avoids.

Rollup construction moved into a free `rollup_alert()` function that returns `None` for a single occurrence — the "no rollup needed" case and the count arithmetic now live in one place, and tests can assert the count directly.

## Secondary observation from the issue

`log_metrics()` was only called at shutdown, so `suppressed_total` / `aggregated_total` were invisible for the entire life of a running agent. The flush worker now logs them every 5 minutes, but only when the counters have changed since the last log, so an idle agent stays quiet.

## Docs

The counting semantics are stated in `docs/configuration.md` (with a worked 5-alert example), the `event.count` row of `docs/output.md`, the `[dedup]` comment block in `config.toml`, and a new "Counting semantics" section in the `src/alerts/dedup.rs` module docs.

## Tests

- `flush_expired_emits_rollup_with_count` and `flush_all_drains_all_entries` now assert the count *value*, not just that a rollup was emitted.
- `rollup_count_plus_live_alert_equals_real_event_count` (unit) asserts the acceptance criterion directly over a 7-alert burst.
- `summed_event_count_matches_real_volume_across_windows` (integration) writes 3 windows x 4 alerts through a real sink and file, and asserts the summed `event.count` equals 12.
- The integration suite gained a `total_event_count()` helper that sums the way a SIEM would (absent = 1); the existing rollup tests assert against it too.

`cargo test` and `cargo clippy --all-targets -- -D warnings` are clean on macOS.

Fixes #160