### PR TITLE
feat(capture): record normalized events and add rustinel capture

### DIFF
--- a/.github/workflows/privileged-smoke.yml
+++ b/.github/workflows/privileged-smoke.yml
@@ -31,6 +31,9 @@ jobs:
         run: cargo test --locked --test yara_memory -- --include-ignored
       - name: Run ignored active response smoke tests
         run: cargo test --locked --test active_response -- --include-ignored
+      # Ctrl-C delivery is signal-based, so the capture smoke test is Unix-only.
+      - name: Run ignored capture smoke tests
+        run: cargo test --locked --test capture_command -- --include-ignored
 
   windows-privileged-smoke:
     name: Privileged Smoke (Windows)

--- a/config.toml
+++ b/config.toml
@@ -89,6 +89,13 @@ aggregation_max_entries = 20000
 aggregation_window_secs = 60
 aggregation_interval_buffer_size = 50
 
+# 6a. Behavioral Recording (rustinel capture)
+#   Recordings hold normalized events - command lines, file paths, destinations,
+#   and user names - so treat them like alert output: they are written
+#   owner-only and kept apart from alert and operational logs.
+[capture]
+directory = "captures"      # default parent for rustinel-capture-<UTC timestamp>.ndjson
+
 # 7. Atomic IOC Detection (Hashes, IPs, Domains, Path Regex)
 [ioc]
 enabled = true

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -48,6 +48,50 @@ Notes:
 - `--sigma-engine <builtin|rsigma>` selects the Sigma matching backend, overriding `scanner.sigma_engine`. `rsigma` requires a build with the `rsigma-engine` feature (included in the official release binaries). See [Detection](detection.md#detection-engine).
 - Linux foreground execution is the normal runtime model unless you wrap the binary in a service manager.
 
+### `capture`
+
+Record endpoint behavior to a file that can be replayed against detectors later.
+
+```text
+rustinel capture [--config <PATH>] [--output <PATH>] [--log-level <LEVEL>]
+```
+
+Capture is passive. It starts the same sensors as `run` and records every
+normalized event, but evaluates no rules, writes no alerts, and never invokes
+active response. Rustinel does not launch the activity being observed: start
+capture first, run the sample yourself, then press Ctrl-C.
+
+```powershell
+# In a disposable VM
+rustinel capture
+# ... run the sample, script, or Atomic test in another window ...
+# Ctrl-C
+```
+
+```bash
+sudo ./rustinel capture --output /tmp/lab/run-42.ndjson
+```
+
+Behavior:
+
+- Requires the same privileges as `run`, and fails with the same preflight errors.
+- Without `--output`, the recording is written to
+  `<capture.directory>/rustinel-capture-<UTC timestamp>.ndjson`, creating the
+  directory if needed. `--output` overrides that path entirely.
+- Each recording has a manifest sidecar next to it, named after the recording
+  with a `.manifest.json` extension.
+- Ctrl-C drains queued events and finalizes the manifest as `complete`. A
+  capture that is killed, or that lost events, stays `incomplete` and is
+  rejected by replay by default.
+- Progress and final counts go to stderr. Event payloads are never printed.
+- Recordings can be replayed on any platform: a Windows recording replays on
+  Linux and vice versa.
+
+Recordings contain full command lines, file paths, network destinations, and
+user names for all observed activity, so handle them as sensitive artifacts.
+See [Output Format](output.md#behavioral-recordings) for the stream and manifest
+layout.
+
 ### `doctor`
 
 Run read-only preflight and health checks without starting the agent.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,11 +39,11 @@ Production note:
 
 ## Managed Layouts
 
-| Platform | Config | Rules | Logs and alerts |
-| --- | --- | --- | --- |
-| Windows | `C:\ProgramData\Rustinel\config.toml` | `C:\ProgramData\Rustinel\rules` | `C:\ProgramData\Rustinel\logs` |
-| Linux | `/etc/rustinel/config.toml` | `/var/lib/rustinel/rules` | `/var/log/rustinel` |
-| macOS | `/Library/Application Support/Rustinel/config.toml` | `/Library/Application Support/Rustinel/rules` | `/Library/Logs/Rustinel` |
+| Platform | Config | Rules | Logs and alerts | Recordings |
+| --- | --- | --- | --- | --- |
+| Windows | `C:\ProgramData\Rustinel\config.toml` | `C:\ProgramData\Rustinel\rules` | `C:\ProgramData\Rustinel\logs` | `C:\ProgramData\Rustinel\captures` |
+| Linux | `/etc/rustinel/config.toml` | `/var/lib/rustinel/rules` | `/var/log/rustinel` | `/var/lib/rustinel/captures` |
+| macOS | `/Library/Application Support/Rustinel/config.toml` | `/Library/Application Support/Rustinel/rules` | `/Library/Logs/Rustinel` | `/Library/Application Support/Rustinel/captures` |
 
 ## Example `config.toml`
 
@@ -84,6 +84,9 @@ enabled = true
 window_secs = 60
 max_entries = 10000
 
+[capture]
+directory = "captures"
+
 [response]
 enabled = false
 prevention_enabled = false
@@ -112,10 +115,10 @@ max_file_size_mb = 50
 
 Use Windows path prefixes on Windows and Unix path prefixes on Linux.
 
-On Unix, Rustinel restricts configured log and alert directories to mode `0700`
-and their rolling files to `0600`. This prevents other local users from reading
-operational context or alert details. Windows continues to use the owning
-account's configured ACLs.
+On Unix, Rustinel restricts configured log, alert, and recording directories to
+mode `0700` and their files to `0600`. This prevents other local users from
+reading operational context, alert details, or recorded endpoint behavior.
+Windows continues to use the owning account's configured ACLs.
 
 ## Platform-Aware Defaults
 
@@ -140,6 +143,7 @@ account's configured ACLs.
 | `dedup.enabled` | `true` |
 | `dedup.window_secs` | `60` |
 | `dedup.max_entries` | `10000` |
+| `capture.directory` | `captures` |
 | `response.enabled` | `false` |
 | `response.prevention_enabled` | `false` |
 | `response.min_severity` | `critical` |
@@ -269,6 +273,22 @@ Set `enabled = false` for high-fidelity environments where every individual aler
 ```
 dedup: suppressed_total=1420 aggregated_rollup_alerts=38 pending_keys=0
 ```
+
+### Capture
+
+Behavioral recordings are written only by `rustinel capture`; an ordinary `run`
+never touches this directory.
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `directory` | `captures` | Parent directory for recordings, unless `capture --output` gives an explicit path |
+
+Recordings hold normalized events for *all* observed activity, including full
+command lines, file paths, network destinations, and user names — they are more
+revealing than alert output, which only contains what a rule matched. Keep them
+out of shared directories and off general-purpose log shipping. See
+[Output Format](output.md#behavioral-recordings) for the stream and manifest
+layout.
 
 ### Active Response
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -1,9 +1,10 @@
 # Output Format
 
-Rustinel emits two outputs:
+Rustinel emits three outputs:
 
 - Operational logs for runtime state and troubleshooting
 - ECS NDJSON alerts for detections
+- Behavioral recordings, written only by `rustinel capture`
 
 ## Operational Logs
 
@@ -130,6 +131,65 @@ Format:
 | Task | `edr.task` |
 
 The full field set depends on event type and platform. Windows alerts can include PE metadata, registry details, PowerShell content, and service or task context. Linux and macOS alerts currently focus on process, network, file, and DNS fields.
+
+## Behavioral Recordings
+
+A recording is the endpoint-behavior analogue of a packet capture: the normalized
+events Rustinel's detectors consume, saved so the same activity can be evaluated
+again later without re-running the sample that produced it. Recordings are
+produced only by `rustinel capture`; an ordinary `run` never writes one.
+
+Location:
+
+- Default: `captures/rustinel-capture-<UTC timestamp>.ndjson`, configurable with
+  `capture.directory`
+
+A recording is two files:
+
+| File | Content |
+| --- | --- |
+| `<name>.ndjson` | The payload: one normalized event per line, in observed order |
+| `<name>.manifest.json` | The sidecar describing the payload and whether it is complete |
+
+The payload holds canonical normalized events, recorded immediately after
+normalization. It is not alert output: no rule ever ran against these events,
+and they carry no alert-only process-context enrichment. Repeated events are
+kept as-is, because capture does not deduplicate.
+
+```json
+{"timestamp":"2026-08-16T09:12:44Z","platform":"windows","provider":"etw","category":"Process","event_id":1,"opcode":1,"fields":{"Image":"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe","CommandLine":"powershell.exe -EncodedCommand ...","ProcessId":"6132","ParentImage":"C:\\Windows\\explorer.exe"}}
+```
+
+The manifest records what the payload contains and whether it can be trusted:
+
+```json
+{
+  "schema_version": 1,
+  "payload": "rustinel-capture-20260816T091240Z.ndjson",
+  "rustinel_version": "1.3.0",
+  "platform": "windows",
+  "started_at": "2026-08-16T09:12:40Z",
+  "ended_at": "2026-08-16T09:14:02Z",
+  "status": "complete",
+  "events": { "received": 1841, "written": 1841, "lost": 0 },
+  "payload_bytes": 612884,
+  "payload_sha256": "9f2c…"
+}
+```
+
+`status` is the field that matters. The manifest is written as `incomplete` when
+the session starts and is only rewritten as `complete` at clean shutdown with
+every received event accounted for. A recording is therefore `incomplete`
+whenever the process was killed before it could finalize, or events were lost
+because the writer could not keep up. `received` always equals
+`written + lost`, so loss is visible rather than implied.
+
+Recordings are as sensitive as alerts, and often more so: they contain full
+command lines, file paths, network destinations, and user names for *all*
+observed activity, not only what a rule matched. They are written owner-only
+(`0600`, in a `0700` directory on Unix) and are kept separate from alert and
+operational log output. Treat sharing a recording the way you would treat
+sharing a memory dump from the same host.
 
 ## SIEM Shipping
 

--- a/src/capture/manifest.rs
+++ b/src/capture/manifest.rs
@@ -1,0 +1,206 @@
+//! Behavioral-recording manifest.
+//!
+//! Every recording is a pair: the NDJSON payload holding one canonical
+//! [`NormalizedEvent`](crate::models::NormalizedEvent) per line, and this
+//! sidecar describing what the payload contains and whether it can be trusted.
+//!
+//! The manifest is written twice. Once when the capture session opens, marked
+//! [`CaptureStatus::Incomplete`] so a recording left behind by a killed process
+//! is never mistaken for a finished one, and once at clean shutdown with the
+//! final counters and payload checksum.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::sensor::Platform;
+
+/// Version of the recording format: the manifest layout together with the
+/// NDJSON event schema it describes. Consumers reject versions they do not
+/// understand rather than guessing at unknown fields.
+pub const CAPTURE_SCHEMA_VERSION: u32 = 1;
+
+/// Suffix appended to the payload stem to derive the manifest path.
+const MANIFEST_EXTENSION: &str = "manifest.json";
+
+/// Whether a recording covers the whole capture session.
+///
+/// Only [`CaptureStatus::Complete`] recordings carry every event the sensors
+/// produced. Anything else means the stream has holes, whether from an
+/// interrupted session or from events the writer could not keep up with.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CaptureStatus {
+    /// The session ended cleanly and no event was lost.
+    Complete,
+    /// The session was interrupted, or events were lost while writing.
+    Incomplete,
+}
+
+impl CaptureStatus {
+    pub fn is_complete(self) -> bool {
+        matches!(self, Self::Complete)
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Complete => "complete",
+            Self::Incomplete => "incomplete",
+        }
+    }
+}
+
+/// Per-session event accounting.
+///
+/// `received` always equals `written + lost`: every event handed to the capture
+/// sink is accounted for, so loss can never hide behind a plausible-looking
+/// count.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CaptureEventCounts {
+    /// Normalized events handed to the capture sink.
+    pub received: u64,
+    /// Events serialized and written to the payload.
+    pub written: u64,
+    /// Events dropped because the queue was full, or that failed to serialize
+    /// or write.
+    pub lost: u64,
+}
+
+/// Sidecar describing a behavioral recording.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CaptureManifest {
+    /// Recording format version; see [`CAPTURE_SCHEMA_VERSION`].
+    pub schema_version: u32,
+    /// File name of the NDJSON payload this manifest describes.
+    pub payload: String,
+    /// Rustinel version that produced the recording.
+    pub rustinel_version: String,
+    /// Platform whose sensors produced the events.
+    pub platform: Platform,
+    /// RFC 3339 timestamp of when capture started.
+    pub started_at: String,
+    /// RFC 3339 timestamp of when capture was finalized; absent while running.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ended_at: Option<String>,
+    /// Whether the recording covers the whole session.
+    pub status: CaptureStatus,
+    /// Event accounting for the session.
+    pub events: CaptureEventCounts,
+    /// Payload size in bytes at finalization.
+    pub payload_bytes: u64,
+    /// SHA-256 of the payload, present once the recording is finalized.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payload_sha256: Option<String>,
+}
+
+impl CaptureManifest {
+    /// Build the manifest for a session that has just started.
+    pub fn started(payload_path: &Path, platform: Platform, started_at: String) -> Self {
+        Self {
+            schema_version: CAPTURE_SCHEMA_VERSION,
+            payload: payload_file_name(payload_path),
+            rustinel_version: env!("CARGO_PKG_VERSION").to_string(),
+            platform,
+            started_at,
+            ended_at: None,
+            status: CaptureStatus::Incomplete,
+            events: CaptureEventCounts::default(),
+            payload_bytes: 0,
+            payload_sha256: None,
+        }
+    }
+
+    /// Whether this manifest describes a recording a consumer can trust in
+    /// full: a known schema version, a clean finish, and a payload checksum to
+    /// verify against.
+    pub fn is_replayable(&self) -> bool {
+        self.schema_version == CAPTURE_SCHEMA_VERSION
+            && self.status.is_complete()
+            && self.payload_sha256.is_some()
+    }
+}
+
+/// Manifest path for a payload: the payload path with its extension replaced by
+/// `manifest.json`, so `capture.ndjson` is described by `capture.manifest.json`.
+pub fn manifest_path_for(payload_path: &Path) -> PathBuf {
+    payload_path.with_extension(MANIFEST_EXTENSION)
+}
+
+fn payload_file_name(payload_path: &Path) -> String {
+    payload_path
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn manifest_path_replaces_the_payload_extension() {
+        assert_eq!(
+            manifest_path_for(Path::new("/captures/session.ndjson")),
+            PathBuf::from("/captures/session.manifest.json")
+        );
+    }
+
+    #[test]
+    fn manifest_path_appends_when_the_payload_has_no_extension() {
+        assert_eq!(
+            manifest_path_for(Path::new("/captures/session")),
+            PathBuf::from("/captures/session.manifest.json")
+        );
+    }
+
+    #[test]
+    fn a_started_manifest_is_not_replayable() {
+        let manifest = CaptureManifest::started(
+            Path::new("/captures/session.ndjson"),
+            Platform::Linux,
+            "2026-08-16T10:00:00Z".to_string(),
+        );
+
+        assert_eq!(manifest.payload, "session.ndjson");
+        assert_eq!(manifest.status, CaptureStatus::Incomplete);
+        assert!(!manifest.is_replayable());
+    }
+
+    #[test]
+    fn a_finalized_manifest_round_trips_through_json() {
+        let mut manifest = CaptureManifest::started(
+            Path::new("session.ndjson"),
+            Platform::Windows,
+            "2026-08-16T10:00:00Z".to_string(),
+        );
+        manifest.ended_at = Some("2026-08-16T10:05:00Z".to_string());
+        manifest.status = CaptureStatus::Complete;
+        manifest.events = CaptureEventCounts {
+            received: 3,
+            written: 3,
+            lost: 0,
+        };
+        manifest.payload_bytes = 128;
+        manifest.payload_sha256 = Some("abc123".to_string());
+
+        let json = serde_json::to_string(&manifest).expect("manifest serializes");
+        let parsed: CaptureManifest = serde_json::from_str(&json).expect("manifest deserializes");
+
+        assert_eq!(parsed, manifest);
+        assert!(parsed.is_replayable());
+    }
+
+    #[test]
+    fn a_recording_from_a_future_schema_is_not_replayable() {
+        let mut manifest = CaptureManifest::started(
+            Path::new("session.ndjson"),
+            Platform::MacOS,
+            "2026-08-16T10:00:00Z".to_string(),
+        );
+        manifest.status = CaptureStatus::Complete;
+        manifest.payload_sha256 = Some("abc123".to_string());
+        manifest.schema_version = CAPTURE_SCHEMA_VERSION + 1;
+
+        assert!(!manifest.is_replayable());
+    }
+}

--- a/src/capture/mod.rs
+++ b/src/capture/mod.rs
@@ -1,0 +1,24 @@
+//! Behavioral recording.
+//!
+//! Capture is the endpoint-behavior analogue of a packet capture: it records
+//! the canonical normalized events Rustinel's event-based detectors consume,
+//! not raw ETW/eBPF/ESF payloads and not alert output. A recording can be
+//! re-evaluated later against a different detector configuration, on any
+//! platform, without re-running the sample that produced it.
+//!
+//! A recording is two files: a streaming NDJSON payload with one
+//! [`NormalizedEvent`](crate::models::NormalizedEvent) per line, and a
+//! [`CaptureManifest`] sidecar recording what the payload contains and whether
+//! it is trustworthy.
+//!
+//! Recordings describe endpoint activity in detail — command lines, file paths,
+//! destinations, and user names — so they carry the same sensitivity, and the
+//! same owner-only file permissions, as alert output.
+
+pub mod manifest;
+mod writer;
+
+pub use manifest::{
+    manifest_path_for, CaptureEventCounts, CaptureManifest, CaptureStatus, CAPTURE_SCHEMA_VERSION,
+};
+pub use writer::{CaptureRecorder, CaptureSink};

--- a/src/capture/writer.rs
+++ b/src/capture/writer.rs
@@ -1,0 +1,573 @@
+//! Capture sink and NDJSON payload writer.
+//!
+//! [`CaptureSink`] sits at the post-normalization boundary of the shared event
+//! pipeline: it is handed each canonical [`NormalizedEvent`] before alert-only
+//! enrichment or any detector evaluation, so a recording reflects what the
+//! sensors observed rather than what detection made of it.
+//!
+//! Serialization happens on the calling thread and the resulting line is handed
+//! to a background writer through a bounded queue. When that queue is full the
+//! event is counted as lost and the recording is finalized as
+//! [`CaptureStatus::Incomplete`] — capture never silently discards an event.
+
+use std::fs::{File, OpenOptions};
+use std::io::{BufWriter, Write};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use anyhow::Context;
+use sha2::{Digest, Sha256};
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use tracing::{info, warn};
+
+use crate::capture::manifest::{
+    manifest_path_for, CaptureEventCounts, CaptureManifest, CaptureStatus,
+};
+use crate::models::NormalizedEvent;
+use crate::sensor::Platform;
+use crate::utils::fs::{restrict_directory_permissions, restrict_file_permissions};
+use crate::utils::{now_timestamp_string, LogRateLimiter};
+
+/// Target name for capture operational logs.
+const TARGET_CAPTURE: &str = "capture";
+
+/// Queue depth between the normalization boundary and the writer task. Deep
+/// enough to absorb sensor bursts, bounded so a stalled disk cannot grow memory
+/// without limit.
+const QUEUE_CAPACITY: usize = 16_384;
+
+/// Events buffered before the payload is flushed. Bounds how much of the tail
+/// a killed process can lose, and keeps the file readable with standard tools
+/// while the session is still running.
+const FLUSH_INTERVAL_EVENTS: u64 = 512;
+
+/// Minimum spacing between loss warnings, so a saturated queue cannot flood the
+/// operational log.
+const LOSS_LOG_WINDOW: Duration = Duration::from_secs(10);
+
+/// Event accounting shared between the sink and the writer task.
+#[derive(Debug, Default)]
+struct CaptureCounters {
+    received: AtomicU64,
+    written: AtomicU64,
+    lost: AtomicU64,
+}
+
+impl CaptureCounters {
+    fn snapshot(&self) -> CaptureEventCounts {
+        CaptureEventCounts {
+            received: self.received.load(Ordering::Relaxed),
+            written: self.written.load(Ordering::Relaxed),
+            lost: self.lost.load(Ordering::Relaxed),
+        }
+    }
+}
+
+/// Handle used by the event pipeline to record normalized events.
+///
+/// Cloning is cheap; every clone feeds the same recording.
+#[derive(Clone)]
+pub struct CaptureSink {
+    tx: mpsc::Sender<String>,
+    counters: Arc<CaptureCounters>,
+    loss_log: Arc<Mutex<LogRateLimiter>>,
+}
+
+impl CaptureSink {
+    /// Record one normalized event into the payload.
+    ///
+    /// Never blocks the caller: the event is either queued for the writer or
+    /// counted as lost.
+    pub fn record(&self, event: &NormalizedEvent) {
+        self.counters.received.fetch_add(1, Ordering::Relaxed);
+
+        let line = match serde_json::to_string(event) {
+            Ok(line) => line,
+            Err(err) => {
+                self.count_loss("serialize", &err.to_string());
+                return;
+            }
+        };
+
+        if let Err(err) = self.tx.try_send(line) {
+            let reason = match err {
+                mpsc::error::TrySendError::Full(_) => "queue full",
+                mpsc::error::TrySendError::Closed(_) => "writer stopped",
+            };
+            self.count_loss("enqueue", reason);
+        }
+    }
+
+    /// Current event accounting for the session.
+    pub fn counts(&self) -> CaptureEventCounts {
+        self.counters.snapshot()
+    }
+
+    fn count_loss(&self, stage: &str, reason: &str) {
+        let lost = self.counters.lost.fetch_add(1, Ordering::Relaxed) + 1;
+
+        let decision = match self.loss_log.lock() {
+            Ok(mut limiter) => limiter.should_emit(stage),
+            // A poisoned limiter must not silence the loss report.
+            Err(poisoned) => poisoned.into_inner().should_emit(stage),
+        };
+        if decision.should_emit {
+            warn!(
+                target: TARGET_CAPTURE,
+                stage,
+                reason,
+                lost_total = lost,
+                suppressed_warnings = decision.suppressed_since_last_emit,
+                "Capture lost an event; the recording will be marked incomplete"
+            );
+        }
+    }
+}
+
+/// An open capture session: the NDJSON payload, its manifest, and the
+/// background task writing to them.
+pub struct CaptureRecorder {
+    sink: CaptureSink,
+    payload_path: PathBuf,
+    manifest_path: PathBuf,
+    manifest: CaptureManifest,
+    counters: Arc<CaptureCounters>,
+    /// Held so the writer keeps running; dropped by [`Self::finish`] to signal
+    /// shutdown.
+    tx: Option<mpsc::Sender<String>>,
+    worker: JoinHandle<PayloadDigest>,
+}
+
+/// What the writer task observed about the payload it produced.
+struct PayloadDigest {
+    bytes: u64,
+    sha256: String,
+    write_failed: bool,
+}
+
+impl CaptureRecorder {
+    /// Open a capture session writing to `payload_path`.
+    ///
+    /// Creates the parent directory when needed, restricts the recording to the
+    /// owner, and writes an initial manifest marked
+    /// [`CaptureStatus::Incomplete`] so an interrupted session is never
+    /// mistaken for a finished one.
+    ///
+    /// Must be called from within a Tokio runtime.
+    pub fn start(payload_path: PathBuf, platform: Platform) -> anyhow::Result<Self> {
+        let manifest_path = manifest_path_for(&payload_path);
+        let file = create_payload_file(&payload_path)?;
+
+        let manifest = CaptureManifest::started(&payload_path, platform, now_timestamp_string());
+        write_manifest(&manifest_path, &manifest)?;
+
+        let counters = Arc::new(CaptureCounters::default());
+        let (tx, rx) = mpsc::channel::<String>(QUEUE_CAPACITY);
+        let worker_counters = Arc::clone(&counters);
+        let worker_path = payload_path.clone();
+        let worker = tokio::task::spawn_blocking(move || {
+            write_payload(rx, file, worker_counters, worker_path)
+        });
+
+        info!(
+            target: TARGET_CAPTURE,
+            payload = %payload_path.display(),
+            manifest = %manifest_path.display(),
+            "Capture session started"
+        );
+
+        Ok(Self {
+            sink: CaptureSink {
+                tx: tx.clone(),
+                counters: Arc::clone(&counters),
+                loss_log: Arc::new(Mutex::new(LogRateLimiter::new(LOSS_LOG_WINDOW))),
+            },
+            payload_path,
+            manifest_path,
+            manifest,
+            counters,
+            tx: Some(tx),
+            worker,
+        })
+    }
+
+    /// Sink handle for the event pipeline.
+    pub fn sink(&self) -> CaptureSink {
+        self.sink.clone()
+    }
+
+    /// Path of the NDJSON payload.
+    pub fn payload_path(&self) -> &Path {
+        &self.payload_path
+    }
+
+    /// Path of the manifest sidecar.
+    pub fn manifest_path(&self) -> &Path {
+        &self.manifest_path
+    }
+
+    /// Current event accounting, for progress reporting.
+    pub fn counts(&self) -> CaptureEventCounts {
+        self.counters.snapshot()
+    }
+
+    /// Drain queued events, flush the payload, and finalize the manifest.
+    ///
+    /// The recording is marked [`CaptureStatus::Complete`] only when every
+    /// received event reached the payload.
+    pub async fn finish(mut self) -> anyhow::Result<CaptureManifest> {
+        // Dropping every sender ends the writer loop once the queue drains.
+        drop(self.tx.take());
+        drop(self.sink);
+
+        let digest = self
+            .worker
+            .await
+            .context("capture writer task failed to complete")?;
+
+        let events = self.counters.snapshot();
+        let status = if events.lost == 0 && !digest.write_failed {
+            CaptureStatus::Complete
+        } else {
+            CaptureStatus::Incomplete
+        };
+
+        self.manifest.ended_at = Some(now_timestamp_string());
+        self.manifest.status = status;
+        self.manifest.events = events;
+        self.manifest.payload_bytes = digest.bytes;
+        self.manifest.payload_sha256 = Some(digest.sha256);
+        write_manifest(&self.manifest_path, &self.manifest)?;
+
+        Ok(self.manifest)
+    }
+}
+
+fn create_payload_file(payload_path: &Path) -> anyhow::Result<File> {
+    if let Some(directory) = payload_path
+        .parent()
+        .filter(|dir| !dir.as_os_str().is_empty())
+    {
+        std::fs::create_dir_all(directory).with_context(|| {
+            format!("failed to create capture directory {}", directory.display())
+        })?;
+        if let Err(err) = restrict_directory_permissions(directory) {
+            warn!(
+                target: TARGET_CAPTURE,
+                directory = %directory.display(),
+                error = %err,
+                "Unable to restrict capture directory permissions"
+            );
+        }
+    }
+
+    let file = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(payload_path)
+        .with_context(|| format!("failed to create recording {}", payload_path.display()))?;
+
+    restrict_file_permissions(payload_path).with_context(|| {
+        format!(
+            "failed to restrict permissions on recording {}",
+            payload_path.display()
+        )
+    })?;
+
+    Ok(file)
+}
+
+fn write_manifest(manifest_path: &Path, manifest: &CaptureManifest) -> anyhow::Result<()> {
+    let body = serde_json::to_string_pretty(manifest).context("failed to serialize manifest")?;
+    std::fs::write(manifest_path, format!("{body}\n"))
+        .with_context(|| format!("failed to write manifest {}", manifest_path.display()))?;
+    restrict_file_permissions(manifest_path).with_context(|| {
+        format!(
+            "failed to restrict permissions on manifest {}",
+            manifest_path.display()
+        )
+    })?;
+    Ok(())
+}
+
+/// Writer loop: one JSON object per line, hashing the payload as it goes so the
+/// manifest checksum never requires a second pass over the file.
+fn write_payload(
+    mut rx: mpsc::Receiver<String>,
+    file: File,
+    counters: Arc<CaptureCounters>,
+    payload_path: PathBuf,
+) -> PayloadDigest {
+    let mut writer = BufWriter::new(file);
+    let mut hasher = Sha256::new();
+    let mut bytes = 0u64;
+    let mut since_flush = 0u64;
+    let mut write_failed = false;
+
+    while let Some(line) = rx.blocking_recv() {
+        let mut record = line.into_bytes();
+        record.push(b'\n');
+
+        match writer.write_all(&record) {
+            Ok(()) => {
+                hasher.update(&record);
+                bytes += record.len() as u64;
+                counters.written.fetch_add(1, Ordering::Relaxed);
+                since_flush += 1;
+            }
+            Err(err) => {
+                counters.lost.fetch_add(1, Ordering::Relaxed);
+                if !write_failed {
+                    warn!(
+                        target: TARGET_CAPTURE,
+                        payload = %payload_path.display(),
+                        error = %err,
+                        "Failed to write to the recording; it will be marked incomplete"
+                    );
+                }
+                write_failed = true;
+            }
+        }
+
+        if since_flush >= FLUSH_INTERVAL_EVENTS {
+            since_flush = 0;
+            if let Err(err) = writer.flush() {
+                warn!(
+                    target: TARGET_CAPTURE,
+                    payload = %payload_path.display(),
+                    error = %err,
+                    "Failed to flush the recording"
+                );
+                write_failed = true;
+            }
+        }
+    }
+
+    if let Err(err) = writer.flush() {
+        warn!(
+            target: TARGET_CAPTURE,
+            payload = %payload_path.display(),
+            error = %err,
+            "Failed to flush the recording at shutdown"
+        );
+        write_failed = true;
+    }
+
+    PayloadDigest {
+        bytes,
+        sha256: hex::encode(hasher.finalize()),
+        write_failed,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+    use crate::models::{EventCategory, EventFields, ProcessCreationFields};
+
+    fn process_event(pid: &str) -> NormalizedEvent {
+        NormalizedEvent {
+            timestamp: "2026-08-16T10:00:00Z".to_string(),
+            platform: Platform::Windows,
+            provider: "etw".to_string(),
+            category: EventCategory::Process,
+            event_id: 1,
+            event_id_string: "1".to_string(),
+            opcode: 1,
+            fields: EventFields::ProcessCreation(ProcessCreationFields {
+                image: Some(r"C:\Windows\System32\cmd.exe".to_string()),
+                original_file_name: None,
+                product: None,
+                description: None,
+                target_image: None,
+                command_line: Some("cmd.exe /c whoami".to_string()),
+                process_id: Some(pid.to_string()),
+                process_start_time: None,
+                parent_process_id: None,
+                parent_image: None,
+                parent_command_line: None,
+                current_directory: None,
+                integrity_level: None,
+                user: None,
+                logon_id: None,
+                logon_guid: None,
+            }),
+            process_context: None,
+        }
+    }
+
+    fn read_manifest(path: &Path) -> CaptureManifest {
+        let body = std::fs::read_to_string(path).expect("manifest exists");
+        serde_json::from_str(&body).expect("manifest parses")
+    }
+
+    #[tokio::test]
+    async fn records_every_event_in_order() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let payload = temp.path().join("session.ndjson");
+        let recorder =
+            CaptureRecorder::start(payload.clone(), Platform::Windows).expect("capture starts");
+        let sink = recorder.sink();
+
+        for pid in ["100", "200", "100"] {
+            sink.record(&process_event(pid));
+        }
+        drop(sink);
+
+        let manifest = recorder.finish().await.expect("capture finalizes");
+
+        let body = std::fs::read_to_string(&payload).expect("payload exists");
+        let pids: Vec<String> = body
+            .lines()
+            .map(|line| {
+                let value: serde_json::Value = serde_json::from_str(line).expect("line parses");
+                value["fields"]["ProcessId"]
+                    .as_str()
+                    .expect("ProcessId present")
+                    .to_string()
+            })
+            .collect();
+
+        // Repeated events are kept: capture does not deduplicate.
+        assert_eq!(pids, vec!["100", "200", "100"]);
+        assert_eq!(
+            manifest.events,
+            CaptureEventCounts {
+                received: 3,
+                written: 3,
+                lost: 0,
+            }
+        );
+        assert_eq!(manifest.status, CaptureStatus::Complete);
+    }
+
+    #[tokio::test]
+    async fn finalized_manifest_describes_the_payload() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let payload = temp.path().join("session.ndjson");
+        let recorder =
+            CaptureRecorder::start(payload.clone(), Platform::Windows).expect("capture starts");
+        let manifest_path = recorder.manifest_path().to_path_buf();
+        recorder.sink().record(&process_event("100"));
+
+        let manifest = recorder.finish().await.expect("capture finalizes");
+        let persisted = read_manifest(&manifest_path);
+
+        let body = std::fs::read(&payload).expect("payload exists");
+        assert_eq!(manifest.payload, "session.ndjson");
+        assert_eq!(manifest.payload_bytes, body.len() as u64);
+        assert_eq!(
+            manifest.payload_sha256.as_deref(),
+            Some(hex::encode(Sha256::digest(&body)).as_str())
+        );
+        assert_eq!(manifest.platform, Platform::Windows);
+        assert_eq!(manifest.rustinel_version, env!("CARGO_PKG_VERSION"));
+        assert!(manifest.ended_at.is_some());
+        assert!(manifest.is_replayable());
+        assert_eq!(persisted, manifest);
+    }
+
+    #[tokio::test]
+    async fn a_session_in_progress_is_marked_incomplete_on_disk() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let payload = temp.path().join("session.ndjson");
+        let recorder = CaptureRecorder::start(payload, Platform::Linux).expect("capture starts");
+        let manifest_path = recorder.manifest_path().to_path_buf();
+        recorder.sink().record(&process_event("100"));
+
+        // The state a killed process would leave behind: the manifest exists,
+        // but nothing has finalized it.
+        let manifest = read_manifest(&manifest_path);
+        assert_eq!(manifest.status, CaptureStatus::Incomplete);
+        assert!(manifest.payload_sha256.is_none());
+        assert!(manifest.ended_at.is_none());
+        assert!(!manifest.is_replayable());
+
+        recorder.finish().await.expect("capture finalizes");
+    }
+
+    #[tokio::test]
+    async fn lost_events_are_counted_and_mark_the_recording_incomplete() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let payload = temp.path().join("session.ndjson");
+        let recorder = CaptureRecorder::start(payload, Platform::Linux).expect("capture starts");
+        let sink = recorder.sink();
+
+        // A closed queue stands in for a writer that can no longer accept
+        // events; the sink must account for the loss rather than ignore it.
+        let saturated = CaptureSink {
+            tx: mpsc::channel::<String>(1).0,
+            counters: Arc::clone(&sink.counters),
+            loss_log: Arc::clone(&sink.loss_log),
+        };
+        drop(sink);
+        saturated.record(&process_event("100"));
+        let counts = saturated.counts();
+        drop(saturated);
+
+        assert_eq!(counts.received, 1);
+        assert_eq!(counts.lost, 1);
+
+        let manifest = recorder.finish().await.expect("capture finalizes");
+        assert_eq!(manifest.status, CaptureStatus::Incomplete);
+        assert_eq!(
+            manifest.events.received,
+            manifest.events.written + manifest.events.lost
+        );
+        assert!(!manifest.is_replayable());
+    }
+
+    #[tokio::test]
+    async fn generic_events_are_recorded_alongside_typed_ones() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let payload = temp.path().join("session.ndjson");
+        let recorder =
+            CaptureRecorder::start(payload.clone(), Platform::MacOS).expect("capture starts");
+        let sink = recorder.sink();
+
+        let mut generic = process_event("100");
+        generic.category = EventCategory::Process;
+        generic.fields = EventFields::Generic(HashMap::from([(
+            "Image".to_string(),
+            "/bin/zsh".to_string(),
+        )]));
+        sink.record(&generic);
+        drop(sink);
+
+        recorder.finish().await.expect("capture finalizes");
+
+        let body = std::fs::read_to_string(&payload).expect("payload exists");
+        assert_eq!(body.lines().count(), 1);
+        assert!(body.contains("/bin/zsh"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn recording_files_are_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let payload = temp.path().join("nested").join("session.ndjson");
+        let recorder =
+            CaptureRecorder::start(payload.clone(), Platform::MacOS).expect("capture starts");
+        let manifest_path = recorder.manifest_path().to_path_buf();
+        recorder.finish().await.expect("capture finalizes");
+
+        let mode = |path: &Path| {
+            std::fs::metadata(path)
+                .expect("metadata")
+                .permissions()
+                .mode()
+                & 0o777
+        };
+        assert_eq!(mode(&payload), 0o600);
+        assert_eq!(mode(&manifest_path), 0o600);
+        assert_eq!(mode(payload.parent().expect("parent")), 0o700);
+    }
+}

--- a/src/capture/writer.rs
+++ b/src/capture/writer.rs
@@ -13,7 +13,7 @@
 use std::fs::{File, OpenOptions};
 use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -139,6 +139,8 @@ pub struct CaptureRecorder {
     /// shutdown.
     tx: Option<mpsc::Sender<String>>,
     worker: JoinHandle<PayloadDigest>,
+    /// Set for loss the sink cannot observe, such as a sensor dying mid-session.
+    forced_incomplete: Arc<AtomicBool>,
 }
 
 /// What the writer task observed about the payload it produced.
@@ -191,7 +193,23 @@ impl CaptureRecorder {
             counters,
             tx: Some(tx),
             worker,
+            forced_incomplete: Arc::new(AtomicBool::new(false)),
         })
+    }
+
+    /// Mark the recording as incomplete for a reason the sink cannot see.
+    ///
+    /// Event loss inside the capture pipeline is already counted, but a sensor
+    /// that stops feeding events produces a recording that looks lossless while
+    /// missing everything after the failure.
+    pub fn mark_incomplete(&self, reason: &str) {
+        if !self.forced_incomplete.swap(true, Ordering::Relaxed) {
+            warn!(
+                target: TARGET_CAPTURE,
+                reason,
+                "Recording will be marked incomplete"
+            );
+        }
     }
 
     /// Sink handle for the event pipeline.
@@ -229,7 +247,10 @@ impl CaptureRecorder {
             .context("capture writer task failed to complete")?;
 
         let events = self.counters.snapshot();
-        let status = if events.lost == 0 && !digest.write_failed {
+        let status = if events.lost == 0
+            && !digest.write_failed
+            && !self.forced_incomplete.load(Ordering::Relaxed)
+        {
             CaptureStatus::Complete
         } else {
             CaptureStatus::Incomplete

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -75,6 +75,16 @@ pub enum Commands {
         #[arg(long, value_enum, value_name = "ENGINE")]
         sigma_engine: Option<SigmaEngineArg>,
     },
+    /// Record endpoint behavior to a replayable file without evaluating detections
+    ///
+    /// Capture is passive: start it first, then run the sample, script, or test
+    /// you want to record, and press Ctrl-C when the session is complete.
+    Capture {
+        /// Recording path.
+        /// Defaults to <capture.directory>/rustinel-capture-<UTC timestamp>.ndjson
+        #[arg(long, value_name = "PATH")]
+        output: Option<std::path::PathBuf>,
+    },
     /// Check configuration, paths, and runtime prerequisites
     Doctor {
         /// Emit structured JSON output
@@ -271,6 +281,45 @@ mod tests {
             }
             _ => panic!("expected setup command"),
         }
+    }
+
+    #[test]
+    fn capture_defaults_to_a_generated_output_path() {
+        let cli = Cli::try_parse_from(["rustinel", "capture"]).expect("capture should parse");
+
+        match cli.command {
+            Some(Commands::Capture { output }) => assert_eq!(output, None),
+            _ => panic!("expected capture command"),
+        }
+    }
+
+    #[test]
+    fn capture_accepts_an_explicit_output_path() {
+        let cli =
+            Cli::try_parse_from(["rustinel", "capture", "--output", "/tmp/lab/run-42.ndjson"])
+                .expect("capture should parse");
+
+        match cli.command {
+            Some(Commands::Capture { output }) => {
+                assert_eq!(
+                    output,
+                    Some(std::path::PathBuf::from("/tmp/lab/run-42.ndjson"))
+                );
+            }
+            _ => panic!("expected capture command"),
+        }
+    }
+
+    #[test]
+    fn capture_accepts_the_global_config_flag() {
+        let cli = Cli::try_parse_from(["rustinel", "capture", "--config", "/tmp/rustinel.toml"])
+            .expect("capture should parse");
+
+        assert_eq!(
+            cli.config,
+            Some(std::path::PathBuf::from("/tmp/rustinel.toml"))
+        );
+        assert!(matches!(cli.command, Some(Commands::Capture { .. })));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -53,6 +53,7 @@ pub struct InstallLayout {
     pub ioc_dir: PathBuf,
     pub logs_dir: PathBuf,
     pub alerts_dir: PathBuf,
+    pub captures_dir: PathBuf,
 }
 
 impl InstallLayout {
@@ -67,18 +68,21 @@ impl InstallLayout {
                 ioc_dir: PathBuf::from(r"C:\ProgramData\Rustinel\rules\current\ioc"),
                 logs_dir: PathBuf::from(r"C:\ProgramData\Rustinel\logs"),
                 alerts_dir: PathBuf::from(r"C:\ProgramData\Rustinel\logs"),
+                captures_dir: PathBuf::from(r"C:\ProgramData\Rustinel\captures"),
             },
             InstallPlatform::Linux => Self::from_roots(
                 platform,
                 PathBuf::from("/etc/rustinel/config.toml"),
                 PathBuf::from("/var/lib/rustinel/rules"),
                 PathBuf::from("/var/log/rustinel"),
+                PathBuf::from("/var/lib/rustinel/captures"),
             ),
             InstallPlatform::Macos => Self::from_roots(
                 platform,
                 PathBuf::from("/Library/Application Support/Rustinel/config.toml"),
                 PathBuf::from("/Library/Application Support/Rustinel/rules"),
                 PathBuf::from("/Library/Logs/Rustinel"),
+                PathBuf::from("/Library/Application Support/Rustinel/captures"),
             ),
         }
     }
@@ -97,6 +101,7 @@ impl InstallLayout {
             ioc_dir: rules_dir.join("ioc"),
             alerts_dir: logs_dir.clone(),
             logs_dir,
+            captures_dir: root.join("captures"),
         }
     }
 
@@ -110,6 +115,7 @@ impl InstallLayout {
         cfg.scanner.yara_rules_path = self.yara_rules_dir.clone();
         cfg.logging.directory = self.logs_dir.clone();
         cfg.alerts.directory = self.alerts_dir.clone();
+        cfg.capture.directory = self.captures_dir.clone();
         cfg.ioc.hashes_path = layout_join(self.platform, &self.ioc_dir, "hashes.txt");
         cfg.ioc.ips_path = layout_join(self.platform, &self.ioc_dir, "ips.txt");
         cfg.ioc.domains_path = layout_join(self.platform, &self.ioc_dir, "domains.txt");
@@ -122,6 +128,7 @@ impl InstallLayout {
         config_file: PathBuf,
         rules_dir: PathBuf,
         logs_dir: PathBuf,
+        captures_dir: PathBuf,
     ) -> Self {
         let current_dir = layout_join(platform, &rules_dir, "current");
         let ioc_dir = layout_join(platform, &current_dir, "ioc");
@@ -134,6 +141,7 @@ impl InstallLayout {
             ioc_dir,
             alerts_dir: logs_dir.clone(),
             logs_dir,
+            captures_dir,
         }
     }
 }
@@ -289,6 +297,7 @@ pub struct AppConfig {
     pub ioc: IocConfig,
     pub reload: ReloadConfig,
     pub dedup: DedupConfig,
+    pub capture: CaptureConfig,
 }
 
 /// Scanner configuration (Sigma and YARA rules)
@@ -401,6 +410,15 @@ pub struct DedupConfig {
     pub max_entries: usize,
 }
 
+/// Behavioral recording configuration
+#[derive(Debug, Clone, Deserialize)]
+pub struct CaptureConfig {
+    /// Directory holding behavioral recordings written by `rustinel capture`.
+    /// Kept apart from alert and operational log output, and restricted to the
+    /// owner because recordings describe endpoint activity in detail.
+    pub directory: PathBuf,
+}
+
 impl AppConfig {
     /// Load configuration from defaults, config.toml, and environment variables
     pub fn new() -> Result<Self, config::ConfigError> {
@@ -496,7 +514,9 @@ impl AppConfig {
             // Alert deduplication
             .set_default("dedup.enabled", true)?
             .set_default("dedup.window_secs", 60i64)?
-            .set_default("dedup.max_entries", 10000i64)?;
+            .set_default("dedup.max_entries", 10000i64)?
+            // Behavioral recording
+            .set_default("capture.directory", "captures")?;
 
         let builder = match selected_config {
             Some(path) => builder.add_source(config::File::from(path).required(true)),
@@ -542,6 +562,12 @@ impl AppConfig {
             &mut self.alerts.directory,
             base_dir,
             "ALERTS__DIRECTORY",
+            environment,
+        );
+        resolve_path_from_config(
+            &mut self.capture.directory,
+            base_dir,
+            "CAPTURE__DIRECTORY",
             environment,
         );
         resolve_path_from_config(
@@ -737,6 +763,9 @@ impl Default for AppConfig {
                 enabled: true,
                 window_secs: 60,
                 max_entries: 10_000,
+            },
+            capture: CaptureConfig {
+                directory: PathBuf::from("captures"),
             },
         };
 

--- a/src/engine/handler.rs
+++ b/src/engine/handler.rs
@@ -1,4 +1,11 @@
-//! Sigma detection event handler.
+//! Normalized-event handler: the shared boundary between sensors and everything
+//! downstream of normalization.
+//!
+//! Sensor events are normalized exactly once here. What happens next depends on
+//! how the handler is configured: live protection evaluates the normalized
+//! event against the detectors, and capture records it. Both read the same
+//! canonical event from the same stateful [`Normalizer`], so a recording
+//! contains precisely what live detection would have seen.
 
 use std::sync::Arc;
 
@@ -6,6 +13,7 @@ use tokio::sync::mpsc;
 use tracing::{debug, info};
 
 use crate::alerts::AlertSink;
+use crate::capture::CaptureSink;
 use crate::normalizer::Normalizer;
 use crate::reload::DetectorStore;
 use crate::response::ResponseEngine;
@@ -14,10 +22,8 @@ use crate::sensor::{SensorAction, SensorEvent, SensorEventHandler};
 /// Target name for engine operational logs.
 const TARGET_ENGINE: &str = "engine";
 
-/// Sigma detection handler that normalizes events and checks them against Sigma rules.
-pub struct SigmaDetectionHandler {
-    /// Normalizer for converting sensor events to the normalized event model.
-    pub normalizer: Arc<Normalizer>,
+/// Detection side of the pipeline: rule evaluation, alerting, and response.
+pub struct DetectionPipeline {
     /// Live detector store (sigma/ioc hot-reloaded atomically).
     pub detectors: Arc<DetectorStore>,
     /// Hash worker channel (optional).
@@ -28,7 +34,40 @@ pub struct SigmaDetectionHandler {
     pub response_engine: ResponseEngine,
 }
 
-impl SensorEventHandler for SigmaDetectionHandler {
+/// Handler that normalizes sensor events and dispatches them to capture,
+/// detection, or both.
+pub struct NormalizedEventHandler {
+    /// Normalizer for converting sensor events to the normalized event model.
+    pub normalizer: Arc<Normalizer>,
+    /// Behavioral recording sink. Fed immediately after normalization, before
+    /// alert-only enrichment or any detector evaluation.
+    pub capture: Option<CaptureSink>,
+    /// Detection pipeline. Absent when the session only records, which is what
+    /// keeps capture from evaluating rules or invoking active response.
+    pub detection: Option<DetectionPipeline>,
+}
+
+impl NormalizedEventHandler {
+    /// Live protection: evaluate every normalized event against the detectors.
+    pub fn detecting(normalizer: Arc<Normalizer>, detection: DetectionPipeline) -> Self {
+        Self {
+            normalizer,
+            capture: None,
+            detection: Some(detection),
+        }
+    }
+
+    /// Capture: record every normalized event and evaluate nothing.
+    pub fn recording(normalizer: Arc<Normalizer>, capture: CaptureSink) -> Self {
+        Self {
+            normalizer,
+            capture: Some(capture),
+            detection: None,
+        }
+    }
+}
+
+impl SensorEventHandler for NormalizedEventHandler {
     fn handle_event(&self, event: &SensorEvent) {
         tracing::trace!(
             target: TARGET_ENGINE,
@@ -49,7 +88,17 @@ impl SensorEventHandler for SigmaDetectionHandler {
                     }
                 }
 
-                if let Some(tx) = &self.ioc_hash_tx {
+                // Record before enrichment: a recording holds the canonical
+                // event, not the alert-only process context added below.
+                if let Some(capture) = &self.capture {
+                    capture.record(&normalized_event);
+                }
+
+                let Some(detection) = &self.detection else {
+                    return;
+                };
+
+                if let Some(tx) = &detection.ioc_hash_tx {
                     if event.category() == crate::models::EventCategory::Process
                         && event.action == SensorAction::Start
                     {
@@ -78,7 +127,7 @@ impl SensorEventHandler for SigmaDetectionHandler {
                     }
                 }
 
-                let sigma = self.detectors.sigma();
+                let sigma = detection.detectors.sigma();
                 if let Some(mut alert) = sigma.check_event(&normalized_event) {
                     self.normalizer
                         .enrich_process_context(&mut alert.event, event.pid.unwrap_or(0));
@@ -91,13 +140,13 @@ impl SensorEventHandler for SigmaDetectionHandler {
                         "Sigma detection triggered"
                     );
 
-                    self.alert_sink.write_alert(&alert);
-                    self.response_engine.handle_alert(&alert);
+                    detection.alert_sink.write_alert(&alert);
+                    detection.response_engine.handle_alert(&alert);
                 } else {
                     tracing::trace!(target: TARGET_ENGINE, "No Sigma rule matched this event");
                 }
 
-                let ioc_engine = self.detectors.ioc();
+                let ioc_engine = detection.detectors.ioc();
                 let ioc_matches = ioc_engine.check_event(&normalized_event);
                 if !ioc_matches.is_empty() {
                     for ioc_match in ioc_matches {
@@ -112,8 +161,8 @@ impl SensorEventHandler for SigmaDetectionHandler {
                             category = ?alert.event.category,
                             "IOC detection triggered"
                         );
-                        self.alert_sink.write_alert(&alert);
-                        self.response_engine.handle_alert(&alert);
+                        detection.alert_sink.write_alert(&alert);
+                        detection.response_engine.handle_alert(&alert);
                     }
                 }
             }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -20,7 +20,7 @@ mod rsigma_adapter;
 #[cfg(feature = "rsigma-engine")]
 mod rsigma_backend;
 
-pub use handler::SigmaDetectionHandler;
+pub use handler::{DetectionPipeline, NormalizedEventHandler};
 pub(crate) use logsource::{current_platform, platform_product, RuleLoadDecision};
 pub use logsource::{LogSource, LogSourceClassification, LogSourceKey, LogSourceStatus};
 pub(crate) use matcher::{FieldPattern, NumericOp, PatternMatcher};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 //! Exposes core modules for use by binaries and tests.
 
 pub mod alerts;
+pub mod capture;
 pub mod cli;
 pub mod config;
 pub mod doctor;

--- a/src/runtime/capture.rs
+++ b/src/runtime/capture.rs
@@ -1,0 +1,321 @@
+//! Shared runtime for `rustinel capture`.
+//!
+//! Capture is a passive runtime mode, not a lab orchestrator: it starts the
+//! same sensors live protection uses, records every normalized event, and stops
+//! on Ctrl-C. The user launches the sample, script, or Atomic test separately —
+//! Rustinel never runs the activity being observed.
+//!
+//! The platform modules own sensor startup and privileges; everything before
+//! and after that lives here.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use tracing::{error, info};
+
+use crate::capture::{CaptureRecorder, CaptureStatus};
+use crate::config::AppConfig;
+use crate::engine::NormalizedEventHandler;
+use crate::normalizer::Normalizer;
+use crate::runtime::logging::{init_operational_logging, log_startup_banner};
+use crate::sensor::{Platform, SensorEvent, SensorEventRouter};
+use crate::state::{ConnectionAggregator, DnsCache, ProcessCache, SidCache};
+
+/// Capacity of the sensor-to-router channel, matching the live runtimes.
+const SENSOR_CHANNEL_CAPACITY: usize = 8192;
+
+/// How often the running event count is reported on stderr.
+const PROGRESS_INTERVAL: Duration = Duration::from_secs(10);
+
+/// Arguments accepted by `rustinel capture`.
+#[derive(Debug, Clone, Default)]
+pub struct CaptureOptions {
+    /// Explicit recording path; overrides the generated default.
+    pub output: Option<PathBuf>,
+    /// Override for `logging.level`.
+    pub log_level: Option<String>,
+    /// Explicit configuration file path.
+    pub config_path: Option<PathBuf>,
+}
+
+/// Configuration and logging, established before platform preflight so that a
+/// privilege failure is reported through the normal logging pipeline.
+pub(crate) struct CaptureContext {
+    config: AppConfig,
+    _log_guard: tracing_appender::non_blocking::WorkerGuard,
+}
+
+impl CaptureContext {
+    /// Load configuration the same way `run` does and initialize logging.
+    pub(crate) fn load(options: &CaptureOptions, runtime_label: &str) -> anyhow::Result<Self> {
+        let mut config = match AppConfig::from_config_path(options.config_path.clone()) {
+            Ok(config) => config,
+            Err(err) => {
+                eprintln!("Failed to load configuration: {}", err);
+                eprintln!("Hint: run rustinel doctor --config <path> to inspect configuration and runtime prerequisites.");
+                return Err(anyhow::anyhow!("configuration error: {}", err));
+            }
+        };
+        // Capture is a foreground command; mirror `run`'s console behavior.
+        config.logging.console_output = true;
+        if let Some(level) = options.log_level.clone() {
+            if !level.trim().is_empty() {
+                config.logging.level = level;
+            }
+        }
+
+        let log_guard = init_operational_logging(&config);
+        log_startup_banner(runtime_label);
+
+        Ok(Self {
+            config,
+            _log_guard: log_guard,
+        })
+    }
+
+    /// Open the recording and build the record-only event pipeline.
+    pub(crate) fn start_recording(
+        self,
+        options: &CaptureOptions,
+        platform: Platform,
+    ) -> anyhow::Result<CaptureSession> {
+        let payload_path = resolve_output_path(&self.config, options.output.as_deref(), Utc::now());
+        let recorder = CaptureRecorder::start(payload_path, platform)?;
+
+        let process_cache = Arc::new(ProcessCache::with_max_entries(
+            self.config.process.max_entries,
+        ));
+        let normalizer = Arc::new(Normalizer::new(
+            Arc::clone(&process_cache),
+            Arc::new(SidCache::new()),
+            Arc::new(DnsCache::new()),
+            Arc::new(ConnectionAggregator::with_limits_and_window(
+                self.config.network.aggregation_max_entries,
+                self.config.network.aggregation_interval_buffer_size,
+                self.config.network.aggregation_window_secs,
+            )),
+            self.config.network.aggregation_enabled,
+        ));
+
+        // The only handler: no detectors, no alert sink, no response engine.
+        let mut router = SensorEventRouter::new();
+        router.register_handler(Box::new(NormalizedEventHandler::recording(
+            normalizer,
+            recorder.sink(),
+        )));
+
+        eprintln!("Recording to {}", recorder.payload_path().display());
+        eprintln!("Start the activity you want to record, then press Ctrl+C to finish.");
+
+        let progress = spawn_progress_reporter(&recorder);
+
+        Ok(CaptureSession {
+            _context: self,
+            recorder,
+            router: Arc::new(router),
+            process_cache,
+            progress,
+        })
+    }
+}
+
+/// A running capture session.
+pub(crate) struct CaptureSession {
+    /// Held for the lifetime of the session: dropping it closes the log writer.
+    _context: CaptureContext,
+    recorder: CaptureRecorder,
+    router: Arc<SensorEventRouter>,
+    #[cfg_attr(not(windows), allow(dead_code))]
+    process_cache: Arc<ProcessCache>,
+    progress: JoinHandle<()>,
+}
+
+impl CaptureSession {
+    /// Process metadata cache, so platforms that can enumerate running
+    /// processes seed it before the sensors start. Only Windows does today.
+    #[cfg(windows)]
+    pub(crate) fn process_cache(&self) -> &Arc<ProcessCache> {
+        &self.process_cache
+    }
+
+    /// Start the router worker and hand back the channel the sensors feed.
+    pub(crate) fn sensor_channel(&self) -> (mpsc::Sender<SensorEvent>, JoinHandle<()>) {
+        let (tx, mut rx) = mpsc::channel::<SensorEvent>(SENSOR_CHANNEL_CAPACITY);
+        let router = Arc::clone(&self.router);
+        let worker = tokio::task::spawn_blocking(move || {
+            while let Some(event) = rx.blocking_recv() {
+                router.route_event(&event);
+            }
+        });
+        (tx, worker)
+    }
+
+    /// Mark the recording as incomplete for loss the capture sink cannot see,
+    /// such as a sensor that stopped feeding events mid-session. Only the ETW
+    /// runtime detects that today.
+    #[cfg(windows)]
+    pub(crate) fn mark_incomplete(&self, reason: &str) {
+        self.recorder.mark_incomplete(reason);
+    }
+
+    /// Give up on a session whose sensors never started.
+    ///
+    /// Removes the empty recording this session just created rather than
+    /// leaving an artifact that looks like a failed capture of something.
+    pub(crate) async fn abandon(self, sensor_worker: JoinHandle<()>) {
+        drop(self.router);
+        let _ = sensor_worker.await;
+        self.progress.abort();
+        let _ = self.progress.await;
+
+        let payload_path = self.recorder.payload_path().to_path_buf();
+        let manifest_path = self.recorder.manifest_path().to_path_buf();
+        let _ = self.recorder.finish().await;
+        let _ = std::fs::remove_file(&payload_path);
+        let _ = std::fs::remove_file(&manifest_path);
+    }
+
+    /// Wait for a clean shutdown request.
+    pub(crate) async fn wait_for_shutdown() {
+        match tokio::signal::ctrl_c().await {
+            Ok(()) => info!("Received Ctrl+C, finalizing recording"),
+            Err(err) => error!("Failed to listen for Ctrl+C: {}", err),
+        }
+    }
+
+    /// Drain queued events, finalize the manifest, and report final counts.
+    ///
+    /// Call after the sensors have been shut down.
+    pub(crate) async fn finish(self, sensor_worker: JoinHandle<()>) -> anyhow::Result<()> {
+        drop(self.router);
+        let _ = sensor_worker.await;
+        self.progress.abort();
+        let _ = self.progress.await;
+
+        let payload_path = self.recorder.payload_path().to_path_buf();
+        let manifest_path = self.recorder.manifest_path().to_path_buf();
+        let manifest = self.recorder.finish().await?;
+
+        info!(
+            target: "capture",
+            status = manifest.status.as_str(),
+            received = manifest.events.received,
+            written = manifest.events.written,
+            lost = manifest.events.lost,
+            "Capture finished"
+        );
+
+        eprintln!();
+        eprintln!("Recording: {}", payload_path.display());
+        eprintln!("Manifest:  {}", manifest_path.display());
+        eprintln!(
+            "Events:    {} recorded, {} lost",
+            manifest.events.written, manifest.events.lost
+        );
+        eprintln!("Status:    {}", manifest.status.as_str());
+        if manifest.status != CaptureStatus::Complete {
+            eprintln!(
+                "This recording is incomplete and will be rejected by replay. \
+                 {} events could not be written.",
+                manifest.events.lost
+            );
+        }
+
+        Ok(())
+    }
+}
+
+/// Report the running event count on stderr. Event payloads are never printed.
+fn spawn_progress_reporter(recorder: &CaptureRecorder) -> JoinHandle<()> {
+    let sink = recorder.sink();
+    tokio::spawn(async move {
+        let mut reported = 0u64;
+        loop {
+            tokio::time::sleep(PROGRESS_INTERVAL).await;
+            let counts = sink.counts();
+            if counts.received == reported {
+                continue;
+            }
+            reported = counts.received;
+            if counts.lost > 0 {
+                eprintln!("  {} events recorded, {} lost", counts.written, counts.lost);
+            } else {
+                eprintln!("  {} events recorded", counts.written);
+            }
+        }
+    })
+}
+
+/// Recording path for a session: the explicit `--output` path when given,
+/// otherwise a timestamped file under the configured capture directory.
+pub fn resolve_output_path(
+    config: &AppConfig,
+    explicit: Option<&Path>,
+    started_at: DateTime<Utc>,
+) -> PathBuf {
+    match explicit {
+        Some(path) => path.to_path_buf(),
+        None => config
+            .capture
+            .directory
+            .join(default_recording_name(started_at)),
+    }
+}
+
+/// Default recording file name. The timestamp is UTC and uses no characters
+/// that need quoting or are rejected by Windows filesystems.
+fn default_recording_name(started_at: DateTime<Utc>) -> String {
+    format!(
+        "rustinel-capture-{}.ndjson",
+        started_at.format("%Y%m%dT%H%M%SZ")
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn started_at() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 8, 16, 9, 12, 40)
+            .single()
+            .expect("valid timestamp")
+    }
+
+    #[test]
+    fn default_name_uses_a_path_safe_utc_timestamp() {
+        let name = default_recording_name(started_at());
+
+        assert_eq!(name, "rustinel-capture-20260816T091240Z.ndjson");
+        assert!(
+            !name.contains(':'),
+            "colons are not valid in Windows file names"
+        );
+    }
+
+    #[test]
+    fn default_output_lands_in_the_configured_capture_directory() {
+        let mut config = AppConfig::default();
+        config.capture.directory = PathBuf::from("/var/lib/rustinel/captures");
+
+        assert_eq!(
+            resolve_output_path(&config, None, started_at()),
+            PathBuf::from("/var/lib/rustinel/captures/rustinel-capture-20260816T091240Z.ndjson")
+        );
+    }
+
+    #[test]
+    fn an_explicit_output_path_overrides_the_default() {
+        let config = AppConfig::default();
+        let explicit = PathBuf::from("/tmp/lab/run-42.ndjson");
+
+        assert_eq!(
+            resolve_output_path(&config, Some(&explicit), started_at()),
+            explicit
+        );
+    }
+}

--- a/src/runtime/capture.rs
+++ b/src/runtime/capture.rs
@@ -166,6 +166,11 @@ impl CaptureSession {
     ///
     /// Removes the empty recording this session just created rather than
     /// leaving an artifact that looks like a failed capture of something.
+    ///
+    /// Only the eBPF and ESF runtimes learn about a failed start synchronously;
+    /// an ETW session reports it by ending, which the Windows runtime handles
+    /// with [`Self::mark_incomplete`] instead.
+    #[cfg(not(windows))]
     pub(crate) async fn abandon(self, sensor_worker: JoinHandle<()>) {
         drop(self.router);
         let _ = sensor_worker.await;

--- a/src/runtime/linux.rs
+++ b/src/runtime/linux.rs
@@ -5,6 +5,7 @@ use crate::memory::MemoryScanConfig;
 use crate::normalizer::Normalizer;
 use crate::reload::DetectorStore;
 use crate::response::ResponseEngine;
+use crate::runtime::capture::{CaptureContext, CaptureOptions, CaptureSession};
 use crate::runtime::logging::{init_logging, log_startup_banner};
 use crate::runtime::{ioc as runtime_ioc, yara as runtime_yara};
 use crate::scanner::{YaraEventHandler, YaraMemoryJob};
@@ -31,6 +32,29 @@ pub fn run(
         config_path,
         sigma_engine,
     ))
+}
+
+/// Linux capture runtime: the same eBPF sensor as `run`, recording normalized
+/// events instead of evaluating them.
+pub fn run_capture(options: CaptureOptions) -> anyhow::Result<()> {
+    let runtime = Builder::new_multi_thread().enable_all().build()?;
+    runtime.block_on(async move {
+        let context = CaptureContext::load(&options, "Linux eBPF")?;
+        let session = context.start_recording(&options, Platform::Linux)?;
+        let (sensor_tx, sensor_worker) = session.sensor_channel();
+
+        let sensor = Arc::new(EbpfSensor::new());
+        info!("Starting eBPF sensor...");
+        if let Err(e) = sensor.start(sensor_tx) {
+            error!("eBPF sensor failed to start: {:#}", e);
+            session.abandon(sensor_worker).await;
+            return Err(e);
+        }
+
+        CaptureSession::wait_for_shutdown().await;
+        sensor.shutdown();
+        session.finish(sensor_worker).await
+    })
 }
 
 /// Linux eBPF EDR main loop. Mirrors `run_edr` but replaces ETW with the

--- a/src/runtime/linux.rs
+++ b/src/runtime/linux.rs
@@ -1,5 +1,5 @@
 use crate::alerts::dedup::{spawn_flush_worker, Deduplicator};
-use crate::engine::{Engine, SigmaDetectionHandler};
+use crate::engine::{DetectionPipeline, Engine, NormalizedEventHandler};
 use crate::ioc::IocEngine;
 use crate::memory::MemoryScanConfig;
 use crate::normalizer::Normalizer;
@@ -262,13 +262,15 @@ async fn run_linux_edr(
     ));
 
     // 12. Detection handlers + router
-    let sigma_handler = SigmaDetectionHandler {
-        normalizer: Arc::clone(&normalizer),
-        detectors: Arc::clone(&detectors),
-        ioc_hash_tx,
-        alert_sink: alert_sink.clone(),
-        response_engine: response_engine.clone(),
-    };
+    let sigma_handler = NormalizedEventHandler::detecting(
+        Arc::clone(&normalizer),
+        DetectionPipeline {
+            detectors: Arc::clone(&detectors),
+            ioc_hash_tx,
+            alert_sink: alert_sink.clone(),
+            response_engine: response_engine.clone(),
+        },
+    );
 
     let yara_handler = if cfg.scanner.yara_enabled {
         let yara_handler = YaraEventHandler {

--- a/src/runtime/logging.rs
+++ b/src/runtime/logging.rs
@@ -165,6 +165,56 @@ pub fn init_logging(
     (app_guard, alert_guard, AlertSink::new(alert_writer))
 }
 
+/// Initialize operational logging only, without the alert pipeline.
+///
+/// Used by `rustinel capture`, which never emits alerts: initializing the alert
+/// appender would create an alert file for a session that has nothing to write
+/// to it, blurring the line between recordings and detection output.
+pub fn init_operational_logging(
+    cfg: &config::AppConfig,
+) -> tracing_appender::non_blocking::WorkerGuard {
+    let (app_writer, app_guard) =
+        build_daily_writer("operational", &cfg.logging.directory, &cfg.logging.filename);
+    let base_filter = build_log_filter(&cfg.logging);
+
+    let app_layer = fmt::layer()
+        .with_writer(app_writer)
+        .compact()
+        .with_ansi(false)
+        .with_target(true)
+        .with_filter(base_filter.clone());
+
+    let console_layer = if cfg.logging.console_output {
+        Some(
+            fmt::layer()
+                .compact()
+                .with_ansi(console_ansi_supported())
+                .with_target(true)
+                .with_filter(base_filter),
+        )
+    } else {
+        None
+    };
+
+    tracing_subscriber::registry()
+        .with(app_layer)
+        .with(console_layer)
+        .init();
+
+    app_guard
+}
+
+/// Windows terminals other than Windows Terminal render ANSI escapes literally.
+#[cfg(windows)]
+fn console_ansi_supported() -> bool {
+    std::env::var("WT_SESSION").is_ok()
+}
+
+#[cfg(not(windows))]
+fn console_ansi_supported() -> bool {
+    true
+}
+
 fn build_daily_writer(
     label: &str,
     directory: &Path,

--- a/src/runtime/macos.rs
+++ b/src/runtime/macos.rs
@@ -1,5 +1,5 @@
 use crate::alerts::dedup::{spawn_flush_worker, Deduplicator};
-use crate::engine::{Engine, SigmaDetectionHandler};
+use crate::engine::{DetectionPipeline, Engine, NormalizedEventHandler};
 use crate::ioc::IocEngine;
 use crate::memory::MemoryScanConfig;
 use crate::normalizer::Normalizer;
@@ -262,13 +262,15 @@ async fn run_macos_edr(
     ));
 
     // 12. Detection handlers + router
-    let sigma_handler = SigmaDetectionHandler {
-        normalizer: Arc::clone(&normalizer),
-        detectors: Arc::clone(&detectors),
-        ioc_hash_tx,
-        alert_sink: alert_sink.clone(),
-        response_engine: response_engine.clone(),
-    };
+    let sigma_handler = NormalizedEventHandler::detecting(
+        Arc::clone(&normalizer),
+        DetectionPipeline {
+            detectors: Arc::clone(&detectors),
+            ioc_hash_tx,
+            alert_sink: alert_sink.clone(),
+            response_engine: response_engine.clone(),
+        },
+    );
 
     let yara_handler = if cfg.scanner.yara_enabled {
         let yara_handler = YaraEventHandler {

--- a/src/runtime/macos.rs
+++ b/src/runtime/macos.rs
@@ -5,6 +5,7 @@ use crate::memory::MemoryScanConfig;
 use crate::normalizer::Normalizer;
 use crate::reload::DetectorStore;
 use crate::response::ResponseEngine;
+use crate::runtime::capture::{CaptureContext, CaptureOptions, CaptureSession};
 use crate::runtime::logging::{init_logging, log_startup_banner};
 use crate::runtime::{ioc as runtime_ioc, yara as runtime_yara};
 use crate::scanner::{YaraEventHandler, YaraMemoryJob};
@@ -31,6 +32,45 @@ pub fn run(
         config_path,
         sigma_engine,
     ))
+}
+
+/// macOS capture runtime: the same Endpoint Security and network sensors as
+/// `run`, recording normalized events instead of evaluating them.
+pub fn run_capture(options: CaptureOptions) -> anyhow::Result<()> {
+    let runtime = Builder::new_multi_thread().enable_all().build()?;
+    runtime.block_on(async move {
+        let context = CaptureContext::load(&options, "macOS ESF")?;
+        let session = context.start_recording(&options, Platform::MacOS)?;
+        let (sensor_tx, sensor_worker) = session.sensor_channel();
+
+        let esf_sensor = Arc::new(EsfSensor::new());
+        let bpf_sensor = Arc::new(BpfSensor::new());
+        info!("Starting macOS sensors...");
+
+        // Endpoint Security is the primary source; failing to start it is fatal.
+        if let Err(e) = esf_sensor.start(sensor_tx.clone()) {
+            error!("macOS Endpoint Security sensor failed to start: {:#}", e);
+            drop(sensor_tx);
+            session.abandon(sensor_worker).await;
+            return Err(e);
+        }
+
+        // Network/DNS capture is best-effort; degrade to ESF-only if it fails,
+        // exactly as `run` does. A reduced sensor set is a narrower recording,
+        // not a lossy one, so the recording still finalizes as complete.
+        if let Err(e) = bpf_sensor.start(sensor_tx) {
+            warn!(
+                "macOS network/DNS sensor unavailable: {:#}; recording Endpoint Security only",
+                e
+            );
+            eprintln!("Warning: network and DNS events will not be recorded ({e:#})");
+        }
+
+        CaptureSession::wait_for_shutdown().await;
+        esf_sensor.shutdown();
+        bpf_sensor.shutdown();
+        session.finish(sensor_worker).await
+    })
 }
 
 /// macOS EDR main loop. Mirrors `run_linux_edr`, sourcing process and file

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1,3 +1,4 @@
+pub mod capture;
 pub mod ioc;
 #[cfg(target_os = "linux")]
 mod linux;

--- a/src/runtime/orchestration.rs
+++ b/src/runtime/orchestration.rs
@@ -1,4 +1,6 @@
 use crate::cli::{Cli, Commands};
+#[cfg(any(windows, target_os = "linux", target_os = "macos"))]
+use crate::runtime::capture::CaptureOptions;
 
 #[cfg(windows)]
 pub fn run() -> anyhow::Result<()> {
@@ -29,6 +31,13 @@ pub fn run() -> anyhow::Result<()> {
             cli.config,
             sigma_engine.map(|engine| engine.kind()),
         ),
+        Some(Commands::Capture { output }) => {
+            crate::runtime::windows::run_capture(CaptureOptions {
+                output,
+                log_level: cli.log_level,
+                config_path: cli.config,
+            })
+        }
         None => crate::runtime::windows::run_console(true, cli.log_level, cli.config, None),
         Some(Commands::Doctor { .. }) => unreachable!("doctor is handled before service dispatch"),
         Some(Commands::Service { action }) => crate::platform::handle_service_command(action),
@@ -83,6 +92,11 @@ pub fn run() -> anyhow::Result<()> {
             cli.config,
             sigma_engine.map(|engine| engine.kind()),
         ),
+        Some(Commands::Capture { output }) => crate::runtime::linux::run_capture(CaptureOptions {
+            output,
+            log_level: cli.log_level,
+            config_path: cli.config,
+        }),
         None => crate::runtime::linux::run(true, cli.log_level, cli.config, None),
     }
 }
@@ -121,6 +135,11 @@ pub fn run() -> anyhow::Result<()> {
             cli.config,
             sigma_engine.map(|engine| engine.kind()),
         ),
+        Some(Commands::Capture { output }) => crate::runtime::macos::run_capture(CaptureOptions {
+            output,
+            log_level: cli.log_level,
+            config_path: cli.config,
+        }),
         None => crate::runtime::macos::run(true, cli.log_level, cli.config, None),
     }
 }

--- a/src/runtime/windows.rs
+++ b/src/runtime/windows.rs
@@ -5,6 +5,7 @@ use crate::memory::MemoryScanConfig;
 use crate::normalizer::Normalizer;
 use crate::reload::DetectorStore;
 use crate::response::ResponseEngine;
+use crate::runtime::capture::{CaptureContext, CaptureOptions, CaptureSession};
 use crate::runtime::logging::{init_logging, log_startup_banner};
 use crate::runtime::{ioc as runtime_ioc, yara as runtime_yara};
 use crate::scanner::{YaraEventHandler, YaraMemoryJob};
@@ -163,6 +164,106 @@ fn spawn_shutdown_handler(
     })
 }
 
+/// ETW providers require an elevated token. Shared by `run` and `capture` so
+/// both fail with the same clear preflight error.
+fn ensure_administrator_privileges() -> anyhow::Result<()> {
+    use windows::Win32::Foundation::HANDLE;
+    use windows::Win32::Security::{
+        GetTokenInformation, TokenElevation, TOKEN_ELEVATION, TOKEN_QUERY,
+    };
+    use windows::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+
+    unsafe {
+        let mut token = HANDLE::default();
+        if OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token).is_ok() {
+            let mut elevation = TOKEN_ELEVATION::default();
+            let mut return_length = 0u32;
+
+            if GetTokenInformation(
+                token,
+                TokenElevation,
+                Some(&mut elevation as *mut _ as *mut _),
+                std::mem::size_of::<TOKEN_ELEVATION>() as u32,
+                &mut return_length,
+            )
+            .is_ok()
+            {
+                if elevation.TokenIsElevated == 0 {
+                    error!("❌ ERROR: This application requires Administrator privileges!");
+                    error!("   Please run as Administrator to access ETW providers.");
+                    return Err(anyhow::anyhow!(
+                        "Insufficient privileges - Administrator access required"
+                    ));
+                } else {
+                    info!("✓ Running with Administrator privileges");
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Windows capture runtime: the same ETW session as `run`, recording normalized
+/// events instead of evaluating them.
+pub fn run_capture(options: CaptureOptions) -> anyhow::Result<()> {
+    let runtime = Builder::new_multi_thread().enable_all().build()?;
+    runtime.block_on(async move {
+        let context = CaptureContext::load(&options, "Windows ETW")?;
+        ensure_administrator_privileges()?;
+        let session = context.start_recording(&options, Platform::Windows)?;
+
+        // Cold start: seed the process cache so early events resolve parents.
+        match crate::platform::windows::snapshot_processes(session.process_cache()) {
+            Ok(count) => info!(
+                "✓ Process Cache initialized with {} existing processes",
+                count
+            ),
+            Err(e) => warn!(
+                "Failed to snapshot processes: {}. Cache will populate from ETW events.",
+                e
+            ),
+        }
+
+        let (sensor_tx, sensor_worker) = session.sensor_channel();
+        let sensor = Arc::new(EtwSensor::new());
+        let sensor_for_trace = Arc::clone(&sensor);
+        let mut trace_handle =
+            tokio::task::spawn_blocking(move || sensor_for_trace.start(sensor_tx));
+
+        // An ETW session that ends on its own takes the recording with it:
+        // everything after that point is missing, which the capture sink cannot
+        // see, so the recording has to be marked incomplete explicitly.
+        let mut sensor_failure = None;
+        tokio::select! {
+            _ = CaptureSession::wait_for_shutdown() => {
+                sensor.shutdown();
+                if let Err(err) = (&mut trace_handle).await {
+                    error!("Failed to join ETW sensor thread: {}", err);
+                }
+            }
+            result = &mut trace_handle => {
+                let reason = match result {
+                    Ok(Ok(())) => "ETW session closed unexpectedly".to_string(),
+                    Ok(Err(err)) => format!("ETW session failed: {err:#}"),
+                    Err(err) => format!("ETW sensor thread did not finish cleanly: {err}"),
+                };
+                error!("🚨 {}", reason);
+                session.mark_incomplete(&reason);
+                sensor.shutdown();
+                sensor_failure = Some(anyhow::anyhow!(reason));
+            }
+        }
+
+        session.finish(sensor_worker).await?;
+
+        match sensor_failure {
+            Some(err) => Err(err),
+            None => Ok(()),
+        }
+    })
+}
+
 async fn run_edr(
     shutdown_mode: ShutdownMode,
     console_output_override: Option<bool>,
@@ -220,41 +321,7 @@ async fn run_edr(
     );
 
     // Verify running with appropriate privileges
-    {
-        use windows::Win32::Foundation::HANDLE;
-        use windows::Win32::Security::{
-            GetTokenInformation, TokenElevation, TOKEN_ELEVATION, TOKEN_QUERY,
-        };
-        use windows::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
-
-        unsafe {
-            let mut token = HANDLE::default();
-            if OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token).is_ok() {
-                let mut elevation = TOKEN_ELEVATION::default();
-                let mut return_length = 0u32;
-
-                if GetTokenInformation(
-                    token,
-                    TokenElevation,
-                    Some(&mut elevation as *mut _ as *mut _),
-                    std::mem::size_of::<TOKEN_ELEVATION>() as u32,
-                    &mut return_length,
-                )
-                .is_ok()
-                {
-                    if elevation.TokenIsElevated == 0 {
-                        error!("❌ ERROR: This application requires Administrator privileges!");
-                        error!("   Please run as Administrator to access ETW providers.");
-                        return Err(anyhow::anyhow!(
-                            "Insufficient privileges - Administrator access required"
-                        ));
-                    } else {
-                        info!("✓ Running with Administrator privileges");
-                    }
-                }
-            }
-        }
-    }
+    ensure_administrator_privileges()?;
 
     // Initialize modules
     info!("Initializing modules...");

--- a/src/runtime/windows.rs
+++ b/src/runtime/windows.rs
@@ -1,5 +1,5 @@
 use crate::alerts::dedup::{spawn_flush_worker, Deduplicator};
-use crate::engine::{Engine, SigmaDetectionHandler};
+use crate::engine::{DetectionPipeline, Engine, NormalizedEventHandler};
 use crate::ioc::IocEngine;
 use crate::memory::MemoryScanConfig;
 use crate::normalizer::Normalizer;
@@ -513,14 +513,16 @@ async fn run_edr(
     info!("✓ ETW sensor initialized");
     info!("✓ Normalizer initialized");
 
-    // Create Sigma detection handler
-    let sigma_handler = SigmaDetectionHandler {
-        normalizer: Arc::clone(&normalizer),
-        detectors: Arc::clone(&detectors),
-        ioc_hash_tx,
-        alert_sink: alert_sink.clone(),
-        response_engine: response_engine.clone(),
-    };
+    // Create the normalized-event handler in live detection mode
+    let sigma_handler = NormalizedEventHandler::detecting(
+        Arc::clone(&normalizer),
+        DetectionPipeline {
+            detectors: Arc::clone(&detectors),
+            ioc_hash_tx,
+            alert_sink: alert_sink.clone(),
+            response_engine: response_engine.clone(),
+        },
+    );
 
     // Create YARA event handler
     let yara_handler = if cfg.scanner.yara_enabled {

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -1,0 +1,71 @@
+//! Filesystem permission helpers for security-sensitive output.
+//!
+//! Recordings and alerts describe endpoint activity in detail, so their files
+//! are owner-only. On Windows the managed install layout carries the ACLs and
+//! these helpers are no-ops.
+
+use std::fs;
+use std::io;
+use std::path::Path;
+
+/// Restrict a directory to owner-only access.
+#[cfg(unix)]
+pub fn restrict_directory_permissions(directory: &Path) -> io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    fs::set_permissions(directory, fs::Permissions::from_mode(0o700))
+}
+
+#[cfg(not(unix))]
+pub fn restrict_directory_permissions(_directory: &Path) -> io::Result<()> {
+    Ok(())
+}
+
+/// Restrict a file to owner-only read/write.
+#[cfg(unix)]
+pub fn restrict_file_permissions(path: &Path) -> io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    fs::set_permissions(path, fs::Permissions::from_mode(0o600))
+}
+
+#[cfg(not(unix))]
+pub fn restrict_file_permissions(_path: &Path) -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+
+    #[test]
+    fn restricts_directory_and_file_to_the_owner() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let directory = temp.path().join("captures");
+        fs::create_dir(&directory).expect("create dir");
+        let file = directory.join("session.ndjson");
+        fs::write(&file, b"{}").expect("write file");
+        fs::set_permissions(&file, fs::Permissions::from_mode(0o644)).expect("relax file");
+
+        restrict_directory_permissions(&directory).expect("restrict dir");
+        restrict_file_permissions(&file).expect("restrict file");
+
+        assert_eq!(
+            fs::metadata(&directory)
+                .expect("dir metadata")
+                .permissions()
+                .mode()
+                & 0o777,
+            0o700
+        );
+        assert_eq!(
+            fs::metadata(&file)
+                .expect("file metadata")
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
+        );
+    }
+}

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -4,6 +4,9 @@
 //! are owner-only. On Windows the managed install layout carries the ACLs and
 //! these helpers are no-ops.
 
+// `fs` is only reachable from the Unix implementations below; the Windows
+// no-ops would leave it unused.
+#[cfg(unix)]
 use std::fs;
 use std::io;
 use std::path::Path;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -3,6 +3,7 @@
 //! Provides helper functions for path normalization and PE parsing.
 
 pub(crate) mod file_identity;
+pub mod fs;
 pub mod log_rate_limiter;
 pub mod path;
 #[cfg(windows)]

--- a/tests/capture_command.rs
+++ b/tests/capture_command.rs
@@ -1,0 +1,158 @@
+//! End-to-end smoke test for `rustinel capture`.
+//!
+//! Capture drives the real sensors, so this needs the same privileges as
+//! `rustinel run` and is ignored by default. It runs in the privileged smoke
+//! job, where it is the only check that a clean Ctrl-C really produces a
+//! complete NDJSON/manifest pair.
+
+#![cfg(unix)]
+
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use rustinel::capture::{manifest_path_for, CaptureManifest, CaptureStatus};
+
+/// How long the capture is allowed to take to open its recording.
+const STARTUP_TIMEOUT: Duration = Duration::from_secs(30);
+/// How long the capture is allowed to take to finalize after Ctrl-C.
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(30);
+
+fn write_config(root: &Path) -> std::path::PathBuf {
+    let config_path = root.join("config.toml");
+    std::fs::write(
+        &config_path,
+        format!(
+            "[logging]\nlevel = \"info\"\ndirectory = \"{logs}\"\nfilename = \"rustinel.log\"\n\
+             \n[capture]\ndirectory = \"{captures}\"\n",
+            logs = root.join("logs").display(),
+            captures = root.join("captures").display(),
+        ),
+    )
+    .expect("write config");
+    config_path
+}
+
+fn wait_for(deadline: Duration, mut ready: impl FnMut() -> bool) -> bool {
+    let start = Instant::now();
+    while start.elapsed() < deadline {
+        if ready() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+    false
+}
+
+fn read_manifest(path: &Path) -> CaptureManifest {
+    serde_json::from_str(&std::fs::read_to_string(path).expect("manifest exists"))
+        .expect("manifest parses")
+}
+
+#[test]
+#[ignore = "requires sensor privileges; runs in the privileged smoke job"]
+fn ctrl_c_finalizes_a_complete_recording() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let config_path = write_config(temp.path());
+    let payload = temp.path().join("captures").join("smoke.ndjson");
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_rustinel"))
+        .arg("capture")
+        .arg("--config")
+        .arg(&config_path)
+        .arg("--output")
+        .arg(&payload)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("capture starts");
+
+    let manifest_path = manifest_path_for(&payload);
+    assert!(
+        wait_for(STARTUP_TIMEOUT, || manifest_path.exists()),
+        "capture did not open a recording within {STARTUP_TIMEOUT:?}"
+    );
+    assert_eq!(
+        read_manifest(&manifest_path).status,
+        CaptureStatus::Incomplete,
+        "a running capture is marked incomplete until it finalizes"
+    );
+
+    // Generate a little activity for the sensors to observe.
+    for _ in 0..3 {
+        let _ = Command::new("/bin/sh")
+            .args(["-c", "echo rustinel-capture-smoke > /dev/null"])
+            .status();
+    }
+    std::thread::sleep(Duration::from_secs(2));
+
+    // SIGINT is what Ctrl-C delivers; the capture must finalize on it.
+    let pid = child.id() as i32;
+    // SAFETY: `pid` belongs to the child spawned above, which is still running.
+    let signalled = unsafe { libc::kill(pid, libc::SIGINT) };
+    assert_eq!(signalled, 0, "failed to signal the capture process");
+
+    assert!(
+        wait_for(SHUTDOWN_TIMEOUT, || child
+            .try_wait()
+            .expect("poll capture process")
+            .is_some()),
+        "capture did not exit within {SHUTDOWN_TIMEOUT:?} of Ctrl-C"
+    );
+    let status = child.wait().expect("capture exits");
+    assert!(status.success(), "capture exited with {status}");
+
+    let manifest = read_manifest(&manifest_path);
+    assert_eq!(manifest.status, CaptureStatus::Complete);
+    assert!(manifest.is_replayable());
+    assert_eq!(
+        manifest.events.received,
+        manifest.events.written + manifest.events.lost
+    );
+    assert!(
+        manifest.events.written > 0,
+        "the session recorded no events at all"
+    );
+
+    let payload_lines = std::fs::read_to_string(&payload)
+        .expect("recording exists")
+        .lines()
+        .count();
+    assert_eq!(payload_lines as u64, manifest.events.written);
+}
+
+#[test]
+#[ignore = "requires sensor privileges; runs in the privileged smoke job"]
+fn a_killed_capture_leaves_an_incomplete_recording() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let config_path = write_config(temp.path());
+    let payload = temp.path().join("captures").join("killed.ndjson");
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_rustinel"))
+        .arg("capture")
+        .arg("--config")
+        .arg(&config_path)
+        .arg("--output")
+        .arg(&payload)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("capture starts");
+
+    let manifest_path = manifest_path_for(&payload);
+    assert!(
+        wait_for(STARTUP_TIMEOUT, || manifest_path.exists()),
+        "capture did not open a recording within {STARTUP_TIMEOUT:?}"
+    );
+
+    child.kill().expect("kill capture");
+    child.wait().expect("capture exits");
+
+    let manifest = read_manifest(&manifest_path);
+    assert_eq!(manifest.status, CaptureStatus::Incomplete);
+    assert!(manifest.payload_sha256.is_none());
+    assert!(
+        !manifest.is_replayable(),
+        "an interrupted recording must be rejected by replay"
+    );
+}

--- a/tests/capture_recording.rs
+++ b/tests/capture_recording.rs
@@ -1,0 +1,228 @@
+//! Behavioral recording at the shared normalization boundary.
+//!
+//! These tests drive the same `SensorEventRouter` the platform runtimes use, so
+//! they exercise the real capture boundary rather than the writer in isolation.
+
+#[cfg(test)]
+mod common;
+
+use std::path::Path;
+use std::sync::Arc;
+
+use common::{
+    dns_query_event, file_create_event, network_connect_event, process_start_event, SigmaFixture,
+    TestNormalizer, YaraFixture,
+};
+use rustinel::{
+    alerts::AlertSink,
+    capture::{CaptureRecorder, CaptureStatus},
+    config::ResponseConfig,
+    engine::{DetectionPipeline, Engine, NormalizedEventHandler},
+    ioc::IocEngine,
+    reload::DetectorStore,
+    scanner::Scanner,
+    sensor::{Platform, SensorEventRouter},
+};
+use serde_json::Value;
+
+fn read_lines(path: &Path) -> Vec<Value> {
+    std::fs::read_to_string(path)
+        .expect("recording exists")
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("recording line is JSON"))
+        .collect()
+}
+
+#[tokio::test]
+async fn capture_records_every_normalized_event_in_order() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let payload = temp.path().join("captures").join("session.ndjson");
+    let recorder =
+        CaptureRecorder::start(payload.clone(), Platform::Linux).expect("capture starts");
+
+    let harness = TestNormalizer::new(false);
+    let handler = NormalizedEventHandler::recording(Arc::new(harness.normalizer), recorder.sink());
+    let mut router = SensorEventRouter::new();
+    router.register_handler(Box::new(handler));
+
+    // A repeated event must appear twice: capture does not deduplicate.
+    router.route_event(&process_start_event(Platform::Linux));
+    router.route_event(&network_connect_event(Platform::Linux));
+    router.route_event(&file_create_event(Platform::Linux));
+    router.route_event(&process_start_event(Platform::Linux));
+    drop(router);
+
+    let manifest = recorder.finish().await.expect("capture finalizes");
+
+    let events = read_lines(&payload);
+    let categories: Vec<&str> = events
+        .iter()
+        .map(|event| event["category"].as_str().expect("category present"))
+        .collect();
+    assert_eq!(
+        categories,
+        vec!["Process", "Network", "File", "Process"],
+        "events are recorded in observed order, repeats included"
+    );
+
+    assert_eq!(manifest.status, CaptureStatus::Complete);
+    assert_eq!(manifest.events.received, 4);
+    assert_eq!(manifest.events.written, 4);
+    assert_eq!(manifest.events.lost, 0);
+    assert_eq!(manifest.platform, Platform::Linux);
+}
+
+#[tokio::test]
+async fn capture_records_canonical_events_without_alert_enrichment() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let payload = temp.path().join("session.ndjson");
+    let recorder =
+        CaptureRecorder::start(payload.clone(), Platform::Linux).expect("capture starts");
+
+    let harness = TestNormalizer::new(false);
+    let handler = NormalizedEventHandler::recording(Arc::new(harness.normalizer), recorder.sink());
+    let mut router = SensorEventRouter::new();
+    router.register_handler(Box::new(handler));
+    // A process start first, so the cache holds context the alert path would
+    // otherwise graft onto the later non-process events.
+    router.route_event(&process_start_event(Platform::Linux));
+    router.route_event(&dns_query_event(Platform::Linux));
+    drop(router);
+
+    recorder.finish().await.expect("capture finalizes");
+
+    let events = read_lines(&payload);
+    let dns = events.last().expect("dns event recorded");
+    assert_eq!(dns["category"], "Dns");
+    assert!(
+        dns.get("process_context").is_none(),
+        "alert-only process context must not be baked into a recording: {dns}"
+    );
+}
+
+#[tokio::test]
+async fn capture_does_not_evaluate_detectors_or_write_alerts() {
+    let fixture = SigmaFixture::new();
+    // A rule that the recorded process start would match under live protection.
+    fixture.write_process_rule(Platform::Linux);
+    let mut sigma = Engine::new_for_platform(Platform::Linux);
+    sigma
+        .load_rules(fixture.rules_dir())
+        .expect("load sigma rule");
+    assert!(sigma.stats().total_rules > 0, "fixture rule is loaded");
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let alerts = temp.path().join("alerts.ndjson");
+    let payload = temp.path().join("captures").join("session.ndjson");
+    let recorder =
+        CaptureRecorder::start(payload.clone(), Platform::Linux).expect("capture starts");
+
+    let harness = TestNormalizer::new(false);
+    let handler = NormalizedEventHandler::recording(Arc::new(harness.normalizer), recorder.sink());
+    let mut router = SensorEventRouter::new();
+    router.register_handler(Box::new(handler));
+    router.route_event(&process_start_event(Platform::Linux));
+    drop(router);
+
+    recorder.finish().await.expect("capture finalizes");
+
+    assert_eq!(read_lines(&payload).len(), 1, "the event was recorded");
+    assert!(
+        !alerts.exists(),
+        "capture must not produce alert output alongside the recording"
+    );
+}
+
+#[tokio::test]
+async fn live_protection_does_not_write_a_recording() {
+    let fixture = SigmaFixture::new();
+    fixture.write_process_rule(Platform::Linux);
+    let mut sigma = Engine::new_for_platform(Platform::Linux);
+    sigma
+        .load_rules(fixture.rules_dir())
+        .expect("load sigma rule");
+
+    let yara_fixture = YaraFixture::new();
+    let detectors = DetectorStore::new(
+        Arc::new(sigma),
+        Arc::new(Scanner::new(yara_fixture.rules_dir()).expect("empty yara scanner")),
+        Arc::new(IocEngine::disabled()),
+    );
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let alerts = temp.path().join("alerts.ndjson");
+    let captures = temp.path().join("captures");
+    let file = std::fs::File::create(&alerts).expect("create alert output");
+    let (writer, guard) = tracing_appender::non_blocking(file);
+    let (response, response_handle) = rustinel::response::ResponseEngine::new(Arc::new(
+        arc_swap::ArcSwap::from(Arc::new(ResponseConfig {
+            enabled: false,
+            prevention_enabled: false,
+            min_severity: "critical".to_string(),
+            channel_capacity: 4,
+            allowlist_images: Vec::new(),
+            allowlist_paths: Vec::new(),
+        })),
+    ));
+
+    let harness = TestNormalizer::new(false);
+    let handler = NormalizedEventHandler::detecting(
+        Arc::new(harness.normalizer),
+        DetectionPipeline {
+            detectors,
+            ioc_hash_tx: None,
+            alert_sink: AlertSink::new(writer),
+            response_engine: response,
+        },
+    );
+    assert!(
+        handler.capture.is_none(),
+        "the live pipeline carries no capture sink"
+    );
+
+    let mut router = SensorEventRouter::new();
+    router.register_handler(Box::new(handler));
+    router.route_event(&process_start_event(Platform::Linux));
+    drop(router);
+    drop(guard);
+    response_handle.abort();
+
+    assert!(
+        std::fs::read_to_string(&alerts)
+            .expect("alert output readable")
+            .contains("\"rule.name\""),
+        "live protection still alerts"
+    );
+    assert!(
+        !captures.exists(),
+        "ordinary run must not produce a recording"
+    );
+}
+
+#[tokio::test]
+async fn shutdown_finalizes_queued_events_and_the_manifest() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let payload = temp.path().join("session.ndjson");
+    let recorder =
+        CaptureRecorder::start(payload.clone(), Platform::Linux).expect("capture starts");
+    let manifest_path = recorder.manifest_path().to_path_buf();
+
+    let harness = TestNormalizer::new(false);
+    let handler = NormalizedEventHandler::recording(Arc::new(harness.normalizer), recorder.sink());
+    let mut router = SensorEventRouter::new();
+    router.register_handler(Box::new(handler));
+    for _ in 0..64 {
+        router.route_event(&process_start_event(Platform::Linux));
+    }
+    drop(router);
+
+    let manifest = recorder.finish().await.expect("capture finalizes");
+    let persisted: rustinel::capture::CaptureManifest =
+        serde_json::from_str(&std::fs::read_to_string(&manifest_path).expect("manifest exists"))
+            .expect("manifest parses");
+
+    assert_eq!(read_lines(&payload).len(), 64, "queued events are drained");
+    assert_eq!(manifest.events.written, 64);
+    assert_eq!(persisted, manifest);
+    assert!(persisted.is_replayable());
+}

--- a/tests/router_and_handlers.rs
+++ b/tests/router_and_handlers.rs
@@ -8,7 +8,7 @@ use rustinel::utils::hash_command_line;
 use rustinel::{
     alerts::AlertSink,
     config::ResponseConfig,
-    engine::{Engine, SigmaDetectionHandler},
+    engine::{DetectionPipeline, Engine, NormalizedEventHandler},
     ioc::IocEngine,
     reload::DetectorStore,
     scanner::{normalize_allowlist_paths, Scanner, YaraEventHandler},
@@ -48,13 +48,15 @@ async fn router_invokes_sigma_handler_and_writes_alert() {
     ));
 
     let harness = TestNormalizer::new(false);
-    let handler = SigmaDetectionHandler {
-        normalizer: Arc::new(harness.normalizer),
-        detectors,
-        ioc_hash_tx: None,
-        alert_sink: AlertSink::new(writer),
-        response_engine: response,
-    };
+    let handler = NormalizedEventHandler::detecting(
+        Arc::new(harness.normalizer),
+        DetectionPipeline {
+            detectors,
+            ioc_hash_tx: None,
+            alert_sink: AlertSink::new(writer),
+            response_engine: response,
+        },
+    );
 
     let mut router = SensorEventRouter::new();
     router.register_handler(Box::new(handler));


### PR DESCRIPTION
Adds behavioral recording: the capture sink that writes canonical normalized events as NDJSON, and the `rustinel capture` command that drives it.

Closes #228
Closes #229

The two issues ship together because #228 alone is unreachable code — its own acceptance criteria are written in terms of `rustinel capture`. The commits are kept separate for review.

## The capture boundary

`SigmaDetectionHandler` becomes `NormalizedEventHandler`, carrying an optional capture sink and an optional `DetectionPipeline`. Capture is fed immediately after normalization, before alert-only process-context enrichment and before any detector runs, so a recording holds what live detection *would have* seen.

A recording session simply has no detection pipeline. That is what keeps capture from evaluating rules or invoking active response — a missing pipeline rather than a flag someone can later get wrong. Live protection is unchanged and carries no capture sink.

## Loss is explicit

Serialization happens on the calling thread; lines go to a bounded queue drained by a background writer that hashes the payload as it writes. Anything that does not reach the payload is counted, warned about (rate-limited), and reflected in the manifest, where `received == written + lost` always holds.

The manifest is written `incomplete` when the session opens and rewritten `complete` only on a clean, lossless finish, so a recording left behind by a killed process is never mistaken for a finished one.

Recordings are more revealing than alerts — full command lines, paths, destinations, and user names for *all* activity, not just what matched. They are owner-only (`0600` in a `0700` directory on Unix) under the new `capture.directory`, kept apart from alert and operational log output.

## The command

`rustinel capture [--output PATH]`, wired into all three platform runtimes through a shared `src/runtime/capture.rs`. It reuses `run`'s configuration discovery, preflight, privileges, and sensor setup, and overrides only what happens downstream of normalization. The Windows elevation check moves into a shared `ensure_administrator_privileges` so both commands fail with the same preflight error.

Three edge cases that were judgment calls:

- **Sensors that never start** (Linux eBPF, macOS ESF) remove the empty recording rather than leave a misleading artifact.
- **An ETW session that dies mid-capture** marks the recording incomplete explicitly. That loss happens upstream of the sink, so it cannot be counted, only declared.
- **macOS's best-effort BPF sensor failing** does *not* mark the recording incomplete. A narrower sensor set is a narrower recording, not a lossy one — same degrade-and-continue behavior as `run`.

Capture also initializes operational logging only, so a recording session never opens the alert file it would never write to.

## Validation

Unit and integration tests pass on all three platforms in CI. `tests/capture_recording.rs` drives the real `SensorEventRouter` and covers ordering with repeats, absence of alert enrichment, no detector evaluation, and manifest finalization.

**Live ETW validation on a Windows 11 lab VM**, against real telemetry:

| Check | Result |
| --- | --- |
| Events recorded | 24,834 in ~15s (a second run: 36,434 / 1.9 MB) |
| Unparseable NDJSON lines | 0 |
| Categories | Registry 20803, File 2510, Wmi 1404, Scripting 86, Dns 19, Process 12 |
| `process_context` leakage | 0 occurrences |
| Progress reporting on stderr | working |
| Manifest while running | `incomplete` |
| Force-killed capture | stays `incomplete`, no `ended_at` |

A benign PowerShell process creation was recorded with the full normalized field set a Sigma `process_creation` rule needs (`Image`, `OriginalFileName`, `Product`, `Description`, `CommandLine`, `ProcessId`, `ProcessStartTime`, `ParentProcessId`, `ParentImage`, `ParentCommandLine`). Zero `process_context` across 24,834 events confirms alert-only enrichment stays out of recordings.

The `mark_incomplete` path also fired for real: when the ETW session died, the recording was finalized as `incomplete` with `ended_at` and `payload_sha256`.

**Not yet proven:** a clean Ctrl-C producing `status: complete`. Delivering a console Ctrl-C to a child of a non-interactive SSH session did not work (four approaches tried); that constrains `rustinel run` identically and is not evidence about capture. `tests/capture_command.rs` covers this path via SIGINT but needs sensor privileges, so it is `#[ignore]`d and wired into the Linux privileged smoke job — dispatch **Privileged Smoke** to close it.

## Follow-up

- Left for #230 as that issue specifies: the golden PowerShell fixture, its Sigma rule, and the `NormalizedEvent` round-trip fixes. `#[serde(untagged)]` on `EventFields` plus `#[serde(skip)]` on `event_id_string` mean the recordings written here do not yet deserialize back correctly.
- Pre-existing, unrelated to this PR: force-killing rustinel leaves the machine-global `rustinel-etw-trace` ETW session running, and the next start dies with a misleading `0x80071069 ERROR_WMI_INSTANCE_NOT_FOUND`. Affects `run` and `capture` equally; `logman stop rustinel-etw-trace -ets` clears it.