### PR TITLE
fix(engine): report unsupported RSigma correlations and filters

### DIFF
--- a/docs/detection.md
+++ b/docs/detection.md
@@ -49,22 +49,24 @@ cargo build --release --features rsigma-engine
 
 ### Engine Conformance
 
-The built-in engine implements the stateless subset of the Sigma specification that covers typical field-matching rules. The RSigma engine implements the full specification plus experimental features. Both agree on the common surface: the modifiers listed under [Supported Modifiers](#supported-modifiers), wildcards, keyword search, list-as-OR and map-as-AND selections, and `1 of` and `all of` conditions.
+The built-in engine implements the stateless subset of the Sigma specification that covers typical field-matching rules. The RSigma parser and evaluator cover a broader stateless surface. Rustinel does not currently integrate stateful correlation evaluation or filter application into its RSigma runtime. Each parsed correlation or filter document is therefore reported as unsupported with its source path, identity, and reason, and the counts are included in startup and reload summaries. Stateful correlation support remains tracked by [issue #143](https://github.com/Karib0u/rustinel/issues/143).
 
-The built-in engine does not implement the following, whereas RSigma does. Run such rulesets under `--sigma-engine rsigma`:
+Both backends agree on the common surface: the modifiers listed under [Supported Modifiers](#supported-modifiers), wildcards, keyword search, list-as-OR and map-as-AND selections, and `1 of` and `all of` conditions.
 
-| Sigma feature | Built-in | RSigma |
+The built-in engine does not implement the following. RSigma provides broader stateless support, while stateful correlation and filter documents are reported as unsupported. Run rulesets that rely on the stateless RSigma features under `--sigma-engine rsigma`:
+
+| Sigma feature | Built-in runtime | RSigma runtime |
 | --- | --- | --- |
 | `N of` condition quantifiers such as `2 of selection*` | No (only `1 of` and `all of`) | Yes |
 | Array-scope quantifiers `field[any]` and `field[all]`, and element-scope blocks ([SEP #212](https://github.com/SigmaHQ/sigma-specification/issues/212)) | No | Yes |
-| Correlations (`event_count`, `value_count`, `temporal`, `temporal_ordered`, `value_sum`, `value_avg`, `value_percentile`, `value_median`) | No | Yes |
-| Filter rules | No | Yes |
-| Collection actions `reset` and `repeat` (`global` is supported by both) | No | Yes |
+| Correlations (`event_count`, `value_count`, `temporal`, `temporal_ordered`, `value_sum`, `value_avg`, `value_percentile`, `value_median`) | No | No, reported unsupported |
+| Filter rules | No | No, reported unsupported |
+| Collection actions `reset` and `repeat` (`global` is supported by both) | No | Yes for stateless rule documents |
 | `expand` modifier and `%placeholder%` expansion | No | Yes |
 | `sigma-version` aware evaluation ([SEP #213](https://github.com/SigmaHQ/sigma-specification/issues/213)) | No | Yes |
 | Full rule-object metadata (status, date, author, references, falsepositives, related, fields, custom attributes) | Dropped | Preserved |
 
-On an unsupported construct the built-in engine may skip the rule at load, fail to match, or mis-evaluate a complex condition, so rulesets that rely on these features should run under the RSigma engine.
+On an unsupported construct the built-in engine may skip the rule at load, fail to match, or mis-evaluate a complex condition. The RSigma runtime reports parsed correlation and filter documents as unsupported rather than evaluating them. Rulesets that rely on stateful features should wait for the integration tracked by issue #143.
 
 Array matching and `sigma-version` are proposed Sigma Enhancement Proposals ([SEP #212](https://github.com/SigmaHQ/sigma-specification/issues/212) and [SEP #213](https://github.com/SigmaHQ/sigma-specification/issues/213)) targeting the next major Sigma release; RSigma is their reference implementation and supports them ahead of standardization.
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -17,7 +17,7 @@ This page documents Rustinel's known limitations for the current release.
 | Registry value *data* is never captured; `Details` holds the value *name* instead | Windows |
 | Process events carry no hashes (`Hashes` / `Imphash`) | Windows |
 | Command line is lost for short-lived processes | Windows | Linux |
-| No correlation, aggregation, or temporal rules | Engine |
+| No stateful correlation or filter evaluation; unsupported documents are reported at load time | Engine |
 | Rules are silently inert when no collector backs their logsource | Engine |
 | Telemetry is dropped under burst load (no backpressure) | Pipeline |
 
@@ -105,11 +105,14 @@ macOS support is experimental and detection-only.
 
 ## Detection engine (Sigma)
 
-- **No correlation, aggregation, or temporal rules (silent risk).** Each event is
-  matched independently - no state, window, count, or throttle. Sigma correlation
-  (`event_count`, `value_count`, `temporal`, `temporal_ordered`) and legacy
-  aggregations (`| count() by ...`, `near`) are unsupported, so brute-force,
-  beaconing, and "N events in M minutes" detections can't be expressed.
+- **No stateful correlation or filter evaluation (explicit runtime boundary).**
+  Each event is matched independently - no state, window, count, or throttle.
+  Sigma correlation (`event_count`, `value_count`, `temporal`,
+  `temporal_ordered`) and legacy aggregations (`| count() by ...`, `near`) are
+  unsupported, so brute-force, beaconing, and "N events in M minutes"
+  detections can't be expressed. Sigma filter documents are not applied. The
+  RSigma parser recognizes both document types, but Rustinel reports them as
+  unsupported with source context and counts them in load and reload summaries.
 - **Unsupported modifiers reject the whole rule.** A rule using a modifier
   outside the supported set (e.g. `|expand`, `|gzip`, `|minlength`) is dropped at
   load, not partially matched.

--- a/src/doctor/rules.rs
+++ b/src/doctor/rules.rs
@@ -288,6 +288,30 @@ fn validate_sigma_rules(cfg: &AppConfig, platform: InstallPlatform) -> Diagnosti
         .with_fix("Fix the listed Sigma rules or remove them from the active pack");
     }
 
+    if !stats.unsupported_rules.is_empty() {
+        let detail = stats
+            .unsupported_rules
+            .iter()
+            .take(5)
+            .map(|rule| {
+                format!(
+                    "{}: {} {}: {}",
+                    rule.source_path, rule.kind, rule.identity, rule.reason
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("; ");
+        return DiagnosticResult::warn(
+            "sigma_rules_unsupported",
+            format!(
+                "{} Sigma documents are unsupported by the runtime",
+                stats.unsupported_rules.len()
+            ),
+            detail,
+        )
+        .with_fix("Use stateless Sigma rules until stateful support is implemented");
+    }
+
     if stats.total_rules == 0 {
         return DiagnosticResult::warn(
             "sigma_rules_parse",

--- a/src/engine/loader.rs
+++ b/src/engine/loader.rs
@@ -14,19 +14,32 @@ impl Engine {
         // Recursively load all rules
         self.load_rules_recursive(rules_dir)?;
 
-        info!("Loaded {} Sigma rules total", self.rule_count);
-        for (logsource, count) in self.stats().rules_by_logsource {
+        let stats = self.stats();
+        info!("Loaded {} Sigma rules total", stats.total_rules);
+        for (logsource, count) in &stats.rules_by_logsource {
             info!("  Logsource '{}': {} rules", logsource, count);
         }
         info!(
-            "Skipped rules - deferred: {}, unknown_logsource: {}, product_mismatch: {}, inactive_collectors: {}",
-            self.skipped_deferred_rules,
-            self.skipped_unknown_logsource_rules,
-            self.skipped_product_rules,
-            self.inactive_collector_rules
+            "Skipped rules - deferred: {}, unknown_logsource: {}, product_mismatch: {}, inactive_collectors: {}; unsupported documents - correlations: {}, filters: {}",
+            stats.skipped_deferred_rules,
+            stats.skipped_unknown_logsource_rules,
+            stats.skipped_product_rules,
+            stats.inactive_collector_rules,
+            stats.unsupported_correlation_rules,
+            stats.unsupported_filter_rules
         );
 
-        if self.rule_files_found > 0 && self.rule_count == 0 {
+        for unsupported in &stats.unsupported_rules {
+            warn!(
+                source = %unsupported.source_path,
+                kind = %unsupported.kind,
+                identity = %unsupported.identity,
+                reason = %unsupported.reason,
+                "Sigma document is unsupported by the active runtime"
+            );
+        }
+
+        if self.rule_files_found > 0 && self.rule_count == 0 && stats.unsupported_rules.is_empty() {
             warn!("Sigma rules found but none compiled successfully");
         }
 

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -26,7 +26,7 @@ pub use logsource::{LogSource, LogSourceClassification, LogSourceKey, LogSourceS
 pub(crate) use matcher::{FieldPattern, NumericOp, PatternMatcher};
 pub(crate) use rule::CompiledRule;
 pub use rule::{Detection, FieldCriterion, Selection, SigmaRule};
-pub use stats::EngineStats;
+pub use stats::{EngineStats, UnsupportedRule, UnsupportedRuleKind};
 
 use anyhow::{Context, Result};
 use base64::{engine::general_purpose, Engine as _};
@@ -202,6 +202,9 @@ pub struct Engine {
     /// Failed rule paths and error messages (for diagnostics)
     failed_rules: Vec<(String, String)>,
 
+    /// Parsed documents that the active runtime cannot evaluate.
+    unsupported_rules: Vec<UnsupportedRule>,
+
     /// Rules skipped at load time due to unsupported logsource product.
     skipped_product_rules: usize,
 
@@ -298,6 +301,7 @@ impl Engine {
             rule_count: 0,
             rule_files_found: 0,
             failed_rules: Vec::new(),
+            unsupported_rules: Vec::new(),
             skipped_product_rules: 0,
             skipped_deferred_rules: 0,
             skipped_unknown_logsource_rules: 0,
@@ -325,6 +329,22 @@ impl Engine {
             #[cfg(not(feature = "rsigma-engine"))]
             SigmaEngineKind::Rsigma => self.check_event_builtin(event),
         }
+    }
+
+    #[cfg(feature = "rsigma-engine")]
+    pub(crate) fn record_unsupported_rule(
+        &mut self,
+        source_path: &Path,
+        kind: UnsupportedRuleKind,
+        identity: impl Into<String>,
+        reason: impl Into<String>,
+    ) {
+        self.unsupported_rules.push(UnsupportedRule {
+            source_path: source_path.display().to_string(),
+            kind,
+            identity: identity.into(),
+            reason: reason.into(),
+        });
     }
 }
 

--- a/src/engine/rsigma_backend.rs
+++ b/src/engine/rsigma_backend.rs
@@ -21,7 +21,7 @@ use rsigma_parser::{
     parse_sigma_yaml, Level as RsLevel, LogSource as RsLogSource, SigmaRule as RsRule,
 };
 
-use super::{Engine, LogSourceKey, MatchRank, RuleLoadDecision};
+use super::{Engine, LogSourceKey, MatchRank, RuleLoadDecision, UnsupportedRuleKind};
 use crate::engine::rsigma_adapter::RsigmaEvent;
 use crate::models::{
     Alert, AlertSeverity, DetectionEngine, MatchDebugLevel, MatchDetails, NormalizedEvent,
@@ -148,6 +148,13 @@ fn value_to_string(value: &serde_json::Value) -> Option<String> {
     }
 }
 
+fn document_identity(id: Option<&str>, title: &str) -> String {
+    match id {
+        Some(id) => format!("id '{id}', title '{title}'"),
+        None => format!("title '{title}'"),
+    }
+}
+
 impl Engine {
     /// RSigma variant of the single-file rule loader.
     ///
@@ -163,6 +170,23 @@ impl Engine {
         for error in &collection.errors {
             self.failed_rules
                 .push((path.display().to_string(), error.clone()));
+        }
+
+        for correlation in &collection.correlations {
+            self.record_unsupported_rule(
+                path,
+                UnsupportedRuleKind::Correlation,
+                document_identity(correlation.id.as_deref(), &correlation.title),
+                "RSigma correlation documents are parsed but stateful correlation evaluation is not integrated into Rustinel; support remains tracked by issue #143",
+            );
+        }
+        for filter in &collection.filters {
+            self.record_unsupported_rule(
+                path,
+                UnsupportedRuleKind::Filter,
+                document_identity(filter.id.as_deref(), &filter.title),
+                "RSigma filter documents are parsed but filter application is not integrated into Rustinel's stateless event matcher",
+            );
         }
 
         let match_detail = match_detail_level(self.match_debug);

--- a/src/engine/stats.rs
+++ b/src/engine/stats.rs
@@ -1,4 +1,32 @@
 use super::*;
+use std::fmt;
+
+/// The kind of Sigma document that the RSigma parser accepted but Rustinel
+/// does not currently evaluate at runtime.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnsupportedRuleKind {
+    Correlation,
+    Filter,
+}
+
+impl fmt::Display for UnsupportedRuleKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Correlation => f.write_str("correlation"),
+            Self::Filter => f.write_str("filter"),
+        }
+    }
+}
+
+/// Context for a parsed Sigma document that was not loaded by the active
+/// runtime because its document type is not supported.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnsupportedRule {
+    pub source_path: String,
+    pub kind: UnsupportedRuleKind,
+    pub identity: String,
+    pub reason: String,
+}
 
 impl Engine {
     pub fn stats(&self) -> EngineStats {
@@ -43,6 +71,17 @@ impl Engine {
             SigmaEngineKind::Rsigma => builtin_counts(),
         };
 
+        let unsupported_correlation_rules = self
+            .unsupported_rules
+            .iter()
+            .filter(|rule| rule.kind == UnsupportedRuleKind::Correlation)
+            .count();
+        let unsupported_filter_rules = self
+            .unsupported_rules
+            .iter()
+            .filter(|rule| rule.kind == UnsupportedRuleKind::Filter)
+            .count();
+
         EngineStats {
             total_rules: self.rule_count,
             rule_files_found: self.rule_files_found,
@@ -59,6 +98,9 @@ impl Engine {
                 .map(|(k, v)| (k.display(), *v))
                 .collect(),
             failed_rules: self.failed_rules.clone(),
+            unsupported_rules: self.unsupported_rules.clone(),
+            unsupported_correlation_rules,
+            unsupported_filter_rules,
             skipped_product_rules: self.skipped_product_rules,
             skipped_deferred_rules: self.skipped_deferred_rules,
             skipped_unknown_logsource_rules: self.skipped_unknown_logsource_rules,
@@ -79,6 +121,10 @@ pub struct EngineStats {
     pub unknown_logsource_rules: HashMap<String, usize>,
     #[allow(dead_code)] // Used by validation binaries outside this crate.
     pub failed_rules: Vec<(String, String)>,
+    /// Parsed documents that the active runtime cannot evaluate.
+    pub unsupported_rules: Vec<UnsupportedRule>,
+    pub unsupported_correlation_rules: usize,
+    pub unsupported_filter_rules: usize,
     pub skipped_product_rules: usize,
     pub skipped_deferred_rules: usize,
     pub skipped_unknown_logsource_rules: usize,

--- a/src/reload/mod.rs
+++ b/src/reload/mod.rs
@@ -153,7 +153,10 @@ pub fn spawn_reload_worker(
                         match engine.load_rules(&scanner_cfg.sigma_rules_path) {
                             Ok(()) => {
                                 let stats = engine.stats();
-                                if stats.rule_files_found > 0 && stats.total_rules == 0 {
+                                if stats.rule_files_found > 0
+                                    && stats.total_rules == 0
+                                    && stats.unsupported_rules.is_empty()
+                                {
                                     warn!(
                                         target: "reload",
                                         path = ?scanner_cfg.sigma_rules_path,
@@ -170,11 +173,22 @@ pub fn spawn_reload_worker(
                                         "Some Sigma rules failed to compile, but loading the working rules"
                                     );
                                 }
+                                if !stats.unsupported_rules.is_empty() {
+                                    warn!(
+                                        target: "reload",
+                                        path = ?scanner_cfg.sigma_rules_path,
+                                        unsupported = ?stats.unsupported_rules,
+                                        "Some Sigma documents are unsupported by the active runtime"
+                                    );
+                                }
                                 store.swap_sigma(Arc::new(engine));
                                 info!(
                                     target: "reload",
                                     component = "sigma",
                                     total_rules = stats.total_rules,
+                                    unsupported_rules = stats.unsupported_rules.len(),
+                                    unsupported_correlation_rules = stats.unsupported_correlation_rules,
+                                    unsupported_filter_rules = stats.unsupported_filter_rules,
                                     elapsed_ms = started.elapsed().as_millis() as u64,
                                     "Sigma rules hot-reloaded"
                                 );

--- a/src/runtime/linux.rs
+++ b/src/runtime/linux.rs
@@ -117,6 +117,9 @@ async fn run_linux_edr(
                 skipped_unknown_logsource_rules = stats.skipped_unknown_logsource_rules,
                 skipped_product_rules = stats.skipped_product_rules,
                 inactive_collector_rules = stats.inactive_collector_rules,
+                unsupported_rules = stats.unsupported_rules.len(),
+                unsupported_correlation_rules = stats.unsupported_correlation_rules,
+                unsupported_filter_rules = stats.unsupported_filter_rules,
                 "Sigma engine initialized"
             );
             for (logsource, count) in stats.rules_by_logsource {

--- a/src/runtime/macos.rs
+++ b/src/runtime/macos.rs
@@ -117,6 +117,9 @@ async fn run_macos_edr(
                 skipped_unknown_logsource_rules = stats.skipped_unknown_logsource_rules,
                 skipped_product_rules = stats.skipped_product_rules,
                 inactive_collector_rules = stats.inactive_collector_rules,
+                unsupported_rules = stats.unsupported_rules.len(),
+                unsupported_correlation_rules = stats.unsupported_correlation_rules,
+                unsupported_filter_rules = stats.unsupported_filter_rules,
                 "Sigma engine initialized"
             );
             for (logsource, count) in stats.rules_by_logsource {

--- a/src/runtime/windows.rs
+++ b/src/runtime/windows.rs
@@ -324,6 +324,9 @@ async fn run_edr(
                 skipped_unknown_logsource_rules = stats.skipped_unknown_logsource_rules,
                 skipped_product_rules = stats.skipped_product_rules,
                 inactive_collector_rules = stats.inactive_collector_rules,
+                unsupported_rules = stats.unsupported_rules.len(),
+                unsupported_correlation_rules = stats.unsupported_correlation_rules,
+                unsupported_filter_rules = stats.unsupported_filter_rules,
                 "Sigma Engine initialized"
             );
             for (logsource, count) in stats.rules_by_logsource {

--- a/tests/rsigma_unsupported.rs
+++ b/tests/rsigma_unsupported.rs
@@ -1,0 +1,144 @@
+#![cfg(feature = "rsigma-engine")]
+
+use std::fs;
+
+use rustinel::engine::{Engine, SigmaEngineKind, UnsupportedRuleKind};
+use rustinel::models::MatchDebugLevel;
+use rustinel::sensor::Platform;
+use tempfile::TempDir;
+
+fn engine_for(path: &std::path::Path) -> Engine {
+    let mut engine = Engine::new_for_platform_with_logging_level_and_match_debug(
+        Platform::Linux,
+        "info",
+        MatchDebugLevel::Off,
+        SigmaEngineKind::Rsigma,
+    );
+    engine.load_rules(path).expect("Sigma rules should load");
+    engine
+}
+
+#[test]
+fn reports_correlations_and_filters_without_discarding_context() {
+    let fixture = TempDir::new().expect("temporary rule directory");
+    let path = fixture.path().join("collection.yml");
+    fs::write(
+        &path,
+        r#"title: Base Process Rule
+id: base-process-rule
+logsource:
+  product: linux
+  category: process_creation
+detection:
+  selection:
+    Image: /usr/bin/curl
+  condition: selection
+---
+title: Repeated Process Rule
+id: repeated-process-rule
+correlation:
+  type: event_count
+  rules:
+    - base-process-rule
+  group-by:
+    - Image
+  timespan: 5m
+  condition:
+    gte: 2
+level: high
+---
+title: Suppress Admin Process
+id: suppress-admin-process
+logsource:
+  product: linux
+  category: process_creation
+filter:
+  rules:
+    - base-process-rule
+  selection:
+    User: alice
+  condition: selection
+"#,
+    )
+    .expect("write Sigma fixture");
+
+    let stats = engine_for(fixture.path()).stats();
+
+    assert_eq!(stats.total_rules, 1);
+    assert!(stats.failed_rules.is_empty());
+    assert_eq!(stats.unsupported_rules.len(), 2);
+    assert_eq!(stats.unsupported_correlation_rules, 1);
+    assert_eq!(stats.unsupported_filter_rules, 1);
+
+    let correlation = stats
+        .unsupported_rules
+        .iter()
+        .find(|rule| rule.kind == UnsupportedRuleKind::Correlation)
+        .expect("correlation diagnostic");
+    assert_eq!(correlation.source_path, path.display().to_string());
+    assert!(correlation.identity.contains("repeated-process-rule"));
+    assert!(correlation.identity.contains("Repeated Process Rule"));
+    assert!(correlation.reason.contains("stateful correlation"));
+    assert!(correlation.reason.contains("#143"));
+
+    let filter = stats
+        .unsupported_rules
+        .iter()
+        .find(|rule| rule.kind == UnsupportedRuleKind::Filter)
+        .expect("filter diagnostic");
+    assert_eq!(filter.source_path, path.display().to_string());
+    assert!(filter.identity.contains("suppress-admin-process"));
+    assert!(filter.reason.contains("filter application"));
+}
+
+#[test]
+fn reload_engine_stats_only_include_documents_in_the_new_collection() {
+    let fixture = TempDir::new().expect("temporary rule directory");
+    let path = fixture.path().join("collection.yml");
+    fs::write(
+        &path,
+        r#"title: Base Process Rule
+logsource:
+  product: linux
+  category: process_creation
+detection:
+  selection:
+    Image: /usr/bin/curl
+  condition: selection
+---
+title: Repeated Process Rule
+correlation:
+  type: event_count
+  rules: Base Process Rule
+  group-by: Image
+  timespan: 5m
+  condition:
+    gte: 2
+"#,
+    )
+    .expect("write Sigma fixture");
+
+    let initial_stats = engine_for(fixture.path()).stats();
+    assert_eq!(initial_stats.unsupported_correlation_rules, 1);
+    assert_eq!(initial_stats.unsupported_filter_rules, 0);
+
+    fs::write(
+        &path,
+        r#"title: Reloaded Process Rule
+logsource:
+  product: linux
+  category: process_creation
+detection:
+  selection:
+    Image: /usr/bin/curl
+  condition: selection
+"#,
+    )
+    .expect("rewrite Sigma fixture");
+
+    let reloaded_stats = engine_for(fixture.path()).stats();
+    assert_eq!(reloaded_stats.total_rules, 1);
+    assert_eq!(reloaded_stats.unsupported_rules.len(), 0);
+    assert_eq!(reloaded_stats.unsupported_correlation_rules, 0);
+    assert_eq!(reloaded_stats.unsupported_filter_rules, 0);
+}


### PR DESCRIPTION
## Summary

- Record parsed RSigma correlation and filter documents as unsupported instead of silently discarding them.
- Include source path, document identity, explicit reason, and per-kind counts in engine diagnostics.
- Surface unsupported counts in startup, reload, and doctor output.
- Align detection and limitations documentation with the runtime boundary.

## Root cause

The RSigma adapter iterated only `collection.rules`, while `rsigma-parser` exposes correlations and filters in separate collection fields. Those documents were therefore ignored without diagnostics.

Stateful correlation implementation remains out of scope for this change and is tracked by #143.

## Validation

- `cargo test`
- `cargo test --features rsigma-engine`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #179