### PR TITLE
fix(sensor): align file Modify normalization across Linux, macOS, and Windows

### DIFF
--- a/docs/detection.md
+++ b/docs/detection.md
@@ -110,7 +110,7 @@ rule instead of one is tracked separately by
 | `file_event` | Yes | Yes | Yes | Base file family |
 | `file_create` | Yes | Yes | Yes | Derived from file event ID / opcode (ESF event type on macOS) |
 | `file_delete` | Yes | Yes | Yes | Derived from file event ID / opcode (ESF event type on macOS) |
-| `file_change` | Yes | Yes | No | Derived from file event ID / opcode. On Windows the events routed here are Kernel-File name-cache entries and writes that arrive without a path, rather than content changes ([#238](https://github.com/Karib0u/rustinel/issues/238)); on macOS a modification is reported as `file_create`, so this category never matches ([#239](https://github.com/Karib0u/rustinel/issues/239)) |
+| `file_change` | Yes | Yes | Yes | Derived from file event ID / opcode. On Windows the events routed here are Kernel-File name-cache entries and writes that arrive without a path, rather than content changes, so a rule keyed on `TargetFilename` still cannot match there ([#238](https://github.com/Karib0u/rustinel/issues/238)) |
 | `file_rename` | Yes | Yes | Yes | Derived from file event ID / opcode (ESF event type on macOS) |
 | `dns_query` | Yes | Yes | Yes | Generic `category: dns` and `service: dns`, `category: network` are also supported |
 | `registry_event` / `registry_*` | Yes | No | No | Windows only |
@@ -121,6 +121,29 @@ rule instead of one is tracked separately by
 | `task_creation` | Yes | No | No | Windows only |
 
 macOS telemetry comes from two sources: Endpoint Security (ESF) for process and file events (`provider: esf`), and `/dev/bpf` packet capture for network and DNS (`provider: bpf`). Its coverage mirrors Linux; the Windows-only families above are not collected on macOS.
+
+#### File Event Numbering
+
+Every sensor routes its native file telemetry through one shared table, so the
+same logical action carries the same identifiers — and therefore lands in the
+same categories — on all three platforms:
+
+| Action | `event_id` | `action_code` | Categories |
+| --- | --- | --- | --- |
+| Create | 11 | 64 | `file_event`, `file_create` |
+| Modify | 65 | 65 | `file_event`, `file_change` |
+| Delete | 23 | 70 | `file_delete` |
+| Rename | 71 | 71 | `file_event`, `file_rename` |
+
+The identifiers are Sysmon-compatible where Sysmon has an equivalent event
+(11 = FileCreate, 23 = FileDelete). Sysmon has no file-modify or file-rename
+event, so those reuse the action code as the `event_id`. A delete is
+deliberately not a member of `file_event`.
+
+Note that `file_change` here means "the file was modified", which is broader
+than Sysmon Event ID 2 (file creation time changed). Whether generic writes
+belong in this category, or whether it should be narrowed to timestomping, is
+still open in [#238](https://github.com/Karib0u/rustinel/issues/238).
 
 ### Field Model
 

--- a/src/sensor/linux/ebpf.rs
+++ b/src/sensor/linux/ebpf.rs
@@ -41,11 +41,9 @@ use super::events::{
 const EVENT_ID_PROCESS_CREATE: u16 = 1;
 const EVENT_ID_PROCESS_TERMINATE: u16 = 5;
 const EVENT_ID_NETWORK_CONNECT: u16 = 3;
-const EVENT_ID_FILE_CREATE: u16 = 11;
-const EVENT_ID_FILE_DELETE: u16 = 23;
-const EVENT_ID_FILE_CHANGE: u16 = 65;
-const EVENT_ID_FILE_RENAME: u16 = 71;
 const EVENT_ID_DNS_QUERY: u16 = 22;
+// File event IDs come from `SensorNormalization::for_file_action`, the shared
+// table in `crate::sensor`, so they cannot drift from the other platforms.
 
 const PROCESS_EVENT_EXEC: u32 = 1;
 const PROCESS_EVENT_EXIT: u32 = 2;
@@ -509,13 +507,15 @@ fn build_file_event(ev: &FileEvent) -> Option<SensorEvent> {
         return None;
     }
 
-    let (action, event_id, action_code) = match ev.kind {
-        1 => (SensorAction::Create, EVENT_ID_FILE_CREATE, 64u8),
-        2 => (SensorAction::Delete, EVENT_ID_FILE_DELETE, 70u8),
-        3 => (SensorAction::Rename, EVENT_ID_FILE_RENAME, 71u8),
-        4 => (SensorAction::Modify, EVENT_ID_FILE_CHANGE, 65u8),
+    let action = match ev.kind {
+        1 => SensorAction::Create,
+        2 => SensorAction::Delete,
+        3 => SensorAction::Rename,
+        4 => SensorAction::Modify,
         _ => return None,
     };
+    let normalization = SensorNormalization::for_file_action(action)
+        .expect("file actions are covered by the shared file normalization table");
 
     let user = resolved_linux_user(ev.uid);
     let comm = bytes_to_string(&ev.comm);
@@ -530,10 +530,7 @@ fn build_file_event(ev: &FileEvent) -> Option<SensorEvent> {
         platform: Platform::Linux,
         provider: "ebpf",
         action,
-        normalization: SensorNormalization {
-            event_id,
-            action_code,
-        },
+        normalization,
         pid: Some(ev.pid),
         timestamp: SystemTime::now(),
         process_start_key: None,
@@ -955,7 +952,10 @@ mod tests {
 
         let event = build_file_event(&raw).expect("delete file event should build");
         assert_eq!(event.action, SensorAction::Delete);
-        assert_eq!(event.normalization.event_id, EVENT_ID_FILE_DELETE);
+        assert_eq!(
+            event.normalization,
+            SensorNormalization::for_file_action(SensorAction::Delete).unwrap()
+        );
 
         match event.payload {
             SensorPayload::File(fields) => {
@@ -1016,7 +1016,10 @@ mod tests {
 
         let event = build_file_event(&raw).expect("rename file event should build");
         assert_eq!(event.action, SensorAction::Rename);
-        assert_eq!(event.normalization.event_id, EVENT_ID_FILE_RENAME);
+        assert_eq!(
+            event.normalization,
+            SensorNormalization::for_file_action(SensorAction::Rename).unwrap()
+        );
 
         match event.payload {
             SensorPayload::File(fields) => {

--- a/src/sensor/linux/events.rs
+++ b/src/sensor/linux/events.rs
@@ -202,20 +202,19 @@ pub mod mapping {
     }
 
     pub fn file_event_to_sensor(event: &FileEvent) -> SensorEvent {
-        let (action, event_id, action_code) = match event.kind {
-            2 => (SensorAction::Delete, 23, 70),
-            3 => (SensorAction::Rename, 71, 71),
-            4 => (SensorAction::Modify, 11, 65),
-            _ => (SensorAction::Create, 11, 64),
+        let action = match event.kind {
+            2 => SensorAction::Delete,
+            3 => SensorAction::Rename,
+            4 => SensorAction::Modify,
+            _ => SensorAction::Create,
         };
+        let normalization = SensorNormalization::for_file_action(action)
+            .expect("file actions are covered by the shared file normalization table");
         SensorEvent {
             platform: Platform::Linux,
             provider: PROVIDER,
             action,
-            normalization: SensorNormalization {
-                event_id,
-                action_code,
-            },
+            normalization,
             pid: Some(event.pid),
             timestamp: SystemTime::now(),
             process_start_key: None,

--- a/src/sensor/macos/esf.rs
+++ b/src/sensor/macos/esf.rs
@@ -45,10 +45,6 @@ const SHUTDOWN_POLL: Duration = Duration::from_millis(200);
 const EVENT_ID_PROCESS_CREATE: u16 = 1;
 /// Sysmon-compatible event ID emitted for process-terminate events.
 const EVENT_ID_PROCESS_TERMINATE: u16 = 5;
-/// Sysmon-compatible event IDs emitted for file events.
-const EVENT_ID_FILE_CREATE: u16 = 11;
-const EVENT_ID_FILE_DELETE: u16 = 23;
-const EVENT_ID_FILE_RENAME: u16 = 71;
 
 /// Endpoint Security event subscriptions for the macOS sensor.
 const SUBSCRIPTIONS: &[es_event_type_t] = &[
@@ -396,17 +392,19 @@ enum FileAction {
 }
 
 impl FileAction {
-    /// Return the (action, event id, action code) triple for this class,
-    /// matching the Linux sensor's Sysmon-compatible numbering.
+    /// Return the (action, event id, action code) triple for this class, taken
+    /// from the shared [`FILE_EVENT_NORMALIZATION`] table so macOS lands in the
+    /// same Sigma category as Linux and Windows for the same operation.
     fn normalization(self) -> (SensorAction, u16, u8) {
-        match self {
-            FileAction::Create => (SensorAction::Create, EVENT_ID_FILE_CREATE, 64),
-            FileAction::Delete => (SensorAction::Delete, EVENT_ID_FILE_DELETE, 70),
-            FileAction::Rename => (SensorAction::Rename, EVENT_ID_FILE_RENAME, 71),
-            // Sysmon has no file-modify event, so report modify under
-            // FileCreate (11) like the Linux sensor; the action code stays 65.
-            FileAction::Modify => (SensorAction::Modify, EVENT_ID_FILE_CREATE, 65),
-        }
+        let action = match self {
+            FileAction::Create => SensorAction::Create,
+            FileAction::Delete => SensorAction::Delete,
+            FileAction::Rename => SensorAction::Rename,
+            FileAction::Modify => SensorAction::Modify,
+        };
+        let normalization = SensorNormalization::for_file_action(action)
+            .expect("file actions are covered by the shared file normalization table");
+        (action, normalization.event_id, normalization.action_code)
     }
 }
 
@@ -590,6 +588,13 @@ fn try_send(tx: &Sender<SensorEvent>, event: SensorEvent) {
 mod tests {
     use super::*;
 
+    /// The expected numbering for `action`, read from the shared table rather
+    /// than from a macOS-local constant — asserting against a sensor's own
+    /// constant is what let the platforms drift apart in the first place.
+    fn shared(action: SensorAction) -> SensorNormalization {
+        SensorNormalization::for_file_action(action).expect("file action is in the shared table")
+    }
+
     #[test]
     fn not_permitted_hint_points_at_full_disk_access() {
         let msg = new_client_error_hint(&NewClientError::NotPermitted);
@@ -664,7 +669,7 @@ mod tests {
         let event = file_event(raw_file(FileAction::Create, "/tmp/new.txt", None))
             .expect("create event should build");
         assert_eq!(event.action, SensorAction::Create);
-        assert_eq!(event.normalization.event_id, EVENT_ID_FILE_CREATE);
+        assert_eq!(event.normalization, shared(SensorAction::Create));
         assert_eq!(event.pid, Some(55));
         assert!(event.process_start_key.is_none());
 
@@ -684,7 +689,7 @@ mod tests {
         let event = file_event(raw_file(FileAction::Delete, "/tmp/old.txt", None))
             .expect("delete event should build");
         assert_eq!(event.action, SensorAction::Delete);
-        assert_eq!(event.normalization.event_id, EVENT_ID_FILE_DELETE);
+        assert_eq!(event.normalization, shared(SensorAction::Delete));
     }
 
     #[test]
@@ -696,7 +701,7 @@ mod tests {
         ))
         .expect("rename event should build");
         assert_eq!(event.action, SensorAction::Rename);
-        assert_eq!(event.normalization.event_id, EVENT_ID_FILE_RENAME);
+        assert_eq!(event.normalization, shared(SensorAction::Rename));
 
         match event.payload {
             SensorPayload::File(fields) => {
@@ -712,9 +717,10 @@ mod tests {
         let event = file_event(raw_file(FileAction::Modify, "/tmp/changed.txt", None))
             .expect("modify event should build");
         assert_eq!(event.action, SensorAction::Modify);
-        // Matches the Linux sensor: modify reports under FileCreate (11).
-        assert_eq!(event.normalization.event_id, EVENT_ID_FILE_CREATE);
-        assert_eq!(event.normalization.event_id, 11);
+        // Modify must not report under FileCreate (11): that would route macOS
+        // writes into `file_create` instead of `file_change` (issue #239).
+        assert_eq!(event.normalization, shared(SensorAction::Modify));
+        assert_eq!(event.normalization.event_id, 65);
     }
 
     #[test]

--- a/src/sensor/mod.rs
+++ b/src/sensor/mod.rs
@@ -122,6 +122,71 @@ pub struct SensorNormalization {
     pub action_code: u8,
 }
 
+/// The single numbering table for file events, shared by every platform sensor.
+///
+/// `Engine::sigma_file_categories_for_event` matches on `event_id` first and
+/// only falls back to `action_code`, so a sensor that picks its own `event_id`
+/// silently changes which Sigma category its events are evaluated against. The
+/// sensors previously each carried their own copy of this mapping and had
+/// drifted apart on `Modify`; routing all of them through this table is what
+/// keeps the same logical action in the same category on every platform.
+///
+/// The identifiers are Sysmon-compatible where Sysmon has an equivalent event
+/// (11 = FileCreate, 23 = FileDelete). Sysmon has no file-modify or file-rename
+/// event, so those reuse the action code as the `event_id`.
+pub const FILE_EVENT_NORMALIZATION: &[(SensorAction, SensorNormalization)] = &[
+    (
+        SensorAction::Create,
+        SensorNormalization {
+            event_id: 11,
+            action_code: 64,
+        },
+    ),
+    (
+        SensorAction::Modify,
+        SensorNormalization {
+            event_id: 65,
+            action_code: 65,
+        },
+    ),
+    (
+        SensorAction::Delete,
+        SensorNormalization {
+            event_id: 23,
+            action_code: 70,
+        },
+    ),
+    (
+        SensorAction::Rename,
+        SensorNormalization {
+            event_id: 71,
+            action_code: 71,
+        },
+    ),
+];
+
+impl SensorNormalization {
+    /// Return the shared file-event numbering for `action`.
+    ///
+    /// `None` for actions that are not file actions, which lets a caller drop
+    /// the event rather than invent a number for it.
+    pub fn for_file_action(action: SensorAction) -> Option<Self> {
+        FILE_EVENT_NORMALIZATION
+            .iter()
+            .find(|(candidate, _)| *candidate == action)
+            .map(|(_, normalization)| *normalization)
+    }
+
+    /// Reverse lookup of [`Self::for_file_action`], for sensors that recover
+    /// the action from an already-computed action code.
+    pub fn for_file_action_code(action_code: u8) -> Option<Self> {
+        FILE_EVENT_NORMALIZATION
+            .iter()
+            .find(|(_, normalization)| normalization.action_code == action_code)
+            .map(|(_, normalization)| *normalization)
+    }
+}
+
 /// Shared event router that dispatches decoded sensor events to downstream handlers.
 pub struct SensorEventRouter {
     handlers: Vec<Box<dyn SensorEventHandler>>,

--- a/src/sensor/windows/mapper.rs
+++ b/src/sensor/windows/mapper.rs
@@ -56,16 +56,12 @@ fn action_code_for_record(
 }
 
 /// Maps a routed file action to the platform-shared action code scheme
-/// (64 = create, 65 = modify, 70 = delete, 71 = rename) used by the Linux
-/// and macOS sensors as well.
+/// (64 = create, 65 = modify, 70 = delete, 71 = rename), read from the same
+/// [`crate::sensor::FILE_EVENT_NORMALIZATION`] table the Linux and macOS
+/// sensors use.
 fn file_action_code(action: SensorAction) -> u8 {
-    match action {
-        SensorAction::Create => 64,
-        SensorAction::Delete => 70,
-        SensorAction::Rename => 71,
-        SensorAction::Modify => 65,
-        _ => 0,
-    }
+    SensorNormalization::for_file_action(action)
+        .map_or(0, |normalization| normalization.action_code)
 }
 
 fn raw_event_id_for_record(category: EventCategory, action_code: u8, record: &EventRecord) -> u16 {
@@ -95,10 +91,13 @@ pub fn map_to_sysmon_id(category: EventCategory, action_code: u8, raw_event_id: 
             10 => 7,
             _ => raw_event_id,
         },
+        // 72 has no entry in the shared table: no sensor emits it, but it is
+        // accepted here as an alias for delete because the engine's opcode
+        // fallback treats it as one.
         EventCategory::File => match action_code {
-            64 => 11,
-            70 | 72 => 23,
-            _ => raw_event_id,
+            72 => 23,
+            code => SensorNormalization::for_file_action_code(code)
+                .map_or(raw_event_id, |normalization| normalization.event_id),
         },
         EventCategory::Registry => match action_code {
             36 | 38 | 41 => 12,
@@ -121,7 +120,7 @@ pub fn map_to_sysmon_id(category: EventCategory, action_code: u8, raw_event_id: 
 mod tests {
     use super::{file_action_code, map_to_sysmon_id};
     use crate::models::EventCategory;
-    use crate::sensor::SensorAction;
+    use crate::sensor::{SensorAction, FILE_EVENT_NORMALIZATION};
 
     #[test]
     fn process_start_maps_to_sysmon_1() {
@@ -135,10 +134,15 @@ mod tests {
 
     #[test]
     fn file_actions_map_to_shared_action_codes() {
-        assert_eq!(file_action_code(SensorAction::Create), 64);
-        assert_eq!(file_action_code(SensorAction::Modify), 65);
-        assert_eq!(file_action_code(SensorAction::Delete), 70);
-        assert_eq!(file_action_code(SensorAction::Rename), 71);
+        for (action, expected) in FILE_EVENT_NORMALIZATION {
+            let code = file_action_code(*action);
+            assert_eq!(code, expected.action_code, "action code for {action:?}");
+            assert_eq!(
+                map_to_sysmon_id(EventCategory::File, code, u16::from(code)),
+                expected.event_id,
+                "event id for {action:?}"
+            );
+        }
     }
 
     #[test]
@@ -173,9 +177,9 @@ mod tests {
     fn file_modify_does_not_map_to_sysmon_11() {
         let code = file_action_code(SensorAction::Modify);
         assert_eq!(code, 65);
-        // Modify must NOT map to Sysmon ID 11 (FileCreate); it should
-        // fall through to its raw_event_id (65) which routes to
-        // file_change in the detection engine.
+        // Modify must NOT map to Sysmon ID 11 (FileCreate); the shared table
+        // gives it event ID 65, which routes to file_change in the detection
+        // engine. Reporting it under 11 is the macOS bug from issue #239.
         assert_eq!(
             map_to_sysmon_id(EventCategory::File, code, u16::from(code)),
             65

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -171,8 +171,6 @@ pub fn file_create_event(platform: Platform) -> SensorEvent {
     file_event(
         platform,
         SensorAction::Create,
-        11,
-        64,
         None,
         Some(test_file_path(platform)),
     )
@@ -182,8 +180,15 @@ pub fn file_delete_event(platform: Platform) -> SensorEvent {
     file_event(
         platform,
         SensorAction::Delete,
-        23,
-        70,
+        None,
+        Some(test_file_path(platform)),
+    )
+}
+
+pub fn file_modify_event(platform: Platform) -> SensorEvent {
+    file_event(
+        platform,
+        SensorAction::Modify,
         None,
         Some(test_file_path(platform)),
     )
@@ -193,8 +198,6 @@ pub fn file_rename_event(platform: Platform) -> SensorEvent {
     file_event(
         platform,
         SensorAction::Rename,
-        71,
-        71,
         Some(test_file_path(platform)),
         Some(renamed_test_file_path(platform)),
     )
@@ -223,11 +226,11 @@ pub fn dns_query_event(platform: Platform) -> SensorEvent {
     }
 }
 
-fn file_event(
+/// Build a file event whose numbering comes from the shared sensor table, so
+/// fixtures cannot encode a mapping that no sensor actually emits.
+pub fn file_event(
     platform: Platform,
     action: SensorAction,
-    event_id: u16,
-    action_code: u8,
     source_filename: Option<&str>,
     target_filename: Option<&str>,
 ) -> SensorEvent {
@@ -235,10 +238,8 @@ fn file_event(
         platform,
         provider: provider_for(platform),
         action,
-        normalization: SensorNormalization {
-            event_id,
-            action_code,
-        },
+        normalization: SensorNormalization::for_file_action(action)
+            .expect("file action is in the shared table"),
         pid: Some(TEST_PID),
         timestamp: test_time(),
         process_start_key: None,

--- a/tests/platform_mapping.rs
+++ b/tests/platform_mapping.rs
@@ -2,9 +2,14 @@
 mod common;
 
 use common::{
-    dns_query_event, file_create_event, network_connect_event, process_start_event, TestNormalizer,
+    dns_query_event, file_create_event, file_event, network_connect_event, process_start_event,
+    test_file_path, TestNormalizer,
 };
-use rustinel::{engine::Engine, models::EventFields, sensor::Platform};
+use rustinel::{
+    engine::Engine,
+    models::EventFields,
+    sensor::{Platform, SensorAction, SensorNormalization, FILE_EVENT_NORMALIZATION},
+};
 
 #[cfg(target_os = "linux")]
 fn write_cstr<const N: usize>(dst: &mut [u8; N], value: &str) {
@@ -163,6 +168,112 @@ fn equivalent_windows_and_linux_events_normalize_to_shared_sigma_fields() {
                 assert_eq!(w.record_type, l.record_type);
             }
             _ => panic!("event shape mismatch"),
+        }
+    }
+}
+
+/// Every Sigma file category the engine can route an event into.
+const ALL_FILE_CATEGORIES: &[&str] = &[
+    "file_event",
+    "file_create",
+    "file_change",
+    "file_delete",
+    "file_rename",
+];
+
+/// The single table for the file action to Sigma category mapping.
+///
+/// Sensors used to carry a private copy of the numbering behind this and had
+/// drifted apart on `Modify` (issue #239): macOS reported it under FileCreate
+/// (11), so macOS writes were evaluated against `file_create` rules while the
+/// same operation on Linux matched `file_change`. Asserting the mapping here,
+/// for every platform from one table, is what stops that recurring.
+const FILE_ACTION_CATEGORIES: &[(SensorAction, &[&str])] = &[
+    (SensorAction::Create, &["file_event", "file_create"]),
+    (SensorAction::Modify, &["file_event", "file_change"]),
+    (SensorAction::Delete, &["file_delete"]),
+    (SensorAction::Rename, &["file_event", "file_rename"]),
+];
+
+/// An engine holding exactly one rule, in `category`, that matches any file
+/// event carrying a `.txt` target. Membership in `category` is then simply
+/// whether the rule fires.
+fn engine_for_category(fixture: &common::SigmaFixture, category: &str) -> Engine {
+    fixture.write_rule(
+        "category-probe.yml",
+        &format!(
+            r#"title: File Category Probe
+logsource:
+  category: {category}
+detection:
+  selection:
+    TargetFilename|endswith: ".txt"
+  condition: selection
+level: medium
+"#
+        ),
+    );
+
+    let mut engine = Engine::new_for_platform(Platform::Linux);
+    engine
+        .load_rules(fixture.rules_dir())
+        .expect("load category probe rule");
+    engine
+}
+
+#[test]
+fn file_actions_carry_the_shared_normalization_on_every_platform() {
+    for platform in [Platform::Windows, Platform::Linux, Platform::MacOS] {
+        for (action, expected) in FILE_EVENT_NORMALIZATION {
+            let event = file_event(platform, *action, None, Some(test_file_path(platform)));
+            assert_eq!(
+                event.normalization, *expected,
+                "{action:?} normalization on {platform:?}"
+            );
+        }
+    }
+}
+
+#[test]
+fn same_file_action_yields_same_sigma_categories_on_every_platform() {
+    // The category table and the sensor numbering table must cover the same
+    // actions, or an action could gain a normalization without ever having its
+    // category pinned down.
+    assert_eq!(
+        FILE_ACTION_CATEGORIES.len(),
+        FILE_EVENT_NORMALIZATION.len(),
+        "every normalized file action needs a category expectation"
+    );
+
+    for (action, expected_categories) in FILE_ACTION_CATEGORIES {
+        assert!(
+            SensorNormalization::for_file_action(*action).is_some(),
+            "{action:?} has a category expectation but no shared normalization"
+        );
+
+        for category in ALL_FILE_CATEGORIES {
+            let should_match = expected_categories.contains(category);
+
+            for platform in [Platform::Windows, Platform::Linux, Platform::MacOS] {
+                let fixture = common::SigmaFixture::new();
+                let engine = engine_for_category(&fixture, category);
+                let normalized = TestNormalizer::new(false)
+                    .normalizer
+                    .normalize(&file_event(
+                        platform,
+                        *action,
+                        None,
+                        Some(test_file_path(platform)),
+                    ))
+                    .expect("file event normalizes");
+
+                assert_eq!(
+                    engine.check_event(&normalized).is_some(),
+                    should_match,
+                    "{action:?} on {platform:?} should {} match `{category}`",
+                    if should_match { "" } else { "not" },
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
Closes #239.

## Problem

`Engine::sigma_file_categories_for_event` matches on `event_id` first and only falls through to `opcode`, so the `action_code == 65` arm that yields `file_change` was unreachable whenever `event_id` was 11.

Every sensor already agreed that a file modification is `action_code` 65. It was the `event_id` that had drifted:

| Sensor | Modify `event_id` | Resulting categories |
|---|---|---|
| Linux eBPF | 65 | `file_event`, `file_change` |
| Linux `events.rs` | 11 | `file_event`, `file_create` |
| macOS ESF | 11 | `file_event`, `file_create` |
| Windows ETW | 65 (since #236) | `file_event`, `file_change` |

So a macOS file modification was evaluated against `file_create` rules, and a `file_change` rule that fired on Linux did not fire on macOS for the same underlying operation.

## Change

Add `FILE_EVENT_NORMALIZATION` in `src/sensor/mod.rs` as the single table for the file action to `(event_id, action_code)` mapping, and route all four call sites through it. macOS `Modify` now carries `event_id` 65.

Windows was already correct after #236 but restated the mapping locally; it now derives from the same table.

## Tests

The issue notes this was invisible because each sensor's tests asserted against its own constant. Those assertions now read from the shared table, and `tests/platform_mapping.rs` pins the full action to category mapping for all three platforms from one place.

Confirmed the new test is not vacuous: reverting `Modify` to `event_id` 11 in the table fails it with `Modify on Windows should not match file_create`.

## Verification

Full suite and `clippy --all-targets -- -D clippy::all` green on all three platforms — macOS locally, Linux and Windows on lab VMs.

## Note on sequencing

The issue suggests this should follow #238. I think that reads the dependency backwards: converging the mapping into one const is what makes #238's revision a one-line edit instead of a four-site change. #238 is stacked on this branch and does exactly that.

This PR deliberately does not redefine what `file_change` means — that decision belongs to #238.