### PR TITLE
fix(reload): stop the watcher deadlocking on rule trees over 100 directories

### DIFF
--- a/src/reload/mod.rs
+++ b/src/reload/mod.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant, UNIX_EPOCH};
 
 use arc_swap::ArcSwap;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, watch};
 use tracing::{info, warn};
 
 use crate::config::{IocConfig, ReloadConfig, ScannerConfig};
@@ -326,23 +326,152 @@ pub fn spawn_reload_worker(
     })
 }
 
+/// Maximum time [`ReloadPoller::shutdown`] waits for the task before aborting it.
+const POLLER_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Handle to a running hot-reload poller task.
+///
+/// Carries an explicit shutdown signal rather than relying on
+/// [`tokio::task::JoinHandle::abort`], which cannot interrupt a task parked inside a
+/// synchronous watcher call.
+pub struct ReloadPoller {
+    handle: tokio::task::JoinHandle<()>,
+    shutdown: watch::Sender<bool>,
+}
+
+impl ReloadPoller {
+    /// Signal the poller to stop and wait for it to finish.
+    ///
+    /// Aborts the task if it does not observe the signal within
+    /// [`POLLER_SHUTDOWN_TIMEOUT`], so shutdown can never stall the process.
+    pub async fn shutdown(self) {
+        let ReloadPoller {
+            mut handle,
+            shutdown,
+        } = self;
+        let _ = shutdown.send(true);
+        if tokio::time::timeout(POLLER_SHUTDOWN_TIMEOUT, &mut handle)
+            .await
+            .is_err()
+        {
+            warn!(target: "reload", "Hot-reload poller did not stop in time; aborting");
+            handle.abort();
+            let _ = handle.await;
+        }
+    }
+}
+
+/// Collect the paths to watch, and how deeply, for the enabled subsystems.
+fn watch_targets(
+    scanner_cfg: &ScannerConfig,
+    ioc_cfg: &IocConfig,
+    config_path: Option<&PathBuf>,
+) -> Vec<(PathBuf, notify::RecursiveMode)> {
+    let mut targets = Vec::new();
+
+    if scanner_cfg.sigma_enabled {
+        targets.push((
+            scanner_cfg.sigma_rules_path.clone(),
+            notify::RecursiveMode::Recursive,
+        ));
+    }
+    if scanner_cfg.yara_enabled {
+        targets.push((
+            scanner_cfg.yara_rules_path.clone(),
+            notify::RecursiveMode::Recursive,
+        ));
+    }
+    if ioc_cfg.enabled {
+        let mut parents = HashSet::new();
+        for path in [
+            &ioc_cfg.hashes_path,
+            &ioc_cfg.ips_path,
+            &ioc_cfg.domains_path,
+            &ioc_cfg.paths_regex_path,
+        ] {
+            let normalized = normalize_path(path);
+            if let Some(parent) = normalized.parent() {
+                parents.insert(parent.to_path_buf());
+            }
+        }
+        for parent in parents {
+            targets.push((parent, notify::RecursiveMode::NonRecursive));
+        }
+    }
+    if let Some(cfg_path) = config_path {
+        let normalized = normalize_path(cfg_path);
+        if let Some(parent) = normalized.parent() {
+            targets.push((parent.to_path_buf(), notify::RecursiveMode::NonRecursive));
+        }
+    }
+
+    targets
+}
+
+/// Create the filesystem watcher and register every target.
+///
+/// Synchronous on purpose: `Watcher::watch()` blocks waiting on the watcher's own
+/// event thread, so callers run this on a blocking thread.
+fn build_watcher(
+    targets: &[(PathBuf, notify::RecursiveMode)],
+    tx: mpsc::Sender<()>,
+) -> Option<notify::RecommendedWatcher> {
+    use notify::Watcher;
+
+    let mut watcher =
+        match notify::recommended_watcher(move |res: Result<notify::Event, notify::Error>| {
+            if res.is_ok() {
+                // Must not block: this runs on the watcher's event thread, the same
+                // thread `watch()` waits on for its acknowledgement. A recursive
+                // registration over a large tree emits an event per directory, which
+                // would fill the channel before the receive loop starts and deadlock
+                // setup. A full channel already means a wake-up is pending, and the
+                // loop re-fingerprints everything after debouncing, so dropping the
+                // signal costs nothing.
+                let _ = tx.try_send(());
+            }
+        }) {
+            Ok(w) => w,
+            Err(e) => {
+                warn!(
+                    target: "reload",
+                    error = %e,
+                    "Failed to initialize recommended watcher"
+                );
+                return None;
+            }
+        };
+
+    for (path, mode) in targets {
+        if let Err(e) = watcher.watch(path, *mode) {
+            warn!(
+                target: "reload",
+                path = ?path,
+                error = %e,
+                "Failed to watch path, inotify/watcher setup failed"
+            );
+            return None;
+        }
+    }
+
+    Some(watcher)
+}
+
 pub fn spawn_reload_poller(
     scanner_cfg: ScannerConfig,
     ioc_cfg: IocConfig,
     reload_cfg: ReloadConfig,
     config_path: Option<PathBuf>,
     reload_tx: mpsc::UnboundedSender<ReloadTarget>,
-) -> tokio::task::JoinHandle<()> {
-    use notify::Watcher;
+) -> ReloadPoller {
+    let (shutdown, mut shutdown_rx) = watch::channel(false);
 
-    tokio::spawn(async move {
+    let handle = tokio::spawn(async move {
         if !reload_cfg.enabled {
             return;
         }
 
-        let mut watcher_setup_ok = true;
         let (tx, mut rx) = mpsc::channel::<()>(100);
-        let mut watcher = None;
 
         let mut sigma_fp = scanner_cfg
             .sigma_enabled
@@ -353,76 +482,17 @@ pub fn spawn_reload_poller(
         let mut ioc_fp = ioc_cfg.enabled.then(|| fingerprint_ioc_files(&ioc_cfg));
         let mut config_fp = config_path.as_ref().map(|path| fingerprint_file(path));
 
-        match notify::recommended_watcher(move |res: Result<notify::Event, notify::Error>| {
-            if res.is_ok() {
-                let _ = tx.blocking_send(());
+        let targets = watch_targets(&scanner_cfg, &ioc_cfg, config_path.as_ref());
+        let setup = tokio::task::spawn_blocking(move || build_watcher(&targets, tx));
+        let watcher = tokio::select! {
+            res = setup => res.ok().flatten(),
+            _ = shutdown_rx.changed() => {
+                info!(target: "reload", "Hot-reload poller shutting down during watcher setup");
+                return;
             }
-        }) {
-            Ok(mut w) => {
-                let mut watch_targets = Vec::new();
-                if scanner_cfg.sigma_enabled {
-                    watch_targets.push((
-                        scanner_cfg.sigma_rules_path.clone(),
-                        notify::RecursiveMode::Recursive,
-                    ));
-                }
-                if scanner_cfg.yara_enabled {
-                    watch_targets.push((
-                        scanner_cfg.yara_rules_path.clone(),
-                        notify::RecursiveMode::Recursive,
-                    ));
-                }
-                if ioc_cfg.enabled {
-                    let mut parents = HashSet::new();
-                    for path in [
-                        &ioc_cfg.hashes_path,
-                        &ioc_cfg.ips_path,
-                        &ioc_cfg.domains_path,
-                        &ioc_cfg.paths_regex_path,
-                    ] {
-                        let normalized = normalize_path(path);
-                        if let Some(parent) = normalized.parent() {
-                            parents.insert(parent.to_path_buf());
-                        }
-                    }
-                    for parent in parents {
-                        watch_targets.push((parent, notify::RecursiveMode::NonRecursive));
-                    }
-                }
-                if let Some(cfg_path) = &config_path {
-                    let normalized = normalize_path(cfg_path);
-                    if let Some(parent) = normalized.parent() {
-                        watch_targets
-                            .push((parent.to_path_buf(), notify::RecursiveMode::NonRecursive));
-                    }
-                }
+        };
 
-                for (path, mode) in &watch_targets {
-                    if let Err(e) = w.watch(path, *mode) {
-                        warn!(
-                            target: "reload",
-                            path = ?path,
-                            error = %e,
-                            "Failed to watch path, inotify/watcher setup failed"
-                        );
-                        watcher_setup_ok = false;
-                        break;
-                    }
-                }
-                if watcher_setup_ok {
-                    watcher = Some(w);
-                }
-            }
-            Err(e) => {
-                warn!(
-                    target: "reload",
-                    error = %e,
-                    "Failed to initialize recommended watcher"
-                );
-                watcher_setup_ok = false;
-            }
-        }
-
+        let watcher_setup_ok = watcher.is_some();
         if !watcher_setup_ok {
             warn!(target: "reload", "inotify is not available for the rules directory");
         }
@@ -438,17 +508,25 @@ pub fn spawn_reload_poller(
 
         loop {
             if watcher_setup_ok {
-                // Wait for filesystem event
-                if rx.recv().await.is_none() {
-                    break; // channel closed
+                // Wait for a filesystem event, or for shutdown
+                tokio::select! {
+                    _ = shutdown_rx.changed() => break,
+                    event = rx.recv() => {
+                        if event.is_none() {
+                            break; // channel closed
+                        }
+                    }
                 }
                 // Debounce: sleep to let multiple events coalesce
                 tokio::time::sleep(debounce_interval).await;
                 // Drain extra events
                 while rx.try_recv().is_ok() {}
             } else {
-                // Fallback: poll every 60 seconds
-                tokio::time::sleep(poll_interval).await;
+                // Fallback: poll on the configured interval
+                tokio::select! {
+                    _ = shutdown_rx.changed() => break,
+                    _ = tokio::time::sleep(poll_interval) => {}
+                }
             }
 
             if scanner_cfg.sigma_enabled {
@@ -494,7 +572,9 @@ pub fn spawn_reload_poller(
 
         drop(watcher);
         info!(target: "reload", "Hot-reload poller shutting down");
-    })
+    });
+
+    ReloadPoller { handle, shutdown }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/runtime/linux.rs
+++ b/src/runtime/linux.rs
@@ -188,7 +188,7 @@ async fn run_linux_edr(
         Arc::clone(&ioc_engine),
     );
 
-    let mut reload_poller_handle = None;
+    let mut reload_poller = None;
     let mut reload_worker_handle = None;
     let mut reload_tx = None;
     if cfg.reload.enabled {
@@ -205,7 +205,7 @@ async fn run_linux_edr(
             response_config.clone(),
             rx,
         ));
-        reload_poller_handle = Some(reload::spawn_reload_poller(
+        reload_poller = Some(reload::spawn_reload_poller(
             cfg.scanner.clone(),
             cfg.ioc.clone(),
             cfg.reload.clone(),
@@ -360,9 +360,8 @@ async fn run_linux_edr(
     if let Some(h) = ioc_hash_worker_handle.take() {
         let _ = h.await;
     }
-    if let Some(h) = reload_poller_handle.take() {
-        h.abort();
-        let _ = h.await;
+    if let Some(poller) = reload_poller.take() {
+        poller.shutdown().await;
     }
     drop(reload_tx.take());
     if let Some(h) = reload_worker_handle.take() {

--- a/src/runtime/macos.rs
+++ b/src/runtime/macos.rs
@@ -204,7 +204,7 @@ async fn run_macos_edr(
         Arc::clone(&ioc_engine),
     );
 
-    let mut reload_poller_handle = None;
+    let mut reload_poller = None;
     let mut reload_worker_handle = None;
     let mut reload_tx = None;
     if cfg.reload.enabled {
@@ -221,7 +221,7 @@ async fn run_macos_edr(
             response_config.clone(),
             rx,
         ));
-        reload_poller_handle = Some(reload::spawn_reload_poller(
+        reload_poller = Some(reload::spawn_reload_poller(
             cfg.scanner.clone(),
             cfg.ioc.clone(),
             cfg.reload.clone(),
@@ -388,9 +388,8 @@ async fn run_macos_edr(
     if let Some(h) = ioc_hash_worker_handle.take() {
         let _ = h.await;
     }
-    if let Some(h) = reload_poller_handle.take() {
-        h.abort();
-        let _ = h.await;
+    if let Some(poller) = reload_poller.take() {
+        poller.shutdown().await;
     }
     drop(reload_tx.take());
     if let Some(h) = reload_worker_handle.take() {

--- a/src/runtime/windows.rs
+++ b/src/runtime/windows.rs
@@ -500,7 +500,7 @@ async fn run_edr(
             (None, None)
         };
 
-    let mut reload_poller_handle = None;
+    let mut reload_poller = None;
     let mut reload_worker_handle = None;
     let mut reload_tx = None;
     if cfg.reload.enabled {
@@ -519,7 +519,7 @@ async fn run_edr(
             rx,
         ));
 
-        reload_poller_handle = Some(reload::spawn_reload_poller(
+        reload_poller = Some(reload::spawn_reload_poller(
             cfg.scanner.clone(),
             cfg.ioc.clone(),
             cfg.reload.clone(),
@@ -728,10 +728,9 @@ async fn run_edr(
         }
     }
 
-    if let Some(handle) = reload_poller_handle.take() {
+    if let Some(poller) = reload_poller.take() {
         info!("Signaling hot-reload poller to shut down...");
-        handle.abort();
-        let _ = handle.await;
+        poller.shutdown().await;
         info!("Hot-reload poller thread finished");
     }
     drop(reload_tx.take());

--- a/tests/reload.rs
+++ b/tests/reload.rs
@@ -297,7 +297,7 @@ async fn test_reload_poller_fallback_polling() {
 
     // Spawning the poller with a non-existent path will trigger the watcher failure
     // and cause it to fall back to the 100ms polling loop (in test configuration)
-    let handle =
+    let poller =
         rustinel::reload::spawn_reload_poller(scanner_cfg, ioc_cfg, reload_cfg, None, reload_tx);
 
     // Give it a moment to initialize and fail watcher setup
@@ -329,7 +329,121 @@ level: high
 
     assert_eq!(event, ReloadTarget::Sigma);
 
-    handle.abort();
+    poller.shutdown().await;
+}
+
+/// Regression test for a watcher-setup deadlock on deep rule trees.
+///
+/// notify watches `IN_OPEN`, so walking a tree to register it recursively queues one
+/// inotify event per directory. The callback used to block once the wake-up channel
+/// filled, parking notify's event-loop thread — the same thread the *next*
+/// `Watcher::watch()` call waits on for its acknowledgement. Setup never returned,
+/// hot reload never activated, and the process never shut down.
+///
+/// Reproducing it therefore needs both a tree larger than the channel (100) and a
+/// second watch target registered after it; here, the config file's parent.
+#[tokio::test]
+async fn test_reload_poller_handles_rule_tree_with_many_directories() {
+    use rustinel::config::IocConfig;
+    use std::path::PathBuf;
+    use std::time::Duration;
+
+    // More directories than the wake-up channel can hold (capacity 100).
+    const DIR_COUNT: usize = 150;
+
+    let tempdir = tempfile::tempdir().expect("create tempdir");
+    let sigma_dir = tempdir.path().join("sigma");
+    for i in 0..DIR_COUNT {
+        let sub = sigma_dir.join(format!("category_{i:03}"));
+        std::fs::create_dir_all(&sub).expect("create rule subdir");
+        std::fs::write(sub.join("rule.yml"), sigma_rule_yaml("test.exe")).expect("write rule");
+    }
+
+    let config_dir = tempdir.path().join("etc");
+    std::fs::create_dir_all(&config_dir).expect("create config dir");
+    let config_path = config_dir.join("rustinel.toml");
+    std::fs::write(&config_path, "").expect("write config");
+
+    let scanner_cfg = ScannerConfig {
+        sigma_enabled: true,
+        sigma_rules_path: sigma_dir.clone(),
+        sigma_engine: "builtin".to_string(),
+        yara_enabled: false,
+        yara_rules_path: PathBuf::from(""),
+        yara_allowlist_paths: Vec::new(),
+        yara_scan_timeout_ms: 10_000,
+        yara_max_file_mb: 64,
+        yara_memory_enabled: false,
+        yara_memory_queue_capacity: 0,
+        yara_memory_delay_ms: 0,
+        yara_memory_max_process_mb: 0,
+        yara_memory_max_region_mb: 0,
+        yara_memory_include_private: false,
+        yara_memory_include_image: false,
+        yara_memory_include_mapped: false,
+    };
+
+    let ioc_cfg = IocConfig {
+        enabled: false,
+        hashes_path: PathBuf::from(""),
+        ips_path: PathBuf::from(""),
+        domains_path: PathBuf::from(""),
+        paths_regex_path: PathBuf::from(""),
+        default_severity: "high".to_string(),
+        max_file_size_mb: 0,
+        hash_allowlist_paths: Vec::new(),
+    };
+
+    // A poll interval far beyond the test timeout: only a working watcher can
+    // produce the reload event below.
+    let reload_cfg = ReloadConfig {
+        enabled: true,
+        debounce_ms: 10,
+        fallback_poll_interval_ms: 3_600_000,
+    };
+
+    let (reload_tx, mut reload_rx) = mpsc::unbounded_channel();
+    let poller = rustinel::reload::spawn_reload_poller(
+        scanner_cfg,
+        ioc_cfg,
+        reload_cfg,
+        Some(config_path),
+        reload_tx,
+    );
+
+    // Let watcher setup finish before touching the tree.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    std::fs::write(
+        sigma_dir.join("category_000").join("added.yml"),
+        sigma_rule_yaml("added.exe"),
+    )
+    .expect("write rule");
+
+    let event = tokio::time::timeout(Duration::from_secs(10), reload_rx.recv())
+        .await
+        .expect("watcher setup deadlocked: no reload event")
+        .expect("Channel closed unexpectedly");
+    assert_eq!(event, ReloadTarget::Sigma);
+
+    tokio::time::timeout(Duration::from_secs(5), poller.shutdown())
+        .await
+        .expect("poller did not shut down");
+}
+
+fn sigma_rule_yaml(image: &str) -> String {
+    format!(
+        r#"title: Test Rule {image}
+logsource:
+  product: windows
+  category: process_creation
+detection:
+  selection:
+    Image: "{image}"
+  condition: selection
+level: high
+"#
+    )
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Fixes #278.

Pointing `scanner.sigma_rules_path` at a nested rules tree — a SigmaHQ checkout has 175 directories — deadlocked hot-reload setup on Linux. Hot reload silently never activated, and the agent never exited on SIGINT, so under systemd `stop` waited out `TimeoutStopSec` and then SIGKILLed, losing the shutdown telemetry snapshot and any queued alert flush.

### Root cause

The issue was right about the channel, but the trigger is narrower than directory count alone.

notify's inotify backend registers each watch with `WatchMask::OPEN`, so the `WalkDir` pass that registers a tree recursively queues one inotify event per directory it opens. Those events pile up harmlessly — nothing is waiting on them. The deadlock is the **next** `watch()` call: `watch_inner` posts an `AddWatch` message and blocks on a reply from notify's event-loop thread, and when `poll()` returns both the inotify fd and the message channel as ready, that thread drains the inotify events *first*, invoking the callback for each. At event 101 the callback's `blocking_send` on the capacity-100 channel parked the thread, and the acknowledgement `watch()` was waiting on never came. That is the gdb trace in the issue: parked in `mpmc::Channel::recv` inside `INotifyWatcher::watch`.

So reproducing it needs a tree bigger than the channel **and** a second watch target registered after it. Rustinel always has one — the config file's parent, plus the YARA and IOC paths — which is why this bites in the field but not in a sigma-only harness.

## What changed

`src/reload/mod.rs`:

- **The callback uses `try_send`.** A full channel already means a wake-up is pending, and the loop re-fingerprints every target after debouncing, so a coalesced signal costs nothing.
- **Watcher construction and registration moved to `spawn_blocking`.** `Watcher::watch()` is synchronous, so while it ran the task could not be cancelled at any await point — which is why the `JoinHandle::abort()` the runtimes already issued on shutdown never took effect. Setup now also races against shutdown, so a slow registration can't hold up exit.
- **The poller gets an explicit shutdown signal**, the second issue raised in #278. `spawn_reload_poller` returns a `ReloadPoller` instead of a bare `JoinHandle`; `shutdown()` signals the task, waits, and only falls back to aborting after 5 s. Both loop arms — the watcher wait and the fallback poll — select on it, so termination no longer depends on the channel closing or a `reload_tx.send` failing.

The watch-target list and the watcher build are now two small functions rather than one nested `match`, which is what makes the blocking half separable.

`src/runtime/{linux,macos,windows}.rs` call `poller.shutdown().await` in place of `abort()` + `await`.

## Type of change

- [x] `bug` - bug fix

## Test plan

- [x] Tested on Windows
- [x] Tested on Linux
- [x] Existing tests pass (`cargo test`)
- [x] New tests added

**New regression test** (`tests/reload.rs`) builds a 150-directory tree plus a second watch target, and asserts both that a change is detected — with the fallback poll interval set to an hour, so only a live watcher can produce the event — and that shutdown completes. It is a real negative control, not just a passing test:

```
# with `blocking_send` restored, on Linux
test test_reload_poller_handles_rule_tree_with_many_directories ... FAILED
watcher setup deadlocked: no reload event: Elapsed(())
```

**Linux** (Ubuntu 26.04, kernel 7.0): full `cargo test` and `cargo clippy --all-targets` clean. End to end with the real SigmaHQ tree (175 directories) under the release binary and a live eBPF sensor:

```
INFO reload: Hot-reload poller/watcher started watcher_active=true
INFO rustinel::runtime::linux: Received Ctrl+C, shutting down
INFO reload: Hot-reload poller shutting down
INFO rustinel::runtime::linux: Shutdown complete
```

`Hot-reload poller/watcher started` never appeared before this change; SIGINT to `Shutdown complete` is now 3 s, against the >400 s hang reported in the issue.

**Windows**: `cargo test --locked` (292 unit + all integration suites) and `cargo clippy --locked --all-targets -- -D clippy::all` both clean. The deadlock was never reproducible there — `ReadDirectoryChangesW` registers recursively without emitting setup events — so this is a no-regression check on the shutdown-path change.

## Checklist

- [ ] Label added to this PR
- [x] Docs updated (if behaviour changed) — no user-facing behaviour or config change
