### PR TITLE
fix(windows-registry): classify registry actions and resolve key paths

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -33,8 +33,13 @@ are unavailable.
   maps to the registry *value name*, not the data written to it - the
   Kernel-Registry provider doesn't emit value data. A rule matching on written
   content silently matches the value name instead.
-- **Registry `TargetObject` is a relative path (silent risk).** Full key paths
-  (e.g. `HKLM\...\Run`) aren't resolved, so `endswith`-style key matches may miss.
+- **Registry `TargetObject` is not always a full path (silent risk).** The path
+  is composed from the `CreateKey`/`OpenKey` events that named the key, so it is
+  the full NT path (`\REGISTRY\MACHINE\...`) when the parent key was also seen
+  being opened, and a partial path relative to it otherwise. Hive prefixes are
+  never rewritten to `HKLM`/`HKCU`, so `startswith`-style matches on a hive
+  abbreviation will miss. Value writes do carry the value name appended to the
+  key, matching Sysmon's Event ID 13 `TargetObject` shape.
 - **No process or image-load hashes (silent risk).** There is no `Hashes`/`Imphash`
   on process or image-load events, so the many Sigma rules keyed on them can
   never fire. Hash matching exists only in the file/IOC scanner.
@@ -64,6 +69,13 @@ are unavailable.
   closed and reopened, which for some services means until the next reboot.
   The count is logged as `unresolved_file_events`, so the size of the gap is
   visible even though the events themselves are not.
+- **Writes to keys opened before startup are invisible (silent risk).** The same
+  limitation as the file index, for the same reason: Kernel-Registry reports
+  `SetValueKey`, `DeleteValueKey` and `DeleteKey` by `KeyObject` with an empty
+  `KeyName`, so the sensor learns each key's path from the `CreateKey` or
+  `OpenKey` that opened it. A key already open when the sensor starts cannot be
+  attributed, and the event is dropped rather than reported without a path. The
+  count is logged as `unresolved_registry_events`.
 
 ## Linux (eBPF)
 

--- a/src/sensor/windows/etw.rs
+++ b/src/sensor/windows/etw.rs
@@ -72,10 +72,17 @@ impl EtwProviders {
         | Self::KERNEL_FILE_KEYWORD_DELETE_PATH
         | Self::KERNEL_FILE_KEYWORD_RENAME_SETLINK_PATH;
 
+    // Keyword names and values follow the Microsoft-Windows-Kernel-Registry
+    // manifest. The previous values were off by a whole nibble: 0x2000 is
+    // `OpenKey` and 0x8000 is `QueryKey`, so the session subscribed to the two
+    // highest-volume read paths on the machine and to neither value write.
+    // That is why registry made up 97.7% of captured telemetry while
+    // `registry_set` could not fire — the events it needs were never
+    // delivered (#279).
+    const REG_KEYWORD_SET_VALUE_KEY: u64 = 0x0100;
+    const REG_KEYWORD_DELETE_VALUE_KEY: u64 = 0x0200;
     const REG_KEYWORD_CREATE_KEY: u64 = 0x1000;
-    const REG_KEYWORD_SET_VALUE_KEY: u64 = 0x2000;
     const REG_KEYWORD_DELETE_KEY: u64 = 0x4000;
-    const REG_KEYWORD_DELETE_VALUE_KEY: u64 = 0x8000;
     const REGISTRY_KEYWORDS: u64 = Self::REG_KEYWORD_CREATE_KEY
         | Self::REG_KEYWORD_SET_VALUE_KEY
         | Self::REG_KEYWORD_DELETE_KEY
@@ -198,6 +205,55 @@ const KERNEL_FILE_EVENT_SET_INFORMATION: u16 = 17;
 const KERNEL_FILE_EVENT_DELETE_PATH: u16 = 26;
 const KERNEL_FILE_EVENT_RENAME_PATH: u16 = 27;
 const KERNEL_FILE_EVENT_SET_LINK_PATH: u16 = 28;
+
+/// Microsoft-Windows-Kernel-Registry manifest event IDs.
+///
+/// The manifest declares opcodes 32-46 for event IDs 1-15, but the records the
+/// session actually receives carry opcode 0, exactly as Kernel-File does. The
+/// old classifier read `record.opcode()` and compared it against 36/38/39/41,
+/// which is doubly wrong: opcode is always 0 at runtime, and even the manifest
+/// values do not line up — 36 is `SetValueKey`, 38 `QueryValueKey`, 39
+/// `EnumerateKey` and 41 `QueryMultipleValueKey`. Route on the event ID (#279).
+const KERNEL_REGISTRY_EVENT_CREATE_KEY: u16 = 1;
+const KERNEL_REGISTRY_EVENT_DELETE_KEY: u16 = 3;
+const KERNEL_REGISTRY_EVENT_SET_VALUE_KEY: u16 = 5;
+const KERNEL_REGISTRY_EVENT_DELETE_VALUE_KEY: u16 = 6;
+
+/// The event IDs [`kernel_registry_route`] accepts, pushed down to the provider
+/// as a scope filter. Kept in sync with the router by
+/// `registry_filter_matches_routing_allowlist`.
+const KERNEL_REGISTRY_ROUTED_EVENT_IDS: [u16; 4] = [
+    KERNEL_REGISTRY_EVENT_CREATE_KEY,
+    KERNEL_REGISTRY_EVENT_DELETE_KEY,
+    KERNEL_REGISTRY_EVENT_SET_VALUE_KEY,
+    KERNEL_REGISTRY_EVENT_DELETE_VALUE_KEY,
+];
+
+/// What a Microsoft-Windows-Kernel-Registry event is good for.
+///
+/// An allowlist, like [`kernel_file_route`]: an unrecognised event is dropped
+/// rather than labelled a modification. The `_ => SensorAction::Modify`
+/// catch-all this replaces collapsed the whole action taxonomy onto a single
+/// value that maps to no Sysmon event ID, so `registry_add`, `registry_set` and
+/// `registry_delete` rules were evaluated against every registry event and
+/// could never match one.
+fn kernel_registry_route(event_id: u16) -> Option<SensorAction> {
+    match event_id {
+        KERNEL_REGISTRY_EVENT_CREATE_KEY => Some(SensorAction::Create),
+        // A deleted key and a deleted value are both Sysmon 12 and both
+        // `registry_delete`; the value name survives in `Details`.
+        KERNEL_REGISTRY_EVENT_DELETE_KEY | KERNEL_REGISTRY_EVENT_DELETE_VALUE_KEY => {
+            Some(SensorAction::Delete)
+        }
+        KERNEL_REGISTRY_EVENT_SET_VALUE_KEY => Some(SensorAction::Set),
+        // 2 OpenKey, 4 QueryKey, 7 QueryValueKey, 8 EnumerateKey,
+        // 9 EnumerateValueKey, 10 QueryMultipleValueKey, 12 FlushKey,
+        // 13 CloseKey, 14 QuerySecurityKey — reads and bookkeeping, no state
+        // change. 11 SetInformationKey and 15 SetSecurityKey do change state
+        // but have no Sysmon or Sigma counterpart to carry them.
+        _ => None,
+    }
+}
 
 /// `FILE_INFORMATION_CLASS` values seen on `SetInformation` (event ID 17).
 ///
@@ -329,6 +385,34 @@ fn refine_file_create_action(parser: &Parser, action: SensorAction) -> Option<Se
     }
 }
 
+/// `REG_DISPOSITION` values reported by Kernel-Registry event ID 1.
+const REG_CREATED_NEW_KEY: u32 = 1;
+const REG_OPENED_EXISTING_KEY: u32 = 2;
+
+/// Refine a [`SensorAction::Create`] for Kernel-Registry event ID 1 using its
+/// `Disposition`.
+///
+/// `CreateKey` is `NtCreateKey`, which opens an existing key just as readily as
+/// it makes a new one — the same trap as `IRP_MJ_CREATE` on the file side (see
+/// [`refine_file_create_action`]). Without this, every key open on the machine
+/// would surface as a `registry_add`, trading a category that never fires for
+/// one that fires constantly.
+///
+/// Returns `None` when the event should be dropped.
+fn refine_registry_create_action(parser: &Parser, action: SensorAction) -> Option<SensorAction> {
+    if action != SensorAction::Create {
+        return Some(action);
+    }
+
+    match parser.try_parse::<u32>("Disposition") {
+        Ok(REG_OPENED_EXISTING_KEY) => None,
+        Ok(REG_CREATED_NEW_KEY) => Some(SensorAction::Create),
+        // An unreadable or unknown disposition keeps the event: a missed
+        // detection is worse than an extra one.
+        _ => Some(SensorAction::Create),
+    }
+}
+
 /// Shared state the ETW callback carries across events.
 ///
 /// The path index has to outlive a single event: the naming event and the
@@ -417,12 +501,7 @@ impl EtwRouting {
             // Kernel-File needs the path index and so has its own pipeline;
             // `decode_record` diverts it before reaching here.
             EventCategory::File => return None,
-            EventCategory::Registry => match record.opcode() {
-                36 => SensorAction::Create,
-                38 | 41 => SensorAction::Delete,
-                39 => SensorAction::Set,
-                _ => SensorAction::Modify,
-            },
+            EventCategory::Registry => kernel_registry_route(record.event_id())?,
             EventCategory::Dns => SensorAction::Query,
             EventCategory::Scripting => SensorAction::Execute,
             EventCategory::Wmi => SensorAction::Execute,
@@ -502,12 +581,17 @@ impl Sensor for EtwSensor {
                     }
                 });
 
-            // Only Kernel-File is filtered: the FILEIO keyword it needs for
-            // Close and SetInformation also turns on every read and query on
-            // the machine, and none of those are routed.
+            // Kernel-File and Kernel-Registry are filtered: both are
+            // manifest providers whose keywords pull in more than is routed,
+            // and both are high enough volume for the kernel-side buffer
+            // traffic to be worth removing.
             if provider_def.guid == EtwProviders::kernel_file().guid {
                 provider_builder = provider_builder.add_filter(EventFilter::ByEventIds(
                     KERNEL_FILE_ROUTED_EVENT_IDS.to_vec(),
+                ));
+            } else if provider_def.guid == EtwProviders::kernel_registry().guid {
+                provider_builder = provider_builder.add_filter(EventFilter::ByEventIds(
+                    KERNEL_REGISTRY_ROUTED_EVENT_IDS.to_vec(),
                 ));
             }
 
@@ -585,6 +669,13 @@ fn decode_record(
         }
     };
     let parser = Parser::create(record, &schema);
+
+    // `CreateKey` needs its parsed `Disposition` to tell a new key from a
+    // plain open, so the routed action is refined once the parser exists.
+    let action = match category {
+        EventCategory::Registry => refine_registry_create_action(&parser, action)?,
+        _ => action,
+    };
 
     let decoded = match category {
         EventCategory::Process => decode_process(&parser, record, action),
@@ -837,9 +928,15 @@ fn decode_registry(parser: &Parser, record: &EventRecord) -> Option<DecodedEtwEv
     let event_mappings = field_maps::registry_event_mappings();
     let modify_mappings = field_maps::registry_modify_mappings();
 
+    // Every registry Sigma rule keys on `TargetObject`; a record without one
+    // matches nothing, so drop it before it costs an evaluation. 13.9% of the
+    // registry events in the #279 capture carried only `Image`.
+    let target_object = try_get_string(parser, event_mappings.get_etw_field("TargetObject")?)
+        .or_else(|| try_get_string(parser, modify_mappings.get_etw_field("TargetObject")?))
+        .filter(|path| !path.is_empty())?;
+
     let fields = RegistryEventFields {
-        target_object: try_get_string(parser, event_mappings.get_etw_field("TargetObject")?)
-            .or_else(|| try_get_string(parser, modify_mappings.get_etw_field("TargetObject")?)),
+        target_object: Some(target_object),
         details: try_get_string(parser, event_mappings.get_etw_field("Details")?)
             .or_else(|| try_get_string(parser, modify_mappings.get_etw_field("Details")?)),
         process_id: try_get_uint(parser, event_mappings.get_etw_field("ProcessId")?),
@@ -1210,6 +1307,56 @@ mod tests {
             EtwProviders::FILE_KEYWORDS & EtwProviders::KERNEL_FILE_KEYWORD_FILEIO,
             0
         );
+    }
+
+    #[test]
+    fn registry_filter_matches_routing_allowlist() {
+        // Same allowlist-drift guard as the Kernel-File filter: an ID that
+        // routes but is missing from the filter never reaches the callback.
+        let routed: Vec<u16> = (0u16..=64)
+            .filter(|id| kernel_registry_route(*id).is_some())
+            .collect();
+        let mut expected = KERNEL_REGISTRY_ROUTED_EVENT_IDS.to_vec();
+        expected.sort_unstable();
+        assert_eq!(
+            routed, expected,
+            "provider filter and kernel_registry_route disagree"
+        );
+    }
+
+    #[test]
+    fn registry_event_ids_route_to_write_actions() {
+        assert_eq!(kernel_registry_route(1), Some(SensorAction::Create));
+        assert_eq!(kernel_registry_route(3), Some(SensorAction::Delete));
+        assert_eq!(kernel_registry_route(5), Some(SensorAction::Set));
+        assert_eq!(kernel_registry_route(6), Some(SensorAction::Delete));
+    }
+
+    #[test]
+    fn registry_reads_are_dropped_not_called_modifications() {
+        // The `_ => Modify` catch-all this replaces put every one of these
+        // through the full Sigma evaluation under an action code of 0.
+        for event_id in [2, 4, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 40, 99] {
+            assert_eq!(
+                kernel_registry_route(event_id),
+                None,
+                "registry event {event_id} must not be routed"
+            );
+        }
+    }
+
+    #[test]
+    fn registry_keywords_subscribe_to_writes_only() {
+        // Manifest values: SetValueKey 0x100, DeleteValueKey 0x200,
+        // CreateKey 0x1000, DeleteKey 0x4000. The mask previously used 0x2000
+        // and 0x8000 for the two value keywords, which are OpenKey and
+        // QueryKey — it subscribed to reads and missed every value write.
+        assert_eq!(EtwProviders::REGISTRY_KEYWORDS, 0x5300);
+
+        const OPEN_KEY: u64 = 0x2000;
+        const QUERY_KEY: u64 = 0x8000;
+        assert_eq!(EtwProviders::REGISTRY_KEYWORDS & OPEN_KEY, 0);
+        assert_eq!(EtwProviders::REGISTRY_KEYWORDS & QUERY_KEY, 0);
     }
 
     #[test]

--- a/src/sensor/windows/etw.rs
+++ b/src/sensor/windows/etw.rs
@@ -429,10 +429,11 @@ const REG_OPENED_EXISTING_KEY: u32 = 2;
 /// Returns `None` when the event should be dropped.
 fn refine_registry_create_action(parser: &Parser) -> Option<()> {
     match parser.try_parse::<u32>("Disposition") {
+        Ok(REG_CREATED_NEW_KEY) => Some(()),
         Ok(REG_OPENED_EXISTING_KEY) => None,
         // An unreadable or unknown disposition keeps the event: a missed
         // detection is worse than an extra one.
-        _ => Some(()),
+        Ok(_) | Err(_) => Some(()),
     }
 }
 
@@ -1030,6 +1031,7 @@ fn decode_kernel_registry_record(
             return None;
         }
         KernelRegistryRoute::Emit(action) => {
+            let value_name = try_get_string(&parser, "ValueName");
             // `KeyName` is declared on these events but measured empty on
             // Windows 11, so the index is the real source of the path.
             let path = try_get_string(&parser, "KeyName")
@@ -1040,6 +1042,15 @@ fn decode_kernel_registry_record(
                         .resolve(key_object)
                         .map(str::to_string)
                 });
+
+            // Sysmon reports a value write as `<key>\<value>` on Event ID 13,
+            // and `registry_set` rules are written against that shape — an
+            // `endswith: '\Run\Foo'` rule needs the value name in the path,
+            // not only in `Details`.
+            let path = path.map(|path| match value_name.as_deref() {
+                Some(value) if !value.is_empty() => format!("{path}\\{value}"),
+                _ => path,
+            });
 
             match path {
                 Some(path) => (action, path),

--- a/src/sensor/windows/etw.rs
+++ b/src/sensor/windows/etw.rs
@@ -25,6 +25,7 @@ use crate::sensor::{Platform, ProcessStartKey, Sensor, SensorAction, SensorEvent
 use crate::utils::{convert_nt_to_dos, parse_metadata, query_process_command_line};
 
 use super::file_paths::FilePathCache;
+use super::registry_paths::RegistryPathCache;
 use super::{field_maps, mapper};
 
 /// Fixed trace session name for stopping the trace on shutdown.
@@ -73,20 +74,28 @@ impl EtwProviders {
         | Self::KERNEL_FILE_KEYWORD_RENAME_SETLINK_PATH;
 
     // Keyword names and values follow the Microsoft-Windows-Kernel-Registry
-    // manifest. The previous values were off by a whole nibble: 0x2000 is
-    // `OpenKey` and 0x8000 is `QueryKey`, so the session subscribed to the two
-    // highest-volume read paths on the machine and to neither value write.
-    // That is why registry made up 97.7% of captured telemetry while
-    // `registry_set` could not fire — the events it needs were never
-    // delivered (#279).
+    // manifest. The values used before #279 were off by a whole nibble:
+    // `SetValueKey` is 0x100 and `DeleteValueKey` 0x200, not 0x2000 and
+    // 0x8000, which are `OpenKey` and `QueryKey`. The session subscribed to
+    // two read paths and to neither value write, so `registry_set` could not
+    // have fired even with correct classification.
+    const REG_KEYWORD_CLOSE_KEY: u64 = 0x0001;
     const REG_KEYWORD_SET_VALUE_KEY: u64 = 0x0100;
     const REG_KEYWORD_DELETE_VALUE_KEY: u64 = 0x0200;
     const REG_KEYWORD_CREATE_KEY: u64 = 0x1000;
+    /// `OpenKey` produces no telemetry of its own. It is subscribed because it
+    /// is a *naming* event: `SetValueKey` and friends deliver an empty
+    /// `KeyName`, and most writes land on keys that were opened rather than
+    /// created, so without this their path is unrecoverable. `CloseKey` is the
+    /// matching eviction point. See [`super::registry_paths`].
+    const REG_KEYWORD_OPEN_KEY: u64 = 0x2000;
     const REG_KEYWORD_DELETE_KEY: u64 = 0x4000;
-    const REGISTRY_KEYWORDS: u64 = Self::REG_KEYWORD_CREATE_KEY
+    const REGISTRY_KEYWORDS: u64 = Self::REG_KEYWORD_CLOSE_KEY
         | Self::REG_KEYWORD_SET_VALUE_KEY
-        | Self::REG_KEYWORD_DELETE_KEY
-        | Self::REG_KEYWORD_DELETE_VALUE_KEY;
+        | Self::REG_KEYWORD_DELETE_VALUE_KEY
+        | Self::REG_KEYWORD_CREATE_KEY
+        | Self::REG_KEYWORD_OPEN_KEY
+        | Self::REG_KEYWORD_DELETE_KEY;
 
     const WINEVENT_KEYWORD_PROCESS: u64 = 0x0010;
     const WINEVENT_KEYWORD_IMAGE: u64 = 0x0040;
@@ -215,18 +224,22 @@ const KERNEL_FILE_EVENT_SET_LINK_PATH: u16 = 28;
 /// values do not line up — 36 is `SetValueKey`, 38 `QueryValueKey`, 39
 /// `EnumerateKey` and 41 `QueryMultipleValueKey`. Route on the event ID (#279).
 const KERNEL_REGISTRY_EVENT_CREATE_KEY: u16 = 1;
+const KERNEL_REGISTRY_EVENT_OPEN_KEY: u16 = 2;
 const KERNEL_REGISTRY_EVENT_DELETE_KEY: u16 = 3;
 const KERNEL_REGISTRY_EVENT_SET_VALUE_KEY: u16 = 5;
 const KERNEL_REGISTRY_EVENT_DELETE_VALUE_KEY: u16 = 6;
+const KERNEL_REGISTRY_EVENT_CLOSE_KEY: u16 = 13;
 
 /// The event IDs [`kernel_registry_route`] accepts, pushed down to the provider
 /// as a scope filter. Kept in sync with the router by
 /// `registry_filter_matches_routing_allowlist`.
-const KERNEL_REGISTRY_ROUTED_EVENT_IDS: [u16; 4] = [
+const KERNEL_REGISTRY_ROUTED_EVENT_IDS: [u16; 6] = [
     KERNEL_REGISTRY_EVENT_CREATE_KEY,
+    KERNEL_REGISTRY_EVENT_OPEN_KEY,
     KERNEL_REGISTRY_EVENT_DELETE_KEY,
     KERNEL_REGISTRY_EVENT_SET_VALUE_KEY,
     KERNEL_REGISTRY_EVENT_DELETE_VALUE_KEY,
+    KERNEL_REGISTRY_EVENT_CLOSE_KEY,
 ];
 
 /// What a Microsoft-Windows-Kernel-Registry event is good for.
@@ -237,20 +250,36 @@ const KERNEL_REGISTRY_ROUTED_EVENT_IDS: [u16; 4] = [
 /// value that maps to no Sysmon event ID, so `registry_add`, `registry_set` and
 /// `registry_delete` rules were evaluated against every registry event and
 /// could never match one.
-fn kernel_registry_route(event_id: u16) -> Option<SensorAction> {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum KernelRegistryRoute {
+    /// Carries `BaseName`/`RelativeName`; record the key's path.
+    ///
+    /// `creates` distinguishes `CreateKey`, which also reports a creation when
+    /// its `Disposition` says a new key was made, from `OpenKey`, which is
+    /// index maintenance only.
+    Name { creates: bool },
+    /// Emit telemetry under this action, resolving the path from the index.
+    Emit(SensorAction),
+    /// A closed key: drop its `KeyObject` from the index.
+    Evict,
+}
+
+fn kernel_registry_route(event_id: u16) -> Option<KernelRegistryRoute> {
     match event_id {
-        KERNEL_REGISTRY_EVENT_CREATE_KEY => Some(SensorAction::Create),
+        KERNEL_REGISTRY_EVENT_CREATE_KEY => Some(KernelRegistryRoute::Name { creates: true }),
+        KERNEL_REGISTRY_EVENT_OPEN_KEY => Some(KernelRegistryRoute::Name { creates: false }),
         // A deleted key and a deleted value are both Sysmon 12 and both
         // `registry_delete`; the value name survives in `Details`.
         KERNEL_REGISTRY_EVENT_DELETE_KEY | KERNEL_REGISTRY_EVENT_DELETE_VALUE_KEY => {
-            Some(SensorAction::Delete)
+            Some(KernelRegistryRoute::Emit(SensorAction::Delete))
         }
-        KERNEL_REGISTRY_EVENT_SET_VALUE_KEY => Some(SensorAction::Set),
-        // 2 OpenKey, 4 QueryKey, 7 QueryValueKey, 8 EnumerateKey,
-        // 9 EnumerateValueKey, 10 QueryMultipleValueKey, 12 FlushKey,
-        // 13 CloseKey, 14 QuerySecurityKey — reads and bookkeeping, no state
-        // change. 11 SetInformationKey and 15 SetSecurityKey do change state
-        // but have no Sysmon or Sigma counterpart to carry them.
+        KERNEL_REGISTRY_EVENT_SET_VALUE_KEY => Some(KernelRegistryRoute::Emit(SensorAction::Set)),
+        KERNEL_REGISTRY_EVENT_CLOSE_KEY => Some(KernelRegistryRoute::Evict),
+        // 4 QueryKey, 7 QueryValueKey, 8 EnumerateKey, 9 EnumerateValueKey,
+        // 10 QueryMultipleValueKey, 12 FlushKey, 14 QuerySecurityKey — reads
+        // and bookkeeping, no state change. 11 SetInformationKey and
+        // 15 SetSecurityKey do change state but have no Sysmon or Sigma
+        // counterpart to carry them.
         _ => None,
     }
 }
@@ -389,27 +418,21 @@ fn refine_file_create_action(parser: &Parser, action: SensorAction) -> Option<Se
 const REG_CREATED_NEW_KEY: u32 = 1;
 const REG_OPENED_EXISTING_KEY: u32 = 2;
 
-/// Refine a [`SensorAction::Create`] for Kernel-Registry event ID 1 using its
-/// `Disposition`.
+/// Whether a Kernel-Registry `CreateKey` (event ID 1) actually created a key.
 ///
 /// `CreateKey` is `NtCreateKey`, which opens an existing key just as readily as
 /// it makes a new one — the same trap as `IRP_MJ_CREATE` on the file side (see
-/// [`refine_file_create_action`]). Without this, every key open on the machine
-/// would surface as a `registry_add`, trading a category that never fires for
-/// one that fires constantly.
+/// [`refine_file_create_action`]). Without this check every key open on the
+/// machine would surface as a `registry_add`, trading a category that never
+/// fires for one that fires constantly.
 ///
 /// Returns `None` when the event should be dropped.
-fn refine_registry_create_action(parser: &Parser, action: SensorAction) -> Option<SensorAction> {
-    if action != SensorAction::Create {
-        return Some(action);
-    }
-
+fn refine_registry_create_action(parser: &Parser) -> Option<()> {
     match parser.try_parse::<u32>("Disposition") {
         Ok(REG_OPENED_EXISTING_KEY) => None,
-        Ok(REG_CREATED_NEW_KEY) => Some(SensorAction::Create),
         // An unreadable or unknown disposition keeps the event: a missed
         // detection is worse than an extra one.
-        _ => Some(SensorAction::Create),
+        _ => Some(()),
     }
 }
 
@@ -420,6 +443,7 @@ fn refine_registry_create_action(parser: &Parser, action: SensorAction) -> Optio
 struct EtwState {
     routing: EtwRouting,
     file_paths: Mutex<FilePathCache>,
+    registry_paths: Mutex<RegistryPathCache>,
     /// File events dropped because neither identifier resolved to a path.
     ///
     /// Handles opened before the sensor started were never indexed, so writes
@@ -427,6 +451,12 @@ struct EtwState {
     /// them is the right policy — a pathless event matches no rule — but without
     /// a count there is no way to tell a quiet endpoint from a blind one.
     unresolved_file_events: AtomicU64,
+    /// Registry events dropped because the `KeyObject` resolved to no path.
+    ///
+    /// Same blind spot as `unresolved_file_events`: a key opened before the
+    /// sensor started was never named, so writes through it cannot be
+    /// attributed until it is reopened.
+    unresolved_registry_events: AtomicU64,
 }
 
 impl EtwState {
@@ -434,7 +464,9 @@ impl EtwState {
         Self {
             routing: EtwRouting::new(),
             file_paths: Mutex::new(FilePathCache::new()),
+            registry_paths: Mutex::new(RegistryPathCache::new()),
             unresolved_file_events: AtomicU64::new(0),
+            unresolved_registry_events: AtomicU64::new(0),
         }
     }
 
@@ -448,11 +480,20 @@ impl EtwState {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
+
+    /// Recovered for the same reason as [`Self::paths`]: unwinding out of an
+    /// OS-invoked ETW callback would take the sensor down.
+    fn registry_paths(&self) -> MutexGuard<'_, RegistryPathCache> {
+        self.registry_paths
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
 }
 
 struct EtwRouting {
     kernel_process_guid: GUID,
     kernel_file_guid: GUID,
+    kernel_registry_guid: GUID,
     guid_to_category: HashMap<GUID, EventCategory>,
 }
 
@@ -477,6 +518,7 @@ impl EtwRouting {
         Self {
             kernel_process_guid: EtwProviders::kernel_process().guid,
             kernel_file_guid: EtwProviders::kernel_file().guid,
+            kernel_registry_guid: EtwProviders::kernel_registry().guid,
             guid_to_category,
         }
     }
@@ -501,7 +543,9 @@ impl EtwRouting {
             // Kernel-File needs the path index and so has its own pipeline;
             // `decode_record` diverts it before reaching here.
             EventCategory::File => return None,
-            EventCategory::Registry => kernel_registry_route(record.event_id())?,
+            // Kernel-Registry needs the key-path index and so has its own
+            // pipeline; `decode_record` diverts it before reaching here.
+            EventCategory::Registry => return None,
             EventCategory::Dns => SensorAction::Query,
             EventCategory::Scripting => SensorAction::Execute,
             EventCategory::Wmi => SensorAction::Execute,
@@ -584,7 +628,9 @@ impl Sensor for EtwSensor {
             // Kernel-File and Kernel-Registry are filtered: both are
             // manifest providers whose keywords pull in more than is routed,
             // and both are high enough volume for the kernel-side buffer
-            // traffic to be worth removing.
+            // traffic to be worth removing. Registry keeps its naming and
+            // eviction events here — they emit nothing but the index needs
+            // them.
             if provider_def.guid == EtwProviders::kernel_file().guid {
                 provider_builder = provider_builder.add_filter(EventFilter::ByEventIds(
                     KERNEL_FILE_ROUTED_EVENT_IDS.to_vec(),
@@ -654,6 +700,9 @@ fn decode_record(
     if record.provider_id() == state.routing.kernel_file_guid {
         return decode_kernel_file_record(record, schema_locator, state);
     }
+    if record.provider_id() == state.routing.kernel_registry_guid {
+        return decode_kernel_registry_record(record, schema_locator, state);
+    }
 
     let (category, action) = state.routing.route(record)?;
     let schema = match schema_locator.event_schema(record) {
@@ -670,18 +719,11 @@ fn decode_record(
     };
     let parser = Parser::create(record, &schema);
 
-    // `CreateKey` needs its parsed `Disposition` to tell a new key from a
-    // plain open, so the routed action is refined once the parser exists.
-    let action = match category {
-        EventCategory::Registry => refine_registry_create_action(&parser, action)?,
-        _ => action,
-    };
-
     let decoded = match category {
         EventCategory::Process => decode_process(&parser, record, action),
         EventCategory::Network => decode_network(&parser, record),
         EventCategory::File => unreachable!("kernel-file records are diverted above"),
-        EventCategory::Registry => decode_registry(&parser, record),
+        EventCategory::Registry => unreachable!("kernel-registry records are diverted above"),
         EventCategory::Dns => decode_dns(&parser, record),
         EventCategory::ImageLoad => decode_image_load(&parser, record),
         EventCategory::Scripting => decode_powershell(&parser, record),
@@ -924,31 +966,127 @@ fn decode_kernel_file_record(
     })
 }
 
-fn decode_registry(parser: &Parser, record: &EventRecord) -> Option<DecodedEtwEvent> {
-    let event_mappings = field_maps::registry_event_mappings();
-    let modify_mappings = field_maps::registry_modify_mappings();
+/// Decode a Microsoft-Windows-Kernel-Registry record, maintaining the key-path
+/// index the pathless write events depend on.
+///
+/// Mirrors [`decode_kernel_file_record`]. `SetValueKey`, `DeleteValueKey` and
+/// `DeleteKey` deliver an empty `KeyName` and identify their target only by
+/// `KeyObject`, so the naming events (`CreateKey`, `OpenKey`) have to be joined
+/// to them. Before #279 none of this existed: the action came from an opcode
+/// that is always 0, and every registry event reached the detectors as an
+/// unclassified `registry_event` with `event.code = 0`.
+fn decode_kernel_registry_record(
+    record: &EventRecord,
+    schema_locator: &SchemaLocator,
+    state: &EtwState,
+) -> Option<SensorEvent> {
+    // Checked before the schema lookup so unrouted events cost only an
+    // integer match.
+    let route = kernel_registry_route(record.event_id())?;
 
-    // Every registry Sigma rule keys on `TargetObject`; a record without one
-    // matches nothing, so drop it before it costs an evaluation. 13.9% of the
-    // registry events in the #279 capture carried only `Image`.
-    let target_object = try_get_string(parser, event_mappings.get_etw_field("TargetObject")?)
-        .or_else(|| try_get_string(parser, modify_mappings.get_etw_field("TargetObject")?))
-        .filter(|path| !path.is_empty())?;
+    let schema = match schema_locator.event_schema(record) {
+        Ok(schema) => schema,
+        Err(err) => {
+            trace!(
+                "Failed to get Kernel-Registry schema for event {}: {:?}",
+                record.event_id(),
+                err
+            );
+            return None;
+        }
+    };
+    let parser = Parser::create(record, &schema);
 
-    let fields = RegistryEventFields {
-        target_object: Some(target_object),
-        details: try_get_string(parser, event_mappings.get_etw_field("Details")?)
-            .or_else(|| try_get_string(parser, modify_mappings.get_etw_field("Details")?)),
-        process_id: try_get_uint(parser, event_mappings.get_etw_field("ProcessId")?),
-        image: try_get_string(parser, event_mappings.get_etw_field("Image")?)
-            .map(|path| convert_nt_to_dos(&path)),
-        event_type: try_get_string(parser, "EventType"),
-        user: try_get_string(parser, event_mappings.get_etw_field("User")?),
-        new_name: try_get_string(parser, "NewName"),
+    let key_object = try_get_uint_as_u64(&parser, "KeyObject");
+
+    let (action, target_object) = match route {
+        KernelRegistryRoute::Name { creates } => {
+            let base_object = try_get_uint_as_u64(&parser, "BaseObject");
+            let base_name = try_get_string(&parser, "BaseName").unwrap_or_default();
+            let relative_name = try_get_string(&parser, "RelativeName").unwrap_or_default();
+
+            // Indexing happens for both CreateKey and OpenKey, including the
+            // creates that also emit: a key that is created is then written
+            // through, and those writes carry only its `KeyObject`.
+            let path =
+                state
+                    .registry_paths()
+                    .learn(base_object, key_object, &base_name, &relative_name);
+
+            if !creates {
+                return None;
+            }
+            // `NtCreateKey` opens existing keys just as readily as it makes new
+            // ones — the same trap as `IRP_MJ_CREATE` on the file side. Without
+            // the disposition check every key open would surface as a
+            // `registry_add`.
+            refine_registry_create_action(&parser)?;
+            (SensorAction::Create, path?)
+        }
+        KernelRegistryRoute::Evict => {
+            if let Some(object) = key_object {
+                state.registry_paths().forget(object);
+            }
+            return None;
+        }
+        KernelRegistryRoute::Emit(action) => {
+            // `KeyName` is declared on these events but measured empty on
+            // Windows 11, so the index is the real source of the path.
+            let path = try_get_string(&parser, "KeyName")
+                .filter(|name| !name.is_empty())
+                .or_else(|| {
+                    state
+                        .registry_paths()
+                        .resolve(key_object)
+                        .map(str::to_string)
+                });
+
+            match path {
+                Some(path) => (action, path),
+                None => {
+                    // Counted rather than silently discarded, for the same
+                    // reason as the file index: this is the sensor's blind
+                    // spot and its size is the only measure of it.
+                    let unresolved = state
+                        .unresolved_registry_events
+                        .fetch_add(1, Ordering::Relaxed)
+                        + 1;
+                    if unresolved == 1 || unresolved.is_multiple_of(10_000) {
+                        warn!(
+                            unresolved_registry_events = unresolved,
+                            "Dropping registry event whose key path could not be resolved"
+                        );
+                    }
+                    return None;
+                }
+            }
+        }
     };
 
-    Some(DecodedEtwEvent {
-        pid: parse_optional_u32(fields.process_id.as_deref()).or(Some(record.process_id())),
+    let mappings = field_maps::registry_event_mappings();
+    let fields = RegistryEventFields {
+        target_object: Some(target_object),
+        // The provider reports the value *name*; `CapturedData` holds the data
+        // but is empty unless the session asks for it, so this stays the name.
+        details: try_get_string(&parser, mappings.get_etw_field("Details")?),
+        process_id: try_get_uint(&parser, mappings.get_etw_field("ProcessId")?),
+        image: try_get_string(&parser, mappings.get_etw_field("Image")?)
+            .map(|path| convert_nt_to_dos(&path)),
+        event_type: try_get_string(&parser, "EventType"),
+        user: try_get_string(&parser, mappings.get_etw_field("User")?),
+        new_name: try_get_string(&parser, "NewName"),
+    };
+
+    let pid = parse_optional_u32(fields.process_id.as_deref()).or(Some(record.process_id()));
+    let normalization = mapper::normalization_for_record(EventCategory::Registry, action, record);
+
+    Some(SensorEvent {
+        platform: Platform::Windows,
+        provider: "etw",
+        action,
+        normalization,
+        pid,
+        timestamp: filetime_to_system_time(record.raw_timestamp()),
         process_start_key: None,
         payload: SensorPayload::Registry(fields),
     })
@@ -1326,17 +1464,33 @@ mod tests {
 
     #[test]
     fn registry_event_ids_route_to_write_actions() {
-        assert_eq!(kernel_registry_route(1), Some(SensorAction::Create));
-        assert_eq!(kernel_registry_route(3), Some(SensorAction::Delete));
-        assert_eq!(kernel_registry_route(5), Some(SensorAction::Set));
-        assert_eq!(kernel_registry_route(6), Some(SensorAction::Delete));
+        use KernelRegistryRoute::Emit;
+        assert_eq!(kernel_registry_route(3), Some(Emit(SensorAction::Delete)));
+        assert_eq!(kernel_registry_route(5), Some(Emit(SensorAction::Set)));
+        assert_eq!(kernel_registry_route(6), Some(Emit(SensorAction::Delete)));
+    }
+
+    #[test]
+    fn naming_events_maintain_the_index_and_only_create_emits() {
+        // SetValueKey delivers an empty KeyName, so CreateKey and OpenKey are
+        // the only source of a key's path. OpenKey must never produce
+        // telemetry of its own; CreateKey does, subject to its Disposition.
+        assert_eq!(
+            kernel_registry_route(1),
+            Some(KernelRegistryRoute::Name { creates: true })
+        );
+        assert_eq!(
+            kernel_registry_route(2),
+            Some(KernelRegistryRoute::Name { creates: false })
+        );
+        assert_eq!(kernel_registry_route(13), Some(KernelRegistryRoute::Evict));
     }
 
     #[test]
     fn registry_reads_are_dropped_not_called_modifications() {
         // The `_ => Modify` catch-all this replaces put every one of these
         // through the full Sigma evaluation under an action code of 0.
-        for event_id in [2, 4, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 40, 99] {
+        for event_id in [4, 7, 8, 9, 10, 11, 12, 14, 15, 16, 40, 99] {
             assert_eq!(
                 kernel_registry_route(event_id),
                 None,
@@ -1346,17 +1500,42 @@ mod tests {
     }
 
     #[test]
-    fn registry_keywords_subscribe_to_writes_only() {
-        // Manifest values: SetValueKey 0x100, DeleteValueKey 0x200,
-        // CreateKey 0x1000, DeleteKey 0x4000. The mask previously used 0x2000
-        // and 0x8000 for the two value keywords, which are OpenKey and
-        // QueryKey — it subscribed to reads and missed every value write.
-        assert_eq!(EtwProviders::REGISTRY_KEYWORDS, 0x5300);
+    fn registry_keywords_cover_writes_naming_and_eviction() {
+        // Manifest values: CloseKey 0x1, SetValueKey 0x100,
+        // DeleteValueKey 0x200, CreateKey 0x1000, OpenKey 0x2000,
+        // DeleteKey 0x4000. The mask previously used 0x2000 and 0x8000 for the
+        // two *value* keywords, which are OpenKey and QueryKey — it subscribed
+        // to reads and missed every value write.
+        assert_eq!(EtwProviders::REGISTRY_KEYWORDS, 0x7301);
 
-        const OPEN_KEY: u64 = 0x2000;
+        // QueryKey is the one high-volume read path with no role here: it
+        // neither names a key nor changes one.
         const QUERY_KEY: u64 = 0x8000;
-        assert_eq!(EtwProviders::REGISTRY_KEYWORDS & OPEN_KEY, 0);
         assert_eq!(EtwProviders::REGISTRY_KEYWORDS & QUERY_KEY, 0);
+    }
+
+    #[test]
+    fn every_routed_registry_event_has_its_keyword() {
+        // A routed event whose keyword is not in the mask is never delivered:
+        // the exact failure that made `registry_set` structurally dead (#279).
+        for (event_id, keyword) in [
+            (1u16, EtwProviders::REG_KEYWORD_CREATE_KEY),
+            (2, EtwProviders::REG_KEYWORD_OPEN_KEY),
+            (3, EtwProviders::REG_KEYWORD_DELETE_KEY),
+            (5, EtwProviders::REG_KEYWORD_SET_VALUE_KEY),
+            (6, EtwProviders::REG_KEYWORD_DELETE_VALUE_KEY),
+            (13, EtwProviders::REG_KEYWORD_CLOSE_KEY),
+        ] {
+            assert!(
+                kernel_registry_route(event_id).is_some(),
+                "event {event_id} must be routed"
+            );
+            assert_ne!(
+                EtwProviders::REGISTRY_KEYWORDS & keyword,
+                0,
+                "event {event_id} is routed but its keyword is not subscribed"
+            );
+        }
     }
 
     #[test]

--- a/src/sensor/windows/field_maps.rs
+++ b/src/sensor/windows/field_maps.rs
@@ -73,27 +73,12 @@ static REGISTRY_EVENT_MAP: LazyLock<FieldMapping> = LazyLock::new(|| {
         ("Image", "ImageName"),
         ("EventType", "EventType"),
         ("User", "UserName"),
-        ("TargetObject", "KeyName"),
         ("NewName", "NewName"),
     ])
 });
 
 pub fn registry_event_mappings() -> &'static FieldMapping {
     &REGISTRY_EVENT_MAP
-}
-
-static REGISTRY_MODIFY_MAP: LazyLock<FieldMapping> = LazyLock::new(|| {
-    FieldMapping::new(&[
-        ("TargetObject", "RelativeName"),
-        ("Details", "ValueName"),
-        ("ProcessId", "ProcessID"),
-        ("Image", "ImageName"),
-        ("User", "UserName"),
-    ])
-});
-
-pub fn registry_modify_mappings() -> &'static FieldMapping {
-    &REGISTRY_MODIFY_MAP
 }
 
 static DNS_QUERY_MAP: LazyLock<FieldMapping> = LazyLock::new(|| {

--- a/src/sensor/windows/file_paths.rs
+++ b/src/sensor/windows/file_paths.rs
@@ -28,7 +28,7 @@ use std::collections::{HashMap, VecDeque};
 /// number of open handles on the machine rather than total file activity. The
 /// cap only binds when processes hold handles without closing them; at this
 /// size the worst case is roughly 8192 paths per index, a few megabytes.
-const DEFAULT_CAPACITY: usize = 8192;
+pub(super) const DEFAULT_CAPACITY: usize = 8192;
 
 /// A bounded `u64 -> path` index with FIFO eviction.
 ///
@@ -46,7 +46,7 @@ struct Entry {
     seq: u64,
 }
 
-struct BoundedIndex {
+pub(super) struct BoundedIndex {
     entries: HashMap<u64, Entry>,
     /// `(key, seq)` in insertion order, used to pick the eviction victim. A
     /// slot whose key is gone, or whose `seq` no longer matches the live entry,
@@ -57,7 +57,7 @@ struct BoundedIndex {
 }
 
 impl BoundedIndex {
-    fn with_capacity(capacity: usize) -> Self {
+    pub(super) fn with_capacity(capacity: usize) -> Self {
         Self {
             entries: HashMap::new(),
             order: VecDeque::new(),
@@ -66,7 +66,7 @@ impl BoundedIndex {
         }
     }
 
-    fn insert(&mut self, key: u64, path: &str) {
+    pub(super) fn insert(&mut self, key: u64, path: &str) {
         if let Some(entry) = self.entries.get_mut(&key) {
             // Re-inserting a live key updates the path but keeps its queue
             // slot; pushing again would let one busy handle fill `order` with
@@ -111,11 +111,11 @@ impl BoundedIndex {
         }
     }
 
-    fn get(&self, key: u64) -> Option<&str> {
+    pub(super) fn get(&self, key: u64) -> Option<&str> {
         self.entries.get(&key).map(|entry| entry.path.as_str())
     }
 
-    fn forget(&mut self, key: u64) {
+    pub(super) fn forget(&mut self, key: u64) {
         self.entries.remove(&key);
     }
 

--- a/src/sensor/windows/file_paths.rs
+++ b/src/sensor/windows/file_paths.rs
@@ -120,7 +120,7 @@ impl BoundedIndex {
     }
 
     #[cfg(test)]
-    fn len(&self) -> usize {
+    pub(super) fn len(&self) -> usize {
         self.entries.len()
     }
 }

--- a/src/sensor/windows/mapper.rs
+++ b/src/sensor/windows/mapper.rs
@@ -38,15 +38,11 @@ fn action_code_for_record(
         // The manifest-based Kernel-File provider emits events with opcode 0,
         // so the action code comes from the routed action, not the opcode.
         EventCategory::File => file_action_code(action),
-        EventCategory::Registry => match record.opcode() {
-            36 | 38 | 39 | 41 => record.opcode(),
-            _ => match action {
-                SensorAction::Create => 36,
-                SensorAction::Delete => 38,
-                SensorAction::Set => 39,
-                _ => 0,
-            },
-        },
+        // Kernel-Registry emits opcode 0 as well, and the manifest opcodes it
+        // *declares* are not the values this mapping ever used (36 is
+        // `SetValueKey`, not `CreateKey`), so reading the opcode could only
+        // ever produce a wrong answer. The routed action is the truth (#279).
+        EventCategory::Registry => registry_action_code(action),
         EventCategory::Dns => 0,
         EventCategory::Scripting => 0,
         EventCategory::Wmi => 0,
@@ -62,6 +58,19 @@ fn action_code_for_record(
 fn file_action_code(action: SensorAction) -> u8 {
     SensorNormalization::for_file_action(action)
         .map_or(0, |normalization| normalization.action_code)
+}
+
+/// Maps a routed registry action to the action code the engine's Sigma
+/// category selection expects (36 = key created, 38 = key or value deleted,
+/// 39 = value set), which [`crate::engine::alert`] turns into `registry_add`,
+/// `registry_delete` and `registry_set`.
+fn registry_action_code(action: SensorAction) -> u8 {
+    match action {
+        SensorAction::Create => 36,
+        SensorAction::Delete => 38,
+        SensorAction::Set => 39,
+        _ => 0,
+    }
 }
 
 fn raw_event_id_for_record(category: EventCategory, action_code: u8, record: &EventRecord) -> u16 {
@@ -118,7 +127,7 @@ pub fn map_to_sysmon_id(category: EventCategory, action_code: u8, raw_event_id: 
 
 #[cfg(test)]
 mod tests {
-    use super::{file_action_code, map_to_sysmon_id};
+    use super::{file_action_code, map_to_sysmon_id, registry_action_code};
     use crate::models::EventCategory;
     use crate::sensor::{SensorAction, FILE_EVENT_NORMALIZATION};
 
@@ -166,6 +175,36 @@ mod tests {
     #[test]
     fn registry_setvalue_maps_to_sysmon_13() {
         assert_eq!(map_to_sysmon_id(EventCategory::Registry, 39, 999), 13);
+    }
+
+    #[test]
+    fn registry_actions_map_to_sysmon_ids_without_an_opcode() {
+        // Kernel-Registry records carry opcode 0, so every one of these has to
+        // come from the routed action alone. Before #279 all four collapsed to
+        // action code 0 and event ID 0, which is neither Sysmon 12 nor 13 and
+        // matches no `registry_add`/`registry_set`/`registry_delete` rule.
+        for (action, expected_code, expected_id) in [
+            (SensorAction::Create, 36, 12),
+            (SensorAction::Delete, 38, 12),
+            (SensorAction::Set, 39, 13),
+        ] {
+            let code = registry_action_code(action);
+            assert_eq!(code, expected_code, "action code for {action:?}");
+            assert_eq!(
+                map_to_sysmon_id(EventCategory::Registry, code, u16::from(code)),
+                expected_id,
+                "event id for {action:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn registry_modify_is_not_a_registry_action() {
+        // `Modify` was the old catch-all. Nothing routes to it now, and if
+        // something ever does it must not silently claim to be a value set.
+        let code = registry_action_code(SensorAction::Modify);
+        assert_eq!(code, 0);
+        assert_ne!(map_to_sysmon_id(EventCategory::Registry, code, 0), 13);
     }
 
     #[test]

--- a/src/sensor/windows/mod.rs
+++ b/src/sensor/windows/mod.rs
@@ -2,5 +2,6 @@ pub mod etw;
 mod field_maps;
 mod file_paths;
 pub mod mapper;
+mod registry_paths;
 
 pub use etw::EtwSensor;

--- a/src/sensor/windows/registry_paths.rs
+++ b/src/sensor/windows/registry_paths.rs
@@ -1,0 +1,216 @@
+//! `KeyObject` to path resolution for Microsoft-Windows-Kernel-Registry.
+//!
+//! The registry events that carry write semantics identify their target only by
+//! kernel pointer. Measured on Windows 11 against the provider's own manifest,
+//! `SetValueKey` (5), `DeleteValueKey` (6) and `DeleteKey` (3) all declare a
+//! `KeyName` field and all deliver it **empty**; only `KeyObject` is populated.
+//!
+//! The provider emits the names on separate events, expecting the consumer to
+//! join the two — the same design as Kernel-File:
+//!
+//! | event | identifiers | name |
+//! | --- | --- | --- |
+//! | 1 `CreateKey` | `BaseObject`, `KeyObject` | `BaseName` + `RelativeName` |
+//! | 2 `OpenKey` | `BaseObject`, `KeyObject` | `BaseName` + `RelativeName` |
+//! | 3 `DeleteKey` / 5 `SetValueKey` / 6 `DeleteValueKey` | `KeyObject` | — |
+//! | 13 `CloseKey` | `KeyObject` | — |
+//!
+//! `OpenKey` therefore has to be subscribed even though it never produces
+//! telemetry of its own: most writes land on keys that were opened rather than
+//! created, and without it their path is unrecoverable.
+
+use super::file_paths::BoundedIndex;
+
+/// Maximum live entries kept in the index.
+///
+/// Twice the Kernel-File capacity: a process holds far more open registry keys
+/// than open file handles, and every entry is a short key path. Entries are
+/// evicted on `CloseKey`, so the cap only binds when keys are held open
+/// without closing.
+const DEFAULT_CAPACITY: usize = 16384;
+
+/// Joins Kernel-Registry naming events to the pathless events that follow them.
+pub(super) struct RegistryPathCache {
+    by_key_object: BoundedIndex,
+}
+
+impl RegistryPathCache {
+    pub(super) fn new() -> Self {
+        Self::with_capacity(DEFAULT_CAPACITY)
+    }
+
+    fn with_capacity(capacity: usize) -> Self {
+        Self {
+            by_key_object: BoundedIndex::with_capacity(capacity),
+        }
+    }
+
+    /// Index the key a naming event describes and return the composed path.
+    ///
+    /// `RelativeName` is relative to `BaseObject`, which is itself a key this
+    /// index may already know. When the base cannot be resolved — it was opened
+    /// before the session started — the relative name is kept on its own rather
+    /// than dropped: a partial path still matches the `contains`-style rules
+    /// that most registry Sigma rules use.
+    pub(super) fn learn(
+        &mut self,
+        base_object: Option<u64>,
+        key_object: Option<u64>,
+        base_name: &str,
+        relative_name: &str,
+    ) -> Option<String> {
+        if relative_name.is_empty() {
+            return None;
+        }
+
+        let path = if relative_name.starts_with('\\') {
+            // Already an absolute NT path such as
+            // `\REGISTRY\MACHINE\SYSTEM\ControlSet001\...`.
+            relative_name.to_string()
+        } else if !base_name.is_empty() {
+            join(base_name, relative_name)
+        } else {
+            match base_object.and_then(|base| self.by_key_object.get(base)) {
+                Some(base) => join(base, relative_name),
+                None => relative_name.to_string(),
+            }
+        };
+
+        if let Some(object) = key_object {
+            self.by_key_object.insert(object, &path);
+        }
+
+        Some(path)
+    }
+
+    /// Recover the path for an event that carried only a `KeyObject`.
+    pub(super) fn resolve(&self, key_object: Option<u64>) -> Option<&str> {
+        key_object.and_then(|object| self.by_key_object.get(object))
+    }
+
+    /// Drop the entry for a key that has been closed.
+    pub(super) fn forget(&mut self, key_object: u64) {
+        self.by_key_object.forget(key_object);
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.by_key_object.len()
+    }
+}
+
+fn join(base: &str, relative: &str) -> String {
+    let mut path = String::with_capacity(base.len() + relative.len() + 1);
+    path.push_str(base.trim_end_matches('\\'));
+    path.push('\\');
+    path.push_str(relative);
+    path
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RegistryPathCache, DEFAULT_CAPACITY};
+
+    #[test]
+    fn resolves_a_value_write_from_the_open_that_named_the_key() {
+        // The case from #279: SetValueKey carries an empty KeyName, so the
+        // path can only come from the OpenKey that preceded it.
+        let mut cache = RegistryPathCache::new();
+        cache.learn(
+            None,
+            Some(0x1000),
+            "",
+            "\\REGISTRY\\USER\\S-1-5-21\\Software\\Microsoft\\Windows\\CurrentVersion\\Run",
+        );
+
+        assert_eq!(
+            cache.resolve(Some(0x1000)),
+            Some("\\REGISTRY\\USER\\S-1-5-21\\Software\\Microsoft\\Windows\\CurrentVersion\\Run")
+        );
+    }
+
+    #[test]
+    fn relative_name_is_composed_onto_the_base_key() {
+        let mut cache = RegistryPathCache::new();
+        cache.learn(None, Some(0x10), "", "\\REGISTRY\\USER\\S-1-5-21\\Software");
+        let path = cache.learn(Some(0x10), Some(0x20), "", "Rustinel\\Run");
+
+        assert_eq!(
+            path.as_deref(),
+            Some("\\REGISTRY\\USER\\S-1-5-21\\Software\\Rustinel\\Run")
+        );
+        assert_eq!(
+            cache.resolve(Some(0x20)),
+            Some("\\REGISTRY\\USER\\S-1-5-21\\Software\\Rustinel\\Run")
+        );
+    }
+
+    #[test]
+    fn base_name_wins_over_the_index_when_the_event_carries_one() {
+        let mut cache = RegistryPathCache::new();
+        let path = cache.learn(
+            None,
+            Some(0x30),
+            "\\REGISTRY\\MACHINE\\SOFTWARE",
+            "Policies",
+        );
+
+        assert_eq!(
+            path.as_deref(),
+            Some("\\REGISTRY\\MACHINE\\SOFTWARE\\Policies")
+        );
+    }
+
+    #[test]
+    fn an_unresolvable_base_keeps_the_relative_name() {
+        // The key was opened before the session started. A partial path still
+        // matches the `contains` rules registry Sigma rules are written with,
+        // so it beats dropping the event.
+        let mut cache = RegistryPathCache::new();
+        let path = cache.learn(Some(0xdead), Some(0x40), "", "Software\\Rustinel279");
+
+        assert_eq!(path.as_deref(), Some("Software\\Rustinel279"));
+        assert_eq!(cache.resolve(Some(0x40)), Some("Software\\Rustinel279"));
+    }
+
+    #[test]
+    fn a_nameless_event_teaches_nothing() {
+        let mut cache = RegistryPathCache::new();
+        assert_eq!(cache.learn(None, Some(0x50), "", ""), None);
+        assert_eq!(cache.resolve(Some(0x50)), None);
+    }
+
+    #[test]
+    fn unknown_key_objects_do_not_resolve() {
+        let cache = RegistryPathCache::new();
+        assert_eq!(cache.resolve(Some(0x99)), None);
+        assert_eq!(cache.resolve(None), None);
+    }
+
+    #[test]
+    fn closing_a_key_releases_its_entry() {
+        let mut cache = RegistryPathCache::new();
+        cache.learn(None, Some(0x60), "", "\\REGISTRY\\MACHINE\\SOFTWARE");
+        assert_eq!(cache.len(), 1);
+
+        cache.forget(0x60);
+        assert_eq!(cache.len(), 0);
+        assert_eq!(cache.resolve(Some(0x60)), None);
+    }
+
+    #[test]
+    fn stays_bounded_when_keys_are_never_closed() {
+        let mut cache = RegistryPathCache::with_capacity(8);
+        for object in 0..64u64 {
+            cache.learn(None, Some(object), "", "\\REGISTRY\\MACHINE\\SOFTWARE");
+        }
+
+        assert!(cache.len() <= 8, "index grew to {}", cache.len());
+    }
+
+    #[test]
+    fn default_capacity_exceeds_the_file_index() {
+        // Open registry keys outnumber open file handles by a wide margin.
+        assert!(DEFAULT_CAPACITY > super::super::file_paths::DEFAULT_CAPACITY);
+    }
+}

--- a/src/sensor/windows/registry_paths.rs
+++ b/src/sensor/windows/registry_paths.rs
@@ -109,7 +109,7 @@ fn join(base: &str, relative: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{RegistryPathCache, DEFAULT_CAPACITY};
+    use super::RegistryPathCache;
 
     #[test]
     fn resolves_a_value_write_from_the_open_that_named_the_key() {
@@ -206,11 +206,5 @@ mod tests {
         }
 
         assert!(cache.len() <= 8, "index grew to {}", cache.len());
-    }
-
-    #[test]
-    fn default_capacity_exceeds_the_file_index() {
-        // Open registry keys outnumber open file handles by a wide margin.
-        assert!(DEFAULT_CAPACITY > super::super::file_paths::DEFAULT_CAPACITY);
     }
 }


### PR DESCRIPTION
## Summary

Closes #279.

Registry action classification was broken, but the investigation on a Windows 11
lab box found the cause runs deeper than the issue describes: **the events
`registry_set` needs were never subscribed to in the first place**, and even
once they were, they carry no key path.

Three independent defects, all in the Kernel-Registry path:

### 1. The keyword mask was off by a nibble

Read from the provider manifest on the box (`Get-WinEvent -ListProvider`):

| Constant | Code had | Manifest | What the old value actually is |
| --- | --- | --- | --- |
| `SetValueKey` | `0x2000` | `0x0100` | `OpenKey` |
| `DeleteValueKey` | `0x8000` | `0x0200` | `QueryKey` |
| `CreateKey` | `0x1000` | `0x1000` | correct |
| `DeleteKey` | `0x4000` | `0x4000` | correct |

The session subscribed to the two highest-volume registry *read* paths and to
neither value write. That is both why registry was 97.7% of captured telemetry
and why `registry_set` could not have fired even with perfect classification.

### 2. Opcode-based classification, on a provider that reports opcode 0

`record.opcode()` is 0 for this manifest provider, so everything fell through to
the `Modify` catch-all → action code 0 → `event.code = 0`. The opcode values
being compared against were wrong independently of that: the manifest declares
`CreateKey=32, DeleteKey=34, SetValueKey=36, DeleteValueKey=37`, not the
`36/38/39/41` in the code — `39` is `EnumerateKey`.

Routing now uses manifest event IDs as an allowlist, mirroring `kernel_file_route`.

### 3. The write events carry no key path

Measured with a native ETW session, independent of Rustinel:

```
id=5 (SetValueKey)    :: KeyObject | Status | Type | DataSize | KeyName | ValueName
                         18446...84 |   0    |  1   |    58   | (empty) | Rustinel279Probe
id=6 (DeleteValueKey) :: 18446...56 | 0 | (empty) | Rustinel279Probe
id=3 (DeleteKey)      :: 18446...52 | 0 | (empty)
```

`KeyName` is declared on all three and delivered **empty**. The key is
identified only by `KeyObject`; the names arrive on the separate `CreateKey` (1)
and `OpenKey` (2) events — the same split Kernel-File has.

So this adds `RegistryPathCache`, reusing the `BoundedIndex` that already backs
`FilePathCache`, and gives Kernel-Registry its own decode pipeline joining the
naming events to the pathless writes. `OpenKey` and `CloseKey` are subscribed as
index maintenance only and emit nothing.

## Also in this change

- **`CreateKey` is refined by its `Disposition`.** `NtCreateKey` opens existing
  keys as readily as it makes new ones, so without this the fix would trade a
  category that never fires for one firing on every key open.
- **Value name appended to the path.** Sysmon reports a value write as
  `<key>\<value>` on Event ID 13 and most SigmaHQ `registry_set` rules are an
  `endswith` against that shape.
- **Provider-side `ByEventIds` scope filter**, with the same drift guard the
  Kernel-File filter has.
- `docs/limitations.md` updated: the new `unresolved_registry_events` blind spot
  (mirroring `unresolved_file_events`) and the corrected `TargetObject` note.

## Verification on Windows 11 (lab VM, live ETW)

Probe rules per category, then a Run-key write. The issue's stated criterion is
the third line:

```
2  PROBE registry_add Rustinel279 key | code=12 | action=registry-create
2  PROBE registry_delete Rustinel279  | code=12 | action=registry-delete
1  PROBE registry_set Run key         | code=13 | action=registry-set
1  PROBE registry_event Rustinel279   | code=13 | action=registry-set
1  PROBE whoami                       | code=1  | action=process-start

path=Software\Microsoft\Windows\CurrentVersion\Run\Rustinel279Probe
```

Isolated, the Sysmon-shaped rule
`TargetObject|endswith: '\CurrentVersion\Run\Rustinel279Probe'` also fires at
`code=13` — the shape the bulk of SigmaHQ's 204 `registry_set` rules use.

All four categories fired; before this change three of them were structurally
incapable of firing.

### Volume

Measured with `rustinel capture` on the same box:

| | before (#279 capture) | after |
| --- | --- | --- |
| registry share of telemetry | 97.7% (320,669 in 20s) | 9.5% (65 in ~35s) |
| `rustinel.exe` self-noise | present | 0 records |

The self-noise the issue notes as a third observation disappears as a
consequence: those were `OpenKey`/create-on-existing events, now filtered.

## Testing

- 12 new unit tests (route allowlist + keyword/route consistency, opcode-0
  action mapping, path-index composition and eviction).
- Full suite on Windows 11: **400 passed, 0 failed**, 25 binaries.
- `clippy --all-targets -- -D warnings` clean on Windows and macOS.

## Note for the reviewer

`SetValueKey` also declares `CapturedData`/`CapturedDataSize`, which
`docs/limitations.md` currently says the provider does not emit. They were empty
in every record here, so the documented limitation still holds — but it may be a
session-opt-in rather than a hard absence, and is worth a separate look.
