### PR TITLE
test: isolate telemetry warning limiter state

### DIFF
--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -288,6 +288,12 @@ mod tests {
         for channel in ChannelId::ALL {
             channel.counters().reset();
         }
+        // The warning limiter is process-wide too. Reset it alongside the
+        // counters so tests cannot inherit a channel's rate-limit window.
+        let mut limiter = DROP_WARNINGS
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        *limiter = LogRateLimiter::new(DROP_WARN_INTERVAL);
         guard
     }
 


### PR DESCRIPTION
## Summary

- Reset the process-wide telemetry warning limiter during telemetry test setup.
- Prevent test ordering from suppressing the warning expected by `a_burst_of_drops_emits_one_cumulative_warning`.
- No production behavior changes.

## Type of change

- [x] `bug`
- [ ] `feat` / `enhancement`
- [ ] `refactor`
- [ ] `documentation`
- [ ] `ci`
- [ ] `dependencies`

## Test plan

- [ ] Tested on Windows
- [ ] Tested on Linux
- [x] Existing tests pass (`cargo test`)
- [ ] New tests added (if applicable)

## Checklist

- [ ] Label added to this PR
- [ ] Docs updated (if behaviour changed)

The failure was observed in [run 32998277776](https://github.com/Karib0u/rustinel/actions/runs/32998277776/job/98273102609).