### PR TITLE
chore: prepare release 1.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3172,7 +3172,7 @@ dependencies = [
 
 [[package]]
 name = "rustinel"
-version = "1.3.0-rc.1"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustinel"
-version = "1.3.0-rc.1"
+version = "1.3.0"
 edition = "2021"
 authors = []
 description = "Open-source EDR for Windows, Linux, and macOS with Sigma, YARA, and IOC detection"

--- a/docs/detection.md
+++ b/docs/detection.md
@@ -108,7 +108,7 @@ rule instead of one is tracked separately by
 | `file_event` | Yes | Yes | Yes | Base file family |
 | `file_create` | Yes | Yes | Yes | Derived from file event ID / opcode (ESF event type on macOS) |
 | `file_delete` | Yes | Yes | Yes | Derived from file event ID / opcode (ESF event type on macOS) |
-| `file_change` | Yes | Yes | Yes | Derived from file event ID / opcode (ESF event type on macOS) |
+| `file_change` | Yes | Yes | No | Derived from file event ID / opcode. On Windows the events routed here are Kernel-File name-cache entries and writes that arrive without a path, rather than content changes ([#238](https://github.com/Karib0u/rustinel/issues/238)); on macOS a modification is reported as `file_create`, so this category never matches ([#239](https://github.com/Karib0u/rustinel/issues/239)) |
 | `file_rename` | Yes | Yes | Yes | Derived from file event ID / opcode (ESF event type on macOS) |
 | `dns_query` | Yes | Yes | Yes | Generic `category: dns` and `service: dns`, `category: network` are also supported |
 | `registry_event` / `registry_*` | Yes | No | No | Windows only |


### PR DESCRIPTION
## Summary

Bumps the version from `1.3.0-rc.1` to `1.3.0` and refreshes `Cargo.lock`.

All three issues blocking the v1.3.0 milestone are closed and merged: #226 (#233), #183 (#234), #160 (#235).

Also corrects the `file_change` row in `docs/detection.md`, which claimed support on all three platforms. Verified against the code, neither Windows nor macOS matches that claim:

| | Windows | Linux | macOS |
|---|---|---|---|
| was | Yes | Yes | Yes |
| now | Yes | Yes | **No** |

- **Windows** — the events routed to `file_change` are Kernel-File name-cache entries (IDs 10 and 11) and writes that arrive with no path at all, rather than content changes. Events do reach the category, so the column stays `Yes`, but the Notes now describe what they actually are. Tracked in #238.
- **macOS** — `FileAction::Modify` normalizes to `event_id` 11, and `sigma_file_categories_for_event` matches `event_id` before falling through to `opcode`, so it returns `file_create` and the `file_change` arm is unreachable. The column becomes `No`. Tracked in #239. Note `logsource.rs` still registers `macos/sysmon/file_change` as an active tuple, so those rules load and sit inert — related to #141.

Shipping the old row in a tagged release would have documented a detection capability that does not exist on two of three platforms.

## Type of change
<!-- Add the matching label to this PR before merging -->
- [ ] `feat` / `enhancement` - new feature
- [ ] `bug` - bug fix
- [ ] `refactor` - refactoring, no behaviour change
- [ ] `documentation` - docs only
- [ ] `ci` - CI and release changes
- [ ] `dependencies` - dependency update
- [x] `maintenance` - release housekeeping

## Test plan
- [ ] Tested on Windows
- [ ] Tested on Linux
- [x] Existing tests pass (`cargo test`) — full CI matrix runs on this PR, and `release.yml` re-runs the CI gates on the tag before building
- [ ] New tests added (if applicable) — n/a, version bump and docs

## Checklist
- [x] Label added to this PR
- [x] Docs updated (if behaviour changed)

## Release notes

Labels on every PR merged since `v1.2.0` have been audited — all 40 categorize cleanly and "Other Changes" is empty. Notes will span `v1.2.0`, not `v1.3.0-rc.1`, so the RC-cycle work is not dropped.