### PR TITLE
fix(sensor): propagate ETW trace failures instead of reporting success

### DIFF
--- a/src/runtime/windows.rs
+++ b/src/runtime/windows.rs
@@ -639,18 +639,15 @@ async fn run_edr(
     let sensor_clone = Arc::clone(&sensor);
 
     // We make trace_handle mutable so we can await it.
-    let mut trace_handle = tokio::task::spawn_blocking(move || {
-        if let Err(e) = sensor_clone.start(sensor_tx) {
-            error!("ETW sensor error: {}", e);
-        }
-    });
+    let mut trace_handle = tokio::task::spawn_blocking(move || sensor_clone.start(sensor_tx));
 
     // Wait for either shutdown signal or trace completion.
     tokio::select! {
         _ = shutdown_handler => {
             info!("Shutdown signal received, waiting for ETW session to close...");
             match trace_handle.await {
-                Ok(_) => info!("ETW sensor thread finished"),
+                Ok(Ok(())) => info!("ETW sensor thread finished"),
+                Ok(Err(err)) => warn!("ETW sensor exited with error during shutdown: {err:#}"),
                 Err(e) => error!("Failed to join ETW sensor thread: {}", e),
             }
         }
@@ -662,7 +659,10 @@ async fn run_edr(
             } else {
                 error!("🚨 CRITICAL: ETW sensor thread died unexpectedly!");
                 match result {
-                    Ok(_) => {
+                    Ok(Err(err)) => {
+                        error!("ETW session failed: {err:#}");
+                    }
+                    Ok(Ok(())) => {
                         error!("Trace stopped without panic (unexpected normal termination)");
                         error!("This indicates the ETW session closed unexpectedly");
                     }

--- a/src/sensor/windows/etw.rs
+++ b/src/sensor/windows/etw.rs
@@ -538,12 +538,16 @@ impl Sensor for EtwSensor {
                         Ok(())
                     }
                     Err(err) => {
+                        // Stopping the trace from `shutdown()` makes `process()`
+                        // return an error by design; only a failure while the
+                        // sensor is supposed to keep running is a real one, and
+                        // it must reach the caller — logging alone buries the
+                        // ETW error code in the operational log (#256).
                         if self.shutdown.load(Ordering::Relaxed) {
                             info!("ETW sensor stopped with result: {:?}", err);
                             Ok(())
                         } else {
-                            warn!("ETW trace processing error: {:?}", err);
-                            Ok(())
+                            Err(anyhow::anyhow!("ETW trace processing failed: {:?}", err))
                         }
                     }
                 }


### PR DESCRIPTION
Fixes #256.

## What changed

`EtwSensor::start` returned `Ok(())` when `trace.process()` failed while the sensor was not shutting down, so callers could not tell a hard failure from a normal trace end and the real ETW error only reached the operational log at `warn` level.

- **`src/sensor/windows/etw.rs`** — `start()` now returns `Err` carrying the underlying ETW error (`ETW trace processing failed: …`) when `trace.process()` fails outside shutdown. Shutdown-initiated trace ends remain a normal `Ok` path, unchanged.
- **`src/runtime/windows.rs` (`run_edr`)** — the sensor thread now returns its `Result` instead of swallowing it, and the unexpected-death branch prints `ETW session failed: <error>` before `exit(1)`, so the operator sees the ETW error code (e.g. the `0x80071069` / `ERROR_WMI_INSTANCE_NOT_FOUND` from the issue) without opening the operational log. The shutdown path logs a late-arriving error at `warn` instead of dropping it.
- **`run_capture`** needed no change: its existing `ETW session failed: {err:#}` arm was unreachable before and now fires, marking the recording incomplete with the real cause.

## Acceptance criteria

- [x] A `trace.process()` failure while running propagates as `Err`, not `Ok(())`.
- [x] The `run` and `capture` failure paths name the underlying ETW error.
- [x] Shutdown-initiated trace ends remain a normal, non-error path.
- [x] A transient start failure does not silently look like a clean session end.

The issue's "consider a bounded retry" suggestion is deliberately left out to keep this change to the reporting fix; retrying `start()` re-runs session teardown and provider enablement and deserves its own issue if the transient fault recurs.

## Validation

On the Windows 11 lab box (stable toolchain): `cargo check --all-targets`, `cargo clippy --all-targets -- -D clippy::all`, and `cargo test` (345 passed, 0 failed) all clean.