### PR TITLE
fix(windows-etw): stop collecting WMI IDs that alias Sysmon wmi_event

### DIFF
--- a/docs/detection.md
+++ b/docs/detection.md
@@ -116,7 +116,7 @@ rule instead of one is tracked separately by
 | `registry_event` / `registry_*` | Yes | No | No | Windows only |
 | `image_load` | Yes | No | No | Windows only |
 | `ps_script` | Yes | No | No | Windows only |
-| `wmi_event` | Yes | No | No | Windows only |
+| `wmi_event` | Yes | No | No | Windows only; WMI-Activity numbering, not Sysmon's — see [WMI Event Numbering](#wmi-event-numbering) |
 | `service_creation` | Yes | No | No | Windows only |
 | `task_creation` | Yes | No | No | Windows only |
 
@@ -193,6 +193,24 @@ cover.
 what `|endswith` rules and extension IOCs match on, so an event carrying this
 marker that matched nothing has not been cleared. The field is not part of
 keyword search, so it never contributes to a match on its own.
+
+#### WMI Event Numbering
+
+Windows WMI telemetry comes from `Microsoft-Windows-WMI-Activity`, whose event
+IDs are its own — they are not Sysmon's, and they are not remapped onto them.
+Sysmon's `wmi_event` IDs 19, 20, and 21 mean WMI Event Filter, Event Consumer,
+and Filter-to-Consumer binding; the native provider numbers unrelated operations
+in the same range. Because a rule with only `product: windows` and
+`category: wmi_event` binds to the `(windows, wmi, wmi_event)` tuple, a native
+event whose ID happened to equal 19 or 20 would make a stock SigmaHQ WMI
+persistence rule fire on something else entirely, so those two IDs are not
+collected ([#291](https://github.com/Karib0u/rustinel/issues/291)).
+
+The practical consequence for rule authors: `wmi_event` rules that select on
+`EventID` do not match on Rustinel. Rules that match on the WMI fields —
+`Operation`, `Query`, `EventNamespace`, `Image`, `User`,
+`DestinationHostname` — do. WMI *persistence* telemetry (the Sysmon 19/20/21
+equivalent) is not collected at all today.
 
 ### Field Model
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -58,6 +58,15 @@ are unavailable.
   aren't possible.
 - **DNS `QueryType` is always empty.** The DNS record type is not populated on
   Windows.
+- **WMI persistence events are not collected, and WMI event IDs are not
+  Sysmon's (silent risk).** WMI telemetry comes from
+  `Microsoft-Windows-WMI-Activity`, which has no equivalent of Sysmon's
+  `wmi_event` 19/20/21 (filter, consumer, filter-to-consumer binding) and
+  numbers its own operations in the same range. Nothing is remapped, and the two
+  colliding native IDs are dropped rather than passed through, so a `wmi_event`
+  rule selecting on `EventID` never matches instead of matching the wrong event.
+  Rules keyed on `Operation`, `Query`, `EventNamespace`, `Image` or `User` still
+  work.
 - **No injection or driver-load visibility.** No equivalent of CreateRemoteThread,
   ProcessAccess, named-pipe, or driver-load providers - injection-based TTPs leave
   little telemetry.

--- a/src/sensor/windows/etw.rs
+++ b/src/sensor/windows/etw.rs
@@ -114,7 +114,14 @@ impl EtwProviders {
     const POWERSHELL_RUNSPACE_KEYWORD: u64 = 0x0000_0000_0000_0001;
     const DNS_EVENT_IDS: &'static [u16] = &[3006, 3008];
     const POWERSHELL_EVENT_IDS: &'static [u16] = &[4104];
-    const WMI_EVENT_IDS: &'static [u16] = &[1, 2, 11, 12, 14, 15, 16, 17, 19, 20, 22, 23, 24];
+    // Native WMI-Activity numbering is unrelated to Sysmon's, but both reach
+    // the engine under `(windows, wmi, wmi_event)`, so any collected ID that
+    // happens to equal a Sysmon `wmi_event` ID (19 = filter, 20 = consumer,
+    // 21 = filter-to-consumer binding) makes stock SigmaHQ rules fire on the
+    // wrong event. 19 and 20 are excluded for that reason (#291); mapping them
+    // is not an option, because the native events do not carry the WMI
+    // persistence fields those rules read.
+    const WMI_EVENT_IDS: &'static [u16] = &[1, 2, 11, 12, 14, 15, 16, 17, 22, 23, 24];
     const TASK_EVENT_IDS: &'static [u16] = &[106];
 
     fn kernel_process() -> EtwProvider {
@@ -1629,6 +1636,22 @@ mod tests {
         assert!(!EtwProviders::WMI_EVENT_IDS.contains(&3));
         assert!(!EtwProviders::WMI_EVENT_IDS.contains(&13));
         assert!(!EtwProviders::WMI_EVENT_IDS.contains(&18));
+    }
+
+    #[test]
+    fn wmi_activity_event_ids_do_not_alias_sysmon_wmi_event_ids() {
+        // Sysmon `wmi_event`: 19 = filter, 20 = consumer, 21 = binding.
+        const SYSMON_WMI_EVENT_IDS: &[u16] = &[19, 20, 21];
+
+        for &event_id in EtwProviders::WMI_EVENT_IDS {
+            let sysmon_id = mapper::map_to_sysmon_id(EventCategory::Wmi, 0, event_id);
+            assert!(
+                !SYSMON_WMI_EVENT_IDS.contains(&sysmon_id),
+                "native WMI-Activity event {event_id} reaches the engine as \
+                 Sysmon wmi_event ID {sysmon_id}, so a stock rule selecting \
+                 that ID would match an unrelated event"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes #291

## Problem

`Microsoft-Windows-WMI-Activity` events reach the engine unmapped under the `(windows, wmi, wmi_event)` tuple — the same tuple a stock SigmaHQ rule with only `product: windows` + `category: wmi_event` binds to. Native IDs 19 and 20 collide with Sysmon's WMI Event Filter and Event Consumer, so those rules fired on entirely unrelated events.

Unlike the rest of the coverage audit findings, this is a wrong-answer defect rather than a silence defect: it produces a false positive, which no coverage metric surfaces.

## Change

- Drop 19 and 20 from `WMI_EVENT_IDS` in [etw.rs](src/sensor/windows/etw.rs) so the colliding IDs are never collected. Mapping them onto Sysmon numbering was rejected: the native events don't carry the WMI persistence fields those rules read, so a mapped event would still match wrongly.
- New test asserts the **invariant**, not the list: no ID in `WMI_EVENT_IDS` may reach the engine as a Sysmon `wmi_event` ID (19/20/21) after `map_to_sysmon_id`. Adding a colliding ID back fails it, so the guard survives future edits to the list.
- Document the numbering in [docs/detection.md](docs/detection.md) (new *WMI Event Numbering* section) and the resulting gap in [docs/limitations.md](docs/limitations.md): `wmi_event` rules selecting on `EventID` never match; rules keyed on `Operation`, `Query`, `EventNamespace`, `Image` or `User` still do. Native WMI persistence telemetry (5857/5860/5861 under `service: wmi`) remains uncollected, as the issue notes.

## Verification

`src/sensor/windows/` can't compile on macOS, so this was checked on the Windows lab box:

- `cargo test` — full suite green (`TEST-EXIT-0`), 316 lib tests including the new one.
- `cargo clippy --all-targets -- -D clippy::all` — clean, zero warnings.
- Negative control: re-adding 19/20 to the list makes the new test fail with `native WMI-Activity event 19 reaches the engine as Sysmon wmi_event ID 19`.
- `cargo fmt --check` clean locally.

## Acceptance criteria

- [x] Native WMI-Activity 19/20 are no longer collected.
- [x] A `category: wmi_event` rule selecting `EventID: 19` does not match a native WMI-Activity event — no such event is collected, and the test enforces it for every ID in the list.
- [x] Test covers the ID-collision case.