### PR TITLE
fix(windows-service): subscribe to System event 7045

### DIFF
--- a/.github/workflows/privileged-smoke.yml
+++ b/.github/workflows/privileged-smoke.yml
@@ -58,3 +58,5 @@ jobs:
         run: cargo test --locked --test yara_memory -- --include-ignored
       - name: Run ignored active response smoke tests
         run: cargo test --locked --test active_response -- --include-ignored
+      - name: Run ignored service event log smoke test
+        run: cargo test --locked --test windows_service_event_log -- --include-ignored

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3199,6 +3199,7 @@ dependencies = [
  "pelite",
  "regex",
  "reqwest",
+ "roxmltree",
  "rsigma-eval",
  "rsigma-parser",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,8 @@ mach2 = "0.6"
 pelite = "0.10"
 memmap2 = "0.9"
 ferrisetw = "1.2"
-windows = { version = "0.62.2", features = ["Win32_Foundation", "Win32_System_Diagnostics_Etw", "Win32_Security", "Win32_Security_Authorization", "Win32_System_Threading", "Win32_System_Diagnostics_ToolHelp", "Win32_System_ProcessStatus", "Win32_Storage_FileSystem", "Win32_System_Memory", "Win32_System_Diagnostics_Debug"] }
+roxmltree = "0.21"
+windows = { version = "0.62.2", features = ["Win32_Foundation", "Win32_System_Diagnostics_Etw", "Win32_System_EventLog", "Win32_Security", "Win32_Security_Authorization", "Win32_System_Threading", "Win32_System_Diagnostics_ToolHelp", "Win32_System_ProcessStatus", "Win32_Storage_FileSystem", "Win32_System_Memory", "Win32_System_Diagnostics_Debug"] }
 windows-service = "0.8.1"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Installers only download published release binaries.
 
 A transparent endpoint detection engine you can read, run, test, and extend.
 
-- **Native telemetry:** ETW on Windows, eBPF on Linux, Endpoint Security and `/dev/bpf` on macOS.
+- **Native telemetry:** ETW and Windows Event Log on Windows, eBPF on Linux, Endpoint Security and `/dev/bpf` on macOS.
 - **Detection formats:** Sigma for behavior, YARA for files and memory, IOC matching for hashes, IPs, domains, and path regexes.
 - **Rule reuse:** bring existing Sigma and YARA rules instead of rewriting them into a proprietary format.
 - **SIEM output:** ECS 9.4.0 NDJSON alerts for Elastic, Splunk, and other log pipelines.
@@ -112,7 +112,7 @@ A transparent endpoint detection engine you can read, run, test, and extend.
 
 | Platform | Sensor | Telemetry | Status |
 | --- | --- | --- | --- |
-| Windows 10/11, Server 2016+ | ETW | Process, image load, network, file, registry, DNS, PowerShell, WMI, service, task | Stable |
+| Windows 10/11, Server 2016+ | ETW + Windows Event Log | Process, image load, network, file, registry, DNS, PowerShell, WMI, service, task | Stable |
 | Linux 5.8+ (BTF) | eBPF | Process, network, file, DNS | Stable |
 | macOS 11+ | Endpoint Security + `/dev/bpf` | Process, file, network, DNS | Experimental |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -74,7 +74,8 @@ The key split in the codebase is between the hot event path and the control plan
 
 ### Windows
 
-The Windows sensor is ETW-based and currently covers:
+The Windows sensor uses ETW for realtime providers and a filtered Windows Event
+Log subscription for Service Control Manager event 7045. It currently covers:
 
 - Process
 - Image load
@@ -96,8 +97,11 @@ The ETW providers include:
 - `Microsoft-Windows-DNS-Client`
 - `Microsoft-Windows-PowerShell`
 - `Microsoft-Windows-WMI-Activity`
-- `Microsoft-Windows-Service-Control-Manager`
 - `Microsoft-Windows-TaskScheduler`
+
+Service creation comes from the System event log rather than the classic
+Service Control Manager provider, which does not deliver event 7045 to realtime
+user ETW sessions.
 
 ### Linux
 

--- a/docs/detection.md
+++ b/docs/detection.md
@@ -103,7 +103,7 @@ rule instead of one is tracked separately by
 
 ### Supported Logsource Families
 
-| Family | Windows ETW | Linux eBPF | macOS ESF/bpf | Notes |
+| Family | Windows sensors | Linux eBPF | macOS ESF/bpf | Notes |
 | --- | --- | --- | --- | --- |
 | `process_creation` | Yes | Yes | Yes | Sysmon-style process events |
 | `network_connection` | Yes | Yes | Yes | Generic `service: connection`, `category: network` is also supported; macOS connections are best-effort process-attributed |

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -23,9 +23,10 @@ This page documents Rustinel's known limitations for the current release.
 
 ---
 
-## Windows (ETW)
+## Windows (ETW and Event Log)
 
-Rustinel collects Windows telemetry through ETW rather than a kernel driver.
+Rustinel collects Windows telemetry through ETW, plus System event 7045 through
+a Windows Event Log subscription, rather than using a kernel driver.
 Coverage is the broadest of the three platforms, but several Sysmon-style fields
 are unavailable.
 

--- a/src/sensor/windows/etw.rs
+++ b/src/sensor/windows/etw.rs
@@ -15,8 +15,8 @@ use tracing::{info, trace, warn};
 
 use crate::models::{
     DnsQueryFields, EventCategory, FileEventFields, ImageLoadFields, NetworkConnectionFields,
-    PowerShellScriptFields, ProcessCreationFields, RegistryEventFields, ServiceCreationFields,
-    TaskCreationFields, WmiEventFields,
+    PowerShellScriptFields, ProcessCreationFields, RegistryEventFields, TaskCreationFields,
+    WmiEventFields,
 };
 use crate::sensor::network_events::{
     classify_kernel_network_event, decode_etw_ipv4, decode_etw_port, NetworkAddressFamily,
@@ -24,12 +24,13 @@ use crate::sensor::network_events::{
 use crate::sensor::{Platform, ProcessStartKey, Sensor, SensorAction, SensorEvent, SensorPayload};
 use crate::utils::{convert_nt_to_dos, parse_metadata, query_process_command_line};
 
+use super::event_log::EventLogSubscriptions;
 use super::file_paths::FilePathCache;
 use super::registry_paths::RegistryPathCache;
 use super::{field_maps, mapper};
 
 /// Fixed trace session name for stopping the trace on shutdown.
-const TRACE_SESSION_NAME: &str = "rustinel-etw-trace";
+pub(super) const TRACE_SESSION_NAME: &str = "rustinel-etw-trace";
 const WINDOWS_EPOCH_DELTA_100NS: i64 = 116444736000000000;
 
 /// ETW provider metadata.
@@ -52,7 +53,6 @@ impl EtwProviders {
     const DNS_CLIENT_GUID: &'static str = "1c95126e-7eea-49a9-a3fe-a378b03ddb4d";
     const POWERSHELL_GUID: &'static str = "A0C1853B-5C40-4B15-8766-3CF1C58F985A";
     const WMI_ACTIVITY_GUID: &'static str = "1418EF04-B0B4-4623-BF7E-D74AB47BBDAA";
-    const SERVICE_CONTROL_MANAGER_GUID: &'static str = "555908d1-a6d7-4695-8e1e-26931d2012f4";
     const TASK_SCHEDULER_GUID: &'static str = "de7b24ea-73c8-4a09-985d-5bdadcfa9017";
 
     // Keyword names follow the Microsoft-Windows-Kernel-File manifest.
@@ -112,12 +112,9 @@ impl EtwProviders {
     // filters then keep lifecycle and diagnostic records out of the session.
     const OPERATIONAL_KEYWORD: u64 = 0x8000_0000_0000_0000;
     const POWERSHELL_RUNSPACE_KEYWORD: u64 = 0x0000_0000_0000_0001;
-    const EVENTLOG_CLASSIC_KEYWORD: u64 = 0x0080_0000_0000_0000;
-
     const DNS_EVENT_IDS: &'static [u16] = &[3006, 3008];
     const POWERSHELL_EVENT_IDS: &'static [u16] = &[4104];
     const WMI_EVENT_IDS: &'static [u16] = &[1, 2, 11, 12, 14, 15, 16, 17, 19, 20, 22, 23, 24];
-    const SERVICE_EVENT_IDS: &'static [u16] = &[7045];
     const TASK_EVENT_IDS: &'static [u16] = &[106];
 
     fn kernel_process() -> EtwProvider {
@@ -191,16 +188,6 @@ impl EtwProviders {
         }
     }
 
-    fn service_control_manager() -> EtwProvider {
-        EtwProvider {
-            guid: GUID::from(Self::SERVICE_CONTROL_MANAGER_GUID),
-            name: "Microsoft-Windows-Service-Control-Manager",
-            level: 4,
-            keywords: Self::EVENTLOG_CLASSIC_KEYWORD,
-            event_ids: Self::SERVICE_EVENT_IDS,
-        }
-    }
-
     fn task_scheduler() -> EtwProvider {
         EtwProvider {
             guid: GUID::from(Self::TASK_SCHEDULER_GUID),
@@ -220,7 +207,6 @@ impl EtwProviders {
             Self::dns_client(),
             Self::powershell(),
             Self::wmi_activity(),
-            Self::service_control_manager(),
             Self::task_scheduler(),
         ]
     }
@@ -542,10 +528,6 @@ impl EtwRouting {
         guid_to_category.insert(EtwProviders::dns_client().guid, EventCategory::Dns);
         guid_to_category.insert(EtwProviders::powershell().guid, EventCategory::Scripting);
         guid_to_category.insert(EtwProviders::wmi_activity().guid, EventCategory::Wmi);
-        guid_to_category.insert(
-            EtwProviders::service_control_manager().guid,
-            EventCategory::Service,
-        );
         guid_to_category.insert(EtwProviders::task_scheduler().guid, EventCategory::Task);
 
         Self {
@@ -582,7 +564,8 @@ impl EtwRouting {
             EventCategory::Dns => SensorAction::Query,
             EventCategory::Scripting => SensorAction::Execute,
             EventCategory::Wmi => SensorAction::Execute,
-            EventCategory::Service | EventCategory::Task => SensorAction::Register,
+            EventCategory::Task => SensorAction::Register,
+            EventCategory::Service => unreachable!("service events use the event log source"),
             EventCategory::Process | EventCategory::ImageLoad => unreachable!(),
         };
 
@@ -623,6 +606,9 @@ impl Default for EtwSensor {
 impl Sensor for EtwSensor {
     fn start(&self, tx: Sender<SensorEvent>) -> Result<()> {
         info!("Starting ETW sensor...");
+
+        self.shutdown.store(false, Ordering::Relaxed);
+        let event_logs = EventLogSubscriptions::start(tx.clone(), Arc::clone(&self.shutdown))?;
 
         let _ = stop_trace_by_name(TRACE_SESSION_NAME);
 
@@ -668,8 +654,7 @@ impl Sensor for EtwSensor {
             trace_builder = trace_builder.enable(provider);
         }
 
-        let result = trace_builder.start();
-        match result {
+        let trace_result = match trace_builder.start() {
             Ok((mut trace, _handle)) => {
                 info!(
                     "ETW trace session '{}' started successfully",
@@ -697,7 +682,10 @@ impl Sensor for EtwSensor {
                 }
             }
             Err(err) => Err(anyhow::anyhow!("Failed to start ETW trace: {:?}", err)),
-        }
+        };
+
+        self.shutdown.store(true, Ordering::Relaxed);
+        event_logs.join().and(trace_result)
     }
 
     fn shutdown(&self) {
@@ -750,7 +738,7 @@ fn decode_record(
         EventCategory::ImageLoad => decode_image_load(&parser, record),
         EventCategory::Scripting => decode_powershell(&parser, record),
         EventCategory::Wmi => decode_wmi(&parser, record),
-        EventCategory::Service => decode_service(&parser, record),
+        EventCategory::Service => unreachable!("service events use the event log source"),
         EventCategory::Task => decode_task(&parser, record),
     }?;
 
@@ -1324,28 +1312,6 @@ fn decode_wmi(parser: &Parser, record: &EventRecord) -> Option<DecodedEtwEvent> 
         pid: parse_optional_u32(fields.process_id.as_deref()).or(Some(record.process_id())),
         process_start_key: None,
         payload: SensorPayload::Wmi(fields),
-    })
-}
-
-fn decode_service(parser: &Parser, record: &EventRecord) -> Option<DecodedEtwEvent> {
-    let mappings = field_maps::service_creation_mappings();
-    let fields = ServiceCreationFields {
-        service_name: try_get_string(parser, mappings.get_etw_field("ServiceName")?),
-        service_file_name: try_get_string(parser, mappings.get_etw_field("ServiceFileName")?)
-            .map(|path| convert_nt_to_dos(&path)),
-        service_type: try_get_uint(parser, mappings.get_etw_field("ServiceType")?),
-        start_type: try_get_uint(parser, mappings.get_etw_field("StartType")?),
-        account_name: try_get_string(parser, mappings.get_etw_field("AccountName")?),
-        user: try_get_string(parser, mappings.get_etw_field("User")?),
-        process_id: try_get_uint(parser, mappings.get_etw_field("ProcessId")?),
-        image: try_get_string(parser, mappings.get_etw_field("Image")?)
-            .map(|path| convert_nt_to_dos(&path)),
-    };
-
-    Some(DecodedEtwEvent {
-        pid: parse_optional_u32(fields.process_id.as_deref()).or(Some(record.process_id())),
-        process_start_key: None,
-        payload: SensorPayload::Service(fields),
     })
 }
 

--- a/src/sensor/windows/etw.rs
+++ b/src/sensor/windows/etw.rs
@@ -1625,7 +1625,6 @@ mod tests {
         assert_eq!(powershell.level, 5);
         assert_eq!(powershell.event_ids, &[4104]);
 
-        assert_eq!(EtwProviders::service_control_manager().event_ids, &[7045]);
         assert_eq!(EtwProviders::task_scheduler().event_ids, &[106]);
         assert!(!EtwProviders::WMI_EVENT_IDS.contains(&3));
         assert!(!EtwProviders::WMI_EVENT_IDS.contains(&13));

--- a/src/sensor/windows/event_log/mod.rs
+++ b/src/sensor/windows/event_log/mod.rs
@@ -1,0 +1,341 @@
+//! Windows Event Log subscription infrastructure.
+//!
+//! Each source supplies a channel, an XPath query, and an XML decoder. The
+//! subscription lifecycle, native handles, shutdown, and sensor-channel
+//! delivery stay shared across System, Security, and Application sources.
+
+mod service;
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{mpsc, Arc};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+use anyhow::{anyhow, Context, Result};
+use tokio::sync::mpsc::{error::TrySendError, Sender};
+use tracing::{info, trace, warn};
+use windows::core::PCWSTR;
+use windows::Win32::Foundation::{
+    CloseHandle, ERROR_NO_MORE_ITEMS, HANDLE, WAIT_OBJECT_0, WAIT_TIMEOUT,
+};
+use windows::Win32::System::EventLog::{
+    EvtClose, EvtNext, EvtRender, EvtRenderEventXml, EvtSubscribe, EvtSubscribeToFutureEvents,
+    EVT_HANDLE,
+};
+use windows::Win32::System::Threading::{CreateEventW, ResetEvent, WaitForSingleObject};
+
+use crate::sensor::SensorEvent;
+
+use super::etw::TRACE_SESSION_NAME;
+
+const EVENT_LOG_WAIT: Duration = Duration::from_millis(250);
+
+type EventDecoder = fn(&str) -> Result<SensorEvent>;
+
+#[derive(Clone, Copy)]
+struct EventLogSource {
+    name: &'static str,
+    channel: &'static str,
+    query: &'static str,
+    decoder: EventDecoder,
+}
+
+impl EventLogSource {
+    const fn new(
+        name: &'static str,
+        channel: &'static str,
+        query: &'static str,
+        decoder: EventDecoder,
+    ) -> Self {
+        Self {
+            name,
+            channel,
+            query,
+            decoder,
+        }
+    }
+}
+
+pub(super) struct EventLogSubscriptions {
+    workers: Vec<EventLogSubscription>,
+}
+
+impl EventLogSubscriptions {
+    pub(super) fn start(tx: Sender<SensorEvent>, shutdown: Arc<AtomicBool>) -> Result<Self> {
+        let sources = [service::source()];
+        let mut workers = Vec::with_capacity(sources.len());
+
+        for source in sources {
+            match EventLogSubscription::start(source, tx.clone(), Arc::clone(&shutdown)) {
+                Ok(worker) => workers.push(worker),
+                Err(err) => {
+                    shutdown.store(true, Ordering::Relaxed);
+                    for worker in workers {
+                        let _ = worker.join();
+                    }
+                    return Err(err);
+                }
+            }
+        }
+
+        Ok(Self { workers })
+    }
+
+    pub(super) fn join(self) -> Result<()> {
+        let mut first_error = None;
+        for worker in self.workers {
+            if let Err(err) = worker.join() {
+                first_error.get_or_insert(err);
+            }
+        }
+        first_error.map_or(Ok(()), Err)
+    }
+}
+
+struct EventLogSubscription {
+    worker: JoinHandle<Result<()>>,
+}
+
+impl EventLogSubscription {
+    fn start(
+        source: EventLogSource,
+        tx: Sender<SensorEvent>,
+        shutdown: Arc<AtomicBool>,
+    ) -> Result<Self> {
+        let (startup_tx, startup_rx) = mpsc::sync_channel(1);
+        let worker = thread::Builder::new()
+            .name(format!("event-log-{}", source.name))
+            .spawn(move || run_subscription(source, tx, shutdown, startup_tx))
+            .with_context(|| format!("failed to spawn {} event log worker", source.name))?;
+
+        match startup_rx.recv() {
+            Ok(Ok(())) => Ok(Self { worker }),
+            Ok(Err(err)) => {
+                let _ = worker.join();
+                Err(anyhow!(err))
+            }
+            Err(_) => {
+                let result = worker.join().map_err(|_| {
+                    anyhow!("{} event log worker panicked during startup", source.name)
+                })?;
+                result?;
+                Err(anyhow!(
+                    "{} event log worker stopped during startup",
+                    source.name
+                ))
+            }
+        }
+    }
+
+    fn join(self) -> Result<()> {
+        self.worker
+            .join()
+            .map_err(|_| anyhow!("event log worker panicked"))?
+    }
+}
+
+fn run_subscription(
+    source: EventLogSource,
+    tx: Sender<SensorEvent>,
+    shutdown: Arc<AtomicBool>,
+    startup_tx: mpsc::SyncSender<std::result::Result<(), String>>,
+) -> Result<()> {
+    let result = run_subscription_inner(source, tx, Arc::clone(&shutdown), &startup_tx);
+
+    if result.is_err() && !shutdown.swap(true, Ordering::Relaxed) {
+        // ETW processing is blocking. Stop it so an event log failure reaches
+        // the sensor caller instead of silently removing telemetry.
+        let _ = ferrisetw::trace::stop_trace_by_name(TRACE_SESSION_NAME);
+    }
+
+    result
+}
+
+fn run_subscription_inner(
+    source: EventLogSource,
+    tx: Sender<SensorEvent>,
+    shutdown: Arc<AtomicBool>,
+    startup_tx: &mpsc::SyncSender<std::result::Result<(), String>>,
+) -> Result<()> {
+    // Pull subscriptions use a manual-reset event. It starts signaled so the
+    // first EvtNext establishes the result-set state, matching Microsoft's
+    // reference consumer.
+    let signal = match unsafe { CreateEventW(None, true, true, None) } {
+        Ok(handle) => OwnedKernelHandle(handle),
+        Err(err) => {
+            let message = format!("failed to create {} event log signal: {err}", source.name);
+            let _ = startup_tx.send(Err(message.clone()));
+            return Err(anyhow!(message));
+        }
+    };
+
+    let channel = wide_string(source.channel);
+    let query = wide_string(source.query);
+    let subscription = match unsafe {
+        EvtSubscribe(
+            None,
+            Some(signal.0),
+            PCWSTR(channel.as_ptr()),
+            PCWSTR(query.as_ptr()),
+            None,
+            None,
+            None,
+            EvtSubscribeToFutureEvents.0,
+        )
+    } {
+        Ok(handle) => OwnedEvtHandle(handle),
+        Err(err) => {
+            let message = format!(
+                "failed to subscribe to {} events in {}: {err}",
+                source.name, source.channel
+            );
+            let _ = startup_tx.send(Err(message.clone()));
+            return Err(anyhow!(message));
+        }
+    };
+
+    let _ = startup_tx.send(Ok(()));
+    info!(
+        source = source.name,
+        channel = source.channel,
+        "Event log subscription started"
+    );
+
+    while !shutdown.load(Ordering::Relaxed) {
+        let wait = unsafe { WaitForSingleObject(signal.0, EVENT_LOG_WAIT.as_millis() as u32) };
+        if wait == WAIT_TIMEOUT {
+            continue;
+        }
+        if wait != WAIT_OBJECT_0 {
+            return Err(anyhow!(
+                "{} event log wait failed with status {wait:?}",
+                source.name
+            ));
+        }
+
+        drain_events(source, subscription.0, &tx)?;
+        unsafe { ResetEvent(signal.0) }
+            .map_err(|err| anyhow!("failed to reset {} event log signal: {err}", source.name))?;
+    }
+
+    info!(
+        source = source.name,
+        channel = source.channel,
+        "Event log subscription stopped"
+    );
+    Ok(())
+}
+
+fn drain_events(
+    source: EventLogSource,
+    subscription: EVT_HANDLE,
+    tx: &Sender<SensorEvent>,
+) -> Result<()> {
+    loop {
+        let mut raw_events = [0isize; 16];
+        let mut returned = 0u32;
+        let next = unsafe { EvtNext(subscription, &mut raw_events, 0, 0, &mut returned) };
+
+        match next {
+            Ok(()) => {}
+            Err(err) if err.code() == ERROR_NO_MORE_ITEMS.to_hresult() => return Ok(()),
+            Err(err) => {
+                return Err(anyhow!(
+                    "failed to read {} event log subscription: {err}",
+                    source.name
+                ))
+            }
+        }
+
+        for raw_event in raw_events.into_iter().take(returned as usize) {
+            let event_handle = EVT_HANDLE(raw_event);
+            let decoded = render_event_xml(event_handle).and_then(|xml| (source.decoder)(&xml));
+            unsafe {
+                let _ = EvtClose(event_handle);
+            }
+
+            match decoded {
+                Ok(event) => {
+                    if let Err(TrySendError::Closed(_)) = crate::telemetry::try_send(
+                        crate::telemetry::ChannelId::SensorEvents,
+                        tx,
+                        event,
+                    ) {
+                        trace!(
+                            source = source.name,
+                            "Sensor event channel closed; dropping event"
+                        );
+                    }
+                }
+                Err(err) => warn!(
+                    source = source.name,
+                    error = %err,
+                    "Failed to decode event log record"
+                ),
+            }
+        }
+    }
+}
+
+fn render_event_xml(event: EVT_HANDLE) -> Result<String> {
+    let mut bytes_needed = 0u32;
+    let mut property_count = 0u32;
+    let _ = unsafe {
+        EvtRender(
+            None,
+            event,
+            EvtRenderEventXml.0,
+            0,
+            None,
+            &mut bytes_needed,
+            &mut property_count,
+        )
+    };
+    if bytes_needed < 2 {
+        return Err(anyhow!("event XML render returned an empty buffer"));
+    }
+
+    let mut buffer = vec![0u16; bytes_needed.div_ceil(2) as usize];
+    unsafe {
+        EvtRender(
+            None,
+            event,
+            EvtRenderEventXml.0,
+            bytes_needed,
+            Some(buffer.as_mut_ptr().cast()),
+            &mut bytes_needed,
+            &mut property_count,
+        )
+    }
+    .map_err(|err| anyhow!("failed to render event XML: {err}"))?;
+
+    let length = buffer
+        .iter()
+        .position(|value| *value == 0)
+        .unwrap_or(buffer.len());
+    String::from_utf16(&buffer[..length]).context("event XML was not valid UTF-16")
+}
+
+fn wide_string(value: &str) -> Vec<u16> {
+    value.encode_utf16().chain(std::iter::once(0)).collect()
+}
+
+struct OwnedEvtHandle(EVT_HANDLE);
+
+impl Drop for OwnedEvtHandle {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = EvtClose(self.0);
+        }
+    }
+}
+
+struct OwnedKernelHandle(HANDLE);
+
+impl Drop for OwnedKernelHandle {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = CloseHandle(self.0);
+        }
+    }
+}

--- a/src/sensor/windows/event_log/service.rs
+++ b/src/sensor/windows/event_log/service.rs
@@ -1,0 +1,161 @@
+//! Service Control Manager event decoding.
+
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use anyhow::{anyhow, Context, Result};
+use chrono::DateTime;
+
+use crate::models::ServiceCreationFields;
+use crate::sensor::{Platform, SensorAction, SensorEvent, SensorNormalization, SensorPayload};
+
+use super::EventLogSource;
+
+const SERVICE_EVENT_ID: u16 = 7045;
+
+pub(super) const fn source() -> EventLogSource {
+    EventLogSource::new(
+        "service-installation",
+        "System",
+        "*[System[Provider[@Name='Service Control Manager'] and EventID=7045]]",
+        decode,
+    )
+}
+
+fn decode(xml: &str) -> Result<SensorEvent> {
+    let document = roxmltree::Document::parse(xml).context("invalid service event XML")?;
+    let system = document
+        .descendants()
+        .find(|node| node.has_tag_name("System"))
+        .context("service event XML has no System element")?;
+
+    let event_id = child_text(system, "EventID")
+        .context("service event XML has no EventID")?
+        .parse::<u16>()
+        .context("service event XML has an invalid EventID")?;
+    if event_id != SERVICE_EVENT_ID {
+        return Err(anyhow!("unexpected System event ID {event_id}"));
+    }
+
+    let provider = system
+        .children()
+        .find(|node| node.has_tag_name("Provider"))
+        .and_then(|node| node.attribute("Name"));
+    if provider != Some("Service Control Manager") {
+        return Err(anyhow!("unexpected event 7045 provider {provider:?}"));
+    }
+
+    let field = |name: &str| {
+        document.descendants().find_map(|node| {
+            (node.has_tag_name("Data") && node.attribute("Name") == Some(name))
+                .then(|| node.text().unwrap_or_default().to_string())
+        })
+    };
+
+    let service_name = field("ServiceName").filter(|value| !value.is_empty());
+    let service_file_name = field("ImagePath").filter(|value| !value.is_empty());
+    if service_name.is_none() || service_file_name.is_none() {
+        return Err(anyhow!("event 7045 is missing ServiceName or ImagePath"));
+    }
+
+    let user = system
+        .children()
+        .find(|node| node.has_tag_name("Security"))
+        .and_then(|node| node.attribute("UserID"))
+        .map(str::to_string);
+    let timestamp = system
+        .children()
+        .find(|node| node.has_tag_name("TimeCreated"))
+        .and_then(|node| node.attribute("SystemTime"))
+        .and_then(parse_system_time)
+        .unwrap_or_else(SystemTime::now);
+
+    Ok(SensorEvent {
+        platform: Platform::Windows,
+        provider: "windows_event_log",
+        action: SensorAction::Register,
+        normalization: SensorNormalization {
+            event_id: SERVICE_EVENT_ID,
+            action_code: 0,
+        },
+        pid: None,
+        timestamp,
+        process_start_key: None,
+        payload: SensorPayload::Service(ServiceCreationFields {
+            service_name,
+            service_file_name,
+            service_type: field("ServiceType").filter(|value| !value.is_empty()),
+            start_type: field("StartType").filter(|value| !value.is_empty()),
+            account_name: field("AccountName").filter(|value| !value.is_empty()),
+            user,
+            process_id: None,
+            image: None,
+        }),
+    })
+}
+
+fn child_text<'a, 'input>(node: roxmltree::Node<'a, 'input>, name: &str) -> Option<&'a str> {
+    node.children()
+        .find(|child| child.has_tag_name(name))
+        .and_then(|child| child.text())
+}
+
+fn parse_system_time(value: &str) -> Option<SystemTime> {
+    let timestamp = DateTime::parse_from_rfc3339(value).ok()?;
+    let seconds = timestamp.timestamp();
+    let nanos = timestamp.timestamp_subsec_nanos();
+    if seconds < 0 {
+        return None;
+    }
+    Some(UNIX_EPOCH + Duration::new(seconds as u64, nanos))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::decode;
+    use crate::sensor::{SensorAction, SensorPayload};
+
+    const EVENT_7045: &str = r#"
+<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+  <System>
+    <Provider Name="Service Control Manager" Guid="{555908d1-a6d7-4695-8e1e-26931d2012f4}"/>
+    <EventID Qualifiers="16384">7045</EventID>
+    <TimeCreated SystemTime="2026-08-25T12:34:56.1234567Z"/>
+    <Channel>System</Channel>
+    <Security UserID="S-1-5-18"/>
+  </System>
+  <EventData>
+    <Data Name="ServiceName">RustinelIssue287</Data>
+    <Data Name="ImagePath">C:\Program Files\test service.exe</Data>
+    <Data Name="ServiceType">user mode service</Data>
+    <Data Name="StartType">demand start</Data>
+    <Data Name="AccountName">LocalSystem</Data>
+  </EventData>
+</Event>"#;
+
+    #[test]
+    fn decodes_all_service_creation_fields() {
+        let event = decode(EVENT_7045).expect("7045 should decode");
+        assert_eq!(event.action, SensorAction::Register);
+        assert_eq!(event.normalization.event_id, 7045);
+        assert_eq!(event.provider, "windows_event_log");
+
+        let SensorPayload::Service(fields) = event.payload else {
+            panic!("expected service payload");
+        };
+        assert_eq!(fields.service_name.as_deref(), Some("RustinelIssue287"));
+        assert_eq!(
+            fields.service_file_name.as_deref(),
+            Some(r"C:\Program Files\test service.exe")
+        );
+        assert_eq!(fields.service_type.as_deref(), Some("user mode service"));
+        assert_eq!(fields.start_type.as_deref(), Some("demand start"));
+        assert_eq!(fields.account_name.as_deref(), Some("LocalSystem"));
+        assert_eq!(fields.user.as_deref(), Some("S-1-5-18"));
+    }
+
+    #[test]
+    fn rejects_a_different_provider() {
+        let xml = EVENT_7045.replace("Service Control Manager", "Other Provider");
+        assert!(decode(&xml).is_err());
+    }
+}

--- a/src/sensor/windows/field_maps.rs
+++ b/src/sensor/windows/field_maps.rs
@@ -160,23 +160,6 @@ pub fn wmi_event_mappings() -> &'static FieldMapping {
     &WMI_EVENT_MAP
 }
 
-static SERVICE_CREATION_MAP: LazyLock<FieldMapping> = LazyLock::new(|| {
-    FieldMapping::new(&[
-        ("ServiceName", "ServiceName"),
-        ("ServiceFileName", "ImagePath"),
-        ("ServiceType", "ServiceType"),
-        ("StartType", "StartType"),
-        ("AccountName", "AccountName"),
-        ("User", "UserName"),
-        ("ProcessId", "ProcessID"),
-        ("Image", "ImageName"),
-    ])
-});
-
-pub fn service_creation_mappings() -> &'static FieldMapping {
-    &SERVICE_CREATION_MAP
-}
-
 static TASK_CREATION_MAP: LazyLock<FieldMapping> = LazyLock::new(|| {
     FieldMapping::new(&[
         ("TaskName", "TaskName"),

--- a/src/sensor/windows/mod.rs
+++ b/src/sensor/windows/mod.rs
@@ -1,4 +1,5 @@
 pub mod etw;
+mod event_log;
 mod field_maps;
 mod file_paths;
 pub mod mapper;

--- a/tests/windows_service_event_log.rs
+++ b/tests/windows_service_event_log.rs
@@ -1,0 +1,88 @@
+#![cfg(windows)]
+
+use std::process::Command;
+use std::sync::Arc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use rustinel::sensor::windows::EtwSensor;
+use rustinel::sensor::{Sensor, SensorPayload};
+
+struct TemporaryService(String);
+
+impl Drop for TemporaryService {
+    fn drop(&mut self) {
+        let _ = Command::new("sc.exe").args(["delete", &self.0]).status();
+    }
+}
+
+#[test]
+#[ignore = "requires Administrator privileges; runs in the Windows privileged smoke job"]
+fn service_installation_reaches_the_normalized_sensor_channel() {
+    let (tx, mut rx) = tokio::sync::mpsc::channel(256);
+    let sensor = Arc::new(EtwSensor::new());
+    let worker_sensor = Arc::clone(&sensor);
+    let worker = thread::spawn(move || worker_sensor.start(tx));
+
+    // The subscription startup does not return until EvtSubscribe succeeds,
+    // but the sensor owns that startup on its worker thread. Give both sources a
+    // short window to become ready before producing the one-shot test event.
+    thread::sleep(Duration::from_secs(2));
+
+    let service_name = format!("Rustinel7045Test{}", std::process::id());
+    let temporary_service = TemporaryService(service_name.clone());
+    let create = Command::new("sc.exe")
+        .args([
+            "create",
+            &service_name,
+            "binPath=",
+            r"C:\Windows\System32\cmd.exe /c exit 0",
+            "start=",
+            "demand",
+            "obj=",
+            "LocalSystem",
+        ])
+        .output()
+        .expect("sc.exe must be available");
+    assert!(
+        create.status.success(),
+        "failed to create test service: {}",
+        String::from_utf8_lossy(&create.stderr)
+    );
+
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let mut matched = None;
+    while Instant::now() < deadline {
+        match rx.try_recv() {
+            Ok(event) => {
+                if let SensorPayload::Service(fields) = &event.payload {
+                    if fields.service_name.as_deref() == Some(service_name.as_str()) {
+                        matched = Some(event);
+                        break;
+                    }
+                }
+            }
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty) => {
+                thread::sleep(Duration::from_millis(25));
+            }
+            Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => break,
+        }
+    }
+
+    sensor.shutdown();
+    let sensor_result = worker.join().expect("sensor worker must not panic");
+    drop(temporary_service);
+    sensor_result.expect("sensor must stop cleanly");
+
+    let event = matched.expect("System event 7045 must reach the sensor channel");
+    assert_eq!(event.provider, "windows_event_log");
+    assert_eq!(event.normalization.event_id, 7045);
+    let SensorPayload::Service(fields) = event.payload else {
+        unreachable!();
+    };
+    assert_eq!(fields.service_name.as_deref(), Some(service_name.as_str()));
+    assert!(fields.service_file_name.is_some());
+    assert!(fields.service_type.is_some());
+    assert!(fields.start_type.is_some());
+    assert!(fields.account_name.is_some());
+}


### PR DESCRIPTION
## Summary

- replace the Service Control Manager realtime ETW registration with a filtered Windows Event Log subscription for System event 7045
- normalize service name, image path, service type, start type, account name, user, and timestamp into the existing service payload
- keep subscription lifecycle generic so future Security and Application sources only need source configuration and a decoder
- add decoder coverage, a privileged Windows service creation smoke test, CI wiring, and documentation updates

Fixes #287

## Type of change

- [ ] `feat` / `enhancement` - new feature
- [x] `bug` - bug fix
- [ ] `refactor` - refactoring, no behaviour change
- [ ] `documentation` - docs only
- [ ] `ci` - CI and release changes
- [ ] `dependencies` - dependency update

## Test plan

- [x] Tested on Windows
- [ ] Tested on Linux
- [x] Existing tests pass (`cargo test --locked`)
- [x] New tests added
- [x] Windows `cargo clippy --locked --all-targets -- -D clippy::all`
- [x] Privileged Windows smoke test created a temporary service and observed the normalized event

## Checklist

- [x] Label added to this PR
- [x] Docs updated