### PR TITLE
test(alerts): cover degradation paths

### DIFF
--- a/src/engine/alert.rs
+++ b/src/engine/alert.rs
@@ -650,3 +650,107 @@ impl Engine {
         categories
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::ProcessCreationFields;
+
+    fn process_event(image: String) -> NormalizedEvent {
+        NormalizedEvent {
+            timestamp: "2026-08-16T12:00:00Z".to_string(),
+            platform: Platform::Windows,
+            provider: "test".to_string(),
+            category: EventCategory::Process,
+            event_id: 1,
+            event_id_string: "1".to_string(),
+            opcode: 1,
+            fields: crate::models::EventFields::ProcessCreation(ProcessCreationFields {
+                image: Some(image),
+                command_line: None,
+                process_id: None,
+                process_start_time: None,
+                parent_process_id: None,
+                parent_image: None,
+                parent_command_line: None,
+                current_directory: None,
+                integrity_level: None,
+                user: None,
+                original_file_name: None,
+                product: None,
+                description: None,
+                target_image: None,
+                logon_id: None,
+                logon_guid: None,
+            }),
+            process_context: None,
+        }
+    }
+
+    fn engine_with_image_rule(match_debug: MatchDebugLevel) -> Engine {
+        let mut engine = Engine::new_for_platform_with_logging_level_and_match_debug(
+            Platform::Windows,
+            "warn",
+            match_debug,
+            SigmaEngineKind::Builtin,
+        );
+        let rule: SigmaRule = serde_yaml::from_str(
+            r#"
+title: Test image rule
+id: test-image-rule
+logsource:
+  product: windows
+  category: process_creation
+detection:
+  selection:
+    Image|contains: tool.exe
+  condition: selection
+level: high
+"#,
+        )
+        .expect("test rule parses");
+        let compiled = engine.compile_rule(rule).expect("test rule compiles");
+        engine
+            .rules_by_logsource
+            .entry(compiled.logsource.clone())
+            .or_default()
+            .push(compiled);
+        engine
+    }
+
+    #[test]
+    fn alert_without_match_details_remains_complete() {
+        let engine = engine_with_image_rule(MatchDebugLevel::Off);
+        let event = process_event(r"C:\Program Files\Example\tool.exe".to_string());
+
+        let alert = engine
+            .check_event_builtin(&event)
+            .expect("matching event produces an alert");
+
+        assert_eq!(alert.rule_name, "Test image rule");
+        assert_eq!(alert.rule_id.as_deref(), Some("sigma::test-image-rule"));
+        assert_eq!(alert.severity, AlertSeverity::High);
+        assert!(alert.match_details.is_none());
+        assert_eq!(alert.event.get_field("Image"), event.get_field("Image"));
+    }
+
+    #[test]
+    fn full_match_details_truncate_long_unicode_values_safely() {
+        let engine = engine_with_image_rule(MatchDebugLevel::Full);
+        let image = format!(r"C:\{}\tool.exe", "é".repeat(MAX_MATCH_VALUE_LEN));
+
+        let alert = engine
+            .check_event_builtin(&process_event(image))
+            .expect("matching event produces an alert");
+        let details = alert.match_details.expect("full details are present");
+        let sigma = details.sigma.expect("Sigma details are present");
+        let value = sigma.matches[0]
+            .value
+            .as_deref()
+            .expect("full details include the matched value");
+
+        assert!(value.ends_with("..."));
+        assert!(value.len() <= MAX_MATCH_VALUE_LEN);
+        assert!(details.summary.ends_with("(truncated)"));
+    }
+}

--- a/src/models/event.rs
+++ b/src/models/event.rs
@@ -1083,4 +1083,85 @@ mod round_trip_tests {
             assert_eq!(event.get_field(field), Some("/bin/zsh"));
         }
     }
+
+    #[test]
+    fn absent_process_identity_fields_are_not_synthesized() {
+        let event = NormalizedEvent {
+            timestamp: "2026-08-16T12:00:00Z".to_string(),
+            platform: Platform::Windows,
+            provider: "etw".to_string(),
+            category: EventCategory::Process,
+            event_id: 1,
+            event_id_string: "1".to_string(),
+            opcode: 1,
+            fields: EventFields::ProcessCreation(ProcessCreationFields {
+                image: Some(r"C:\Windows\System32\cmd.exe".to_string()),
+                command_line: None,
+                process_id: None,
+                process_start_time: None,
+                parent_process_id: None,
+                parent_image: None,
+                parent_command_line: None,
+                current_directory: None,
+                integrity_level: None,
+                user: None,
+                original_file_name: None,
+                product: None,
+                description: None,
+                target_image: None,
+                logon_id: None,
+                logon_guid: None,
+            }),
+            process_context: None,
+        };
+
+        for field in ["ProcessId", "ParentProcessId", "User"] {
+            assert_eq!(event.get_field(field), None, "{field} should stay absent");
+            assert!(
+                event
+                    .all_field_values_with_keys()
+                    .iter()
+                    .all(|(key, _)| *key != field),
+                "{field} should not appear in flattened fields"
+            );
+        }
+    }
+
+    #[test]
+    fn unusual_paths_are_preserved_verbatim_in_field_views() {
+        let image = r"\\?\C:\Program Files\ユニコード\tool.exe ";
+        let current_directory = r"\\server\share\folder.with.dots\..\leaf";
+        let mut event = file_event();
+        event.category = EventCategory::Process;
+        event.event_id = 1;
+        event.event_id_string = "1".to_string();
+        event.opcode = 1;
+        event.fields = EventFields::ProcessCreation(ProcessCreationFields {
+            image: Some(image.to_string()),
+            command_line: None,
+            process_id: None,
+            process_start_time: None,
+            parent_process_id: None,
+            parent_image: None,
+            parent_command_line: None,
+            current_directory: Some(current_directory.to_string()),
+            integrity_level: None,
+            user: None,
+            original_file_name: None,
+            product: None,
+            description: None,
+            target_image: None,
+            logon_id: None,
+            logon_guid: None,
+        });
+
+        assert_eq!(event.get_field("Image"), Some(image));
+        assert_eq!(event.get_field("CurrentDirectory"), Some(current_directory));
+        assert!(event
+            .all_field_values_with_keys()
+            .contains(&("Image", image)));
+        assert!(event
+            .all_field_values_with_keys()
+            .contains(&("CurrentDirectory", current_directory)));
+    }
 }


### PR DESCRIPTION
## Summary

Add inline regression coverage for alert and event degradation paths:

- verify alert construction remains complete when match details are disabled
- verify full match details truncate long Unicode values without splitting a code point
- verify absent PID, parent PID, and user fields stay omitted from field views
- verify unusual Windows, UNC, and Unicode paths are preserved verbatim

The assertions exercise the same event field access and alert construction paths covered by the ECS contract tests without changing production behavior.

Closes #137.

## Type of change

- [ ] `feat` / `enhancement` - new feature
- [ ] `bug` - bug fix
- [x] `refactor` - refactoring, no behaviour change
- [ ] `documentation` - docs only
- [ ] `ci` - CI and release changes
- [ ] `dependencies` - dependency update

## Test plan

- [ ] Tested on Windows
- [ ] Tested on Linux
- [x] Existing tests pass (`cargo test --locked`)
- [x] New tests added (if applicable)

Additional checks:

- `cargo clippy --locked --all-targets -- -D clippy::all`
- `cargo fmt --all -- --check`
- `git diff --check`

## Checklist

- [ ] Label added to this PR — contributor account does not have label permission
- [x] Docs updated (if behaviour changed) — no behavior change
