### PR TITLE
feat(pipeline): add telemetry drop counters and backpressure visibility

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -96,6 +96,19 @@ aggregation_interval_buffer_size = 50
 [capture]
 directory = "captures"      # default parent for rustinel-capture-<UTC timestamp>.ndjson
 
+# 6b. Pipeline Telemetry Counters
+#   Every channel between a sensor and the detectors is bounded and sheds load
+#   rather than blocking, so a burst produces a detection gap instead of a
+#   slowdown. The counters below make that gap measurable: `rustinel doctor`
+#   reads the snapshot and reports how many events were dropped, per channel.
+#
+#   The counters and their rate-limited warnings are always on. This section
+#   only controls whether they are written to {logging.directory}/telemetry.json
+#   for another process to read.
+[telemetry]
+enabled = true
+snapshot_interval_secs = 30 # a snapshot is also written at shutdown
+
 # 7. Atomic IOC Detection (Hashes, IPs, Domains, Path Regex)
 [ioc]
 enabled = true

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -159,6 +159,8 @@ Once a platform sensor emits a raw `SensorEvent`, the rest of the runtime is sha
 4. YARA scans and IOC hash calculations run off the hot path in background workers.
 5. Detection hits are written as ECS NDJSON through `AlertSink` and can also be handed to `ResponseEngine`.
 
+Every hop in that list crosses a bounded channel, and each of them sheds load rather than blocking its producer: blocking an ETW callback or an eBPF poll loop would lose the events queued behind it in the kernel instead. Shedding trades a detection gap for stability, so each channel carries atomic counters - accepted, dropped, and peak queue depth - in `src/telemetry`. The runtime publishes them to `telemetry.json` beside the logs, and `rustinel doctor` reads that snapshot, which is what makes the gap measurable from outside the process. See [Pipeline Telemetry](configuration.md#pipeline-telemetry).
+
 ## Detector Store and Hot Reload
 
 Live detector instances sit behind `DetectorStore`:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -161,7 +161,14 @@ sudo rustinel doctor --config /etc/rustinel/config.toml
 Doctor reports `pass`, `warn`, or `fail` for configuration discovery and parsing,
 resolved paths, writable log and alert directories, installed rules pack state,
 pack compatibility and checksum metadata, Sigma, YARA, and IOC parsing, native
-service state, active-response safety, and platform telemetry prerequisites.
+service state, active-response safety, platform telemetry prerequisites, and
+pipeline drop counters.
+
+The `pipeline_telemetry` check reports how much telemetry the agent shed under
+load, per channel, from the snapshot the running agent writes - so a detection
+gap can be sized without searching the operational log. `--json` carries the
+raw per-channel counters under `telemetry`. See
+[Pipeline Telemetry](configuration.md#pipeline-telemetry).
 
 Exit codes are intended for automation:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -91,6 +91,10 @@ max_entries = 10000
 [capture]
 directory = "captures"
 
+[telemetry]
+enabled = true
+snapshot_interval_secs = 30
+
 [response]
 enabled = false
 prevention_enabled = false
@@ -148,6 +152,8 @@ Windows continues to use the owning account's configured ACLs.
 | `dedup.window_secs` | `60` |
 | `dedup.max_entries` | `10000` |
 | `capture.directory` | `captures` |
+| `telemetry.enabled` | `true` |
+| `telemetry.snapshot_interval_secs` | `30` |
 | `response.enabled` | `false` |
 | `response.prevention_enabled` | `false` |
 | `response.min_severity` | `critical` |
@@ -297,6 +303,59 @@ revealing than alert output, which only contains what a rule matched. Keep them
 out of shared directories and off general-purpose log shipping. See
 [Output Format](output.md#behavioral-recordings) for the stream and manifest
 layout.
+
+### Pipeline Telemetry
+
+Every channel between a sensor and the detectors is bounded, and sheds load
+rather than blocking — blocking an ETW callback or an eBPF poll loop would lose
+the events queued behind it in the kernel instead. Shedding is therefore the
+right trade, but it means a burst produces a **detection gap** rather than a
+slowdown, and that gap is only safe to accept if it can be measured.
+
+Rustinel counts, per channel: events accepted, events dropped because the
+channel was full, events dropped because the consumer had already stopped
+(shutdown, not loss), and the deepest queue depth reached. The counters are
+always on. This section controls only whether they are published outside the
+process.
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `enabled` | `true` | Write the counter snapshot that `rustinel doctor` reads |
+| `snapshot_interval_secs` | `30` | Refresh interval; a snapshot is also written at shutdown |
+
+The snapshot is `telemetry.json` inside `logging.directory`. It is rewritten in
+place — never appended — and holds only counts, no endpoint detail.
+
+The counted channels are:
+
+| Channel | What a drop costs |
+| --- | --- |
+| `sensor_events` | Raw sensor events never reached the detectors — the widest gap |
+| `yara_file_scan` | Files were never YARA scanned |
+| `yara_memory_scan` | Processes were never memory scanned |
+| `ioc_hash` | Process images were never hashed for IOC matching |
+| `active_response` | Response actions were never executed |
+| `capture_writer` | Events never reached a `rustinel capture` recording |
+
+Read the counters with:
+
+```bash
+rustinel doctor
+```
+
+The `pipeline_telemetry` check passes when nothing was dropped and warns with
+the per-channel totals when something was, so the size of a detection gap is a
+command rather than a log search. `rustinel doctor --json` carries the full
+per-channel numbers under `telemetry`. Setting `enabled = false` leaves the
+drop totals visible only in the operational log, and `doctor` reports that
+reduced visibility as a warning.
+
+Drops are also logged as they happen, rate-limited to one cumulative line per
+channel per minute:
+
+```
+Pipeline channel full; shedding telemetry channel="sensor_events" capacity=8192 dropped_total=1204 dropped_since_last_warning=1203
+```
 
 ### Active Response
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -354,7 +354,7 @@ Drops are also logged as they happen, rate-limited to one cumulative line per
 channel per minute:
 
 ```
-Pipeline channel full; shedding telemetry channel="sensor_events" capacity=8192 dropped_total=1204 dropped_since_last_warning=1203
+Pipeline channel full; shedding telemetry channel="sensor_events" capacity=8192 dropped_total=1204 accepted_total=1841204 suppressed_warnings=1202
 ```
 
 ### Active Response

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -19,7 +19,7 @@ This page documents Rustinel's known limitations for the current release.
 | Command line is lost for short-lived processes | Windows | Linux |
 | No stateful correlation or filter evaluation; unsupported documents are reported at load time | Engine |
 | Rules are silently inert when no collector backs their logsource | Engine |
-| Telemetry is dropped under burst load (no backpressure) | Pipeline |
+| Telemetry is dropped under burst load; the loss is counted, not prevented | Pipeline |
 
 ---
 
@@ -132,9 +132,21 @@ macOS support is experimental and detection-only.
 
 ## Pipeline & operations
 
-- **Telemetry is dropped under load (silent risk).** Sensor channels are bounded and
-  drop on overflow, with only a periodic warning. Under burst load you get silent
-  detection gaps, not slowdown.
+- **Telemetry is dropped under load.** Sensor channels are bounded and shed
+  events on overflow rather than blocking the producer - blocking an ETW
+  callback or an eBPF poll loop loses the events queued behind it in the kernel
+  instead. Under burst load you get a detection gap, not a slowdown, and
+  Rustinel does not replay what it shed.
+  The loss is no longer silent: every bounded channel counts events accepted,
+  events dropped, and its peak queue depth. `rustinel doctor` reports the
+  totals per channel (`pipeline_telemetry`), and `--json` carries the raw
+  numbers, so a gap can be sized without searching logs. See
+  [Pipeline Telemetry](configuration.md#pipeline-telemetry).
+  What is still missing is any form of *backpressure*: there is no adaptive
+  sampling, no priority shedding, and no way to slow a producer down. Reducing
+  event volume - narrower rules, wider trusted-path allowlists - is the only
+  mitigation; channel sizes are fixed at build time apart from
+  `response.channel_capacity` and `scanner.yara_memory_queue_capacity`.
 - **Rules catalog trust is release-bound in Phase 1.** `rustinel rules install`
   trusts HTTPS GitHub release assets from `Karib0u/rustinel-rules` and requires
   the artifact SHA-256 from the released catalog to match before activation. The
@@ -175,7 +187,8 @@ not be presented as a full commercial EDR replacement today.
 - Richer process telemetry (hashes, more reliable command line) and additional
   providers
 - Correlation / temporal rule support
-- Backpressure and load-shedding visibility
+- Real backpressure: adaptive sampling and priority shedding, rather than only
+  counting what was shed
 - Scheduled YARA memory sweeps and richer memory match metadata
 - macOS hardening toward production readiness
 - Continued documentation of operational security and limitations

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -299,6 +299,30 @@ sudo env RUSTINEL_EBPF_OBJECT=$PWD/ebpf/rustinel-ebpf.o ./target/release/rustine
 
 This is useful for development because it avoids rebuilding the full userspace binary after every eBPF-only change.
 
+## Monitoring Telemetry Loss
+
+Sensor channels are bounded and shed events under burst load, which produces a
+detection gap rather than a slowdown. Rustinel counts what it sheds, so the gap
+is measurable:
+
+```bash
+rustinel doctor
+```
+
+The `pipeline_telemetry` check reports the per-channel drop totals, and
+`rustinel doctor --json` exposes them under `telemetry` for a monitoring agent
+to collect:
+
+```bash
+rustinel doctor --json | jq '.telemetry.channels[] | select(.dropped > 0)'
+```
+
+Treat a growing `sensor_events` drop count as a coverage problem, not a
+performance one: those events never reached any detector. Counts are cumulative
+for an agent run and reset when it restarts. See
+[Pipeline Telemetry](configuration.md#pipeline-telemetry) and
+[Dropped Events And Full Queues](troubleshooting.md#dropped-events-and-full-queues).
+
 ## Safe Upgrade Checklist
 
 1. Back up `config.toml` and your custom `rules/`.
@@ -307,3 +331,4 @@ This is useful for development because it avoids rebuilding the full userspace b
 4. Restart the process or service.
 5. Confirm new startup logs in `rustinel.log.<date>`.
 6. Trigger a known benign rule such as the bundled `whoami` Sigma rule.
+7. Run `rustinel doctor` and confirm `pipeline_telemetry` reports no new drops.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -31,6 +31,7 @@ Before changing config or rules, check these first:
 | Active response does not kill | dry-run mode, severity below threshold, allowlist hit, missing PID or image |
 | Alerts are missing details | `alerts.match_debug = "off"` |
 | Logs mention dropped events or full queues | sensor backpressure, YARA/IOC/response queues saturated |
+| Not sure whether events were lost at all | run `rustinel doctor` and read the `pipeline_telemetry` check |
 
 ## Startup Failures
 
@@ -352,20 +353,53 @@ The response engine skips:
 
 ## Dropped Events And Full Queues
 
+### Did this endpoint lose telemetry, and how much?
+
+Start with `rustinel doctor` rather than the logs:
+
+```bash
+rustinel doctor
+```
+
+The `pipeline_telemetry` check answers directly:
+
+```text
+  [WARN] pipeline_telemetry: 12600 events were dropped under load (snapshot from 2026-08-24T09:30:00Z)
+      detail: sensor_events: 12500 dropped of 412500 offered (3.03%), peak depth 8192/8192; ioc_hash: 100 dropped of 1000 offered (10.00%), peak depth 8192/8192
+```
+
+A `PASS` on this check means nothing was shed - the counters are cumulative for
+the agent run, so a pass is a real answer, not an absence of evidence. The
+`Pipeline channels` block above the checks lists every channel with its
+accepted, dropped, and peak-depth totals, and `rustinel doctor --json` carries
+the same numbers under `telemetry` for collection.
+
+The counts come from `telemetry.json` in `logging.directory`, refreshed every
+`telemetry.snapshot_interval_secs` and once more at shutdown. If it is missing,
+the agent has not run yet, or `telemetry.enabled` is `false` - doctor says
+which. See [Pipeline Telemetry](configuration.md#pipeline-telemetry).
+
+**Read the numbers this way.** `sensor_events` is the widest gap: those events
+never reached any detector, so any rule that would have matched them did not
+fire. Drops on `yara_file_scan`, `yara_memory_scan`, or `ioc_hash` are narrower
+- Sigma still evaluated the event, but that specific scan never ran. A peak
+depth equal to capacity means the channel actually saturated; a peak well below
+capacity with drops recorded means the saturation was brief and bursty.
+
 ### I see “dropping event” or “queue full” in logs
 
 These messages mean the agent is under backpressure somewhere in the pipeline.
-
-Common log lines include:
+Each bounded channel logs a cumulative line at most once a minute:
 
 ```text
-Sensor event channel full; dropping ETW event
-eBPF sensor: event channel full, dropping event
-bpf sensor: event channel full, dropping event
+Pipeline channel full; shedding telemetry channel="sensor_events" capacity=8192 dropped_total=1204 dropped_since_last_warning=1203
 YARA queue full; dropping scan job
 IOC hash queue full; dropping job
 Active response queue full, dropping task
 ```
+
+`dropped_total` is cumulative for the agent run, so the last such line for a
+channel is its running total - there is no need to add the lines up.
 
 What to do:
 
@@ -374,6 +408,8 @@ What to do:
 - widen trusted-path exclusions where appropriate
 - avoid scanning large trusted software trees unnecessarily
 - watch system load while reproducing the issue
+
+Re-run `rustinel doctor` after tuning to confirm the drop count stopped growing.
 
 If the problem is persistent, capture the relevant log excerpt before tuning.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -386,13 +386,17 @@ fire. Drops on `yara_file_scan`, `yara_memory_scan`, or `ioc_hash` are narrower
 depth equal to capacity means the channel actually saturated; a peak well below
 capacity with drops recorded means the saturation was brief and bursty.
 
+A backed-up YARA queue is usually event volume rather than one stuck scan:
+`scanner.yara_scan_timeout_ms` already bounds how long a single scan can hold
+its worker.
+
 ### I see “dropping event” or “queue full” in logs
 
 These messages mean the agent is under backpressure somewhere in the pipeline.
 Each bounded channel logs a cumulative line at most once a minute:
 
 ```text
-Pipeline channel full; shedding telemetry channel="sensor_events" capacity=8192 dropped_total=1204 dropped_since_last_warning=1203
+Pipeline channel full; shedding telemetry channel="sensor_events" capacity=8192 dropped_total=1204 accepted_total=1841204 suppressed_warnings=1202
 YARA queue full; dropping scan job
 IOC hash queue full; dropping job
 Active response queue full, dropping task

--- a/src/capture/writer.rs
+++ b/src/capture/writer.rs
@@ -92,7 +92,9 @@ impl CaptureSink {
             }
         };
 
-        if let Err(err) = self.tx.try_send(line) {
+        if let Err(err) =
+            crate::telemetry::try_send(crate::telemetry::ChannelId::CaptureWriter, &self.tx, line)
+        {
             let reason = match err {
                 mpsc::error::TrySendError::Full(_) => "queue full",
                 mpsc::error::TrySendError::Closed(_) => "writer stopped",

--- a/src/config.rs
+++ b/src/config.rs
@@ -299,6 +299,7 @@ pub struct AppConfig {
     pub reload: ReloadConfig,
     pub dedup: DedupConfig,
     pub capture: CaptureConfig,
+    pub telemetry: TelemetryConfig,
 }
 
 /// Scanner configuration (Sigma and YARA rules)
@@ -434,6 +435,18 @@ pub struct CaptureConfig {
     pub directory: PathBuf,
 }
 
+/// Pipeline telemetry accounting configuration
+#[derive(Debug, Clone, Deserialize)]
+pub struct TelemetryConfig {
+    /// Write the pipeline drop-counter snapshot that `rustinel doctor` reads.
+    /// The in-memory counters and their rate-limited warnings are always on;
+    /// this only controls whether they are persisted for another process.
+    pub enabled: bool,
+    /// How often the snapshot is refreshed, in seconds. A shutdown snapshot is
+    /// always written regardless of where the interval fell.
+    pub snapshot_interval_secs: u64,
+}
+
 impl AppConfig {
     /// Load configuration from defaults, config.toml, and environment variables
     pub fn new() -> Result<Self, config::ConfigError> {
@@ -539,7 +552,10 @@ impl AppConfig {
             .set_default("dedup.window_secs", 60i64)?
             .set_default("dedup.max_entries", 10000i64)?
             // Behavioral recording
-            .set_default("capture.directory", "captures")?;
+            .set_default("capture.directory", "captures")?
+            // Telemetry
+            .set_default("telemetry.enabled", true)?
+            .set_default("telemetry.snapshot_interval_secs", 30i64)?;
 
         let builder = match selected_config {
             Some(path) => builder.add_source(config::File::from(path).required(true)),
@@ -792,6 +808,10 @@ impl Default for AppConfig {
             capture: CaptureConfig {
                 directory: PathBuf::from("captures"),
             },
+            telemetry: TelemetryConfig {
+                enabled: true,
+                snapshot_interval_secs: 30,
+            },
         };
 
         cfg.apply_allowlist_fallbacks();
@@ -830,6 +850,8 @@ mod tests {
         assert_eq!(cfg.reload.debounce_ms, 2000);
         assert_eq!(cfg.alerts.match_debug, MatchDebugLevel::Off);
         assert_eq!(cfg.network.aggregation_window_secs, 60);
+        assert!(cfg.telemetry.enabled);
+        assert_eq!(cfg.telemetry.snapshot_interval_secs, 30);
     }
 
     #[test]

--- a/src/doctor/inspect.rs
+++ b/src/doctor/inspect.rs
@@ -7,6 +7,8 @@ use crate::doctor::path::path_results;
 use crate::doctor::prerequisites::platform_prerequisite_results;
 use crate::doctor::rules::{inspect_rule_pack, rule_validation_results};
 use crate::doctor::services::inspect_service;
+use crate::doctor::telemetry::telemetry_results;
+use crate::telemetry::TelemetrySnapshot;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "lowercase")]
@@ -152,6 +154,10 @@ pub struct DoctorReport {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rule_pack: Option<RulePackDiagnostic>,
     pub service: ServiceDiagnostic,
+    /// Pipeline drop counters read from the running agent's snapshot, when one
+    /// has been written.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub telemetry: Option<TelemetrySnapshot>,
     pub results: Vec<DiagnosticResult>,
 }
 
@@ -177,8 +183,16 @@ impl DoctorReport {
             paths,
             rule_pack,
             service,
+            telemetry: None,
             results,
         }
+    }
+
+    /// Attach the pipeline drop counters, so `--json` carries the per-channel
+    /// numbers behind the summary diagnostic.
+    pub fn with_telemetry(mut self, telemetry: Option<TelemetrySnapshot>) -> Self {
+        self.telemetry = telemetry;
+        self
     }
 }
 
@@ -230,6 +244,9 @@ pub fn inspect_with_options(options: ConfigLoadOptions) -> DoctorReport {
             results.extend(rule_validation_results(&cfg, platform));
             results.extend(platform_prerequisite_results());
 
+            let (pipeline_results, telemetry) = telemetry_results(&cfg, &paths.logs_dir);
+            results.extend(pipeline_results);
+
             let rule_pack = inspect_rule_pack(&paths, &mut results);
             let service = inspect_service(mode, &mut results);
 
@@ -242,6 +259,7 @@ pub fn inspect_with_options(options: ConfigLoadOptions) -> DoctorReport {
                 service,
                 results,
             )
+            .with_telemetry(telemetry)
         }
         Err(err) => {
             results.push(
@@ -324,6 +342,28 @@ pub fn format_human(report: &DoctorReport) -> String {
         output.push_str(&format!("  state: {}\n", pack.state_path.display()));
         if let Some(path) = &pack.manifest_path {
             output.push_str(&format!("  manifest: {}\n", path.display()));
+        }
+    }
+
+    if let Some(telemetry) = &report.telemetry {
+        output.push_str("\nPipeline channels:\n");
+        output.push_str(&format!(
+            "  snapshot: {} (pid {}, up {}s)\n",
+            telemetry.captured_at, telemetry.pid, telemetry.uptime_secs
+        ));
+        let active = telemetry.active_channels();
+        if active.is_empty() {
+            output.push_str("  no channel has carried an event yet\n");
+        }
+        for channel in active {
+            output.push_str(&format!(
+                "  {}: accepted {}, dropped {}, peak depth {}/{}\n",
+                channel.channel,
+                channel.accepted,
+                channel.dropped,
+                channel.high_water_mark,
+                channel.capacity
+            ));
         }
     }
 

--- a/src/doctor/mod.rs
+++ b/src/doctor/mod.rs
@@ -3,6 +3,7 @@ pub mod path;
 pub mod prerequisites;
 pub mod rules;
 pub mod services;
+mod telemetry;
 
 pub use inspect::{
     format_human, inspect, inspect_with_options, run_cli, ConfigDiagnostic, DiagnosticResult,

--- a/src/doctor/telemetry.rs
+++ b/src/doctor/telemetry.rs
@@ -1,0 +1,173 @@
+//! Pipeline drop-counter diagnostics.
+//!
+//! Answers "did this endpoint lose telemetry, and how much?" from the snapshot
+//! the running agent writes, so an operator does not have to grep rotated logs
+//! to size a detection gap.
+
+use crate::config::AppConfig;
+use crate::doctor::inspect::DiagnosticResult;
+use crate::telemetry::{snapshot_path, TelemetrySnapshot};
+use std::path::Path;
+
+/// Inspect the persisted pipeline counters for `logs_dir`.
+///
+/// Returns the snapshot alongside the diagnostic so `--json` can carry the
+/// full per-channel numbers rather than only the summary line.
+pub(crate) fn telemetry_results(
+    cfg: &AppConfig,
+    logs_dir: &Path,
+) -> (Vec<DiagnosticResult>, Option<TelemetrySnapshot>) {
+    if !cfg.telemetry.enabled {
+        return (
+            vec![DiagnosticResult::warn(
+                "pipeline_telemetry",
+                "Pipeline drop counters are not being persisted",
+                "telemetry.enabled is false, so dropped-event totals are only visible in the agent log",
+            )
+            .with_fix("Set telemetry.enabled = true to make drop counters readable here")],
+            None,
+        );
+    }
+
+    let path = snapshot_path(logs_dir);
+    let Some(snapshot) = TelemetrySnapshot::read_from(&path) else {
+        return (
+            vec![DiagnosticResult::pass(
+                "pipeline_telemetry",
+                format!(
+                    "No pipeline telemetry snapshot yet at {} (written once the agent has run)",
+                    path.display()
+                ),
+            )],
+            None,
+        );
+    };
+
+    let dropping = snapshot.dropping_channels();
+    if dropping.is_empty() {
+        let result = DiagnosticResult::pass(
+            "pipeline_telemetry",
+            format!(
+                "No telemetry dropped across {} events (snapshot from {})",
+                snapshot.total_accepted(),
+                snapshot.captured_at
+            ),
+        );
+        return (vec![result], Some(snapshot));
+    }
+
+    let detail = dropping
+        .iter()
+        .map(|channel| channel.describe())
+        .collect::<Vec<_>>()
+        .join("; ");
+
+    let result = DiagnosticResult::warn(
+        "pipeline_telemetry",
+        format!(
+            "{} events were dropped under load (snapshot from {})",
+            snapshot.total_dropped(),
+            snapshot.captured_at
+        ),
+        detail,
+    )
+    .with_fix(
+        "Detection gaps are proportional to these counts. Reduce event volume - narrow broad \
+         rules, widen trusted-path allowlists - and re-run to confirm the totals stop growing; \
+         see docs/troubleshooting.md",
+    );
+
+    (vec![result], Some(snapshot))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::doctor::inspect::DiagnosticStatus;
+    use crate::telemetry::ChannelSnapshot;
+
+    fn snapshot(channels: Vec<ChannelSnapshot>) -> TelemetrySnapshot {
+        TelemetrySnapshot {
+            version: "1.3.0".to_string(),
+            pid: 7,
+            captured_at: "2026-08-24T12:00:00Z".to_string(),
+            uptime_secs: 3600,
+            channels,
+        }
+    }
+
+    fn channel(name: &str, accepted: u64, dropped: u64) -> ChannelSnapshot {
+        ChannelSnapshot {
+            channel: name.to_string(),
+            capacity: 8192,
+            accepted,
+            dropped,
+            dropped_channel_closed: 0,
+            high_water_mark: 8192,
+        }
+    }
+
+    #[test]
+    fn a_missing_snapshot_is_not_a_finding() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let cfg = AppConfig::default();
+
+        let (results, read) = telemetry_results(&cfg, temp.path());
+
+        assert!(read.is_none());
+        assert_eq!(results[0].status, DiagnosticStatus::Pass);
+        assert!(results[0]
+            .message
+            .contains("No pipeline telemetry snapshot"));
+    }
+
+    #[test]
+    fn a_clean_snapshot_passes_and_reports_the_volume() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        snapshot(vec![channel("sensor_events", 5_000, 0)])
+            .write_to(&snapshot_path(temp.path()))
+            .expect("write snapshot");
+
+        let (results, read) = telemetry_results(&AppConfig::default(), temp.path());
+
+        assert_eq!(results[0].status, DiagnosticStatus::Pass);
+        assert!(results[0].message.contains("5000 events"));
+        assert_eq!(read.expect("snapshot").pid, 7);
+    }
+
+    /// The whole point of the check: an operator sees the size of the gap and
+    /// which channel produced it without opening a log file.
+    #[test]
+    fn dropped_telemetry_warns_with_per_channel_counts() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        snapshot(vec![
+            channel("sensor_events", 9_000, 1_000),
+            channel("yara_file_scan", 100, 25),
+        ])
+        .write_to(&snapshot_path(temp.path()))
+        .expect("write snapshot");
+
+        let (results, _) = telemetry_results(&AppConfig::default(), temp.path());
+
+        assert_eq!(results[0].status, DiagnosticStatus::Warn);
+        assert!(results[0].message.contains("1025 events were dropped"));
+
+        let detail = results[0].detail.as_deref().expect("detail");
+        // Worst channel first, so the summary leads with the real gap.
+        assert!(detail.starts_with("sensor_events: 1000 dropped of 10000 offered (10.00%)"));
+        assert!(detail.contains("yara_file_scan: 25 dropped of 125 offered"));
+        assert!(results[0].fix.is_some());
+    }
+
+    #[test]
+    fn disabling_persistence_is_reported_as_a_visibility_gap() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let mut cfg = AppConfig::default();
+        cfg.telemetry.enabled = false;
+
+        let (results, read) = telemetry_results(&cfg, temp.path());
+
+        assert!(read.is_none());
+        assert_eq!(results[0].status, DiagnosticStatus::Warn);
+    }
+}

--- a/src/engine/handler.rs
+++ b/src/engine/handler.rs
@@ -114,7 +114,11 @@ impl SensorEventHandler for NormalizedEventHandler {
                                     .or(event.pid)
                                     .unwrap_or(0);
 
-                                if let Err(err) = tx.try_send((image.to_string(), pid)) {
+                                if let Err(err) = crate::telemetry::try_send(
+                                    crate::telemetry::ChannelId::IocHash,
+                                    tx,
+                                    (image.to_string(), pid),
+                                ) {
                                     debug!(
                                         target: TARGET_ENGINE,
                                         pid = pid,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,4 +23,5 @@ pub mod sensor;
 pub mod service;
 pub mod setup;
 pub mod state;
+pub mod telemetry;
 pub mod utils;

--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -131,7 +131,9 @@ impl ResponseEngine {
             identity: extract_process_identity(alert),
         };
 
-        if let Err(err) = self.tx.try_send(task) {
+        if let Err(err) =
+            crate::telemetry::try_send(crate::telemetry::ChannelId::ActiveResponse, &self.tx, task)
+        {
             warn!(
                 target: TARGET_RESPONSE,
                 error = %err,

--- a/src/runtime/linux.rs
+++ b/src/runtime/linux.rs
@@ -7,6 +7,7 @@ use crate::reload::DetectorStore;
 use crate::response::ResponseEngine;
 use crate::runtime::capture::{CaptureContext, CaptureOptions, CaptureSession};
 use crate::runtime::logging::{init_logging, log_startup_banner};
+use crate::runtime::telemetry::TelemetryReporter;
 use crate::runtime::{ioc as runtime_ioc, yara as runtime_yara};
 use crate::scanner::{YaraEventHandler, YaraMemoryJob};
 use crate::sensor::linux::EbpfSensor;
@@ -103,6 +104,9 @@ async fn run_linux_edr(
     };
 
     log_startup_banner("Linux eBPF");
+
+    // 2b. Pipeline drop counters, published for `rustinel doctor`
+    let telemetry_reporter = TelemetryReporter::start(&cfg);
 
     // 3. Shared state
     let process_cache = Arc::new(ProcessCache::with_max_entries(cfg.process.max_entries));
@@ -373,6 +377,10 @@ async fn run_linux_edr(
     if let Some(dedup) = alert_sink.dedup() {
         dedup.flush_all(&alert_sink);
         dedup.log_metrics();
+    }
+
+    if let Some(reporter) = telemetry_reporter {
+        reporter.finish().await;
     }
 
     info!("Shutdown complete");

--- a/src/runtime/macos.rs
+++ b/src/runtime/macos.rs
@@ -7,6 +7,7 @@ use crate::reload::DetectorStore;
 use crate::response::ResponseEngine;
 use crate::runtime::capture::{CaptureContext, CaptureOptions, CaptureSession};
 use crate::runtime::logging::{init_logging, log_startup_banner};
+use crate::runtime::telemetry::TelemetryReporter;
 use crate::runtime::{ioc as runtime_ioc, yara as runtime_yara};
 use crate::scanner::{YaraEventHandler, YaraMemoryJob};
 use crate::sensor::macos::{BpfSensor, EsfSensor};
@@ -119,6 +120,9 @@ async fn run_macos_edr(
     };
 
     log_startup_banner("macOS ESF");
+
+    // Pipeline drop counters, published for `rustinel doctor`
+    let telemetry_reporter = TelemetryReporter::start(&cfg);
 
     // 3. Shared state
     let process_cache = Arc::new(ProcessCache::with_max_entries(cfg.process.max_entries));
@@ -401,6 +405,10 @@ async fn run_macos_edr(
     if let Some(dedup) = alert_sink.dedup() {
         dedup.flush_all(&alert_sink);
         dedup.log_metrics();
+    }
+
+    if let Some(reporter) = telemetry_reporter {
+        reporter.finish().await;
     }
 
     info!("Shutdown complete");

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -6,6 +6,7 @@ pub mod logging;
 #[cfg(target_os = "macos")]
 mod macos;
 mod orchestration;
+pub mod telemetry;
 #[cfg(windows)]
 mod windows;
 pub mod yara;

--- a/src/runtime/telemetry.rs
+++ b/src/runtime/telemetry.rs
@@ -1,0 +1,51 @@
+//! Runtime wiring for the pipeline drop counters.
+//!
+//! The counters themselves are always live; this is the piece that publishes
+//! them outside the process so `rustinel doctor` can read them.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use tokio::task::JoinHandle;
+use tracing::info;
+
+use crate::config::AppConfig;
+use crate::telemetry::{snapshot_path, spawn_reporter, write_final_snapshot, TARGET_TELEMETRY};
+
+/// Background task publishing the pipeline counters for `rustinel doctor`.
+pub struct TelemetryReporter {
+    path: PathBuf,
+    handle: JoinHandle<()>,
+}
+
+impl TelemetryReporter {
+    /// Start publishing, unless the operator turned persistence off.
+    pub fn start(cfg: &AppConfig) -> Option<Self> {
+        if !cfg.telemetry.enabled {
+            return None;
+        }
+
+        let path = snapshot_path(&cfg.logging.directory);
+        let interval = Duration::from_secs(cfg.telemetry.snapshot_interval_secs.max(1));
+        info!(
+            target: TARGET_TELEMETRY,
+            path = %path.display(),
+            interval_secs = interval.as_secs(),
+            "Publishing pipeline channel counters"
+        );
+
+        let handle = spawn_reporter(path.clone(), interval);
+        Some(Self { path, handle })
+    }
+
+    /// Stop publishing after one final write.
+    ///
+    /// The last interval's drops are the ones an operator is most likely to be
+    /// asking about — an agent that shed events and then stopped — so the
+    /// shutdown snapshot is written rather than left to a tick that never came.
+    pub async fn finish(self) {
+        self.handle.abort();
+        let _ = self.handle.await;
+        write_final_snapshot(&self.path);
+    }
+}

--- a/src/runtime/telemetry.rs
+++ b/src/runtime/telemetry.rs
@@ -7,10 +7,9 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use tokio::task::JoinHandle;
-use tracing::info;
 
 use crate::config::AppConfig;
-use crate::telemetry::{snapshot_path, spawn_reporter, write_final_snapshot, TARGET_TELEMETRY};
+use crate::telemetry::{snapshot_path, spawn_reporter, write_final_snapshot};
 
 /// Background task publishing the pipeline counters for `rustinel doctor`.
 pub struct TelemetryReporter {
@@ -26,15 +25,10 @@ impl TelemetryReporter {
         }
 
         let path = snapshot_path(&cfg.logging.directory);
-        let interval = Duration::from_secs(cfg.telemetry.snapshot_interval_secs.max(1));
-        info!(
-            target: TARGET_TELEMETRY,
-            path = %path.display(),
-            interval_secs = interval.as_secs(),
-            "Publishing pipeline channel counters"
+        let handle = spawn_reporter(
+            path.clone(),
+            Duration::from_secs(cfg.telemetry.snapshot_interval_secs),
         );
-
-        let handle = spawn_reporter(path.clone(), interval);
         Some(Self { path, handle })
     }
 

--- a/src/runtime/windows.rs
+++ b/src/runtime/windows.rs
@@ -7,6 +7,7 @@ use crate::reload::DetectorStore;
 use crate::response::ResponseEngine;
 use crate::runtime::capture::{CaptureContext, CaptureOptions, CaptureSession};
 use crate::runtime::logging::{init_logging, log_startup_banner};
+use crate::runtime::telemetry::TelemetryReporter;
 use crate::runtime::{ioc as runtime_ioc, yara as runtime_yara};
 use crate::scanner::{YaraEventHandler, YaraMemoryJob};
 use crate::sensor::windows::EtwSensor;
@@ -309,6 +310,9 @@ async fn run_edr(
     };
 
     log_startup_banner("Windows ETW");
+
+    // Pipeline drop counters, published for `rustinel doctor`
+    let telemetry_reporter = TelemetryReporter::start(&cfg);
 
     // 2.1 Initialize Active Response Engine (optional)
     let response_config = Arc::new(ArcSwap::from(Arc::new(cfg.response.clone())));
@@ -753,6 +757,10 @@ async fn run_edr(
     if let Some(dedup) = alert_sink.dedup() {
         dedup.flush_all(&alert_sink);
         dedup.log_metrics();
+    }
+
+    if let Some(reporter) = telemetry_reporter {
+        reporter.finish().await;
     }
 
     info!("");

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -597,7 +597,11 @@ impl SensorEventHandler for YaraEventHandler {
             return;
         }
 
-        match self.tx.try_send((path.to_string(), pid)) {
+        match crate::telemetry::try_send(
+            crate::telemetry::ChannelId::YaraFileScan,
+            &self.tx,
+            (path.to_string(), pid),
+        ) {
             Ok(_) => tracing::trace!(
                 target: "scanner",
                 pid = pid,
@@ -615,7 +619,11 @@ impl SensorEventHandler for YaraEventHandler {
 
         if let Some(memory_tx) = &self.memory_tx {
             let expected_identity = capture_process_identity(event, fields, pid, path);
-            match memory_tx.try_send(YaraMemoryJob { expected_identity }) {
+            match crate::telemetry::try_send(
+                crate::telemetry::ChannelId::YaraMemoryScan,
+                memory_tx,
+                YaraMemoryJob { expected_identity },
+            ) {
                 Ok(_) => tracing::trace!(
                     target: "scanner",
                     pid = pid,

--- a/src/sensor/linux/ebpf.rs
+++ b/src/sensor/linux/ebpf.rs
@@ -592,16 +592,15 @@ fn parse_dns_query_name(ev: &DnsEvent) -> Option<String> {
 
 // ── Utilities ────────────────────────────────────────────────────────────────
 
+/// Queue a decoded event, accounting for a drop rather than blocking.
+///
+/// Blocking here would stall the perf-buffer poll loop and lose the events
+/// behind it in the kernel instead, so overflow is shed. The count is what
+/// makes that trade auditable — see [`crate::telemetry`].
 fn try_send(tx: &Sender<SensorEvent>, event: SensorEvent) {
-    match tx.try_send(event) {
-        Ok(_) => {}
-        Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
-            warn!("eBPF sensor: event channel full, dropping event");
-        }
-        Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
-            // Pipeline has shut down; stop logging.
-        }
-    }
+    // Both the full and closed cases are already counted; the reason is in the
+    // rate-limited warning the telemetry module emits.
+    let _ = crate::telemetry::try_send(crate::telemetry::ChannelId::SensorEvents, tx, event);
 }
 
 fn resolved_linux_user(uid: u32) -> String {

--- a/src/sensor/macos/bpf.rs
+++ b/src/sensor/macos/bpf.rs
@@ -631,16 +631,13 @@ fn record_type_name(qtype: u16) -> Option<&'static str> {
     Some(name)
 }
 
+/// Queue a decoded event, accounting for a drop rather than blocking.
+///
+/// The capture loop reads a fixed-size kernel buffer, so blocking here would
+/// overflow that buffer instead. Overflow is shed and counted — see
+/// [`crate::telemetry`].
 fn try_send(tx: &Sender<SensorEvent>, event: SensorEvent) {
-    match tx.try_send(event) {
-        Ok(_) => {}
-        Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
-            warn!("bpf sensor: event channel full, dropping event");
-        }
-        Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
-            // Pipeline has shut down; stop logging.
-        }
-    }
+    let _ = crate::telemetry::try_send(crate::telemetry::ChannelId::SensorEvents, tx, event);
 }
 
 fn read_u32(buf: &[u8], at: usize) -> u32 {

--- a/src/sensor/macos/esf.rs
+++ b/src/sensor/macos/esf.rs
@@ -572,16 +572,12 @@ fn system_time_nanos(time: SystemTime) -> u64 {
         .unwrap_or(0)
 }
 
+/// Queue a decoded event, accounting for a drop rather than blocking.
+///
+/// The ESF message handler runs on the client's own queue and must return
+/// promptly, so overflow is shed and counted — see [`crate::telemetry`].
 fn try_send(tx: &Sender<SensorEvent>, event: SensorEvent) {
-    match tx.try_send(event) {
-        Ok(_) => {}
-        Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
-            warn!("ESF sensor: event channel full, dropping event");
-        }
-        Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
-            // Pipeline has shut down; stop logging.
-        }
-    }
+    let _ = crate::telemetry::try_send(crate::telemetry::ChannelId::SensorEvents, tx, event);
 }
 
 #[cfg(test)]

--- a/src/sensor/windows/etw.rs
+++ b/src/sensor/windows/etw.rs
@@ -444,14 +444,12 @@ struct DecodedEtwEvent {
 /// Windows ETW sensor implementation.
 pub struct EtwSensor {
     shutdown: Arc<AtomicBool>,
-    dropped_events: Arc<AtomicU64>,
 }
 
 impl EtwSensor {
     pub fn new() -> Self {
         Self {
             shutdown: Arc::new(AtomicBool::new(false)),
-            dropped_events: Arc::new(AtomicU64::new(0)),
         }
     }
 
@@ -474,7 +472,6 @@ impl Sensor for EtwSensor {
 
         let mut trace_builder = UserTrace::new().named(TRACE_SESSION_NAME.to_string());
         let state = Arc::new(EtwState::new());
-        let dropped_events = Arc::clone(&self.dropped_events);
 
         for provider_def in EtwProviders::all() {
             info!(
@@ -484,7 +481,6 @@ impl Sensor for EtwSensor {
 
             let state = Arc::clone(&state);
             let tx = tx.clone();
-            let dropped_events = Arc::clone(&dropped_events);
             let mut provider_builder = Provider::by_guid(provider_def.guid)
                 .level(4)
                 .any(provider_def.keywords)
@@ -493,20 +489,16 @@ impl Sensor for EtwSensor {
                         return;
                     };
 
-                    match tx.try_send(event) {
-                        Ok(()) => {}
-                        Err(TrySendError::Full(_)) => {
-                            let dropped = dropped_events.fetch_add(1, Ordering::Relaxed) + 1;
-                            if dropped == 1 || dropped.is_multiple_of(100) {
-                                warn!(
-                                    dropped_events = dropped,
-                                    "Sensor event channel full; dropping ETW event"
-                                );
-                            }
-                        }
-                        Err(TrySendError::Closed(_)) => {
-                            trace!("Sensor event channel closed; dropping ETW event");
-                        }
+                    // Blocking inside an ETW callback stalls the trace
+                    // session and loses events in the kernel buffer instead,
+                    // so overflow is shed. The telemetry counters record both
+                    // outcomes and emit the rate-limited cumulative warning.
+                    if let Err(TrySendError::Closed(_)) = crate::telemetry::try_send(
+                        crate::telemetry::ChannelId::SensorEvents,
+                        &tx,
+                        event,
+                    ) {
+                        trace!("Sensor event channel closed; dropping ETW event");
                     }
                 });
 

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -1,0 +1,457 @@
+//! Pipeline telemetry accounting.
+//!
+//! Every bounded channel between a sensor and the detectors sheds load by
+//! dropping events rather than blocking the producer — an ETW callback or an
+//! eBPF poll loop that blocks stalls the kernel-side buffer behind it. Load
+//! shedding is the right trade, but it is only safe to rely on if the size of
+//! the gap is measurable: a warning in a rotated log file cannot tell an
+//! operator whether a detection failed to fire or never had the event.
+//!
+//! This module gives each channel a set of atomic counters — accepted,
+//! dropped, and the peak queue depth reached — that the runtime periodically
+//! writes to a snapshot file. `rustinel doctor` reads that snapshot, so the
+//! answer to "did we lose telemetry?" is a command, not a log search.
+
+mod snapshot;
+
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::LazyLock;
+use std::time::{Duration, Instant};
+
+use tokio::sync::mpsc::error::TrySendError;
+use tokio::sync::mpsc::Sender;
+use tracing::warn;
+
+pub use snapshot::{
+    snapshot_path, spawn_reporter, write_final_snapshot, ChannelSnapshot, TelemetrySnapshot,
+    SNAPSHOT_FILE_NAME,
+};
+
+/// Tracing target for pipeline telemetry accounting.
+pub const TARGET_TELEMETRY: &str = "telemetry";
+
+/// Minimum spacing between cumulative drop warnings for one channel.
+///
+/// The first drop on a channel always warns; after that the warning carries
+/// the running total, so a burst produces one line rather than one per event.
+const DROP_WARN_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Process start, used as the epoch for the lock-free warning rate limiter.
+static PROCESS_START: LazyLock<Instant> = LazyLock::new(Instant::now);
+
+/// A bounded channel in the event pipeline that can shed load.
+///
+/// Counters are keyed by channel rather than by sensor: on macOS the ESF and
+/// BPF sensors feed one channel, and what an operator needs to know is how
+/// much that channel lost, not which producer lost it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ChannelId {
+    /// Sensor decode threads to the detection router.
+    SensorEvents,
+    /// Process/file events queued for on-disk YARA scanning.
+    YaraFileScan,
+    /// Processes queued for YARA memory scanning.
+    YaraMemoryScan,
+    /// Process images queued for IOC hash lookup.
+    IocHash,
+    /// Alerts queued for active response.
+    ActiveResponse,
+    /// Normalized events queued for the capture recording writer.
+    CaptureWriter,
+}
+
+impl ChannelId {
+    /// Every channel, in the order snapshots report them.
+    pub const ALL: [ChannelId; 6] = [
+        ChannelId::SensorEvents,
+        ChannelId::YaraFileScan,
+        ChannelId::YaraMemoryScan,
+        ChannelId::IocHash,
+        ChannelId::ActiveResponse,
+        ChannelId::CaptureWriter,
+    ];
+
+    /// Stable identifier used in snapshots, log fields, and doctor output.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            ChannelId::SensorEvents => "sensor_events",
+            ChannelId::YaraFileScan => "yara_file_scan",
+            ChannelId::YaraMemoryScan => "yara_memory_scan",
+            ChannelId::IocHash => "ioc_hash",
+            ChannelId::ActiveResponse => "active_response",
+            ChannelId::CaptureWriter => "capture_writer",
+        }
+    }
+
+    /// What is lost when this channel drops, for operator-facing output.
+    pub const fn loss_description(self) -> &'static str {
+        match self {
+            ChannelId::SensorEvents => "raw sensor events never reached the detectors",
+            ChannelId::YaraFileScan => "files were never YARA scanned",
+            ChannelId::YaraMemoryScan => "processes were never memory scanned",
+            ChannelId::IocHash => "process images were never hashed for IOC matching",
+            ChannelId::ActiveResponse => "response actions were never executed",
+            ChannelId::CaptureWriter => "events never reached the recording",
+        }
+    }
+
+    const fn index(self) -> usize {
+        match self {
+            ChannelId::SensorEvents => 0,
+            ChannelId::YaraFileScan => 1,
+            ChannelId::YaraMemoryScan => 2,
+            ChannelId::IocHash => 3,
+            ChannelId::ActiveResponse => 4,
+            ChannelId::CaptureWriter => 5,
+        }
+    }
+
+    /// The process-wide counters for this channel.
+    pub fn counters(self) -> &'static ChannelCounters {
+        &CHANNELS[self.index()]
+    }
+}
+
+/// Process-wide counters, one set per [`ChannelId`].
+///
+/// A static array rather than a registry map: the set of channels is fixed at
+/// compile time, so lookups need no lock and no allocation on the send path.
+static CHANNELS: [ChannelCounters; 6] = [
+    ChannelCounters::new(ChannelId::SensorEvents),
+    ChannelCounters::new(ChannelId::YaraFileScan),
+    ChannelCounters::new(ChannelId::YaraMemoryScan),
+    ChannelCounters::new(ChannelId::IocHash),
+    ChannelCounters::new(ChannelId::ActiveResponse),
+    ChannelCounters::new(ChannelId::CaptureWriter),
+];
+
+/// Atomic accounting for one bounded channel.
+///
+/// All counters are `Relaxed`: they are independent totals read for reporting,
+/// never used to order other memory.
+#[derive(Debug)]
+pub struct ChannelCounters {
+    id: ChannelId,
+    /// Configured channel capacity, learned from the first send.
+    capacity: AtomicUsize,
+    /// Items accepted by the channel.
+    accepted: AtomicU64,
+    /// Items dropped because the channel was full — this is the detection gap.
+    dropped: AtomicU64,
+    /// Items dropped because the consumer was gone, which is shutdown, not loss.
+    dropped_closed: AtomicU64,
+    /// Deepest queue depth observed after a successful send.
+    high_water_mark: AtomicUsize,
+    /// Milliseconds since [`PROCESS_START`] at the last emitted drop warning.
+    last_warn_millis: AtomicU64,
+    /// Cumulative drop total at the last emitted drop warning.
+    warned_at_total: AtomicU64,
+}
+
+impl ChannelCounters {
+    const fn new(id: ChannelId) -> Self {
+        Self {
+            id,
+            capacity: AtomicUsize::new(0),
+            accepted: AtomicU64::new(0),
+            dropped: AtomicU64::new(0),
+            dropped_closed: AtomicU64::new(0),
+            high_water_mark: AtomicUsize::new(0),
+            last_warn_millis: AtomicU64::new(0),
+            warned_at_total: AtomicU64::new(0),
+        }
+    }
+
+    pub fn id(&self) -> ChannelId {
+        self.id
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.capacity.load(Ordering::Relaxed)
+    }
+
+    pub fn accepted(&self) -> u64 {
+        self.accepted.load(Ordering::Relaxed)
+    }
+
+    pub fn dropped(&self) -> u64 {
+        self.dropped.load(Ordering::Relaxed)
+    }
+
+    pub fn dropped_closed(&self) -> u64 {
+        self.dropped_closed.load(Ordering::Relaxed)
+    }
+
+    pub fn high_water_mark(&self) -> usize {
+        self.high_water_mark.load(Ordering::Relaxed)
+    }
+
+    /// Point-in-time view of this channel.
+    pub fn snapshot(&self) -> ChannelSnapshot {
+        ChannelSnapshot {
+            channel: self.id.as_str().to_string(),
+            capacity: self.capacity(),
+            accepted: self.accepted(),
+            dropped: self.dropped(),
+            dropped_channel_closed: self.dropped_closed(),
+            high_water_mark: self.high_water_mark(),
+        }
+    }
+
+    /// Reset every counter. Test-only: the statics outlive individual tests, so
+    /// a test that asserts on totals has to start from a known state.
+    #[cfg(test)]
+    pub fn reset(&self) {
+        self.capacity.store(0, Ordering::Relaxed);
+        self.accepted.store(0, Ordering::Relaxed);
+        self.dropped.store(0, Ordering::Relaxed);
+        self.dropped_closed.store(0, Ordering::Relaxed);
+        self.high_water_mark.store(0, Ordering::Relaxed);
+        self.last_warn_millis.store(0, Ordering::Relaxed);
+        self.warned_at_total.store(0, Ordering::Relaxed);
+    }
+
+    fn record_accepted(&self, capacity: usize, depth: usize) {
+        self.accepted.fetch_add(1, Ordering::Relaxed);
+
+        if self.capacity.load(Ordering::Relaxed) != capacity {
+            self.capacity.store(capacity, Ordering::Relaxed);
+        }
+
+        // Read before the read-modify-write so the steady state — a queue that
+        // is not setting a new record — costs a load rather than a CAS loop.
+        if depth > self.high_water_mark.load(Ordering::Relaxed) {
+            self.high_water_mark.fetch_max(depth, Ordering::Relaxed);
+        }
+    }
+
+    fn record_dropped(&self, capacity: usize) {
+        let dropped = self.dropped.fetch_add(1, Ordering::Relaxed) + 1;
+
+        if self.capacity.load(Ordering::Relaxed) != capacity {
+            self.capacity.store(capacity, Ordering::Relaxed);
+        }
+        // A full channel is by definition at its deepest.
+        if capacity > self.high_water_mark.load(Ordering::Relaxed) {
+            self.high_water_mark.fetch_max(capacity, Ordering::Relaxed);
+        }
+
+        if let Some(since_last_warning) =
+            self.claim_warning(dropped, DROP_WARN_INTERVAL.as_millis() as u64)
+        {
+            warn!(
+                target: TARGET_TELEMETRY,
+                channel = self.id.as_str(),
+                capacity,
+                dropped_total = dropped,
+                dropped_since_last_warning = since_last_warning,
+                accepted_total = self.accepted(),
+                "Pipeline channel full; shedding telemetry"
+            );
+        }
+    }
+
+    fn record_dropped_closed(&self) {
+        self.dropped_closed.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Decide whether this drop should warn, returning how many drops the
+    /// warning covers.
+    ///
+    /// Lock-free on purpose: drops happen exactly when the pipeline is already
+    /// saturated, which is the worst moment to add a contended mutex. Losing a
+    /// race here costs at most one suppressed warning line.
+    fn claim_warning(&self, dropped: u64, interval_millis: u64) -> Option<u64> {
+        let now_millis = PROCESS_START.elapsed().as_millis() as u64;
+        let last_millis = self.last_warn_millis.load(Ordering::Relaxed);
+        let is_first_drop = dropped == 1;
+
+        if !is_first_drop && now_millis.saturating_sub(last_millis) < interval_millis {
+            return None;
+        }
+
+        self.last_warn_millis
+            .compare_exchange(
+                last_millis,
+                now_millis,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            )
+            .ok()?;
+
+        let previous_total = self.warned_at_total.swap(dropped, Ordering::Relaxed);
+        Some(dropped.saturating_sub(previous_total))
+    }
+}
+
+/// Send on a bounded channel without blocking, accounting for the outcome.
+///
+/// Behaves exactly like [`Sender::try_send`] — the caller still decides what a
+/// failure means — but records the send against `channel` so the loss shows up
+/// in the snapshot and in `rustinel doctor` instead of only in the log.
+pub fn try_send<T>(channel: ChannelId, tx: &Sender<T>, value: T) -> Result<(), TrySendError<T>> {
+    let counters = channel.counters();
+    let capacity = tx.max_capacity();
+
+    match tx.try_send(value) {
+        Ok(()) => {
+            // Remaining capacity is sampled after the send, so the depth
+            // includes the item just queued. Another producer can push between
+            // the two calls, which makes this a close estimate rather than an
+            // exact reading — the high-water mark is a saturation signal, not
+            // an accounting figure.
+            let depth = capacity.saturating_sub(tx.capacity());
+            counters.record_accepted(capacity, depth);
+            Ok(())
+        }
+        Err(TrySendError::Full(value)) => {
+            counters.record_dropped(capacity);
+            Err(TrySendError::Full(value))
+        }
+        Err(TrySendError::Closed(value)) => {
+            counters.record_dropped_closed();
+            Err(TrySendError::Closed(value))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Serializes tests that assert on the process-wide statics.
+    fn counter_guard() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let guard = LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        for channel in ChannelId::ALL {
+            channel.counters().reset();
+        }
+        guard
+    }
+
+    #[test]
+    fn channel_identifiers_are_unique_and_indexed_consistently() {
+        for (index, channel) in ChannelId::ALL.iter().enumerate() {
+            assert_eq!(channel.index(), index, "{} is misindexed", channel.as_str());
+            assert_eq!(channel.counters().id(), *channel);
+        }
+    }
+
+    #[tokio::test]
+    async fn accepted_sends_are_counted_with_queue_depth() {
+        let _guard = counter_guard();
+        let (tx, _rx) = tokio::sync::mpsc::channel::<u8>(4);
+
+        for value in 0..3u8 {
+            try_send(ChannelId::IocHash, &tx, value).expect("channel has room");
+        }
+
+        let counters = ChannelId::IocHash.counters();
+        assert_eq!(counters.accepted(), 3);
+        assert_eq!(counters.dropped(), 0);
+        assert_eq!(counters.capacity(), 4);
+        assert_eq!(counters.high_water_mark(), 3);
+    }
+
+    #[tokio::test]
+    async fn a_full_channel_counts_drops_and_pins_the_high_water_mark() {
+        let _guard = counter_guard();
+        let (tx, _rx) = tokio::sync::mpsc::channel::<u8>(2);
+
+        try_send(ChannelId::YaraFileScan, &tx, 1).expect("channel has room");
+        try_send(ChannelId::YaraFileScan, &tx, 2).expect("channel has room");
+        for value in 3..8u8 {
+            let err = try_send(ChannelId::YaraFileScan, &tx, value).expect_err("channel is full");
+            assert!(matches!(err, TrySendError::Full(_)));
+        }
+
+        let counters = ChannelId::YaraFileScan.counters();
+        assert_eq!(counters.accepted(), 2);
+        assert_eq!(counters.dropped(), 5);
+        assert_eq!(counters.dropped_closed(), 0);
+        assert_eq!(counters.high_water_mark(), 2);
+    }
+
+    /// A dropped value has to come back to the caller intact: the sensors rely
+    /// on it to fall back to a less-enriched send rather than lose the event.
+    #[tokio::test]
+    async fn a_dropped_value_is_returned_to_the_caller() {
+        let _guard = counter_guard();
+        let (tx, _rx) = tokio::sync::mpsc::channel::<String>(1);
+
+        try_send(ChannelId::SensorEvents, &tx, "queued".to_string()).expect("channel has room");
+        let err = try_send(ChannelId::SensorEvents, &tx, "shed".to_string())
+            .expect_err("channel is full");
+
+        match err {
+            TrySendError::Full(value) => assert_eq!(value, "shed"),
+            TrySendError::Closed(_) => panic!("channel is full, not closed"),
+        }
+    }
+
+    /// Shutdown is not a detection gap, so a closed channel must not inflate
+    /// the drop count an operator reads as lost telemetry.
+    #[tokio::test]
+    async fn a_closed_channel_is_counted_apart_from_load_shedding() {
+        let _guard = counter_guard();
+        let (tx, rx) = tokio::sync::mpsc::channel::<u8>(4);
+        drop(rx);
+
+        let err = try_send(ChannelId::ActiveResponse, &tx, 1).expect_err("channel is closed");
+        assert!(matches!(err, TrySendError::Closed(_)));
+
+        let counters = ChannelId::ActiveResponse.counters();
+        assert_eq!(counters.dropped(), 0);
+        assert_eq!(counters.dropped_closed(), 1);
+        assert_eq!(counters.accepted(), 0);
+    }
+
+    #[tokio::test]
+    async fn channels_are_counted_independently() {
+        let _guard = counter_guard();
+        let (full_tx, _full_rx) = tokio::sync::mpsc::channel::<u8>(1);
+        let (open_tx, _open_rx) = tokio::sync::mpsc::channel::<u8>(4);
+
+        try_send(ChannelId::CaptureWriter, &full_tx, 1).expect("channel has room");
+        let _ = try_send(ChannelId::CaptureWriter, &full_tx, 2);
+        try_send(ChannelId::IocHash, &open_tx, 3).expect("channel has room");
+
+        assert_eq!(ChannelId::CaptureWriter.counters().dropped(), 1);
+        assert_eq!(ChannelId::IocHash.counters().dropped(), 0);
+        assert_eq!(ChannelId::IocHash.counters().accepted(), 1);
+    }
+
+    /// The first drop must always warn; the rest of a burst folds into the
+    /// next interval so a saturated channel cannot flood the log it is trying
+    /// to make legible.
+    #[tokio::test]
+    async fn cumulative_drop_warnings_are_rate_limited() {
+        let _guard = counter_guard();
+        let counters = ChannelId::YaraMemoryScan.counters();
+
+        let interval = DROP_WARN_INTERVAL.as_millis() as u64;
+
+        assert_eq!(
+            counters.claim_warning(1, interval),
+            Some(1),
+            "first drop always warns"
+        );
+        assert_eq!(
+            counters.claim_warning(2, interval),
+            None,
+            "burst is suppressed"
+        );
+        assert_eq!(
+            counters.claim_warning(3, interval),
+            None,
+            "burst is suppressed"
+        );
+
+        // A zero interval stands in for the wait, so the test never sleeps.
+        assert_eq!(
+            counters.claim_warning(9, 0),
+            Some(8),
+            "the next warning covers every drop since the last one"
+        );
+    }
+}

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -15,12 +15,14 @@
 mod snapshot;
 
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
-use std::sync::LazyLock;
+use std::sync::{LazyLock, Mutex};
 use std::time::{Duration, Instant};
 
 use tokio::sync::mpsc::error::TrySendError;
 use tokio::sync::mpsc::Sender;
 use tracing::warn;
+
+use crate::utils::LogRateLimiter;
 
 pub use snapshot::{
     snapshot_path, spawn_reporter, write_final_snapshot, ChannelSnapshot, TelemetrySnapshot,
@@ -36,7 +38,12 @@ pub const TARGET_TELEMETRY: &str = "telemetry";
 /// the running total, so a burst produces one line rather than one per event.
 const DROP_WARN_INTERVAL: Duration = Duration::from_secs(60);
 
-/// Process start, used as the epoch for the lock-free warning rate limiter.
+/// Keyed by channel, so a burst on one channel cannot swallow the first drop
+/// reported on another.
+static DROP_WARNINGS: LazyLock<Mutex<LogRateLimiter>> =
+    LazyLock::new(|| Mutex::new(LogRateLimiter::new(DROP_WARN_INTERVAL)));
+
+/// Process start, used for the snapshot's uptime.
 static PROCESS_START: LazyLock<Instant> = LazyLock::new(Instant::now);
 
 /// A bounded channel in the event pipeline that can shed load.
@@ -80,18 +87,6 @@ impl ChannelId {
             ChannelId::IocHash => "ioc_hash",
             ChannelId::ActiveResponse => "active_response",
             ChannelId::CaptureWriter => "capture_writer",
-        }
-    }
-
-    /// What is lost when this channel drops, for operator-facing output.
-    pub const fn loss_description(self) -> &'static str {
-        match self {
-            ChannelId::SensorEvents => "raw sensor events never reached the detectors",
-            ChannelId::YaraFileScan => "files were never YARA scanned",
-            ChannelId::YaraMemoryScan => "processes were never memory scanned",
-            ChannelId::IocHash => "process images were never hashed for IOC matching",
-            ChannelId::ActiveResponse => "response actions were never executed",
-            ChannelId::CaptureWriter => "events never reached the recording",
         }
     }
 
@@ -142,10 +137,6 @@ pub struct ChannelCounters {
     dropped_closed: AtomicU64,
     /// Deepest queue depth observed after a successful send.
     high_water_mark: AtomicUsize,
-    /// Milliseconds since [`PROCESS_START`] at the last emitted drop warning.
-    last_warn_millis: AtomicU64,
-    /// Cumulative drop total at the last emitted drop warning.
-    warned_at_total: AtomicU64,
 }
 
 impl ChannelCounters {
@@ -157,8 +148,6 @@ impl ChannelCounters {
             dropped: AtomicU64::new(0),
             dropped_closed: AtomicU64::new(0),
             high_water_mark: AtomicUsize::new(0),
-            last_warn_millis: AtomicU64::new(0),
-            warned_at_total: AtomicU64::new(0),
         }
     }
 
@@ -207,13 +196,10 @@ impl ChannelCounters {
         self.dropped.store(0, Ordering::Relaxed);
         self.dropped_closed.store(0, Ordering::Relaxed);
         self.high_water_mark.store(0, Ordering::Relaxed);
-        self.last_warn_millis.store(0, Ordering::Relaxed);
-        self.warned_at_total.store(0, Ordering::Relaxed);
     }
 
-    fn record_accepted(&self, capacity: usize, depth: usize) {
-        self.accepted.fetch_add(1, Ordering::Relaxed);
-
+    /// Record the channel's shape, whatever the send's outcome was.
+    fn observe(&self, capacity: usize, depth: usize) {
         if self.capacity.load(Ordering::Relaxed) != capacity {
             self.capacity.store(capacity, Ordering::Relaxed);
         }
@@ -225,27 +211,29 @@ impl ChannelCounters {
         }
     }
 
+    fn record_accepted(&self, capacity: usize, depth: usize) {
+        self.accepted.fetch_add(1, Ordering::Relaxed);
+        self.observe(capacity, depth);
+    }
+
     fn record_dropped(&self, capacity: usize) {
         let dropped = self.dropped.fetch_add(1, Ordering::Relaxed) + 1;
-
-        if self.capacity.load(Ordering::Relaxed) != capacity {
-            self.capacity.store(capacity, Ordering::Relaxed);
-        }
         // A full channel is by definition at its deepest.
-        if capacity > self.high_water_mark.load(Ordering::Relaxed) {
-            self.high_water_mark.fetch_max(capacity, Ordering::Relaxed);
-        }
+        self.observe(capacity, capacity);
 
-        if let Some(since_last_warning) =
-            self.claim_warning(dropped, DROP_WARN_INTERVAL.as_millis() as u64)
-        {
+        let decision = match DROP_WARNINGS.lock() {
+            Ok(mut limiter) => limiter.should_emit(self.id.as_str()),
+            // A poisoned limiter must not silence the loss report.
+            Err(poisoned) => poisoned.into_inner().should_emit(self.id.as_str()),
+        };
+        if decision.should_emit {
             warn!(
                 target: TARGET_TELEMETRY,
                 channel = self.id.as_str(),
                 capacity,
                 dropped_total = dropped,
-                dropped_since_last_warning = since_last_warning,
                 accepted_total = self.accepted(),
+                suppressed_warnings = decision.suppressed_since_last_emit,
                 "Pipeline channel full; shedding telemetry"
             );
         }
@@ -253,34 +241,6 @@ impl ChannelCounters {
 
     fn record_dropped_closed(&self) {
         self.dropped_closed.fetch_add(1, Ordering::Relaxed);
-    }
-
-    /// Decide whether this drop should warn, returning how many drops the
-    /// warning covers.
-    ///
-    /// Lock-free on purpose: drops happen exactly when the pipeline is already
-    /// saturated, which is the worst moment to add a contended mutex. Losing a
-    /// race here costs at most one suppressed warning line.
-    fn claim_warning(&self, dropped: u64, interval_millis: u64) -> Option<u64> {
-        let now_millis = PROCESS_START.elapsed().as_millis() as u64;
-        let last_millis = self.last_warn_millis.load(Ordering::Relaxed);
-        let is_first_drop = dropped == 1;
-
-        if !is_first_drop && now_millis.saturating_sub(last_millis) < interval_millis {
-            return None;
-        }
-
-        self.last_warn_millis
-            .compare_exchange(
-                last_millis,
-                now_millis,
-                Ordering::Relaxed,
-                Ordering::Relaxed,
-            )
-            .ok()?;
-
-        let previous_total = self.warned_at_total.swap(dropped, Ordering::Relaxed);
-        Some(dropped.saturating_sub(previous_total))
     }
 }
 
@@ -317,6 +277,8 @@ pub fn try_send<T>(channel: ChannelId, tx: &Sender<T>, value: T) -> Result<(), T
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
 
     /// Serializes tests that assert on the process-wide statics.
@@ -421,37 +383,72 @@ mod tests {
         assert_eq!(ChannelId::IocHash.counters().accepted(), 1);
     }
 
-    /// The first drop must always warn; the rest of a burst folds into the
-    /// next interval so a saturated channel cannot flood the log it is trying
-    /// to make legible.
+    /// The warning is the only live signal while a channel is shedding, so
+    /// both its rate limiting and its field names are part of the contract.
     #[tokio::test]
-    async fn cumulative_drop_warnings_are_rate_limited() {
+    async fn a_burst_of_drops_emits_one_cumulative_warning() {
         let _guard = counter_guard();
-        let counters = ChannelId::YaraMemoryScan.counters();
+        let (tx, _rx) = tokio::sync::mpsc::channel::<u8>(1);
+        let lines = Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
 
-        let interval = DROP_WARN_INTERVAL.as_millis() as u64;
+        let collector = tracing_subscriber::fmt()
+            .with_writer(CollectingWriter(Arc::clone(&lines)))
+            .with_ansi(false)
+            .finish();
+        tracing::subscriber::with_default(collector, || {
+            for value in 0..6u8 {
+                let _ = try_send(ChannelId::SensorEvents, &tx, value);
+            }
+        });
+
+        let lines = lines.lock().expect("collected lines");
+        let warnings: Vec<&String> = lines
+            .iter()
+            .filter(|line| line.contains("shedding telemetry"))
+            .collect();
 
         assert_eq!(
-            counters.claim_warning(1, interval),
-            Some(1),
-            "first drop always warns"
+            warnings.len(),
+            1,
+            "five drops fold into one line: {lines:?}"
         );
-        assert_eq!(
-            counters.claim_warning(2, interval),
-            None,
-            "burst is suppressed"
-        );
-        assert_eq!(
-            counters.claim_warning(3, interval),
-            None,
-            "burst is suppressed"
-        );
+        for field in [
+            "channel=\"sensor_events\"",
+            "capacity=1",
+            "dropped_total=1",
+            "accepted_total=1",
+            "suppressed_warnings=0",
+        ] {
+            assert!(
+                warnings[0].contains(field),
+                "missing {field}: {}",
+                warnings[0]
+            );
+        }
+    }
 
-        // A zero interval stands in for the wait, so the test never sleeps.
-        assert_eq!(
-            counters.claim_warning(9, 0),
-            Some(8),
-            "the next warning covers every drop since the last one"
-        );
+    /// Captures rendered log output so the warning can be asserted on as an
+    /// operator would read it.
+    #[derive(Clone)]
+    struct CollectingWriter(Arc<std::sync::Mutex<Vec<String>>>);
+
+    impl std::io::Write for CollectingWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            let mut lines = self.0.lock().unwrap_or_else(|e| e.into_inner());
+            lines.push(String::from_utf8_lossy(buf).into_owned());
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CollectingWriter {
+        type Writer = Self;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
     }
 }

--- a/src/telemetry/snapshot.rs
+++ b/src/telemetry/snapshot.rs
@@ -61,14 +61,6 @@ impl ChannelSnapshot {
         (self.dropped as f64 / offered as f64) * 100.0
     }
 
-    /// Peak fill level, as a percentage of capacity.
-    pub fn saturation_pct(&self) -> f64 {
-        if self.capacity == 0 {
-            return 0.0;
-        }
-        (self.high_water_mark as f64 / self.capacity as f64) * 100.0
-    }
-
     /// One-line operator summary of this channel.
     pub fn describe(&self) -> String {
         format!(
@@ -177,7 +169,11 @@ impl TelemetrySnapshot {
     }
 }
 
-/// Periodically log and persist the pipeline counters.
+/// Periodically publish the pipeline counters for `rustinel doctor`.
+///
+/// Publishing only writes the snapshot: drops already warn as they happen, so
+/// logging the same numbers every interval would add noise to the log this is
+/// meant to save an operator from reading.
 ///
 /// The returned task runs until it is aborted; the runtime writes one final
 /// snapshot on shutdown so the last interval's drops are not lost with it.
@@ -185,43 +181,40 @@ pub fn spawn_reporter(path: PathBuf, interval: Duration) -> JoinHandle<()> {
     tokio::spawn(async move {
         // Never busy-loop, however the interval was configured.
         let interval = interval.max(Duration::from_secs(1));
-        let mut previous_accepted = 0u64;
-        let mut previous_dropped = 0u64;
+        info!(
+            target: TARGET_TELEMETRY,
+            path = %path.display(),
+            interval_secs = interval.as_secs(),
+            "Publishing pipeline channel counters"
+        );
 
         loop {
             tokio::time::sleep(interval).await;
-
-            let snapshot = TelemetrySnapshot::capture();
-            let accepted = snapshot.total_accepted();
-            let dropped = snapshot.total_dropped();
-
-            // An idle endpoint should not narrate itself every interval.
-            if accepted != previous_accepted || dropped != previous_dropped {
-                for channel in snapshot.active_channels() {
-                    info!(
-                        target: TARGET_TELEMETRY,
-                        channel = %channel.channel,
-                        capacity = channel.capacity,
-                        accepted = channel.accepted,
-                        dropped = channel.dropped,
-                        high_water_mark = channel.high_water_mark,
-                        "Pipeline channel statistics"
-                    );
-                }
-                previous_accepted = accepted;
-                previous_dropped = dropped;
-            }
-
-            persist(&snapshot, &path);
+            persist(&TelemetrySnapshot::capture(), &path);
         }
     })
 }
 
-/// Write the current counters, logging rather than failing on I/O errors.
+/// Log and publish the counters one last time, at shutdown.
 ///
-/// Used for the shutdown snapshot, where there is no later interval to retry.
+/// The summary goes to the log here — and only here — so the totals survive
+/// even if the snapshot cannot be written.
 pub fn write_final_snapshot(path: &Path) {
-    persist(&TelemetrySnapshot::capture(), path);
+    let snapshot = TelemetrySnapshot::capture();
+
+    for channel in snapshot.active_channels() {
+        info!(
+            target: TARGET_TELEMETRY,
+            channel = %channel.channel,
+            capacity = channel.capacity,
+            accepted = channel.accepted,
+            dropped = channel.dropped,
+            high_water_mark = channel.high_water_mark,
+            "Pipeline channel statistics"
+        );
+    }
+
+    persist(&snapshot, path);
 }
 
 fn persist(snapshot: &TelemetrySnapshot, path: &Path) {
@@ -299,7 +292,6 @@ mod tests {
         let channel = channel("sensor_events", 750, 250);
 
         assert!((channel.drop_rate_pct() - 25.0).abs() < f64::EPSILON);
-        assert!((channel.saturation_pct() - 100.0).abs() < f64::EPSILON);
         assert!(channel.describe().contains("250 dropped of 1000 offered"));
     }
 

--- a/src/telemetry/snapshot.rs
+++ b/src/telemetry/snapshot.rs
@@ -1,0 +1,376 @@
+//! Persisted view of the pipeline telemetry counters.
+//!
+//! The running agent and `rustinel doctor` are separate processes, so the
+//! counters have to cross a process boundary to be useful. The runtime writes
+//! a snapshot next to the logs on a fixed interval and once more at shutdown;
+//! doctor reads the last one written. That makes the drop totals answerable
+//! after the fact, including for an agent that has since stopped.
+
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use chrono::{SecondsFormat, Utc};
+use serde::{Deserialize, Serialize};
+use tokio::task::JoinHandle;
+use tracing::{debug, info, warn};
+
+use super::{ChannelId, PROCESS_START, TARGET_TELEMETRY};
+use crate::utils::fs::restrict_file_permissions;
+
+/// File name of the snapshot, written inside the configured log directory.
+pub const SNAPSHOT_FILE_NAME: &str = "telemetry.json";
+
+/// Where the snapshot for `logs_dir` lives.
+pub fn snapshot_path(logs_dir: &Path) -> PathBuf {
+    logs_dir.join(SNAPSHOT_FILE_NAME)
+}
+
+/// Counters for one bounded channel at a point in time.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChannelSnapshot {
+    pub channel: String,
+    /// Configured channel capacity; 0 until the channel is first used.
+    pub capacity: usize,
+    /// Items the channel accepted.
+    pub accepted: u64,
+    /// Items shed because the channel was full — the detection gap.
+    pub dropped: u64,
+    /// Items dropped because the consumer had already stopped, which is
+    /// shutdown rather than telemetry loss.
+    pub dropped_channel_closed: u64,
+    /// Deepest queue depth observed.
+    pub high_water_mark: usize,
+}
+
+impl ChannelSnapshot {
+    /// Whether the channel was ever used. Unused channels are the norm —
+    /// YARA memory scanning is opt-in, capture only runs under `rustinel
+    /// capture` — so reporting suppresses them rather than printing zeros.
+    pub fn is_idle(&self) -> bool {
+        self.accepted == 0 && self.dropped == 0 && self.dropped_channel_closed == 0
+    }
+
+    /// Share of offered items that were shed, as a percentage.
+    pub fn drop_rate_pct(&self) -> f64 {
+        let offered = self.accepted.saturating_add(self.dropped);
+        if offered == 0 {
+            return 0.0;
+        }
+        (self.dropped as f64 / offered as f64) * 100.0
+    }
+
+    /// Peak fill level, as a percentage of capacity.
+    pub fn saturation_pct(&self) -> f64 {
+        if self.capacity == 0 {
+            return 0.0;
+        }
+        (self.high_water_mark as f64 / self.capacity as f64) * 100.0
+    }
+
+    /// One-line operator summary of this channel.
+    pub fn describe(&self) -> String {
+        format!(
+            "{}: {} dropped of {} offered ({:.2}%), peak depth {}/{}",
+            self.channel,
+            self.dropped,
+            self.accepted.saturating_add(self.dropped),
+            self.drop_rate_pct(),
+            self.high_water_mark,
+            self.capacity
+        )
+    }
+}
+
+/// Every channel's counters, plus enough context to know how old they are.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TelemetrySnapshot {
+    /// Agent version that produced the snapshot.
+    pub version: String,
+    /// PID of the agent that produced it, to spot a snapshot from a prior run.
+    pub pid: u32,
+    /// RFC 3339 timestamp of the snapshot.
+    pub captured_at: String,
+    /// How long that agent had been running.
+    pub uptime_secs: u64,
+    pub channels: Vec<ChannelSnapshot>,
+}
+
+impl TelemetrySnapshot {
+    /// Read the live counters.
+    pub fn capture() -> Self {
+        Self {
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            pid: std::process::id(),
+            captured_at: Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true),
+            uptime_secs: PROCESS_START.elapsed().as_secs(),
+            channels: ChannelId::ALL
+                .iter()
+                .map(|channel| channel.counters().snapshot())
+                .collect(),
+        }
+    }
+
+    /// Total items shed across every channel.
+    pub fn total_dropped(&self) -> u64 {
+        self.channels
+            .iter()
+            .map(|channel| channel.dropped)
+            .fold(0u64, u64::saturating_add)
+    }
+
+    /// Total items accepted across every channel.
+    pub fn total_accepted(&self) -> u64 {
+        self.channels
+            .iter()
+            .map(|channel| channel.accepted)
+            .fold(0u64, u64::saturating_add)
+    }
+
+    /// Channels that shed at least one item, worst first.
+    pub fn dropping_channels(&self) -> Vec<&ChannelSnapshot> {
+        let mut dropping: Vec<&ChannelSnapshot> = self
+            .channels
+            .iter()
+            .filter(|channel| channel.dropped > 0)
+            .collect();
+        dropping.sort_by_key(|channel| std::cmp::Reverse(channel.dropped));
+        dropping
+    }
+
+    /// Channels that saw traffic, in declaration order.
+    pub fn active_channels(&self) -> Vec<&ChannelSnapshot> {
+        self.channels
+            .iter()
+            .filter(|channel| !channel.is_idle())
+            .collect()
+    }
+
+    /// Write the snapshot to `path`, replacing any previous one.
+    ///
+    /// Written to a sibling temporary file and renamed, so a reader never sees
+    /// a half-written snapshot and a crash mid-write cannot leave a truncated
+    /// file that parses as "no drops".
+    pub fn write_to(&self, path: &Path) -> io::Result<()> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        let temporary = path.with_extension("json.tmp");
+        let encoded = serde_json::to_vec_pretty(self)
+            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+        fs::write(&temporary, encoded)?;
+        // Best-effort: the snapshot holds no endpoint detail, only counts.
+        let _ = restrict_file_permissions(&temporary);
+        fs::rename(&temporary, path)
+    }
+
+    /// Read a snapshot previously written by a running agent.
+    ///
+    /// A missing or unreadable snapshot is not an error: the agent may never
+    /// have run, or may be running as a user whose files this process cannot
+    /// read.
+    pub fn read_from(path: &Path) -> Option<Self> {
+        let bytes = fs::read(path).ok()?;
+        serde_json::from_slice(&bytes).ok()
+    }
+}
+
+/// Periodically log and persist the pipeline counters.
+///
+/// The returned task runs until it is aborted; the runtime writes one final
+/// snapshot on shutdown so the last interval's drops are not lost with it.
+pub fn spawn_reporter(path: PathBuf, interval: Duration) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        // Never busy-loop, however the interval was configured.
+        let interval = interval.max(Duration::from_secs(1));
+        let mut previous_accepted = 0u64;
+        let mut previous_dropped = 0u64;
+
+        loop {
+            tokio::time::sleep(interval).await;
+
+            let snapshot = TelemetrySnapshot::capture();
+            let accepted = snapshot.total_accepted();
+            let dropped = snapshot.total_dropped();
+
+            // An idle endpoint should not narrate itself every interval.
+            if accepted != previous_accepted || dropped != previous_dropped {
+                for channel in snapshot.active_channels() {
+                    info!(
+                        target: TARGET_TELEMETRY,
+                        channel = %channel.channel,
+                        capacity = channel.capacity,
+                        accepted = channel.accepted,
+                        dropped = channel.dropped,
+                        high_water_mark = channel.high_water_mark,
+                        "Pipeline channel statistics"
+                    );
+                }
+                previous_accepted = accepted;
+                previous_dropped = dropped;
+            }
+
+            persist(&snapshot, &path);
+        }
+    })
+}
+
+/// Write the current counters, logging rather than failing on I/O errors.
+///
+/// Used for the shutdown snapshot, where there is no later interval to retry.
+pub fn write_final_snapshot(path: &Path) {
+    persist(&TelemetrySnapshot::capture(), path);
+}
+
+fn persist(snapshot: &TelemetrySnapshot, path: &Path) {
+    match snapshot.write_to(path) {
+        Ok(()) => debug!(
+            target: TARGET_TELEMETRY,
+            path = %path.display(),
+            "Wrote pipeline telemetry snapshot"
+        ),
+        Err(err) => warn!(
+            target: TARGET_TELEMETRY,
+            path = %path.display(),
+            error = %err,
+            "Failed to write pipeline telemetry snapshot; drop counters remain visible in logs only"
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn channel(name: &str, accepted: u64, dropped: u64) -> ChannelSnapshot {
+        ChannelSnapshot {
+            channel: name.to_string(),
+            capacity: 100,
+            accepted,
+            dropped,
+            dropped_channel_closed: 0,
+            high_water_mark: 100,
+        }
+    }
+
+    fn snapshot(channels: Vec<ChannelSnapshot>) -> TelemetrySnapshot {
+        TelemetrySnapshot {
+            version: "1.3.0".to_string(),
+            pid: 42,
+            captured_at: "2026-08-24T00:00:00Z".to_string(),
+            uptime_secs: 60,
+            channels,
+        }
+    }
+
+    #[test]
+    fn capture_reports_every_channel() {
+        let snapshot = TelemetrySnapshot::capture();
+
+        assert_eq!(snapshot.channels.len(), ChannelId::ALL.len());
+        for (channel, expected) in snapshot.channels.iter().zip(ChannelId::ALL) {
+            assert_eq!(channel.channel, expected.as_str());
+        }
+    }
+
+    #[test]
+    fn dropping_channels_are_ranked_worst_first() {
+        let snapshot = snapshot(vec![
+            channel("yara_file_scan", 10, 5),
+            channel("sensor_events", 1000, 900),
+            channel("ioc_hash", 10, 0),
+        ]);
+
+        let dropping: Vec<&str> = snapshot
+            .dropping_channels()
+            .iter()
+            .map(|channel| channel.channel.as_str())
+            .collect();
+
+        assert_eq!(dropping, vec!["sensor_events", "yara_file_scan"]);
+        assert_eq!(snapshot.total_dropped(), 905);
+        assert_eq!(snapshot.total_accepted(), 1020);
+    }
+
+    #[test]
+    fn drop_rate_is_a_share_of_offered_items() {
+        let channel = channel("sensor_events", 750, 250);
+
+        assert!((channel.drop_rate_pct() - 25.0).abs() < f64::EPSILON);
+        assert!((channel.saturation_pct() - 100.0).abs() < f64::EPSILON);
+        assert!(channel.describe().contains("250 dropped of 1000 offered"));
+    }
+
+    #[test]
+    fn an_unused_channel_reports_no_drop_rate() {
+        let idle = channel("capture_writer", 0, 0);
+
+        assert!(idle.is_idle());
+        assert_eq!(idle.drop_rate_pct(), 0.0);
+    }
+
+    #[test]
+    fn a_snapshot_round_trips_through_the_file() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = snapshot_path(temp.path());
+        let written = snapshot(vec![channel("sensor_events", 5, 2)]);
+
+        written.write_to(&path).expect("write snapshot");
+        let read = TelemetrySnapshot::read_from(&path).expect("read snapshot");
+
+        assert_eq!(read, written);
+        assert_eq!(path.file_name().unwrap(), SNAPSHOT_FILE_NAME);
+    }
+
+    /// The rename leaves nothing behind, so repeated writes cannot accumulate
+    /// stale temporary files in the log directory.
+    #[test]
+    fn writing_a_snapshot_leaves_no_temporary_file() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = snapshot_path(temp.path());
+
+        snapshot(vec![]).write_to(&path).expect("first write");
+        snapshot(vec![channel("ioc_hash", 1, 0)])
+            .write_to(&path)
+            .expect("second write");
+
+        let entries: Vec<String> = fs::read_dir(temp.path())
+            .expect("read dir")
+            .map(|entry| {
+                entry
+                    .expect("entry")
+                    .file_name()
+                    .to_string_lossy()
+                    .into_owned()
+            })
+            .collect();
+
+        assert_eq!(entries, vec![SNAPSHOT_FILE_NAME.to_string()]);
+    }
+
+    #[test]
+    fn a_missing_or_corrupt_snapshot_reads_as_none() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = snapshot_path(temp.path());
+
+        assert!(TelemetrySnapshot::read_from(&path).is_none());
+
+        fs::write(&path, b"{ not json").expect("write garbage");
+        assert!(TelemetrySnapshot::read_from(&path).is_none());
+    }
+
+    /// The snapshot is created if the log directory does not exist yet, which
+    /// is the state of a fresh portable install on its first run.
+    #[test]
+    fn writing_creates_the_log_directory() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let logs_dir = temp.path().join("logs");
+        let path = snapshot_path(&logs_dir);
+
+        snapshot(vec![]).write_to(&path).expect("write snapshot");
+
+        assert!(path.exists());
+    }
+}

--- a/src/utils/log_rate_limiter.rs
+++ b/src/utils/log_rate_limiter.rs
@@ -64,3 +64,54 @@ impl LogRateLimiter {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The contract every caller relies on: the first occurrence is always
+    /// reported, the burst behind it is folded away, and the next emission
+    /// says how much was folded.
+    #[test]
+    fn the_first_event_emits_and_the_burst_behind_it_is_suppressed() {
+        let mut limiter = LogRateLimiter::new(Duration::from_millis(20));
+
+        let first = limiter.should_emit("scan_error");
+        assert!(first.should_emit);
+        assert_eq!(first.suppressed_since_last_emit, 0);
+
+        for _ in 0..4 {
+            assert!(!limiter.should_emit("scan_error").should_emit);
+        }
+
+        std::thread::sleep(Duration::from_millis(25));
+
+        let next = limiter.should_emit("scan_error");
+        assert!(next.should_emit, "the window has elapsed");
+        assert_eq!(
+            next.suppressed_since_last_emit, 4,
+            "the emission accounts for everything it stood in for"
+        );
+        // The count resets once reported, rather than accumulating across
+        // windows and overstating the next burst.
+        for _ in 0..2 {
+            assert!(!limiter.should_emit("scan_error").should_emit);
+        }
+        std::thread::sleep(Duration::from_millis(25));
+        assert_eq!(
+            limiter.should_emit("scan_error").suppressed_since_last_emit,
+            2
+        );
+    }
+
+    /// Keys are independent, so a noisy error cannot silence the first report
+    /// of a different one.
+    #[test]
+    fn keys_are_rate_limited_independently() {
+        let mut limiter = LogRateLimiter::new(Duration::from_secs(60));
+
+        assert!(limiter.should_emit("hash_error").should_emit);
+        assert!(!limiter.should_emit("hash_error").should_emit);
+        assert!(limiter.should_emit("memory_scan_error").should_emit);
+    }
+}

--- a/tests/telemetry_backpressure.rs
+++ b/tests/telemetry_backpressure.rs
@@ -97,28 +97,6 @@ fn accepted_events_are_counted_after_the_queue_drains() {
     assert_eq!(dropped_after - dropped_before, 1);
 }
 
-/// A live snapshot reports every channel, so an operator sees which queues are
-/// idle rather than only the ones that happen to have failed.
-#[test]
-fn a_live_snapshot_covers_every_channel() {
-    let _guard = counters_guard();
-
-    let snapshot = TelemetrySnapshot::capture();
-
-    assert_eq!(snapshot.channels.len(), ChannelId::ALL.len());
-    for expected in ChannelId::ALL {
-        assert!(
-            snapshot
-                .channels
-                .iter()
-                .any(|channel| channel.channel == expected.as_str()),
-            "{} is missing from the snapshot",
-            expected.as_str()
-        );
-    }
-    assert_eq!(snapshot.pid, std::process::id());
-}
-
 fn write_config(root: &std::path::Path) -> std::path::PathBuf {
     let config_path = root.join("config.toml");
     std::fs::create_dir_all(root.join("logs")).expect("create logs dir");

--- a/tests/telemetry_backpressure.rs
+++ b/tests/telemetry_backpressure.rs
@@ -1,0 +1,301 @@
+//! Pipeline backpressure accounting, from a saturated channel through to the
+//! numbers an operator reads in `rustinel doctor`.
+//!
+//! The counters are process-wide statics shared by every test in this binary,
+//! so the assertions here are on deltas taken under a lock rather than on
+//! absolute totals.
+
+#[cfg(test)]
+mod common;
+
+use std::process::Command;
+use std::sync::{Mutex, MutexGuard};
+
+use common::process_start_event;
+use rustinel::config::AppConfig;
+use rustinel::runtime::telemetry::TelemetryReporter;
+use rustinel::scanner::YaraEventHandler;
+use rustinel::sensor::{Platform, SensorEventRouter};
+use rustinel::telemetry::{snapshot_path, ChannelId, ChannelSnapshot, TelemetrySnapshot};
+
+/// Serializes the tests that read the shared counters.
+static COUNTERS: Mutex<()> = Mutex::new(());
+
+fn counters_guard() -> MutexGuard<'static, ()> {
+    COUNTERS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// Accepted and dropped totals for one channel.
+fn totals(channel: ChannelId) -> (u64, u64) {
+    let counters = channel.counters();
+    (counters.accepted(), counters.dropped())
+}
+
+/// A YARA scan queue is bounded, so a burst of process starts beyond its
+/// capacity is shed. Every shed event is a file that is never scanned, and the
+/// count is the only way to know how many.
+#[test]
+fn a_saturated_scan_queue_counts_every_shed_event() {
+    let _guard = counters_guard();
+    let (accepted_before, dropped_before) = totals(ChannelId::YaraFileScan);
+
+    let (tx, _rx) = tokio::sync::mpsc::channel::<(String, u32)>(2);
+    let mut router = SensorEventRouter::new();
+    router.register_handler(Box::new(YaraEventHandler {
+        tx,
+        memory_tx: None,
+        allowlist_paths: Vec::new(),
+    }));
+
+    let event = process_start_event(Platform::Linux);
+    for _ in 0..10 {
+        router.route_event(&event);
+    }
+
+    let (accepted_after, dropped_after) = totals(ChannelId::YaraFileScan);
+    assert_eq!(
+        accepted_after - accepted_before,
+        2,
+        "only the channel's capacity should be accepted"
+    );
+    assert_eq!(
+        dropped_after - dropped_before,
+        8,
+        "every event past capacity is a scan that never happens"
+    );
+
+    let counters = ChannelId::YaraFileScan.counters();
+    assert_eq!(counters.capacity(), 2);
+    assert!(counters.high_water_mark() >= 2, "the queue filled up");
+}
+
+/// Draining the queue lets sends succeed again, so the counters track load
+/// rather than latching after the first drop.
+#[test]
+fn accepted_events_are_counted_after_the_queue_drains() {
+    let _guard = counters_guard();
+    let (accepted_before, dropped_before) = totals(ChannelId::YaraFileScan);
+
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<(String, u32)>(1);
+    let mut router = SensorEventRouter::new();
+    router.register_handler(Box::new(YaraEventHandler {
+        tx,
+        memory_tx: None,
+        allowlist_paths: Vec::new(),
+    }));
+
+    let event = process_start_event(Platform::Linux);
+    router.route_event(&event);
+    router.route_event(&event);
+    rx.try_recv().expect("the queued job is readable");
+    router.route_event(&event);
+
+    let (accepted_after, dropped_after) = totals(ChannelId::YaraFileScan);
+    assert_eq!(accepted_after - accepted_before, 2);
+    assert_eq!(dropped_after - dropped_before, 1);
+}
+
+/// A live snapshot reports every channel, so an operator sees which queues are
+/// idle rather than only the ones that happen to have failed.
+#[test]
+fn a_live_snapshot_covers_every_channel() {
+    let _guard = counters_guard();
+
+    let snapshot = TelemetrySnapshot::capture();
+
+    assert_eq!(snapshot.channels.len(), ChannelId::ALL.len());
+    for expected in ChannelId::ALL {
+        assert!(
+            snapshot
+                .channels
+                .iter()
+                .any(|channel| channel.channel == expected.as_str()),
+            "{} is missing from the snapshot",
+            expected.as_str()
+        );
+    }
+    assert_eq!(snapshot.pid, std::process::id());
+}
+
+fn write_config(root: &std::path::Path) -> std::path::PathBuf {
+    let config_path = root.join("config.toml");
+    std::fs::create_dir_all(root.join("logs")).expect("create logs dir");
+    std::fs::write(
+        &config_path,
+        format!(
+            "[logging]\nlevel = \"info\"\ndirectory = \"{logs}\"\nfilename = \"rustinel.log\"\n\
+             \n[telemetry]\nenabled = true\nsnapshot_interval_secs = 30\n",
+            logs = toml_path(&root.join("logs")),
+        ),
+    )
+    .expect("write config");
+    config_path
+}
+
+/// A Windows path is full of backslashes, and every one of them is an escape
+/// inside a TOML basic string — an unescaped temp path makes the config
+/// unparseable and the check under test never runs.
+fn toml_path(path: &std::path::Path) -> String {
+    path.display().to_string().replace('\\', "\\\\")
+}
+
+fn run_doctor_json(config_path: &std::path::Path) -> serde_json::Value {
+    let output = Command::new(env!("CARGO_BIN_EXE_rustinel"))
+        .arg("doctor")
+        .arg("--json")
+        .arg("--config")
+        .arg(config_path)
+        .output()
+        .expect("doctor runs");
+
+    serde_json::from_slice(&output.stdout).expect("doctor emits JSON")
+}
+
+fn pipeline_check(report: &serde_json::Value) -> &serde_json::Value {
+    report["results"]
+        .as_array()
+        .expect("results array")
+        .iter()
+        .find(|result| result["id"] == "pipeline_telemetry")
+        .expect("doctor reports a pipeline_telemetry check")
+}
+
+fn snapshot_with(channels: Vec<ChannelSnapshot>) -> TelemetrySnapshot {
+    TelemetrySnapshot {
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        pid: 4242,
+        captured_at: "2026-08-24T09:30:00Z".to_string(),
+        uptime_secs: 7200,
+        channels,
+    }
+}
+
+fn channel(name: &str, accepted: u64, dropped: u64) -> ChannelSnapshot {
+    ChannelSnapshot {
+        channel: name.to_string(),
+        capacity: 8192,
+        accepted,
+        dropped,
+        dropped_channel_closed: 0,
+        high_water_mark: 8192,
+    }
+}
+
+/// The acceptance criterion: an operator can quantify telemetry loss from
+/// `rustinel doctor` alone, without searching the agent log.
+#[test]
+fn doctor_quantifies_dropped_telemetry_without_reading_logs() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let config_path = write_config(temp.path());
+    snapshot_with(vec![
+        channel("sensor_events", 400_000, 12_500),
+        channel("ioc_hash", 900, 100),
+    ])
+    .write_to(&snapshot_path(&temp.path().join("logs")))
+    .expect("write snapshot");
+
+    let report = run_doctor_json(&config_path);
+    let check = pipeline_check(&report);
+
+    assert_eq!(check["status"], "warn");
+    let message = check["message"].as_str().expect("message");
+    assert!(
+        message.contains("12600 events were dropped"),
+        "doctor should total the loss: {message}"
+    );
+    let detail = check["detail"].as_str().expect("detail");
+    assert!(detail.contains("sensor_events: 12500 dropped of 412500 offered"));
+    assert!(detail.contains("ioc_hash: 100 dropped of 1000 offered"));
+
+    // The per-channel numbers travel in the report itself, not only in prose.
+    let channels = report["telemetry"]["channels"]
+        .as_array()
+        .expect("telemetry channels");
+    let sensor_events = channels
+        .iter()
+        .find(|channel| channel["channel"] == "sensor_events")
+        .expect("sensor_events channel");
+    assert_eq!(sensor_events["dropped"], 12_500);
+    assert_eq!(sensor_events["high_water_mark"], 8192);
+}
+
+/// A snapshot with no drops is a clean bill of health, not a silent absence.
+#[test]
+fn doctor_confirms_when_no_telemetry_was_lost() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let config_path = write_config(temp.path());
+    snapshot_with(vec![channel("sensor_events", 250_000, 0)])
+        .write_to(&snapshot_path(&temp.path().join("logs")))
+        .expect("write snapshot");
+
+    let report = run_doctor_json(&config_path);
+    let check = pipeline_check(&report);
+
+    assert_eq!(check["status"], "pass");
+    assert!(check["message"]
+        .as_str()
+        .expect("message")
+        .contains("No telemetry dropped across 250000 events"));
+}
+
+/// An endpoint where the agent has never run must not look like a failure.
+#[test]
+fn doctor_is_quiet_before_the_agent_has_ever_run() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let config_path = write_config(temp.path());
+
+    let report = run_doctor_json(&config_path);
+    let check = pipeline_check(&report);
+
+    assert_eq!(check["status"], "pass");
+    assert!(report["telemetry"].is_null(), "there is nothing to report");
+}
+
+/// The counters are only useful to `doctor` once they leave the process, so the
+/// runtime has to actually publish them — on its interval while running, and
+/// once more at shutdown so the last interval's drops are not lost with it.
+#[tokio::test]
+async fn the_runtime_publishes_counters_while_running_and_at_shutdown() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let logs_dir = temp.path().join("logs");
+    let path = snapshot_path(&logs_dir);
+
+    let mut cfg = AppConfig::default();
+    cfg.logging.directory = logs_dir.clone();
+    cfg.telemetry.snapshot_interval_secs = 1;
+
+    let reporter = TelemetryReporter::start(&cfg).expect("telemetry is enabled by default");
+
+    // The reporter creates the log directory itself, as it must on a fresh
+    // portable install whose first run has not written a log yet.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+    while !path.exists() && std::time::Instant::now() < deadline {
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+    let periodic = TelemetrySnapshot::read_from(&path).expect("a snapshot was published");
+    assert_eq!(periodic.channels.len(), ChannelId::ALL.len());
+
+    reporter.finish().await;
+
+    let shutdown = TelemetrySnapshot::read_from(&path).expect("a final snapshot was published");
+    assert_eq!(shutdown.pid, std::process::id());
+    assert!(
+        shutdown.uptime_secs >= periodic.uptime_secs,
+        "the shutdown snapshot must be the newer of the two"
+    );
+}
+
+/// Turning persistence off must leave nothing behind for `doctor` to read as a
+/// stale clean bill of health.
+#[tokio::test]
+async fn disabling_telemetry_publishes_nothing() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let mut cfg = AppConfig::default();
+    cfg.logging.directory = temp.path().to_path_buf();
+    cfg.telemetry.enabled = false;
+
+    assert!(TelemetryReporter::start(&cfg).is_none());
+    assert!(!snapshot_path(temp.path()).exists());
+}


### PR DESCRIPTION
## Summary

Closes #140.

Sensor channels are bounded and shed events rather than blocking their producer — blocking an ETW callback or an eBPF poll loop would lose the events queued behind it in the kernel instead. That trade is sound, but it was only reported as a periodic warning, so an operator could not tell whether a detection failed to fire or never had the event, nor size the gap without searching rotated logs.

**Counters.** A new `src/telemetry` module gives each bounded channel atomic counters — accepted, dropped-because-full, dropped-because-closed, and peak queue depth. Every load-shedding send routes through it: the sensor event channel on all three platforms, the YARA file and memory queues, the IOC hash queue, active response, and the capture writer. Drops that mean shutdown are counted apart from drops that mean loss, so a clean stop cannot inflate the number an operator reads as a detection gap.

**Warnings.** One cumulative warning per channel per minute, via the existing `LogRateLimiter`. This replaces the per-sensor ad-hoc messages and the ETW sensor's private `dropped_events` counter.

**Doctor.** The runtime publishes the counters to `telemetry.json` beside the logs, refreshed on an interval and once more at shutdown. `rustinel doctor` gains a `pipeline_telemetry` check:

```
[WARN] pipeline_telemetry: 9136 events were dropped under load (snapshot from 2026-08-24T18:12:00Z)
    detail: sensor_events: 9134 dropped of 1850338 offered (0.49%), peak depth 8192/8192; ioc_hash: 2 dropped of 4120 offered (0.05%), peak depth 1000/1000
    fix: Detection gaps are proportional to these counts. Reduce event volume - narrow broad rules, widen trusted-path allowlists - and re-run to confirm the totals stop growing; see docs/troubleshooting.md
```

`--json` carries the raw per-channel numbers under `telemetry`, and the human output gains a `Pipeline channels` block listing every channel that carried an event.

New `[telemetry]` config section (`enabled`, `snapshot_interval_secs`). Setting `enabled = false` leaves the totals in the log only, and doctor reports that reduced visibility as a warning.

### Notes for review

- The second commit is a self-review pass that removed ~70 lines: a bespoke lock-free rate limiter reimplementing `LogRateLimiter`, per-interval stats logging that duplicated both the snapshot and the drop warnings (the summary now goes to the log once at shutdown, like dedup's does), and some dead API. Happy to squash if you'd rather it read as one change.
- `LogRateLimiter` had four callers and no tests; since this change depends on it for the rate-limited warnings, it gets tests here.
- The macOS BPF attribution queue is deliberately **not** counted: it is a `std::sync::mpsc::SyncSender`, and an overflow there still delivers the event, just unattributed. Counting it alongside real loss would make the totals misleading.
- The doctor's suggested fix does not offer "raise the channel capacity", because `sensor_events` is hardcoded at 8192. Making it configurable is worth a follow-up.

## Type of change
<!-- Add the matching label to this PR before merging -->
- [x] `feat` / `enhancement` - new feature
- [ ] `bug` - bug fix
- [ ] `refactor` - refactoring, no behaviour change
- [ ] `documentation` - docs only
- [ ] `ci` - CI and release changes
- [ ] `dependencies` - dependency update

## Test plan
- [x] Tested on Windows
- [x] Tested on Linux
- [x] Existing tests pass (`cargo test`)
- [x] New tests added (if applicable)

Verified on all three platforms. Linux (lab-ubuntu) and macOS ran `cargo clippy --all-targets -- -D warnings` and the full suite clean on the rebased tree — 399 tests passing on Linux. Windows (lab-windows) passed clippy on the rebased tree and passed the full suite on the pre-rebase tree; the post-rebase Windows test re-run was cut short, and the rebase brought in #269/#270, which touch `etw.rs` and `scanner/mod.rs`. Worth letting CI confirm Windows.

New coverage: 12 unit tests across the counters, snapshot, and doctor check, plus `tests/telemetry_backpressure.rs` driving a real saturated `YaraEventHandler` queue and invoking the `doctor` binary end-to-end.

## Checklist
- [ ] Label added to this PR
- [x] Docs updated (if behaviour changed)

Docs: `limitations.md` (the pipeline entry loses its "silent risk" framing and gains what is still missing — there is still no real backpressure, only accounting), `configuration.md` (new "Pipeline Telemetry" section), `troubleshooting.md`, `operations.md`, `cli.md`, `architecture.md`, and `config.toml`.