### PR TITLE
fix(build): preserve Windows stack linker flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           components: rustfmt
           cache: false
+          rustflags: ""
       - name: Check formatting
         run: cargo fmt --all -- --check
 
@@ -43,6 +44,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
           cache: false
+          rustflags: ""
       - uses: taiki-e/install-action@b6b84cf49ebfe0176417bdce007c624f0db37f20 # v2.86.2
         with:
           tool: cargo-deny
@@ -68,6 +70,7 @@ jobs:
           toolchain: nightly-2026-08-11
           components: rust-src
           cache: false
+          rustflags: ""
 
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
@@ -101,6 +104,7 @@ jobs:
         with:
           components: clippy
           cache: false
+          rustflags: ""
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           lookup-only: true
@@ -122,6 +126,7 @@ jobs:
         with:
           components: clippy
           cache: false
+          rustflags: ""
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           lookup-only: true
@@ -138,6 +143,7 @@ jobs:
         with:
           components: clippy
           cache: false
+          rustflags: ""
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           lookup-only: true
@@ -154,6 +160,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
           cache: false
+          rustflags: ""
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           lookup-only: true
@@ -174,6 +181,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
           cache: false
+          rustflags: ""
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           lookup-only: true
@@ -189,6 +197,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
           cache: false
+          rustflags: ""
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           lookup-only: true

--- a/.github/workflows/privileged-smoke.yml
+++ b/.github/workflows/privileged-smoke.yml
@@ -24,6 +24,8 @@ jobs:
         with:
           persist-credentials: false
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
+        with:
+          rustflags: ""
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - name: Build memory target
         run: cargo build --locked --example memory_target
@@ -45,6 +47,8 @@ jobs:
         with:
           persist-credentials: false
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
+        with:
+          rustflags: ""
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - name: Build memory target
         run: cargo build --locked --example memory_target

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
           cache: false
+          rustflags: ""
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           lookup-only: true
@@ -69,6 +70,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
           cache: false
+          rustflags: ""
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           lookup-only: true
@@ -104,6 +106,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
           cache: false
+          rustflags: ""
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           lookup-only: true
@@ -117,6 +120,33 @@ jobs:
           }
           $sizeMB = [math]::Round((Get-Item target/release/rustinel.exe).Length / 1MB, 2)
           Write-Output "Binary: target/release/rustinel.exe ($sizeMB MB)"
+          $bytes = [IO.File]::ReadAllBytes("target/release/rustinel.exe")
+          if ($bytes.Length -lt 64 -or $bytes[0] -ne 0x4d -or $bytes[1] -ne 0x5a) {
+            Write-Error "Binary is not a valid DOS executable"
+            exit 1
+          }
+          $peOffset = [BitConverter]::ToInt32($bytes, 0x3c)
+          if ($peOffset -lt 0 -or $peOffset + 24 + 56 -gt $bytes.Length) {
+            Write-Error "Binary has an invalid PE header offset"
+            exit 1
+          }
+          if ($bytes[$peOffset] -ne 0x50 -or $bytes[$peOffset + 1] -ne 0x45 -or $bytes[$peOffset + 2] -ne 0x00 -or $bytes[$peOffset + 3] -ne 0x00) {
+            Write-Error "Binary is not a valid PE executable"
+            exit 1
+          }
+          $optionalHeaderOffset = $peOffset + 24
+          if ([BitConverter]::ToUInt16($bytes, $optionalHeaderOffset) -ne 0x20b) {
+            Write-Error "Binary is not a 64-bit PE executable"
+            exit 1
+          }
+          # PE32+ stores SizeOfStackReserve 48 bytes into the optional header.
+          $stackReserve = [BitConverter]::ToUInt64($bytes, $optionalHeaderOffset + 48)
+          $expectedStackReserve = [uint64]0x1000000
+          Write-Output ("SizeOfStackReserve: 0x{0:X}" -f $stackReserve)
+          if ($stackReserve -ne $expectedStackReserve) {
+            Write-Error ("Expected SizeOfStackReserve 0x{0:X}, got 0x{1:X}" -f $expectedStackReserve, $stackReserve)
+            exit 1
+          }
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
@@ -142,6 +172,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
           cache: false
+          rustflags: ""
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           lookup-only: true

--- a/.github/workflows/rsigma-engine.yml
+++ b/.github/workflows/rsigma-engine.yml
@@ -50,6 +50,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
           components: clippy
+          rustflags: ""
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - name: Clippy (RSigma Engine)
         run: cargo clippy --locked --features rsigma-engine --all-targets -- -D clippy::all

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ members = ["."]
 default-members = ["."]
 resolver = "2"
 
+[lints.rust]
+warnings = "deny"
+
 [features]
 # Opt-in RSigma library backend: swaps Rustinel's built-in Sigma matcher for
 # rsigma-parser + rsigma-eval while keeping Rustinel-owned normalization,

--- a/ebpf/Cargo.toml
+++ b/ebpf/Cargo.toml
@@ -19,5 +19,8 @@ opt-level = 2
 
 [workspace]
 
+[lints.rust]
+warnings = "deny"
+
 [dependencies]
 aya-ebpf = "0.2"


### PR DESCRIPTION
Fixes #267

## Summary
- Disable the toolchain action default RUSTFLAGS so target-specific Cargo linker flags remain active.
- Keep warnings denied through Cargo lint configuration.
- Verify SizeOfStackReserve is 0x1000000 for release Windows binaries.

## Validation
- cargo test --locked
- cargo test --locked --features rsigma-engine
- cargo clippy --locked --all-targets -- -D clippy::all
- cargo fmt --all -- --check