### PR TITLE
fix(windows-file): resolve FileObject paths and settle file_change semantics

### DIFF
--- a/docs/detection.md
+++ b/docs/detection.md
@@ -110,7 +110,7 @@ rule instead of one is tracked separately by
 | `file_event` | Yes | Yes | Yes | Base file family |
 | `file_create` | Yes | Yes | Yes | Derived from file event ID / opcode (ESF event type on macOS) |
 | `file_delete` | Yes | Yes | Yes | Derived from file event ID / opcode (ESF event type on macOS) |
-| `file_change` | Yes | Yes | Yes | Derived from file event ID / opcode. On Windows the events routed here are Kernel-File name-cache entries and writes that arrive without a path, rather than content changes, so a rule keyed on `TargetFilename` still cannot match there ([#238](https://github.com/Karib0u/rustinel/issues/238)) |
+| `file_change` | Yes | No | No | Timestamp or attribute changes only — see [File Event Numbering](#file-event-numbering). Not populated on Linux or macOS, whose sensors do not yet report metadata changes ([#146](https://github.com/Karib0u/rustinel/issues/146)) |
 | `file_rename` | Yes | Yes | Yes | Derived from file event ID / opcode (ESF event type on macOS) |
 | `dns_query` | Yes | Yes | Yes | Generic `category: dns` and `service: dns`, `category: network` are also supported |
 | `registry_event` / `registry_*` | Yes | No | No | Windows only |
@@ -128,22 +128,34 @@ Every sensor routes its native file telemetry through one shared table, so the
 same logical action carries the same identifiers — and therefore lands in the
 same categories — on all three platforms:
 
-| Action | `event_id` | `action_code` | Categories |
-| --- | --- | --- | --- |
-| Create | 11 | 64 | `file_event`, `file_create` |
-| Modify | 65 | 65 | `file_event`, `file_change` |
-| Delete | 23 | 70 | `file_delete` |
-| Rename | 71 | 71 | `file_event`, `file_rename` |
+| Action | Meaning | `event_id` | `action_code` | Categories |
+| --- | --- | --- | --- | --- |
+| Create | File created | 11 | 64 | `file_event`, `file_create` |
+| Set | Timestamps or attributes changed | 2 | 2 | `file_event`, `file_change` |
+| Modify | Content written or truncated | 65 | 65 | `file_event` |
+| Delete | File deleted | 23 | 70 | `file_delete` |
+| Rename | File renamed or hard-linked | 71 | 71 | `file_event`, `file_rename` |
 
 The identifiers are Sysmon-compatible where Sysmon has an equivalent event
-(11 = FileCreate, 23 = FileDelete). Sysmon has no file-modify or file-rename
-event, so those reuse the action code as the `event_id`. A delete is
-deliberately not a member of `file_event`.
+(2 = FileCreateTime, 11 = FileCreate, 23 = FileDelete). Sysmon has no
+file-modify or file-rename event, so those reuse the action code as the
+`event_id`. A delete is deliberately not a member of `file_event`.
 
-Note that `file_change` here means "the file was modified", which is broader
-than Sysmon Event ID 2 (file creation time changed). Whether generic writes
-belong in this category, or whether it should be narrowed to timestomping, is
-still open in [#238](https://github.com/Karib0u/rustinel/issues/238).
+**`file_change` means timestomping, not "was written".** The category
+corresponds to Sysmon Event ID 2, *file creation time changed*. Rules published
+in it are written against timestamp manipulation, so routing ordinary writes
+there would make any rule that keys only on `TargetFilename` — which is most of
+them — fire on routine file activity. Writes are reported under the base
+`file_event` family instead.
+
+On Windows this is derived from Kernel-File `SetInformation` (event ID 17): an
+information class of `FileBasicInformation` is reported as `Set`, while
+`FileAllocationInformation` and `FileEndOfFileInformation` are truncation and
+are reported as `Modify`. One caveat for rule authors: the provider reports
+*which* information class was set but never the values written, so
+`CreationUtcTime` and `PreviousCreationUtcTime` stay empty. A `file_change`
+rule that matches on those fields will not fire; one that matches on
+`TargetFilename` and `Image` will.
 
 ### Field Model
 

--- a/docs/detection.md
+++ b/docs/detection.md
@@ -157,6 +157,17 @@ are reported as `Modify`. One caveat for rule authors: the provider reports
 rule that matches on those fields will not fire; one that matches on
 `TargetFilename` and `Image` will.
 
+**File events that cannot be resolved to a path are dropped.** Kernel-File
+identifies the target of a write or a metadata change by kernel pointer rather
+than by name, so the path is recovered from the earlier event that named the
+handle. When that lookup misses — most often because the handle was already open
+before the sensor started — the event is dropped rather than emitted without a
+`TargetFilename`, since a file event with no path cannot match a rule. This is a
+bounded, deliberate drop of a low-value event class, and it is counted: the
+running total is logged as `unresolved_file_events`, so the size of the gap is
+observable even though the events are not. See
+[Limitations](limitations.md#windows-etw).
+
 ### Field Model
 
 - Sigma evaluates the shared `NormalizedEvent` model with Sysmon-style field names.

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -55,6 +55,15 @@ are unavailable.
 - **No injection or driver-load visibility.** No equivalent of CreateRemoteThread,
   ProcessAccess, named-pipe, or driver-load providers - injection-based TTPs leave
   little telemetry.
+- **Writes through handles opened before startup are invisible (silent risk).**
+  Kernel-File reports writes by kernel pointer, not by path, so the sensor learns
+  each handle's path from the `Create` that opened it. A handle already open when
+  the sensor starts was never seen being named, so writes through it cannot be
+  attributed and are dropped rather than reported without a path. Long-lived
+  holders - database files, service logs - stay unobserved until the handle is
+  closed and reopened, which for some services means until the next reboot.
+  The count is logged as `unresolved_file_events`, so the size of the gap is
+  visible even though the events themselves are not.
 
 ## Linux (eBPF)
 

--- a/src/engine/alert.rs
+++ b/src/engine/alert.rs
@@ -619,15 +619,28 @@ impl Engine {
         subsets
     }
 
+    /// Map a file event to its Sigma logsource categories.
+    ///
+    /// `file_change` corresponds to Sysmon Event ID 2, *file creation time
+    /// changed* — timestomping — not "the file was written". Rules in that
+    /// category are written against timestamp manipulation, so routing plain
+    /// writes there makes any rule that keys only on `TargetFilename` fire on
+    /// ordinary file activity. Writes are therefore reported under the base
+    /// `file_event` family only.
+    ///
+    /// The numbering comes from `sensor::FILE_EVENT_NORMALIZATION`, which is
+    /// the single table every platform sensor maps its file actions through.
     pub(crate) fn sigma_file_categories_for_event(event: &NormalizedEvent) -> Vec<&'static str> {
         match event.event_id {
+            2 => vec!["file_event", "file_change"],
             11 => vec!["file_event", "file_create"],
             23 => vec!["file_delete"],
-            65 => vec!["file_event", "file_change"],
+            65 => vec!["file_event"],
             71 => vec!["file_event", "file_rename"],
             _ => match event.opcode {
+                2 => vec!["file_event", "file_change"],
                 64 => vec!["file_event", "file_create"],
-                65 | 80 => vec!["file_event", "file_change"],
+                65 | 80 => vec!["file_event"],
                 70 | 72 => vec!["file_delete"],
                 71 => vec!["file_event", "file_rename"],
                 _ => vec!["file_event"],

--- a/src/sensor/mod.rs
+++ b/src/sensor/mod.rs
@@ -132,14 +132,26 @@ pub struct SensorNormalization {
 /// keeps the same logical action in the same category on every platform.
 ///
 /// The identifiers are Sysmon-compatible where Sysmon has an equivalent event
-/// (11 = FileCreate, 23 = FileDelete). Sysmon has no file-modify or file-rename
-/// event, so those reuse the action code as the `event_id`.
+/// (2 = FileCreateTime, 11 = FileCreate, 23 = FileDelete). Sysmon has no
+/// file-modify or file-rename event, so those reuse the action code as the
+/// `event_id`.
+///
+/// [`SensorAction::Set`] means the file's metadata was set — its timestamps or
+/// attributes — which is what Sigma's `file_change` category denotes. A plain
+/// write is [`SensorAction::Modify`] and is deliberately *not* `file_change`.
 pub const FILE_EVENT_NORMALIZATION: &[(SensorAction, SensorNormalization)] = &[
     (
         SensorAction::Create,
         SensorNormalization {
             event_id: 11,
             action_code: 64,
+        },
+    ),
+    (
+        SensorAction::Set,
+        SensorNormalization {
+            event_id: 2,
+            action_code: 2,
         },
     ),
     (

--- a/src/sensor/windows/etw.rs
+++ b/src/sensor/windows/etw.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::net::IpAddr;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::Result;
@@ -24,6 +24,7 @@ use crate::sensor::network_events::{
 use crate::sensor::{Platform, ProcessStartKey, Sensor, SensorAction, SensorEvent, SensorPayload};
 use crate::utils::{convert_nt_to_dos, parse_metadata, query_process_command_line};
 
+use super::file_paths::FilePathCache;
 use super::{field_maps, mapper};
 
 /// Fixed trace session name for stopping the trace on shutdown.
@@ -53,11 +54,19 @@ impl EtwProviders {
 
     // Keyword names follow the Microsoft-Windows-Kernel-File manifest.
     const KERNEL_FILE_KEYWORD_FILENAME: u64 = 0x0010;
+    /// Enables Cleanup (13), Close (14), Read (15), SetInformation (17), and
+    /// the query paths. Needed for two things that are otherwise impossible:
+    /// `Close`, which is when a `FileObject` may be released from the path
+    /// index, and `SetInformation`, which is the only report of truncation or
+    /// of a creation-time change. It also turns on high-volume read and query
+    /// events, so [`kernel_file_route`] drops those before the schema lookup.
+    const KERNEL_FILE_KEYWORD_FILEIO: u64 = 0x0020;
     const KERNEL_FILE_KEYWORD_CREATE: u64 = 0x0080;
     const KERNEL_FILE_KEYWORD_WRITE: u64 = 0x0200;
     const KERNEL_FILE_KEYWORD_DELETE_PATH: u64 = 0x0400;
     const KERNEL_FILE_KEYWORD_RENAME_SETLINK_PATH: u64 = 0x0800;
     const FILE_KEYWORDS: u64 = Self::KERNEL_FILE_KEYWORD_FILENAME
+        | Self::KERNEL_FILE_KEYWORD_FILEIO
         | Self::KERNEL_FILE_KEYWORD_CREATE
         | Self::KERNEL_FILE_KEYWORD_WRITE
         | Self::KERNEL_FILE_KEYWORD_DELETE_PATH
@@ -170,19 +179,92 @@ impl EtwProviders {
 }
 
 /// Microsoft-Windows-Kernel-File manifest event IDs.
+const KERNEL_FILE_EVENT_NAME_CREATE: u16 = 10;
+const KERNEL_FILE_EVENT_NAME_DELETE: u16 = 11;
 const KERNEL_FILE_EVENT_CREATE: u16 = 12;
+const KERNEL_FILE_EVENT_CLOSE: u16 = 14;
+const KERNEL_FILE_EVENT_WRITE: u16 = 16;
+const KERNEL_FILE_EVENT_SET_INFORMATION: u16 = 17;
 const KERNEL_FILE_EVENT_DELETE_PATH: u16 = 26;
 const KERNEL_FILE_EVENT_RENAME_PATH: u16 = 27;
 const KERNEL_FILE_EVENT_SET_LINK_PATH: u16 = 28;
 
+/// `FILE_INFORMATION_CLASS` values seen on `SetInformation` (event ID 17).
+///
+/// The event reports only which class was set, never the values written, so
+/// these tell us *that* a timestamp or a file size changed but not to what.
+const FILE_BASIC_INFORMATION: u64 = 4;
+const FILE_ALLOCATION_INFORMATION: u64 = 19;
+const FILE_END_OF_FILE_INFORMATION: u64 = 20;
+
+/// What a Microsoft-Windows-Kernel-File event is good for.
+///
+/// Previously every unrecognised event ID fell into a `_ => Modify` catch-all,
+/// which quietly turned the provider's name-cache bookkeeping into telemetry:
+/// one `CreateNew` produced a create *and* a spurious change event. Routing is
+/// now an allowlist, so an event nobody has looked at is dropped rather than
+/// labelled a modification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum KernelFileRoute {
+    /// Emit telemetry under this action.
+    Emit(SensorAction),
+    /// Carries a name; record it and emit nothing. These are the index the
+    /// provider publishes so consumers can resolve the pathless events.
+    Index,
+    /// A closed handle: drop its `FileObject` from the index.
+    EvictObject,
+    /// A name leaving the kernel's name cache: drop its `FileKey`.
+    EvictKey,
+    /// Action depends on the `InfoClass`, which needs the parsed event.
+    SetInformation,
+}
+
 /// The manifest provider emits file events with opcode 0, so routing must use
 /// manifest event IDs rather than MOF FileIo opcodes.
-fn kernel_file_action(event_id: u16) -> SensorAction {
+///
+/// `None` means "not interesting" — checked before the schema lookup, so the
+/// high-volume `Read` (15), `QueryInformation` (22), and `FSCTL` (23) events
+/// that the `FILEIO` keyword also enables cost only a match on an integer.
+fn kernel_file_route(event_id: u16) -> Option<KernelFileRoute> {
     match event_id {
-        KERNEL_FILE_EVENT_CREATE => SensorAction::Create,
-        KERNEL_FILE_EVENT_DELETE_PATH => SensorAction::Delete,
-        KERNEL_FILE_EVENT_RENAME_PATH => SensorAction::Rename,
-        _ => SensorAction::Modify,
+        KERNEL_FILE_EVENT_CREATE => Some(KernelFileRoute::Emit(SensorAction::Create)),
+        KERNEL_FILE_EVENT_WRITE => Some(KernelFileRoute::Emit(SensorAction::Modify)),
+        KERNEL_FILE_EVENT_DELETE_PATH => Some(KernelFileRoute::Emit(SensorAction::Delete)),
+        KERNEL_FILE_EVENT_RENAME_PATH | KERNEL_FILE_EVENT_SET_LINK_PATH => {
+            Some(KernelFileRoute::Emit(SensorAction::Rename))
+        }
+        KERNEL_FILE_EVENT_SET_INFORMATION => Some(KernelFileRoute::SetInformation),
+        KERNEL_FILE_EVENT_NAME_CREATE => Some(KernelFileRoute::Index),
+        KERNEL_FILE_EVENT_NAME_DELETE => Some(KernelFileRoute::EvictKey),
+        KERNEL_FILE_EVENT_CLOSE => Some(KernelFileRoute::EvictObject),
+        // Deliberately unrouted, with the reason recorded so a future reader
+        // does not have to re-derive it:
+        //   13 Cleanup     — precedes Close; Close is the eviction point
+        //   15 Read        — not a modification
+        //   18 SetDelete   — duplicate of 26 DeletePath, which carries the path
+        //   19 Rename      — duplicate of 27 RenamePath, which carries the path
+        //   22/23/32/34    — query and control paths, no state change
+        _ => None,
+    }
+}
+
+/// Resolve `SetInformation` (event ID 17) to an action via its `InfoClass`.
+///
+/// This is the event that makes truncation and timestamp manipulation visible
+/// at all; both were previously uncollected because the keyword was not
+/// enabled. Returns `None` for the many other information classes, which are
+/// ordinary metadata updates.
+fn set_information_action(parser: &Parser) -> Option<SensorAction> {
+    match try_get_uint_as_u64(parser, "InfoClass")? {
+        // Timestamps and attributes. This is the closest analogue to Sysmon
+        // Event ID 2 (file creation time changed), i.e. timestomping, which is
+        // what Sigma's `file_change` category actually denotes.
+        FILE_BASIC_INFORMATION => Some(SensorAction::Set),
+        // Setting the allocation size or end-of-file position: truncation.
+        // Truncate-to-zero of an existing file is a common wiper and
+        // ransomware pattern and produced no event at all before this.
+        FILE_ALLOCATION_INFORMATION | FILE_END_OF_FILE_INFORMATION => Some(SensorAction::Modify),
+        _ => None,
     }
 }
 
@@ -237,19 +319,27 @@ fn refine_file_create_action(parser: &Parser, action: SensorAction) -> Option<Se
     }
 }
 
-/// DeletePath, RenamePath, and SetLinkPath carry their path in `FilePath`;
-/// the remaining file events use `FileName`.
-fn kernel_file_path_property(event_id: u16) -> &'static str {
-    match event_id {
-        KERNEL_FILE_EVENT_DELETE_PATH
-        | KERNEL_FILE_EVENT_RENAME_PATH
-        | KERNEL_FILE_EVENT_SET_LINK_PATH => "FilePath",
-        _ => "FileName",
+/// Shared state the ETW callback carries across events.
+///
+/// The path index has to outlive a single event: the naming event and the
+/// write it explains are different records, often seconds apart.
+struct EtwState {
+    routing: EtwRouting,
+    file_paths: Mutex<FilePathCache>,
+}
+
+impl EtwState {
+    fn new() -> Self {
+        Self {
+            routing: EtwRouting::new(),
+            file_paths: Mutex::new(FilePathCache::new()),
+        }
     }
 }
 
 struct EtwRouting {
     kernel_process_guid: GUID,
+    kernel_file_guid: GUID,
     guid_to_category: HashMap<GUID, EventCategory>,
 }
 
@@ -273,6 +363,7 @@ impl EtwRouting {
 
         Self {
             kernel_process_guid: EtwProviders::kernel_process().guid,
+            kernel_file_guid: EtwProviders::kernel_file().guid,
             guid_to_category,
         }
     }
@@ -294,7 +385,9 @@ impl EtwRouting {
             EventCategory::Network => {
                 classify_kernel_network_event(record.event_id())?.connection_action()?
             }
-            EventCategory::File => kernel_file_action(record.event_id()),
+            // Kernel-File needs the path index and so has its own pipeline;
+            // `decode_record` diverts it before reaching here.
+            EventCategory::File => return None,
             EventCategory::Registry => match record.opcode() {
                 36 => SensorAction::Create,
                 38 | 41 => SensorAction::Delete,
@@ -351,7 +444,7 @@ impl Sensor for EtwSensor {
         let _ = stop_trace_by_name(TRACE_SESSION_NAME);
 
         let mut trace_builder = UserTrace::new().named(TRACE_SESSION_NAME.to_string());
-        let routing = Arc::new(EtwRouting::new());
+        let state = Arc::new(EtwState::new());
         let dropped_events = Arc::clone(&self.dropped_events);
 
         for provider_def in EtwProviders::all() {
@@ -360,14 +453,14 @@ impl Sensor for EtwSensor {
                 provider_def.name, provider_def.guid, provider_def.keywords
             );
 
-            let routing = Arc::clone(&routing);
+            let state = Arc::clone(&state);
             let tx = tx.clone();
             let dropped_events = Arc::clone(&dropped_events);
             let provider = Provider::by_guid(provider_def.guid)
                 .level(4)
                 .any(provider_def.keywords)
                 .add_callback(move |record, schema_locator| {
-                    let Some(event) = decode_record(record, schema_locator, &routing) else {
+                    let Some(event) = decode_record(record, schema_locator, &state) else {
                         return;
                     };
 
@@ -437,9 +530,13 @@ impl Sensor for EtwSensor {
 fn decode_record(
     record: &EventRecord,
     schema_locator: &SchemaLocator,
-    routing: &EtwRouting,
+    state: &EtwState,
 ) -> Option<SensorEvent> {
-    let (category, action) = routing.route(record)?;
+    if record.provider_id() == state.routing.kernel_file_guid {
+        return decode_kernel_file_record(record, schema_locator, state);
+    }
+
+    let (category, action) = state.routing.route(record)?;
     let schema = match schema_locator.event_schema(record) {
         Ok(schema) => schema,
         Err(err) => {
@@ -454,19 +551,10 @@ fn decode_record(
     };
     let parser = Parser::create(record, &schema);
 
-    // For file events, refine the action based on the IRP_MJ_CREATE
-    // disposition so that pure opens (reads / attribute queries) are
-    // dropped rather than misclassified as file creations.
-    let action = if category == EventCategory::File {
-        refine_file_create_action(&parser, action)?
-    } else {
-        action
-    };
-
     let decoded = match category {
         EventCategory::Process => decode_process(&parser, record, action),
         EventCategory::Network => decode_network(&parser, record),
-        EventCategory::File => decode_file(&parser, record),
+        EventCategory::File => unreachable!("kernel-file records are diverted above"),
         EventCategory::Registry => decode_registry(&parser, record),
         EventCategory::Dns => decode_dns(&parser, record),
         EventCategory::ImageLoad => decode_image_load(&parser, record),
@@ -587,28 +675,120 @@ fn decode_process(
     })
 }
 
-fn decode_file(parser: &Parser, record: &EventRecord) -> Option<DecodedEtwEvent> {
+/// Decode a Microsoft-Windows-Kernel-File record, resolving its path.
+///
+/// Kernel-File is handled apart from the other providers because it is the
+/// only one whose events cannot be understood in isolation: the write events
+/// name their target by kernel pointer and rely on an index the consumer
+/// builds from earlier naming events.
+fn decode_kernel_file_record(
+    record: &EventRecord,
+    schema_locator: &SchemaLocator,
+    state: &EtwState,
+) -> Option<SensorEvent> {
+    // Checked before the schema lookup: the FILEIO keyword needed for Close
+    // and SetInformation also delivers every read and query on the machine,
+    // and decoding those would be pure overhead.
+    let route = kernel_file_route(record.event_id())?;
+
+    let schema = match schema_locator.event_schema(record) {
+        Ok(schema) => schema,
+        Err(err) => {
+            trace!(
+                "Failed to get Kernel-File schema for event {}: {:?}",
+                record.event_id(),
+                err
+            );
+            return None;
+        }
+    };
+    let parser = Parser::create(record, &schema);
+
+    let file_object = try_get_uint_as_u64(&parser, "FileObject");
+    let file_key = try_get_uint_as_u64(&parser, "FileKey");
+    // DeletePath, RenamePath, and SetLinkPath carry `FilePath`; Create and the
+    // name-cache events carry `FileName`.
+    let named_path = try_get_string_any(&parser, &["FilePath", "FileName"]);
+
+    // Any event carrying a name feeds the index, including the ones that also
+    // produce telemetry — a Create both reports a creation and teaches us the
+    // path for the writes that follow on that handle.
+    if let Some(path) = named_path.as_deref() {
+        state
+            .file_paths
+            .lock()
+            .expect("file path index mutex poisoned")
+            .learn(file_object, file_key, path);
+    }
+
+    let action = match route {
+        KernelFileRoute::Index => return None,
+        KernelFileRoute::EvictObject => {
+            if let Some(object) = file_object {
+                state
+                    .file_paths
+                    .lock()
+                    .expect("file path index mutex poisoned")
+                    .forget_object(object);
+            }
+            return None;
+        }
+        KernelFileRoute::EvictKey => {
+            if let Some(key) = file_key {
+                state
+                    .file_paths
+                    .lock()
+                    .expect("file path index mutex poisoned")
+                    .forget_key(key);
+            }
+            return None;
+        }
+        // Event ID 12 fires for every handle request, including plain opens;
+        // the disposition says whether anything was actually created.
+        KernelFileRoute::Emit(SensorAction::Create) => {
+            refine_file_create_action(&parser, SensorAction::Create)?
+        }
+        KernelFileRoute::Emit(action) => action,
+        KernelFileRoute::SetInformation => set_information_action(&parser)?,
+    };
+
+    // A file event with no path cannot match a rule — essentially every file
+    // rule keys on TargetFilename — so an unresolvable event is dropped rather
+    // than sent on to occupy space in a bounded channel.
+    let raw_path = match named_path {
+        Some(path) => path,
+        None => state
+            .file_paths
+            .lock()
+            .expect("file path index mutex poisoned")
+            .resolve(file_object, file_key)?
+            .to_string(),
+    };
+
     let mappings = field_maps::file_event_mappings();
     let fields = FileEventFields {
         source_filename: None,
-        target_filename: try_get_string_any(
-            parser,
-            &[
-                kernel_file_path_property(record.event_id()),
-                mappings.get_etw_field("TargetFilename")?,
-            ],
-        )
-        .map(|path| convert_nt_to_dos(&path)),
-        process_id: try_get_uint(parser, mappings.get_etw_field("ProcessId")?),
-        image: try_get_string(parser, mappings.get_etw_field("Image")?)
+        target_filename: Some(convert_nt_to_dos(&raw_path)),
+        process_id: try_get_uint(&parser, mappings.get_etw_field("ProcessId")?),
+        image: try_get_string(&parser, mappings.get_etw_field("Image")?)
             .map(|path| convert_nt_to_dos(&path)),
-        creation_utc_time: try_get_string(parser, mappings.get_etw_field("CreationUtcTime")?),
-        previous_creation_utc_time: try_get_string(parser, "PreviousCreationTime"),
-        user: try_get_string(parser, mappings.get_etw_field("User")?),
+        // Kernel-File reports which information class was set, never the
+        // values, so unlike Sysmon Event ID 2 these stay empty on Windows.
+        creation_utc_time: try_get_string(&parser, mappings.get_etw_field("CreationUtcTime")?),
+        previous_creation_utc_time: try_get_string(&parser, "PreviousCreationTime"),
+        user: try_get_string(&parser, mappings.get_etw_field("User")?),
     };
 
-    Some(DecodedEtwEvent {
-        pid: parse_optional_u32(fields.process_id.as_deref()).or(Some(record.process_id())),
+    let pid = parse_optional_u32(fields.process_id.as_deref()).or(Some(record.process_id()));
+    let normalization = mapper::normalization_for_record(EventCategory::File, action, record);
+
+    Some(SensorEvent {
+        platform: Platform::Windows,
+        provider: "etw",
+        action,
+        normalization,
+        pid,
+        timestamp: filetime_to_system_time(record.raw_timestamp()),
         process_start_key: None,
         payload: SensorPayload::File(fields),
     })
@@ -925,19 +1105,56 @@ mod tests {
 
     #[test]
     fn kernel_file_event_ids_route_to_actions() {
-        assert_eq!(kernel_file_action(12), SensorAction::Create);
-        assert_eq!(kernel_file_action(16), SensorAction::Modify);
-        assert_eq!(kernel_file_action(26), SensorAction::Delete);
-        assert_eq!(kernel_file_action(27), SensorAction::Rename);
+        use KernelFileRoute::Emit;
+        assert_eq!(kernel_file_route(12), Some(Emit(SensorAction::Create)));
+        assert_eq!(kernel_file_route(16), Some(Emit(SensorAction::Modify)));
+        assert_eq!(kernel_file_route(26), Some(Emit(SensorAction::Delete)));
+        assert_eq!(kernel_file_route(27), Some(Emit(SensorAction::Rename)));
+        assert_eq!(kernel_file_route(28), Some(Emit(SensorAction::Rename)));
     }
 
     #[test]
-    fn kernel_file_path_events_read_file_path() {
-        assert_eq!(kernel_file_path_property(12), "FileName");
-        assert_eq!(kernel_file_path_property(16), "FileName");
-        assert_eq!(kernel_file_path_property(26), "FilePath");
-        assert_eq!(kernel_file_path_property(27), "FilePath");
-        assert_eq!(kernel_file_path_property(28), "FilePath");
+    fn name_cache_events_are_index_maintenance_not_telemetry() {
+        // Measured on Windows 11: one CreateNew emits both a Create (12) and a
+        // NameCreate (10). Treating 10 as telemetry produced a spurious change
+        // event per file creation, and a rename produced three events.
+        assert_eq!(kernel_file_route(10), Some(KernelFileRoute::Index));
+        assert_eq!(kernel_file_route(11), Some(KernelFileRoute::EvictKey));
+        assert_eq!(kernel_file_route(14), Some(KernelFileRoute::EvictObject));
+    }
+
+    #[test]
+    fn unexamined_kernel_file_events_are_dropped_not_called_modifications() {
+        // The old `_ => Modify` catch-all labelled every one of these a file
+        // modification. 18 and 19 are the pathless duplicates of DeletePath
+        // (26) and RenamePath (27); the rest are reads and queries.
+        for event_id in [13, 15, 18, 19, 20, 21, 22, 23, 30, 32, 34, 99] {
+            assert_eq!(
+                kernel_file_route(event_id),
+                None,
+                "event {event_id} must not be routed"
+            );
+        }
+    }
+
+    #[test]
+    fn set_information_needs_its_info_class() {
+        assert_eq!(
+            kernel_file_route(17),
+            Some(KernelFileRoute::SetInformation),
+            "the action depends on InfoClass, which needs the parsed event"
+        );
+    }
+
+    #[test]
+    fn file_keywords_enable_close_and_set_information() {
+        // FILEIO is what delivers Close (14) and SetInformation (17); without
+        // it the path index can never release a handle and truncation and
+        // creation-time changes are never collected at all.
+        assert_ne!(
+            EtwProviders::FILE_KEYWORDS & EtwProviders::KERNEL_FILE_KEYWORD_FILEIO,
+            0
+        );
     }
 
     #[test]

--- a/src/sensor/windows/etw.rs
+++ b/src/sensor/windows/etw.rs
@@ -1,12 +1,12 @@
 use std::collections::HashMap;
 use std::net::IpAddr;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::Result;
 use ferrisetw::parser::Parser;
-use ferrisetw::provider::Provider;
+use ferrisetw::provider::{EventFilter, Provider};
 use ferrisetw::schema_locator::SchemaLocator;
 use ferrisetw::trace::{stop_trace_by_name, TraceTrait, UserTrace};
 use ferrisetw::{EventRecord, GUID};
@@ -178,6 +178,16 @@ impl EtwProviders {
     }
 }
 
+/// The event IDs [`kernel_file_route`] accepts, pushed down to the provider as a
+/// scope filter so the rest are never written into the session at all.
+///
+/// This does not measurably reduce sensor CPU — the unrouted events were already
+/// rejected on an integer match before the schema lookup — but it roughly halves
+/// the ETW buffer volume the kernel moves on our behalf, which is worth having
+/// for free. Kept in sync with `kernel_file_route` by
+/// `filter_matches_routing_allowlist`; a drift would silently delete detections.
+const KERNEL_FILE_ROUTED_EVENT_IDS: [u16; 9] = [10, 11, 12, 14, 16, 17, 26, 27, 28];
+
 /// Microsoft-Windows-Kernel-File manifest event IDs.
 const KERNEL_FILE_EVENT_NAME_CREATE: u16 = 10;
 const KERNEL_FILE_EVENT_NAME_DELETE: u16 = 11;
@@ -326,6 +336,13 @@ fn refine_file_create_action(parser: &Parser, action: SensorAction) -> Option<Se
 struct EtwState {
     routing: EtwRouting,
     file_paths: Mutex<FilePathCache>,
+    /// File events dropped because neither identifier resolved to a path.
+    ///
+    /// Handles opened before the sensor started were never indexed, so writes
+    /// through them cannot be attributed until the handle is reopened. Dropping
+    /// them is the right policy — a pathless event matches no rule — but without
+    /// a count there is no way to tell a quiet endpoint from a blind one.
+    unresolved_file_events: AtomicU64,
 }
 
 impl EtwState {
@@ -333,7 +350,19 @@ impl EtwState {
         Self {
             routing: EtwRouting::new(),
             file_paths: Mutex::new(FilePathCache::new()),
+            unresolved_file_events: AtomicU64::new(0),
         }
+    }
+
+    /// The path index is derived state, so a poisoned lock is recoverable and
+    /// recovering is the only safe option: this runs inside an ETW callback
+    /// invoked by the OS, and unwinding across that boundary would take the
+    /// sensor down. Losing path resolution for the life of the process because
+    /// one callback panicked is a worse failure than a stale cache entry.
+    fn paths(&self) -> MutexGuard<'_, FilePathCache> {
+        self.file_paths
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 }
 
@@ -456,7 +485,7 @@ impl Sensor for EtwSensor {
             let state = Arc::clone(&state);
             let tx = tx.clone();
             let dropped_events = Arc::clone(&dropped_events);
-            let provider = Provider::by_guid(provider_def.guid)
+            let mut provider_builder = Provider::by_guid(provider_def.guid)
                 .level(4)
                 .any(provider_def.keywords)
                 .add_callback(move |record, schema_locator| {
@@ -479,8 +508,18 @@ impl Sensor for EtwSensor {
                             trace!("Sensor event channel closed; dropping ETW event");
                         }
                     }
-                })
-                .build();
+                });
+
+            // Only Kernel-File is filtered: the FILEIO keyword it needs for
+            // Close and SetInformation also turns on every read and query on
+            // the machine, and none of those are routed.
+            if provider_def.guid == EtwProviders::kernel_file().guid {
+                provider_builder = provider_builder.add_filter(EventFilter::ByEventIds(
+                    KERNEL_FILE_ROUTED_EVENT_IDS.to_vec(),
+                ));
+            }
+
+            let provider = provider_builder.build();
 
             trace_builder = trace_builder.enable(provider);
         }
@@ -714,32 +753,20 @@ fn decode_kernel_file_record(
     // produce telemetry — a Create both reports a creation and teaches us the
     // path for the writes that follow on that handle.
     if let Some(path) = named_path.as_deref() {
-        state
-            .file_paths
-            .lock()
-            .expect("file path index mutex poisoned")
-            .learn(file_object, file_key, path);
+        state.paths().learn(file_object, file_key, path);
     }
 
     let action = match route {
         KernelFileRoute::Index => return None,
         KernelFileRoute::EvictObject => {
             if let Some(object) = file_object {
-                state
-                    .file_paths
-                    .lock()
-                    .expect("file path index mutex poisoned")
-                    .forget_object(object);
+                state.paths().forget_object(object);
             }
             return None;
         }
         KernelFileRoute::EvictKey => {
             if let Some(key) = file_key {
-                state
-                    .file_paths
-                    .lock()
-                    .expect("file path index mutex poisoned")
-                    .forget_key(key);
+                state.paths().forget_key(key);
             }
             return None;
         }
@@ -757,12 +784,22 @@ fn decode_kernel_file_record(
     // than sent on to occupy space in a bounded channel.
     let raw_path = match named_path {
         Some(path) => path,
-        None => state
-            .file_paths
-            .lock()
-            .expect("file path index mutex poisoned")
-            .resolve(file_object, file_key)?
-            .to_string(),
+        None => match state.paths().resolve(file_object, file_key) {
+            Some(path) => path.to_string(),
+            None => {
+                // Counted rather than silently discarded: this is the sensor's
+                // blind spot, and its size is the only way to know whether an
+                // endpoint is quiet or unobserved.
+                let unresolved = state.unresolved_file_events.fetch_add(1, Ordering::Relaxed) + 1;
+                if unresolved == 1 || unresolved.is_multiple_of(1000) {
+                    warn!(
+                        unresolved_file_events = unresolved,
+                        "Dropping file event whose path could not be resolved"
+                    );
+                }
+                return None;
+            }
+        },
     };
 
     let mappings = field_maps::file_event_mappings();
@@ -775,7 +812,10 @@ fn decode_kernel_file_record(
         // Kernel-File reports which information class was set, never the
         // values, so unlike Sysmon Event ID 2 these stay empty on Windows.
         creation_utc_time: try_get_string(&parser, mappings.get_etw_field("CreationUtcTime")?),
-        previous_creation_utc_time: try_get_string(&parser, "PreviousCreationTime"),
+        previous_creation_utc_time: try_get_string(
+            &parser,
+            mappings.get_etw_field("PreviousCreationUtcTime")?,
+        ),
         user: try_get_string(&parser, mappings.get_etw_field("User")?),
     };
 
@@ -1102,6 +1142,22 @@ fn parse_optional_u32(value: Option<&str>) -> Option<u32> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn filter_matches_routing_allowlist() {
+        // The provider-side filter is an allowlist: an ID that routes but is
+        // missing here never reaches the callback at all, which would delete a
+        // detection with no error, no dropped-event counter, and nothing in the
+        // log. Derive the expected set from the router so the two cannot drift.
+        let routed: Vec<u16> = (0u16..=64)
+            .filter(|id| kernel_file_route(*id).is_some())
+            .collect();
+        assert_eq!(
+            routed,
+            KERNEL_FILE_ROUTED_EVENT_IDS.to_vec(),
+            "provider filter and kernel_file_route disagree"
+        );
+    }
 
     #[test]
     fn kernel_file_event_ids_route_to_actions() {

--- a/src/sensor/windows/field_maps.rs
+++ b/src/sensor/windows/field_maps.rs
@@ -57,6 +57,7 @@ static FILE_EVENT_MAP: LazyLock<FieldMapping> = LazyLock::new(|| {
         ("ProcessId", "ProcessID"),
         ("Image", "ImageName"),
         ("CreationUtcTime", "CreationTime"),
+        ("PreviousCreationUtcTime", "PreviousCreationTime"),
         ("User", "UserName"),
     ])
 });

--- a/src/sensor/windows/file_paths.rs
+++ b/src/sensor/windows/file_paths.rs
@@ -1,0 +1,270 @@
+//! FileObject/FileKey to path resolution for Microsoft-Windows-Kernel-File.
+//!
+//! The Kernel-File events that carry real write semantics identify their target
+//! only by kernel pointer. Measured on Windows 11 against the provider's own
+//! manifest, event ID 16 (`Write`) and event ID 17 (`SetInformation`) carry
+//! `FileObject` and `FileKey` and no name at all.
+//!
+//! The provider emits the names on separate events, expecting the consumer to
+//! join the two:
+//!
+//! | event | identifiers | name |
+//! | --- | --- | --- |
+//! | 12 `Create` | `FileObject` | `FileName` |
+//! | 10 `NameCreate` | `FileKey` | `FileName` |
+//! | 26 `DeletePath` / 27 `RenamePath` | both | `FilePath` |
+//! | 14 `Close` | both | — |
+//! | 16 `Write` / 17 `SetInformation` | both | — |
+//!
+//! Note that `Create` carries no `FileKey` and `NameCreate` carries no
+//! `FileObject`, which is why two indexes are needed rather than one: neither
+//! identifier is present on every naming event.
+
+use std::collections::{HashMap, VecDeque};
+
+/// Maximum live entries kept per index.
+///
+/// Entries are evicted when the handle closes, so the steady state tracks the
+/// number of open handles on the machine rather than total file activity. The
+/// cap only binds when processes hold handles without closing them; at this
+/// size the worst case is roughly 8192 paths per index, a few megabytes.
+const DEFAULT_CAPACITY: usize = 8192;
+
+/// A bounded `u64 -> path` index with FIFO eviction.
+///
+/// FIFO rather than LRU: the natural lifetime here is the handle's, eviction
+/// on `Close` is the common path, and the cap exists only to stop a leaking
+/// process from growing this without limit. Tracking recency would cost a
+/// touch on every event on the hot path to improve a case that should not
+/// happen in the first place.
+struct BoundedIndex {
+    entries: HashMap<u64, String>,
+    /// Insertion order, used to pick the eviction victim. May contain keys
+    /// already removed by `forget`; those are skipped when popped.
+    order: VecDeque<u64>,
+    capacity: usize,
+}
+
+impl BoundedIndex {
+    fn with_capacity(capacity: usize) -> Self {
+        Self {
+            entries: HashMap::new(),
+            order: VecDeque::new(),
+            capacity,
+        }
+    }
+
+    fn insert(&mut self, key: u64, path: &str) {
+        // Re-inserting a live key updates the path in place; pushing the key
+        // again would let one busy handle fill `order` with duplicates.
+        if self.entries.insert(key, path.to_string()).is_none() {
+            self.order.push_back(key);
+        }
+
+        while self.entries.len() > self.capacity {
+            match self.order.pop_front() {
+                Some(oldest) => {
+                    self.entries.remove(&oldest);
+                }
+                None => break,
+            }
+        }
+
+        // `forget` leaves tombstones behind. Compact once they could otherwise
+        // grow the queue without bound.
+        if self.order.len() > self.capacity.saturating_mul(2) {
+            let entries = &self.entries;
+            self.order.retain(|key| entries.contains_key(key));
+        }
+    }
+
+    fn get(&self, key: u64) -> Option<&str> {
+        self.entries.get(&key).map(String::as_str)
+    }
+
+    fn forget(&mut self, key: u64) {
+        self.entries.remove(&key);
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.entries.len()
+    }
+}
+
+/// Joins Kernel-File naming events to the pathless events that follow them.
+pub(super) struct FilePathCache {
+    by_object: BoundedIndex,
+    by_key: BoundedIndex,
+}
+
+impl FilePathCache {
+    pub(super) fn new() -> Self {
+        Self::with_capacity(DEFAULT_CAPACITY)
+    }
+
+    fn with_capacity(capacity: usize) -> Self {
+        Self {
+            by_object: BoundedIndex::with_capacity(capacity),
+            by_key: BoundedIndex::with_capacity(capacity),
+        }
+    }
+
+    /// Record `path` against whichever identifiers this naming event carried.
+    pub(super) fn learn(&mut self, file_object: Option<u64>, file_key: Option<u64>, path: &str) {
+        if path.is_empty() {
+            return;
+        }
+        if let Some(object) = file_object {
+            self.by_object.insert(object, path);
+        }
+        if let Some(key) = file_key {
+            self.by_key.insert(key, path);
+        }
+    }
+
+    /// Recover the path for an event that carried only identifiers.
+    ///
+    /// `FileObject` is tried first: it is per-handle, so it cannot outlive the
+    /// handle the event belongs to. `FileKey` is per-file and shared between
+    /// handles, which makes it the better fallback but the weaker first guess.
+    pub(super) fn resolve(&self, file_object: Option<u64>, file_key: Option<u64>) -> Option<&str> {
+        file_object
+            .and_then(|object| self.by_object.get(object))
+            .or_else(|| file_key.and_then(|key| self.by_key.get(key)))
+    }
+
+    /// Drop the entry for a handle that has been closed.
+    pub(super) fn forget_object(&mut self, file_object: u64) {
+        self.by_object.forget(file_object);
+    }
+
+    /// Drop the entry for a name that has left the kernel's name cache.
+    pub(super) fn forget_key(&mut self, file_key: u64) {
+        self.by_key.forget(file_key);
+    }
+
+    /// Total live entries across both indexes.
+    #[cfg(test)]
+    pub(super) fn len(&self) -> usize {
+        self.by_object.len() + self.by_key.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BoundedIndex, FilePathCache, DEFAULT_CAPACITY};
+
+    #[test]
+    fn resolves_a_write_from_the_create_that_named_the_handle() {
+        let mut cache = FilePathCache::new();
+        // Event 12 Create: FileObject + FileName, no FileKey.
+        cache.learn(Some(0xAAAA), None, r"\Device\HarddiskVolume3\tmp\a.txt");
+        // Event 16 Write: both identifiers, no name.
+        assert_eq!(
+            cache.resolve(Some(0xAAAA), Some(0xBBBB)),
+            Some(r"\Device\HarddiskVolume3\tmp\a.txt")
+        );
+    }
+
+    #[test]
+    fn falls_back_to_the_file_key_when_the_handle_was_never_named() {
+        let mut cache = FilePathCache::new();
+        // Event 10 NameCreate: FileKey + FileName, no FileObject.
+        cache.learn(None, Some(0xBBBB), r"\Device\HarddiskVolume3\tmp\b.txt");
+        assert_eq!(
+            cache.resolve(Some(0xAAAA), Some(0xBBBB)),
+            Some(r"\Device\HarddiskVolume3\tmp\b.txt")
+        );
+    }
+
+    #[test]
+    fn unknown_identifiers_do_not_resolve() {
+        let cache = FilePathCache::new();
+        assert_eq!(cache.resolve(Some(1), Some(2)), None);
+        assert_eq!(cache.resolve(None, None), None);
+    }
+
+    #[test]
+    fn closing_a_handle_releases_its_entry() {
+        let mut cache = FilePathCache::new();
+        cache.learn(
+            Some(0xAAAA),
+            Some(0xBBBB),
+            r"\Device\HarddiskVolume3\tmp\c.txt",
+        );
+        assert_eq!(cache.len(), 2);
+
+        cache.forget_object(0xAAAA);
+        // The per-file key survives the handle; only the handle entry is gone.
+        assert_eq!(cache.resolve(Some(0xAAAA), None), None);
+        assert_eq!(
+            cache.resolve(None, Some(0xBBBB)),
+            Some(r"\Device\HarddiskVolume3\tmp\c.txt")
+        );
+
+        cache.forget_key(0xBBBB);
+        assert_eq!(cache.len(), 0);
+    }
+
+    #[test]
+    fn empty_paths_are_not_recorded() {
+        let mut cache = FilePathCache::new();
+        cache.learn(Some(0xAAAA), Some(0xBBBB), "");
+        assert_eq!(cache.len(), 0);
+    }
+
+    #[test]
+    fn stays_bounded_when_handles_are_never_closed() {
+        let capacity = 64;
+        let mut cache = FilePathCache::with_capacity(capacity);
+
+        // A process that opens handles forever and closes none.
+        for i in 0..capacity as u64 * 100 {
+            cache.learn(Some(i), Some(i + 1_000_000), &format!("/tmp/file-{i}"));
+        }
+
+        assert_eq!(cache.len(), capacity * 2, "both indexes stay at capacity");
+        // The most recent entry survives; the oldest has been evicted.
+        let newest = capacity as u64 * 100 - 1;
+        assert!(cache.resolve(Some(newest), None).is_some());
+        assert!(cache.resolve(Some(0), None).is_none());
+    }
+
+    #[test]
+    fn repeated_writes_to_one_handle_do_not_grow_the_index() {
+        let mut index = BoundedIndex::with_capacity(8);
+        for _ in 0..1000 {
+            index.insert(42, "/tmp/hot.txt");
+        }
+        assert_eq!(index.len(), 1);
+        assert_eq!(index.order.len(), 1, "no duplicate ordering entries");
+    }
+
+    #[test]
+    fn eviction_tombstones_do_not_accumulate() {
+        let capacity = 16;
+        let mut index = BoundedIndex::with_capacity(capacity);
+
+        // Churn: insert then immediately forget, which leaves a tombstone in
+        // the ordering queue each time.
+        for i in 0..capacity as u64 * 100 {
+            index.insert(i, "/tmp/churn.txt");
+            index.forget(i);
+        }
+
+        assert_eq!(index.len(), 0);
+        assert!(
+            index.order.len() <= capacity * 2 + 1,
+            "ordering queue compacts instead of growing without bound, was {}",
+            index.order.len()
+        );
+    }
+
+    #[test]
+    fn default_capacity_is_applied() {
+        let cache = FilePathCache::new();
+        assert_eq!(cache.by_object.capacity, DEFAULT_CAPACITY);
+        assert_eq!(cache.by_key.capacity, DEFAULT_CAPACITY);
+    }
+}

--- a/src/sensor/windows/file_paths.rs
+++ b/src/sensor/windows/file_paths.rs
@@ -37,12 +37,23 @@ const DEFAULT_CAPACITY: usize = 8192;
 /// process from growing this without limit. Tracking recency would cost a
 /// touch on every event on the hot path to improve a case that should not
 /// happen in the first place.
+/// A live index entry, tagged with the queue slot that owns it.
+struct Entry {
+    path: String,
+    /// Which `order` slot may evict this entry. Kernel pointers are recycled,
+    /// so a key can be inserted, forgotten, and inserted again; without this
+    /// tag the slot left behind by the first insert would evict the second.
+    seq: u64,
+}
+
 struct BoundedIndex {
-    entries: HashMap<u64, String>,
-    /// Insertion order, used to pick the eviction victim. May contain keys
-    /// already removed by `forget`; those are skipped when popped.
-    order: VecDeque<u64>,
+    entries: HashMap<u64, Entry>,
+    /// `(key, seq)` in insertion order, used to pick the eviction victim. A
+    /// slot whose key is gone, or whose `seq` no longer matches the live entry,
+    /// is stale and is discarded rather than acted on.
+    order: VecDeque<(u64, u64)>,
     capacity: usize,
+    next_seq: u64,
 }
 
 impl BoundedIndex {
@@ -51,35 +62,57 @@ impl BoundedIndex {
             entries: HashMap::new(),
             order: VecDeque::new(),
             capacity,
+            next_seq: 0,
         }
     }
 
     fn insert(&mut self, key: u64, path: &str) {
-        // Re-inserting a live key updates the path in place; pushing the key
-        // again would let one busy handle fill `order` with duplicates.
-        if self.entries.insert(key, path.to_string()).is_none() {
-            self.order.push_back(key);
+        if let Some(entry) = self.entries.get_mut(&key) {
+            // Re-inserting a live key updates the path but keeps its queue
+            // slot; pushing again would let one busy handle fill `order` with
+            // duplicates of itself.
+            entry.path.clear();
+            entry.path.push_str(path);
+        } else {
+            let seq = self.next_seq;
+            // Unreachable in practice at u64 width, but this runs in an ETW
+            // callback where a debug overflow panic would take the sensor down.
+            self.next_seq = self.next_seq.wrapping_add(1);
+            self.entries.insert(
+                key,
+                Entry {
+                    path: path.to_string(),
+                    seq,
+                },
+            );
+            self.order.push_back((key, seq));
         }
 
         while self.entries.len() > self.capacity {
             match self.order.pop_front() {
-                Some(oldest) => {
-                    self.entries.remove(&oldest);
+                Some((oldest, seq)) => {
+                    // Only evict when this slot still describes the live entry.
+                    // A slot orphaned by forget-then-reinsert must not remove
+                    // the newer entry that reused the key.
+                    if self.entries.get(&oldest).is_some_and(|e| e.seq == seq) {
+                        self.entries.remove(&oldest);
+                    }
                 }
                 None => break,
             }
         }
 
-        // `forget` leaves tombstones behind. Compact once they could otherwise
-        // grow the queue without bound.
+        // `forget` and key reuse both leave stale slots behind. Compact once
+        // they could otherwise grow the queue without bound.
         if self.order.len() > self.capacity.saturating_mul(2) {
             let entries = &self.entries;
-            self.order.retain(|key| entries.contains_key(key));
+            self.order
+                .retain(|(key, seq)| entries.get(key).is_some_and(|e| e.seq == *seq));
         }
     }
 
     fn get(&self, key: u64) -> Option<&str> {
-        self.entries.get(&key).map(String::as_str)
+        self.entries.get(&key).map(|entry| entry.path.as_str())
     }
 
     fn forget(&mut self, key: u64) {
@@ -239,6 +272,61 @@ mod tests {
         }
         assert_eq!(index.len(), 1);
         assert_eq!(index.order.len(), 1, "no duplicate ordering entries");
+    }
+
+    #[test]
+    fn reused_key_survives_eviction_of_its_own_stale_slot() {
+        // The kernel recycles FILE_OBJECT addresses, so this is the ordinary
+        // handle lifecycle: Create names a handle, Close releases it, and a
+        // later Create names the same pointer value again. The slot the first
+        // insert left in the ordering queue must not evict the second entry.
+        // Other handles must be indexed between the forget and the reinsert.
+        // That puts the orphaned slot ahead of theirs in the queue, so acting
+        // on it evicts the reused key while genuinely older entries survive.
+        let mut index = BoundedIndex::with_capacity(4);
+
+        index.insert(0xAAAA, "/old/path.txt");
+        index.forget(0xAAAA);
+
+        index.insert(0xB, "/b.txt");
+        index.insert(0xC, "/c.txt");
+        index.insert(0xD, "/d.txt");
+
+        index.insert(0xAAAA, "/new/path.txt");
+
+        // One more entry puts the index over capacity and runs a single
+        // eviction. The victim should be 0xB, the oldest live entry.
+        index.insert(0xE, "/e.txt");
+
+        assert_eq!(
+            index.get(0xAAAA),
+            Some("/new/path.txt"),
+            "a reinserted key must not be evicted by the slot its previous \
+             incarnation left behind"
+        );
+        assert_eq!(index.get(0xB), None, "the oldest live entry is the victim");
+    }
+
+    #[test]
+    fn ordering_queue_stays_bounded_when_one_key_is_reused() {
+        // Compaction only drops slots whose key is absent, so before the seq
+        // tag a hot recycled handle grew `order` without limit even though the
+        // index held a single live entry.
+        let capacity = 16;
+        let mut index = BoundedIndex::with_capacity(capacity);
+
+        for _ in 0..10_000 {
+            index.insert(0xBBBB, "/hot.txt");
+            index.forget(0xBBBB);
+        }
+        index.insert(0xBBBB, "/hot.txt");
+
+        assert_eq!(index.len(), 1);
+        assert!(
+            index.order.len() <= capacity * 2 + 1,
+            "ordering queue grew to {} slots for a single live key",
+            index.order.len()
+        );
     }
 
     #[test]

--- a/src/sensor/windows/mapper.rs
+++ b/src/sensor/windows/mapper.rs
@@ -178,8 +178,10 @@ mod tests {
         let code = file_action_code(SensorAction::Modify);
         assert_eq!(code, 65);
         // Modify must NOT map to Sysmon ID 11 (FileCreate); the shared table
-        // gives it event ID 65, which routes to file_change in the detection
-        // engine. Reporting it under 11 is the macOS bug from issue #239.
+        // gives a write its own event ID 65, which routes to the base
+        // `file_event` family. Reporting it under 11 was the macOS bug from
+        // issue #239; routing it to `file_change` was the mis-categorisation
+        // settled in #238.
         assert_eq!(
             map_to_sysmon_id(EventCategory::File, code, u16::from(code)),
             65

--- a/src/sensor/windows/mod.rs
+++ b/src/sensor/windows/mod.rs
@@ -1,5 +1,6 @@
 pub mod etw;
 mod field_maps;
+mod file_paths;
 pub mod mapper;
 
 pub use etw::EtwSensor;

--- a/tests/platform_mapping.rs
+++ b/tests/platform_mapping.rs
@@ -188,9 +188,14 @@ const ALL_FILE_CATEGORIES: &[&str] = &[
 /// (11), so macOS writes were evaluated against `file_create` rules while the
 /// same operation on Linux matched `file_change`. Asserting the mapping here,
 /// for every platform from one table, is what stops that recurring.
+///
+/// `Set` — the file's timestamps or attributes were changed — is what Sigma's
+/// `file_change` denotes (Sysmon Event ID 2). A plain `Modify` is a write and
+/// stays in the base family only (issue #238).
 const FILE_ACTION_CATEGORIES: &[(SensorAction, &[&str])] = &[
     (SensorAction::Create, &["file_event", "file_create"]),
-    (SensorAction::Modify, &["file_event", "file_change"]),
+    (SensorAction::Set, &["file_event", "file_change"]),
+    (SensorAction::Modify, &["file_event"]),
     (SensorAction::Delete, &["file_delete"]),
     (SensorAction::Rename, &["file_event", "file_rename"]),
 ];


### PR DESCRIPTION
Closes #238. #259 has merged; this is rebased onto `main` and is now a two-commit branch.

## Grounding

The ETW property names could not be guessed, so this started with a probe against a live `Microsoft-Windows-Kernel-File` trace on a Windows 11 lab VM. It confirmed all three findings in the issue and added detail that shaped the design:

| id | event | identifiers | name |
|---|---|---|---|
| 10 `NameCreate` | | `FileKey` **only** | `FileName` |
| 12 `Create` | | `FileObject` **only** | `FileName` |
| 14 `Close` | | both | — |
| 16 `Write` | | both | **none** |
| 17 `SetInformation` | | both | **none**, plus `InfoClass` |
| 26/27 `DeletePath`/`RenamePath` | | both | `FilePath` |

Two things that were not in the issue:

- **`Create` carries no `FileKey` and `NameCreate` carries no `FileObject`.** Neither identifier is on every naming event, so the index has to be two maps, not one.
- **`InfoClass` on event 17 separates the cases cleanly**: `4` (`FileBasicInformation`) is a timestamp/attribute change; `19`/`20` are truncation.

`0x20` (`FILEIO`) is the keyword that delivers `Close` and `SetInformation`. Without it there is no eviction point and truncation is never observable.

## Change

1. **Path index** — new `file_paths` module. Both identifiers indexed, released on `Close` (14) and `NameDelete` (11), each index capped at 8192 entries with FIFO eviction so a process that never closes handles cannot grow it without bound. FIFO rather than LRU because the natural lifetime is the handle's and the cap only exists for the leaking case.
2. **Explicit routing** — the `_ => SensorAction::Modify` catch-all is replaced with an allowlist returning `Option`, and each unrouted ID carries the reason it is unrouted. IDs 18 and 19 are dropped as the pathless duplicates of 26 and 27.
3. **`FILEIO` enabled, with a provider-side event-ID filter** — the keyword is what delivers `Close` and `SetInformation`. The high-volume read and query events it also brings are rejected on an integer match before the schema lookup, and an `EventFilter::ByEventIds` allowlist stops most of them being written into the session at all. The cost of this is measured below.
4. **Unresolvable events are dropped** rather than forwarded, since a file event with no path cannot match a rule and would only occupy space in a bounded channel.

## Cost of the `FILEIO` keyword

The keyword is the expensive part of this PR, so it was measured rather than
argued about. Six build arms on a Windows 11 lab VM (6 vCPU), all sharing one
target directory so dependency codegen is identical and only the `rustinel`
crate differs; three rotated-order matrices, 175,000 file operations per run,
plus `rustinel capture` passes to check each arm's detection output.

| Arm | Kernel-File configuration | Agent CPU | ETW buffers | `Set` events | Pathless |
|---|---|---|---|---|---|
| `main` | — | 3.914 s | 9,040 | 0 | 8,596 |
| this PR, keyword removed | no `FILEIO` | 3.579 s | 9,003 | 0 | 0 |
| **this PR (merged form)** | `FILEIO` + event-ID filter | 4.351 s | 10,388 | 3,001 | 0 |
| this PR, unfiltered | `FILEIO` only | 4.641 s | 21,380 | 3,001 | 0 |

- **The path-resolution half is free.** The arm with the keyword removed still
  eliminates all 8,596 pathless events, so that fix does not depend on `FILEIO`.
  Every one of those events was the old `_ => Modify` catch-all.
- **The keyword costs 13–23% agent CPU**, p ≈ 0.001–0.015 across three matrices.
- **Event-ID filtering halves ETW session volume** (21,380 → 10,388 buffers) with
  byte-identical detection output, but does **not** reduce CPU (−6.2%, p = 0.15) —
  the unrouted events were already rejected before the schema lookup.
- A fourth arm dropping `Close` from the allowlist as well brought buffers to
  9,336, level with the no-keyword arm, and still cost +18.5% CPU. So the cost is
  `SetInformation` collection, not read volume and not `Close`. It cannot be
  reduced further with the filters `ferrisetw` exposes today (`ByPids` /
  `ByEventIds` only; no payload filter to narrow on `InfoClass`).

In absolute terms the keyword costs roughly **0.2–0.5% of total CPU capacity** on
this 6-vCPU box under a deliberately file-heavy workload, and nothing measurable
at idle. Against the Windows acceptance targets in `docs/benchmarking.md`: file
IO slowdown **+1.0%** versus a 5% budget, with zero ETW drops and zero lost
buffers in every arm.

### Chosen path

**Keep `FILEIO`, add the event-ID filter.** Timestomping and truncate-to-zero are
not retro-detectable: if the sensor is not collecting event 17, an intrusion that
happens today is invisible forever, and no rule added later recovers it. That
asymmetry is worth half a percent of CPU capacity. The filter ships because
halving kernel data movement is free and costs no detection — not because it
recovers the CPU, which it does not.

Two limits on that conclusion. The idle case could not be resolved on a quiet VM,
and on a busy file server or build agent the `FILEIO` volume is driven by all
system activity rather than by one workload, so ~0.5% is **not** established as an
upper bound. And no shipped rule consumes `file_change` yet, so the capability is
currently paid for ahead of its use.

## Review fixes (second commit)

- **`BoundedIndex` evicted the wrong entry when a key was reused.** `insert`
  pushed a second ordering slot whenever the key was absent from the map — the
  state `forget` leaves behind — so a recycled `FILE_OBJECT` owned two slots.
  Acting on the orphaned one evicted the live entry while genuinely older entries
  survived, and compaction could not reclaim the duplicates because `retain`
  keeps any key present in the map: one hot recycled handle grew the queue to
  10,001 slots at a capacity of 16, defeating the bound the structure exists to
  enforce. Entries now carry a sequence tag and a slot may only evict the entry
  it created. Both regression tests fail against the first commit.
- **Poisoned-mutex panic removed.** The four lock sites run inside an ETW callback
  invoked by the OS, where unwinding takes the sensor down — and `EtwSensor::start`
  returns `Ok` when processing fails, so it would go down quietly. The index is
  derived state, so a poisoned lock is recoverable.
- **Unresolved drops are now counted** as `unresolved_file_events`. Dropping them
  is right, since a pathless event matches no rule, but doing it silently made the
  blind spot unmeasurable: handles opened before the sensor started were never
  indexed, so long-lived holders such as database files and service logs stay
  unobserved until the handle is reopened.
- **The filter is pinned to the router by a test** that derives the allowlist from
  `kernel_file_route`, since a drift would delete detections with no error, no
  counter, and nothing in the log.
- **Drop policy documented** in `docs/detection.md`, and the resulting blind spot
  in `docs/limitations.md`. The Windows acceptance target permits drops only as a
  documented bounded policy for low-value event classes; this is one.

## `file_change` semantics

The issue asks for this to be settled deliberately. It corresponds to Sysmon Event ID 2, *file creation time changed* — not "the file was written". Rules published in that category are written against timestamp manipulation, so routing ordinary writes there makes any rule keyed only on `TargetFilename` fire on routine file activity.

A metadata change is now `SensorAction::Set` with `event_id` 2 and is the only thing in `file_change`; writes stay in the base `file_event` family. Because #259 put this in one table, applying it was a single table edit.

**Caveat worth weighing before merge:** event 17 reports *which* information class was set but never the values, so `CreationUtcTime` and `PreviousCreationUtcTime` cannot be populated from ETW at all. A `file_change` rule keyed on `TargetFilename` now works correctly; one keyed on those timestamp fields still will not fire. This is documented in `docs/detection.md` rather than papered over. If you would rather keep writes in `file_change`, it is a one-line revert of the table entry.

`file_change` is consequently marked Windows-only in the docs — Linux and macOS do not report metadata changes today (#146).

## Verification

Unit tests cannot catch a wrong ETW property name, so the real `EtwSensor` was run against a live trace:

```
01-createnew.txt   Create x1, Modify x1      08-emptycreate.txt  Create x1
03-truncate.txt    Create x1, Modify x2      07-timestomp.txt    Set x1
04-rename-dst.txt  Rename x1

file events reaching the engine with NO path: 0
```

Zero pathless events; truncation observed; `SetFileTime` caught as `Set`; a rename produces one event instead of three; a pure creation produces exactly one. The `Create`+`Modify` pairs elsewhere are two genuine syscalls (`fs::write` creates then writes) — `08-emptycreate` isolates that the spurious name-cache event is gone.

14 new unit tests cover the routing allowlist and the index, including that it stays bounded under a workload that never closes handles. Full suite and `clippy --all-targets -- -D clippy::all` green on macOS, Linux, and Windows.

## Not done

Event **30** fires exactly once per genuinely new file (needs keyword `0x1000`) and would be a cleaner create signal than the `CreateOptions` disposition heuristic from #236. Swapping that is its own change; noting it here so the finding is not lost.
