### PR TITLE
fix(sensor): windows file events

### DIFF
--- a/src/sensor/windows/etw.rs
+++ b/src/sensor/windows/etw.rs
@@ -186,6 +186,57 @@ fn kernel_file_action(event_id: u16) -> SensorAction {
     }
 }
 
+/// IRP_MJ_CREATE disposition values (top byte of CreateOptions).
+///
+/// The disposition controls whether the I/O manager creates a new file,
+/// opens an existing one, or some combination of both.
+const FILE_DISPOSITION_SUPERSEDE: u32 = 0;
+const FILE_DISPOSITION_OPEN: u32 = 1;
+const FILE_DISPOSITION_CREATE: u32 = 2;
+const FILE_DISPOSITION_OPEN_IF: u32 = 3;
+const FILE_DISPOSITION_OVERWRITE: u32 = 4;
+const FILE_DISPOSITION_OVERWRITE_IF: u32 = 5;
+
+/// Refine a [`SensorAction::Create`] for Kernel-File Event ID 12 based on
+/// the `CreateOptions` disposition.
+///
+/// Event ID 12 corresponds to `IRP_MJ_CREATE`, which fires for **every** file
+/// handle request — including plain opens and attribute queries.  Without
+/// inspecting the disposition we would misclassify reads as file creations.
+///
+/// Returns:
+/// * `Some(action)` — the (possibly adjusted) action for this event.
+/// * `None` — the event should be dropped (pure open / read).
+fn refine_file_create_action(parser: &Parser, action: SensorAction) -> Option<SensorAction> {
+    if action != SensorAction::Create {
+        return Some(action);
+    }
+
+    let create_options = parser.try_parse::<u32>("CreateOptions").ok()?;
+    let disposition = (create_options >> 24) & 0xFF;
+
+    match disposition {
+        // Pure open of an existing file — never creates.  Drop the event
+        // to match Sysmon behaviour (Sysmon does not emit FileCreate for
+        // plain opens).
+        FILE_DISPOSITION_OPEN => None,
+
+        // Overwrite of an existing file — the file already exists so this
+        // is a modification, not a creation.
+        FILE_DISPOSITION_OVERWRITE => Some(SensorAction::Modify),
+
+        // SUPERSEDE, CREATE, OPEN_IF, OVERWRITE_IF can all result in a
+        // new file being created.
+        FILE_DISPOSITION_SUPERSEDE
+        | FILE_DISPOSITION_CREATE
+        | FILE_DISPOSITION_OPEN_IF
+        | FILE_DISPOSITION_OVERWRITE_IF => Some(SensorAction::Create),
+
+        // Unknown disposition — keep as Create to be safe.
+        _ => Some(SensorAction::Create),
+    }
+}
+
 /// DeletePath, RenamePath, and SetLinkPath carry their path in `FilePath`;
 /// the remaining file events use `FileName`.
 fn kernel_file_path_property(event_id: u16) -> &'static str {
@@ -402,6 +453,15 @@ fn decode_record(
         }
     };
     let parser = Parser::create(record, &schema);
+
+    // For file events, refine the action based on the IRP_MJ_CREATE
+    // disposition so that pure opens (reads / attribute queries) are
+    // dropped rather than misclassified as file creations.
+    let action = if category == EventCategory::File {
+        refine_file_create_action(&parser, action)?
+    } else {
+        action
+    };
 
     let decoded = match category {
         EventCategory::Process => decode_process(&parser, record, action),

--- a/src/sensor/windows/mapper.rs
+++ b/src/sensor/windows/mapper.rs
@@ -96,7 +96,7 @@ pub fn map_to_sysmon_id(category: EventCategory, action_code: u8, raw_event_id: 
             _ => raw_event_id,
         },
         EventCategory::File => match action_code {
-            64 | 65 => 11,
+            64 => 11,
             70 | 72 => 23,
             _ => raw_event_id,
         },
@@ -167,5 +167,18 @@ mod tests {
     #[test]
     fn network_udp_connect_maps_to_sysmon_3() {
         assert_eq!(map_to_sysmon_id(EventCategory::Network, 15, 999), 3);
+    }
+
+    #[test]
+    fn file_modify_does_not_map_to_sysmon_11() {
+        let code = file_action_code(SensorAction::Modify);
+        assert_eq!(code, 65);
+        // Modify must NOT map to Sysmon ID 11 (FileCreate); it should
+        // fall through to its raw_event_id (65) which routes to
+        // file_change in the detection engine.
+        assert_eq!(
+            map_to_sysmon_id(EventCategory::File, code, u16::from(code)),
+            65
+        );
     }
 }


### PR DESCRIPTION
## Summary
Distinguishes between file operations on Windows, current behavior is to consider file lookup as file creation.

## Type of change
<!-- Add the matching label to this PR before merging -->
- [ ] `feat` / `enhancement` - new feature
- [x] `bug` - bug fix
- [ ] `refactor` - refactoring, no behaviour change
- [ ] `documentation` - docs only
- [ ] `ci` - CI and release changes
- [ ] `dependencies` - dependency update

## Test plan
- [x] Tested on Windows
- [ ] Tested on Linux
- [ ] Existing tests pass (`cargo test`)
- [ ] New tests added (if applicable)

## Checklist
- [ ] Label added to this PR
- [ ] Docs updated (if behaviour changed)
