### PR TITLE
ci: pin nightly toolchain and bpf-linker for the eBPF build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,10 +59,13 @@ jobs:
         with:
           persist-credentials: false
 
+      # bpf-linker links against a specific LLVM, so it has to match the LLVM
+      # the nightly toolchain ships. Both pins move together — bumping one
+      # without the other breaks this job.
       - name: Setup nightly Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
-          toolchain: nightly
+          toolchain: nightly-2026-08-11
           components: rust-src
           cache: false
 
@@ -71,7 +74,7 @@ jobs:
           lookup-only: true
 
       - name: Install bpf-linker
-        run: command -v bpf-linker >/dev/null 2>&1 || cargo install bpf-linker
+        run: command -v bpf-linker >/dev/null 2>&1 || cargo install bpf-linker --version 0.10.4 --locked
 
       - name: Build eBPF object
         run: |


### PR DESCRIPTION
## Summary

`Linux eBPF Build` has been failing since 2026-08-12, which blocks **every** open PR — it is a required status check, and `Tests (Linux)` and `Clippy (Linux)` both `needs:` it, so they report `skipped` and also block.

The failure is environmental, not caused by any PR:

```
Error: could not find llvm-config in directories specified by environment
```

`bpf-linker` 0.11.0 was released on 2026-08-12. It builds against `llvm-sys 231`, which needs a system LLVM 23 that `ubuntu-latest` does not ship. The job's `cargo install bpf-linker` had no version pin, so the next run picked it up and broke.

The job pins every action by SHA but left two inputs floating: the `nightly` channel and the `bpf-linker` version. This pins both to the last known-good pair, taken from the last green run (2026-08-11):

- `nightly-2026-08-11` — resolves to `rustc 1.99.0-nightly (12c36e253 2026-08-10)`, the exact toolchain that run used
- `bpf-linker 0.10.4` with `--locked`

`bpf-linker` links against a specific LLVM, so it has to match the LLVM the nightly ships — the two pins have to move together. Added a comment above the toolchain step saying so, since bumping one alone is the trap that caused this.

## Type of change
- [ ] `feat` / `enhancement` - new feature
- [ ] `bug` - bug fix
- [ ] `refactor` - refactoring, no behaviour change
- [ ] `documentation` - docs only
- [x] `ci` - CI and release changes
- [ ] `dependencies` - dependency update

## Test plan
- [x] Tested on Linux — installed `nightly-2026-08-11` and `bpf-linker 0.10.4` on a clean Ubuntu box (no system LLVM 23; only LLVM 21 present) and ran `cargo build --release` in `ebpf/`. It produced a valid object:
  ```
  ELF 64-bit LSB relocatable, eBPF, version 1 (SYSV), not stripped
  Sections: .text, tracepoint, kprobe/vfs_create, ...
  ```
  Confirms the pinned pair links without a system LLVM and emits real program sections.
- [x] Existing tests pass (`cargo test`) — unaffected; this touches only the eBPF job
- [ ] New tests added (if applicable) — n/a, CI-only change

## Notes

This is a pin, not a permanent fix. Bumping later means moving both pins together and confirming `ebpf/` still builds. The alternative — installing a matching LLVM and setting `LLVM_SYS_<ver>_PREFIX` — keeps the job on floating nightly and would need the same tracking, so pinning is the smaller and more reproducible option.

## Checklist
- [x] Label added to this PR
- [ ] Docs updated (if behaviour changed)