### PR TITLE
feat(ci): release attestation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -390,6 +390,7 @@ jobs:
             rustinel-${{ steps.version.outputs.version }}-x86_64-pc-windows-msvc.zip
             rustinel-${{ steps.version.outputs.version }}-aarch64-apple-darwin.tar.gz
             rustinel-${{ steps.version.outputs.version }}-x86_64-apple-darwin.tar.gz
+            rustinel-${{ steps.version.outputs.version }}-checksums-sha256.txt
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
@@ -453,5 +454,7 @@ jobs:
             All release artifacts have [SLSA build provenance](https://slsa.dev) attestations signed by GitHub:
 
             ```sh
-            gh attestation verify <artifact> --owner Karib0u
+            gh attestation verify <artifact> \
+              --repo Karib0u/rustinel \
+              --signer-workflow Karib0u/rustinel/.github/workflows/release.yml
             ```

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -271,6 +271,8 @@ jobs:
       - build-macos
     permissions:
       contents: write # create the GitHub Release and upload release assets
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -379,6 +381,16 @@ jobs:
         env:
           VERSION: ${{ steps.version.outputs.version }}
 
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: |
+            rustinel-${{ steps.version.outputs.version }}-x86_64-unknown-linux-musl.tar.gz
+            rustinel-${{ steps.version.outputs.version }}-aarch64-unknown-linux-musl.tar.gz
+            rustinel-${{ steps.version.outputs.version }}-x86_64-pc-windows-msvc.zip
+            rustinel-${{ steps.version.outputs.version }}-aarch64-apple-darwin.tar.gz
+            rustinel-${{ steps.version.outputs.version }}-x86_64-apple-darwin.tar.gz
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
@@ -435,3 +447,11 @@ jobs:
             Full install, configuration, and SIEM ingestion guides: https://docs.rustinel.io/getting-started/
 
             Scripts install published release binaries only. Verify downloads with `rustinel-${{ steps.version.outputs.version }}-checksums-sha256.txt`.
+
+            ## Provenance
+
+            All release artifacts have [SLSA build provenance](https://slsa.dev) attestations signed by GitHub:
+
+            ```sh
+            gh attestation verify <artifact> --owner Karib0u
+            ```


### PR DESCRIPTION
## Summary
Adds release artifacts attestation so that anybody downloading released versions can verify that they were compiled using the workflow.

Followup on #266 

## Type of change
<!-- Add the matching label to this PR before merging -->
- [ ] `feat` / `enhancement` - new feature
- [ ] `bug` - bug fix
- [ ] `refactor` - refactoring, no behaviour change
- [ ] `documentation` - docs only
- [x] `ci` - CI and release changes
- [ ] `dependencies` - dependency update

## Test plan
- [ ] Tested on Windows
- [ ] Tested on Linux
- [x] Existing tests pass (`cargo test`)
- [ ] New tests added (if applicable)

## Checklist
- [ ] Label added to this PR
- [ ] Docs updated (if behaviour changed)
