### PR TITLE
fix(dedup): document fixed first-seen windows

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -50,9 +50,9 @@ filename = "alerts.json"    # Will contain newline-delimited JSON (NDJSON)
 match_debug = "off"         # off | summary | full (attach match details to alerts.json)
 
 # 3a. Alert Deduplication
-#   Collapses repeated identical alerts within a sliding window into a single
-#   rollup alert carrying event.count.  The first occurrence always emits
-#   immediately - there is no detection latency penalty.
+#   Collapses repeated identical alerts within a fixed window anchored to the
+#   first occurrence into a single rollup alert carrying event.count.  The first
+#   occurrence always emits immediately - there is no detection latency penalty.
 #
 #   event.count on the rollup is the number of *suppressed* repeats (the first
 #   occurrence is already its own line, which carries no event.count).  Summing

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -248,7 +248,9 @@ Propagation behavior:
 
 ### Deduplication
 
-Alert deduplication collapses repeated identical alerts within a sliding window into a single rollup alert. The **first occurrence always emits immediately** - there is no added detection latency for novel alerts. Only repeats of the same alert within the window are suppressed.
+Alert deduplication collapses repeated identical alerts within a fixed window anchored to the first occurrence into a single rollup alert. The **first occurrence always emits immediately** - there is no added detection latency for novel alerts. Repeats do not extend the window; an alert after the window closes starts a new window and emits immediately.
+
+Long-running activity is split into successive fixed windows, so each window is flushed and reported independently.
 
 A rollup alert is written at window close carrying `event.count` with the number of **suppressed repeats** — that is, the occurrences that were *not* written as their own line. This follows the ECS definition of `event.count` (the number of events a document represents): the live first-occurrence line represents exactly one event and carries no `event.count` at all, so summing `event.count` across every emitted line — counting a missing field as `1`, as SIEMs do — yields the true event volume.
 
@@ -259,7 +261,7 @@ The dedup key is `(engine, rule_name, process.executable, process.parent.executa
 | Option | Default | Description |
 | --- | --- | --- |
 | `enabled` | `true` | Enable alert deduplication |
-| `window_secs` | `60` | Window length in seconds; identical alerts within this window are aggregated |
+| `window_secs` | `60` | Fixed window length in seconds, measured from the first occurrence; repeats do not extend it |
 | `max_entries` | `10000` | Maximum distinct alert keys tracked simultaneously (memory cap) |
 
 Set `enabled = false` for high-fidelity environments where every individual alert event matters.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -18,8 +18,9 @@ configuration test isolation. Each item causes Rustinel to report something and
 to report it wrongly.
 
 Deduplication work stays together: the window semantics and the rollup counters
-are settled in one pass, so the sliding-window fix follows the `event.count`
-over-counting fix in the same subsystem rather than in a later release.
+are settled in one pass, so the window-semantics decision follows the
+`event.count` over-counting fix in the same subsystem rather than in a later
+release.
 
 ## v1.4.0: Normalized-event capture and replay
 

--- a/src/alerts/dedup.rs
+++ b/src/alerts/dedup.rs
@@ -1,4 +1,4 @@
-//! Sliding-window alert deduplication.
+//! Fixed-window alert deduplication.
 //!
 //! The deduplicator groups repeated identical alerts within a configurable time window
 //! and emits a single rollup alert with `event.count` at window close.  The first
@@ -27,8 +27,9 @@
 //! `None`, which is distinct from a present value but stable across repeated alerts.
 //!
 //! # Window semantics
-//! Each key starts a *tumbling* window anchored to the first emission.  Once
-//! `now - first_seen >= window` the entry is expired during the next flush tick,
+//! Each key starts a fixed window anchored to the first emission.  Repeats do not
+//! move the window.  Once `now - first_seen >= window` the entry is expired during
+//! the next flush tick,
 //! at which point a rollup alert is written (if count > 1) and the slot is freed.
 //!
 //! # Metrics
@@ -172,6 +173,7 @@ impl DedupKey {
 
 /// State tracked per unique alert key.
 struct DedupEntry {
+    /// Start of the fixed window. Repeats do not move this timestamp.
     first_seen: Instant,
     count: u64,
     /// A clone of the original internal `Alert` so we can rebuild a complete ECS
@@ -210,6 +212,10 @@ impl Deduplicator {
     /// Record an alert.  Returns `true` if the caller should emit the alert now
     /// (first occurrence), `false` if it was suppressed.
     pub fn record(&self, ecs: &EcsAlert, alert: &Alert) -> bool {
+        self.record_at(Instant::now(), ecs, alert)
+    }
+
+    fn record_at(&self, now: Instant, ecs: &EcsAlert, alert: &Alert) -> bool {
         let key = DedupKey::from_ecs(ecs);
         let mut table = self.table.lock().unwrap();
 
@@ -229,7 +235,7 @@ impl Deduplicator {
         table.insert(
             key,
             DedupEntry {
-                first_seen: Instant::now(),
+                first_seen: now,
                 count: 1,
                 sample: alert.clone(),
             },
@@ -454,6 +460,29 @@ mod tests {
             "third hit must return false (suppress)"
         );
         assert_eq!(dedup.counters.suppressed_total.load(Ordering::Relaxed), 2);
+    }
+
+    #[test]
+    fn fixed_window_does_not_extend_on_repeats() {
+        let dedup = Deduplicator::new(60, 1000);
+        let alert = make_alert("Rule A", "/usr/bin/curl");
+        let ecs = EcsAlert::from(&alert);
+        let start = Instant::now();
+
+        assert!(dedup.record_at(start, &ecs, &alert));
+        assert!(!dedup.record_at(start + Duration::from_secs(59), &ecs, &alert));
+
+        let expired = dedup.drain_expired(start + Duration::from_secs(60));
+        assert_eq!(expired.len(), 1, "the first-seen window must expire");
+        assert_eq!(
+            expired[0].count, 2,
+            "the repeat belongs to the first window"
+        );
+
+        assert!(
+            dedup.record_at(start + Duration::from_secs(60), &ecs, &alert),
+            "an alert after the fixed window must start a new window"
+        );
     }
 
     #[test]

--- a/src/alerts/mod.rs
+++ b/src/alerts/mod.rs
@@ -1,6 +1,6 @@
 //! Alert sink for ECS NDJSON output.
 //!
-//! Writes ECS alerts as one JSON object per line, with optional sliding-window
+//! Writes ECS alerts as one JSON object per line, with optional fixed-window
 //! deduplication that collapses repeated identical alerts into a single rollup
 //! carrying `event.count` — the number of repeats it suppressed, so that the live
 //! first occurrence is not counted twice.  See [`dedup`] for the full semantics.

--- a/src/config.rs
+++ b/src/config.rs
@@ -393,9 +393,9 @@ pub struct ReloadConfig {
 /// Alert deduplication / aggregation configuration
 #[derive(Debug, Clone, Deserialize)]
 pub struct DedupConfig {
-    /// Enable sliding-window alert deduplication
+    /// Enable fixed-window alert deduplication anchored to first occurrence
     pub enabled: bool,
-    /// Window length in seconds; repeated identical alerts are collapsed within this window
+    /// Window length in seconds; repeats do not extend the first-seen window
     pub window_secs: u64,
     /// Maximum number of distinct alert keys to track simultaneously
     pub max_entries: usize,


### PR DESCRIPTION
## Summary

- Document alert deduplication as a fixed window anchored to the first occurrence.
- Add deterministic coverage proving repeats do not extend the window.
- Align source comments, configuration descriptions, user documentation, and roadmap language.

## Root cause

The runtime already expires entries using `first_seen` and does not update that timestamp for repeats, but several public descriptions called the behavior sliding-window deduplication.

## Impact

The behavior is now explicit: sustained activity is split into successive fixed windows, each with its own rollup. No runtime suppression behavior changes.

## Validation

- `cargo fmt --all -- --check`
- `cargo test`
- `git diff --check`

Closes #170