### PR TITLE
test(config): isolate config tests from managed host state

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -419,6 +419,15 @@ impl AppConfig {
     }
 
     pub fn from_options(options: ConfigLoadOptions) -> Result<Self, config::ConfigError> {
+        Self::from_options_with_environment(options, None)
+    }
+
+    // `None` preserves runtime environment discovery. Tests can provide a
+    // controlled map without mutating the process environment.
+    fn from_options_with_environment(
+        options: ConfigLoadOptions,
+        environment: Option<config::Map<String, String>>,
+    ) -> Result<Self, config::ConfigError> {
         let selected_config = options
             .selected_config()
             .map(|selected| absolute_config_path(selected.path));
@@ -493,54 +502,95 @@ impl AppConfig {
             Some(path) => builder.add_source(config::File::from(path).required(true)),
             None => builder,
         };
-        let s = builder
-            .add_source(config::Environment::with_prefix("EDR").separator("__"))
-            .build()?;
+        let environment_source = config::Environment::with_prefix("EDR")
+            .separator("__")
+            .source(environment.clone());
+        let s = builder.add_source(environment_source).build()?;
 
         let mut cfg: Self = s.try_deserialize()?;
         if let Some(config_dir) = config_dir {
-            cfg.resolve_relative_paths(&config_dir);
+            cfg.resolve_relative_paths(&config_dir, environment.as_ref());
         }
         cfg.apply_allowlist_fallbacks();
         Ok(cfg)
     }
 
-    fn resolve_relative_paths(&mut self, base_dir: &Path) {
+    fn resolve_relative_paths(
+        &mut self,
+        base_dir: &Path,
+        environment: Option<&config::Map<String, String>>,
+    ) {
         resolve_path_from_config(
             &mut self.scanner.sigma_rules_path,
             base_dir,
             "SCANNER__SIGMA_RULES_PATH",
+            environment,
         );
         resolve_path_from_config(
             &mut self.scanner.yara_rules_path,
             base_dir,
             "SCANNER__YARA_RULES_PATH",
+            environment,
         );
-        resolve_path_from_config(&mut self.logging.directory, base_dir, "LOGGING__DIRECTORY");
-        resolve_path_from_config(&mut self.alerts.directory, base_dir, "ALERTS__DIRECTORY");
-        resolve_path_from_config(&mut self.ioc.hashes_path, base_dir, "IOC__HASHES_PATH");
-        resolve_path_from_config(&mut self.ioc.ips_path, base_dir, "IOC__IPS_PATH");
-        resolve_path_from_config(&mut self.ioc.domains_path, base_dir, "IOC__DOMAINS_PATH");
+        resolve_path_from_config(
+            &mut self.logging.directory,
+            base_dir,
+            "LOGGING__DIRECTORY",
+            environment,
+        );
+        resolve_path_from_config(
+            &mut self.alerts.directory,
+            base_dir,
+            "ALERTS__DIRECTORY",
+            environment,
+        );
+        resolve_path_from_config(
+            &mut self.ioc.hashes_path,
+            base_dir,
+            "IOC__HASHES_PATH",
+            environment,
+        );
+        resolve_path_from_config(
+            &mut self.ioc.ips_path,
+            base_dir,
+            "IOC__IPS_PATH",
+            environment,
+        );
+        resolve_path_from_config(
+            &mut self.ioc.domains_path,
+            base_dir,
+            "IOC__DOMAINS_PATH",
+            environment,
+        );
         resolve_path_from_config(
             &mut self.ioc.paths_regex_path,
             base_dir,
             "IOC__PATHS_REGEX_PATH",
+            environment,
         );
-        resolve_path_list_from_config(&mut self.allowlist.paths, base_dir, "ALLOWLIST__PATHS");
+        resolve_path_list_from_config(
+            &mut self.allowlist.paths,
+            base_dir,
+            "ALLOWLIST__PATHS",
+            environment,
+        );
         resolve_path_list_from_config(
             &mut self.response.allowlist_paths,
             base_dir,
             "RESPONSE__ALLOWLIST_PATHS",
+            environment,
         );
         resolve_path_list_from_config(
             &mut self.scanner.yara_allowlist_paths,
             base_dir,
             "SCANNER__YARA_ALLOWLIST_PATHS",
+            environment,
         );
         resolve_path_list_from_config(
             &mut self.ioc.hash_allowlist_paths,
             base_dir,
             "IOC__HASH_ALLOWLIST_PATHS",
+            environment,
         );
     }
 
@@ -565,9 +615,24 @@ fn resolve_path(path: &mut PathBuf, base_dir: &Path) {
     }
 }
 
-fn resolve_path_from_config(path: &mut PathBuf, base_dir: &Path, env_key: &str) {
-    if std::env::var_os(format!("EDR__{env_key}")).is_none() {
+fn resolve_path_from_config(
+    path: &mut PathBuf,
+    base_dir: &Path,
+    env_key: &str,
+    environment: Option<&config::Map<String, String>>,
+) {
+    if !environment_contains(environment, env_key) {
         resolve_path(path, base_dir);
+    }
+}
+
+fn environment_contains(environment: Option<&config::Map<String, String>>, env_key: &str) -> bool {
+    let key = format!("EDR__{env_key}");
+    match environment {
+        Some(values) => values
+            .keys()
+            .any(|candidate| candidate.eq_ignore_ascii_case(&key)),
+        None => std::env::var_os(key).is_some(),
     }
 }
 
@@ -591,8 +656,13 @@ fn resolve_path_list(paths: &mut [String], base_dir: &Path) {
     }
 }
 
-fn resolve_path_list_from_config(paths: &mut [String], base_dir: &Path, env_key: &str) {
-    if std::env::var_os(format!("EDR__{env_key}")).is_none() {
+fn resolve_path_list_from_config(
+    paths: &mut [String],
+    base_dir: &Path,
+    env_key: &str,
+    environment: Option<&config::Map<String, String>>,
+) {
+    if !environment_contains(environment, env_key) {
         resolve_path_list(paths, base_dir);
     }
 }
@@ -692,14 +762,7 @@ mod tests {
 
     #[test]
     fn test_config_loads_defaults() {
-        let cfg = AppConfig::from_options(ConfigLoadOptions {
-            explicit_config: None,
-            env_config: None,
-            managed_config: std::path::PathBuf::new(),
-            exe_config: None,
-            cwd_config: std::path::PathBuf::new(),
-        })
-        .unwrap();
+        let cfg = AppConfig::default();
         assert!(cfg.scanner.sigma_enabled);
         assert_eq!(cfg.logging.level, "info");
         assert!(cfg.logging.filter.is_none());
@@ -717,22 +780,49 @@ mod tests {
 
     #[test]
     fn test_config_paths() {
-        let cfg = AppConfig::from_options(ConfigLoadOptions {
-            explicit_config: None,
-            env_config: None,
-            managed_config: std::path::PathBuf::new(),
-            exe_config: None,
-            cwd_config: std::path::PathBuf::from("config.toml"),
-        })
+        let temp = tempfile::tempdir().expect("tempdir");
+        let explicit = temp.path().join("explicit.toml");
+        let managed = temp.path().join("managed.toml");
+        std::fs::write(
+            &explicit,
+            r#"
+[scanner]
+sigma_rules_path = "rules/sigma"
+yara_rules_path = "rules/yara"
+
+[ioc]
+hashes_path = "rules/ioc/hashes.txt"
+ips_path = "rules/ioc/ips.txt"
+paths_regex_path = "rules/ioc/paths_regex.txt"
+"#,
+        )
+        .expect("write explicit config");
+        std::fs::write(
+            &managed,
+            "[scanner]\nsigma_rules_path = \"managed-sigma\"\n",
+        )
+        .expect("write managed config");
+
+        let cfg = AppConfig::from_options_with_environment(
+            ConfigLoadOptions {
+                explicit_config: Some(explicit.clone()),
+                env_config: None,
+                managed_config: managed,
+                exe_config: Some(temp.path().join("missing-exe.toml")),
+                cwd_config: temp.path().join("missing-cwd.toml"),
+            },
+            Some(config::Map::new()),
+        )
         .unwrap();
-        let cwd = std::env::current_dir().expect("current dir");
-        assert_eq!(cfg.scanner.sigma_rules_path, cwd.join("rules/sigma"));
-        assert_eq!(cfg.scanner.yara_rules_path, cwd.join("rules/yara"));
-        assert_eq!(cfg.ioc.hashes_path, cwd.join("rules/ioc/hashes.txt"));
-        assert_eq!(cfg.ioc.ips_path, cwd.join("rules/ioc/ips.txt"));
+        let config_dir = explicit.parent().expect("config directory");
+
+        assert_eq!(cfg.scanner.sigma_rules_path, config_dir.join("rules/sigma"));
+        assert_eq!(cfg.scanner.yara_rules_path, config_dir.join("rules/yara"));
+        assert_eq!(cfg.ioc.hashes_path, config_dir.join("rules/ioc/hashes.txt"));
+        assert_eq!(cfg.ioc.ips_path, config_dir.join("rules/ioc/ips.txt"));
         assert_eq!(
             cfg.ioc.paths_regex_path,
-            cwd.join("rules/ioc/paths_regex.txt")
+            config_dir.join("rules/ioc/paths_regex.txt")
         );
     }
 
@@ -759,6 +849,7 @@ mod tests {
         std::fs::create_dir_all(&env_dir).expect("env dir");
         let explicit = explicit_dir.join("custom.toml");
         let env_config = env_dir.join("config.toml");
+        let managed = temp.path().join("managed.toml");
 
         std::fs::write(
             &explicit,
@@ -783,14 +874,18 @@ paths_regex_path = "explicit-ioc/paths_regex.txt"
         )
         .expect("write explicit config");
         std::fs::write(&env_config, "[logging]\nlevel = \"debug\"\n").expect("write env config");
+        std::fs::write(&managed, "[logging]\nlevel = \"warn\"\n").expect("write managed config");
 
-        let cfg = AppConfig::from_options(ConfigLoadOptions {
-            explicit_config: Some(explicit.clone()),
-            env_config: Some(env_config),
-            managed_config: temp.path().join("managed.toml"),
-            exe_config: Some(temp.path().join("exe.toml")),
-            cwd_config: temp.path().join("cwd.toml"),
-        })
+        let cfg = AppConfig::from_options_with_environment(
+            ConfigLoadOptions {
+                explicit_config: Some(explicit.clone()),
+                env_config: Some(env_config),
+                managed_config: managed,
+                exe_config: Some(temp.path().join("exe.toml")),
+                cwd_config: temp.path().join("cwd.toml"),
+            },
+            Some(config::Map::new()),
+        )
         .expect("load config");
 
         assert_eq!(cfg.logging.level, "trace");
@@ -817,35 +912,44 @@ paths_regex_path = "explicit-ioc/paths_regex.txt"
         std::fs::write(&exe, "[logging]\nlevel = \"debug\"\n").expect("write exe config");
         std::fs::write(&cwd, "[logging]\nlevel = \"trace\"\n").expect("write cwd config");
 
-        let cfg = AppConfig::from_options(ConfigLoadOptions {
-            explicit_config: None,
-            env_config: None,
-            managed_config: managed.clone(),
-            exe_config: Some(exe.clone()),
-            cwd_config: cwd.clone(),
-        })
+        let cfg = AppConfig::from_options_with_environment(
+            ConfigLoadOptions {
+                explicit_config: None,
+                env_config: None,
+                managed_config: managed.clone(),
+                exe_config: Some(exe.clone()),
+                cwd_config: cwd.clone(),
+            },
+            Some(config::Map::new()),
+        )
         .expect("load managed config");
         assert_eq!(cfg.logging.level, "warn");
 
         std::fs::remove_file(&managed).expect("remove managed config");
-        let cfg = AppConfig::from_options(ConfigLoadOptions {
-            explicit_config: None,
-            env_config: None,
-            managed_config: managed,
-            exe_config: Some(exe.clone()),
-            cwd_config: cwd.clone(),
-        })
+        let cfg = AppConfig::from_options_with_environment(
+            ConfigLoadOptions {
+                explicit_config: None,
+                env_config: None,
+                managed_config: managed,
+                exe_config: Some(exe.clone()),
+                cwd_config: cwd.clone(),
+            },
+            Some(config::Map::new()),
+        )
         .expect("load exe config");
         assert_eq!(cfg.logging.level, "debug");
 
         std::fs::remove_file(&exe).expect("remove exe config");
-        let cfg = AppConfig::from_options(ConfigLoadOptions {
-            explicit_config: None,
-            env_config: None,
-            managed_config: temp.path().join("missing-managed.toml"),
-            exe_config: Some(exe),
-            cwd_config: cwd,
-        })
+        let cfg = AppConfig::from_options_with_environment(
+            ConfigLoadOptions {
+                explicit_config: None,
+                env_config: None,
+                managed_config: temp.path().join("missing-managed.toml"),
+                exe_config: Some(exe),
+                cwd_config: cwd,
+            },
+            Some(config::Map::new()),
+        )
         .expect("load cwd config");
         assert_eq!(cfg.logging.level, "trace");
     }
@@ -858,13 +962,16 @@ paths_regex_path = "explicit-ioc/paths_regex.txt"
         std::fs::write(&env_config, "[logging]\nlevel = \"debug\"\n").expect("write env config");
         std::fs::write(&managed, "[logging]\nlevel = \"warn\"\n").expect("write managed config");
 
-        let cfg = AppConfig::from_options(ConfigLoadOptions {
-            explicit_config: None,
-            env_config: Some(env_config),
-            managed_config: managed,
-            exe_config: None,
-            cwd_config: temp.path().join("cwd.toml"),
-        })
+        let cfg = AppConfig::from_options_with_environment(
+            ConfigLoadOptions {
+                explicit_config: None,
+                env_config: Some(env_config),
+                managed_config: managed,
+                exe_config: None,
+                cwd_config: temp.path().join("cwd.toml"),
+            },
+            Some(config::Map::new()),
+        )
         .expect("load env config");
 
         assert_eq!(cfg.logging.level, "debug");
@@ -931,12 +1038,24 @@ paths_regex_path = "explicit-ioc/paths_regex.txt"
 
     #[test]
     fn env_overrides_sigma_engine() {
-        // Mutates process env, scoped to this test and restored below. No other
-        // test asserts scanner.sigma_engine through AppConfig::new(), so setting
-        // it here cannot make a parallel test flaky.
-        std::env::set_var("EDR__SCANNER__SIGMA_ENGINE", "rsigma");
-        let cfg = AppConfig::new().expect("config should load");
-        std::env::remove_var("EDR__SCANNER__SIGMA_ENGINE");
+        let temp = tempfile::tempdir().expect("tempdir");
+        let mut environment = config::Map::new();
+        environment.insert(
+            "EDR__SCANNER__SIGMA_ENGINE".to_string(),
+            "rsigma".to_string(),
+        );
+
+        let cfg = AppConfig::from_options_with_environment(
+            ConfigLoadOptions {
+                explicit_config: None,
+                env_config: None,
+                managed_config: temp.path().join("missing-managed.toml"),
+                exe_config: None,
+                cwd_config: temp.path().join("missing-cwd.toml"),
+            },
+            Some(environment),
+        )
+        .expect("config should load");
         assert_eq!(cfg.scanner.sigma_engine, "rsigma");
     }
 


### PR DESCRIPTION
## Summary

- Use AppConfig::default() for pure default-value assertions.
- Use temporary explicit and managed config fixtures for path and precedence tests.
- Inject environment values into tests instead of mutating the process environment.

## Root cause

Configuration tests relied on runtime discovery and ambient environment state, so an existing managed installation could change their inputs and expected paths.

## Validation

- cargo test --locked --all-targets
- cargo test --locked --lib config::tests with host-style configuration variables present
- cargo fmt --all -- --check
- git diff --check

Closes #171