### PR TITLE
feat(release): support deterministc builds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,11 +2,15 @@
 # YARA-X only needs to regenerate this source when developing its built-in modules.
 # Keeping it disabled avoids read-only filesystem failures during normal project builds.
 YRX_REGENERATE_MODULES_RS = "false"
+# Disable incremental compilation unconditionally for deterministic output.
+CARGO_INCREMENTAL = "0"
 
 [target.x86_64-pc-windows-msvc]
 # Increase stack size for large YARA rulesets.
 # Windows default is 1MB; we raise it to 16MB for large rule compilations.
-rustflags = ["-C", "link-args=/STACK:16777216"]
+# /Brepro tells the MSVC linker to produce deterministic PE headers
+# (no timestamps, no random GUIDs) — essential for reproducible Windows builds.
+rustflags = ["-C", "link-args=/STACK:16777216,/Brepro"]
 
 [target.x86_64-pc-windows-gnu]
 rustflags = ["-C", "link-args=-Wl,--stack,16777216"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,9 +77,14 @@ jobs:
         run: command -v bpf-linker >/dev/null 2>&1 || cargo install bpf-linker --version 0.10.4 --locked
 
       - name: Build eBPF object
+        env:
+          SOURCE_DATE_EPOCH: "0"
+          ZERO_AR_DATE: "1"
         run: |
           cd ebpf
-          cargo build --release
+          SYSROOT=$(rustc +nightly-2026-08-11 --print sysroot)
+          RUSTFLAGS="--remap-path-prefix=$(pwd)=/build --remap-path-prefix=${SYSROOT}=/rustc" \
+            cargo +nightly-2026-08-11 build --release
           cp target/bpfel-unknown-none/release/rustinel-ebpf rustinel-ebpf.o
 
       - name: Upload eBPF artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,10 @@ on:
 env:
   CARGO_TERM_COLOR: always
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  # ── Reproducible Builds ──────────────────────────────
+  SOURCE_DATE_EPOCH: 0
+  ZERO_AR_DATE: 1
+  CARGO_INCREMENTAL: 0
 
 permissions:
   contents: read
@@ -49,6 +53,11 @@ jobs:
       - name: Add target
         run: rustup target add x86_64-unknown-linux-musl
 
+      - name: Set reproducibility flags
+        run: |
+          SYSROOT=$(rustc --print sysroot)
+          echo "RUSTFLAGS=--remap-path-prefix=$(pwd)=/build --remap-path-prefix=${CARGO_HOME:-$HOME/.cargo}=/cargo --remap-path-prefix=${SYSROOT}=/rustc" >> "$GITHUB_ENV"
+
       - name: Build
         run: cargo build --locked --release --features rsigma-engine --target x86_64-unknown-linux-musl
 
@@ -84,6 +93,11 @@ jobs:
         with:
           tool: cross
 
+      - name: Set reproducibility flags
+        run: |
+          SYSROOT=$(rustc --print sysroot)
+          echo "RUSTFLAGS=--remap-path-prefix=$(pwd)=/build --remap-path-prefix=${CARGO_HOME:-$HOME/.cargo}=/cargo --remap-path-prefix=${SYSROOT}=/rustc" >> "$GITHUB_ENV"
+
       - name: Build
         run: cross build --locked --release --features rsigma-engine --target aarch64-unknown-linux-musl
 
@@ -104,9 +118,15 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
           cache: false
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
-        with:
-          lookup-only: true
+      - name: Set reproducibility flags (Windows)
+        shell: pwsh
+        run: |
+          $sysroot = rustc --print sysroot
+          $cwd = (Get-Location).Path
+          $cargoHome = if ($env:CARGO_HOME) { $env:CARGO_HOME } else { "$env:USERPROFILE\.cargo" }
+          $flags = "--remap-path-prefix=$cwd=/build --remap-path-prefix=$cargoHome=/cargo --remap-path-prefix=$sysroot=/rustc"
+          "RUSTFLAGS=$flags" >> $env:GITHUB_ENV
+
       - run: cargo build --locked --release --features rsigma-engine
 
       - name: Verify binary
@@ -148,6 +168,10 @@ jobs:
       - run: rustup target add "$TARGET"
         env:
           TARGET: ${{ matrix.target }}
+      - name: Set reproducibility flags
+        run: |
+          SYSROOT=$(rustc --print sysroot)
+          echo "RUSTFLAGS=--remap-path-prefix=$(pwd)=/build --remap-path-prefix=${CARGO_HOME:-$HOME/.cargo}=/cargo --remap-path-prefix=${SYSROOT}=/rustc" >> "$GITHUB_ENV"
       - run: cargo build --locked --release --features rsigma-engine --target "$TARGET"
         env:
           TARGET: ${{ matrix.target }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,3 +110,14 @@ criterion = "0.8"
 [[bench]]
 name = "sigma_backend"
 harness = false
+
+[profile.release]
+# ── Reproducible Builds ─────────────────────────────────────────
+# These settings eliminate non-determinism in LLVM code generation.
+# Combined with rust-toolchain.toml and --remap-path-prefix in CI,
+# builds from the same commit on any runner will produce bit-for-bit
+# identical binaries.
+codegen-units = 1   # Prevents non-deterministic CGU thread partitioning
+lto = "fat"         # Monolithic LTO avoids ThinLTO thread merge variance
+incremental = false # Disables fingerprint-based incremental caching
+

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.92.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary
This PR makes reproducible builds possible, so that anyone building rustinel from source code in release mode will get bit-by-bit match on the final executable and can verify that no tampering was done.

## Type of change
<!-- Add the matching label to this PR before merging -->
- [x] `feat` / `enhancement` - new feature
- [ ] `bug` - bug fix
- [ ] `refactor` - refactoring, no behaviour change
- [ ] `documentation` - docs only
- [ ] `ci` - CI and release changes
- [ ] `dependencies` - dependency update

## Test plan
- [ ] Tested on Windows
- [x] Tested on Linux
- [ ] Existing tests pass (`cargo test`)
- [ ] New tests added (if applicable)

## Checklist
- [ ] Label added to this PR
- [ ] Docs updated (if behaviour changed)
