### PR TITLE
fix(windows-etw): carry registry value data in Details

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -14,7 +14,6 @@ This page documents Rustinel's known limitations for the current release.
 
 | Limitation | Area |
 | --- | --- |
-| Registry value *data* is never captured; `Details` holds the value *name* instead | Windows |
 | Process events carry no hashes (`Hashes` / `Imphash`) | Windows |
 | Command line is lost for short-lived processes | Windows | Linux |
 | No stateful correlation or filter evaluation; unsupported documents are reported at load time | Engine |
@@ -30,10 +29,13 @@ a Windows Event Log subscription, rather than using a kernel driver.
 Coverage is the broadest of the three platforms, but several Sysmon-style fields
 are unavailable.
 
-- **Registry value data is not captured (silent risk).** Unlike Sysmon, `Details`
-  maps to the registry *value name*, not the data written to it - the
-  Kernel-Registry provider doesn't emit value data. A rule matching on written
-  content silently matches the value name instead.
+- **Registry value data is captured through an undocumented request.** `Details`
+  carries the value data, as Sysmon Event ID 13 defines it, because the session
+  asks the Kernel-Registry provider for it with an undocumented `EnableTraceEx2`
+  filter payload. The mechanism is not contractual and may stop working on a
+  future Windows build; when it does, `Details` falls back to the value *name*
+  and a warning is logged at startup. Binary values render as `Binary Data`,
+  matching Sysmon, so their content is not searchable.
 - **Registry `TargetObject` is not always a full path (silent risk).** The path
   is composed from the `CreateKey`/`OpenKey` events that named the key, so it is
   the full NT path (`\REGISTRY\MACHINE\...`) when the parent key was also seen

--- a/src/sensor/windows/etw.rs
+++ b/src/sensor/windows/etw.rs
@@ -27,7 +27,7 @@ use crate::utils::{convert_nt_to_dos, parse_metadata, query_process_command_line
 use super::event_log::EventLogSubscriptions;
 use super::file_paths::FilePathCache;
 use super::registry_paths::RegistryPathCache;
-use super::{field_maps, mapper};
+use super::{field_maps, mapper, registry_value_data};
 
 /// Fixed trace session name for stopping the trace on shutdown.
 pub(super) const TRACE_SESSION_NAME: &str = "rustinel-etw-trace";
@@ -597,6 +597,41 @@ impl EtwSensor {
     }
 }
 
+/// Ask the registry provider to include value data, once the session exists.
+///
+/// This cannot be part of building the provider: `ferrisetw` has no way to
+/// express the filter payload it needs, so the provider is re-enabled by hand
+/// on the running session. A failure is logged and tolerated — `Details` then
+/// falls back to the value name, exactly as before #292 — because the
+/// mechanism is undocumented and may not hold on every Windows build.
+fn request_registry_value_data() {
+    let provider = EtwProviders::kernel_registry();
+    match registry_value_data::request_value_data(
+        TRACE_SESSION_NAME,
+        to_windows_guid(provider.guid),
+        provider.level,
+        provider.keywords,
+        provider.event_ids,
+    ) {
+        Ok(()) => info!("Registry value data capture enabled"),
+        Err(err) => warn!(
+            "Could not enable registry value data capture ({err:#}); \
+             registry Details will carry the value name"
+        ),
+    }
+}
+
+/// `ferrisetw` is built against a different `windows` version than this crate,
+/// so the two `GUID` types are distinct despite being the same four fields.
+fn to_windows_guid(guid: GUID) -> windows::core::GUID {
+    windows::core::GUID {
+        data1: guid.data1,
+        data2: guid.data2,
+        data3: guid.data3,
+        data4: guid.data4,
+    }
+}
+
 impl Default for EtwSensor {
     fn default() -> Self {
         Self::new()
@@ -660,6 +695,8 @@ impl Sensor for EtwSensor {
                     "ETW trace session '{}' started successfully",
                     TRACE_SESSION_NAME
                 );
+
+                request_registry_value_data();
 
                 match trace.process() {
                     Ok(()) => {
@@ -1066,7 +1103,7 @@ fn decode_kernel_registry_record(
 
     let key_object = try_get_uint_as_u64(&parser, "KeyObject");
 
-    let (action, target_object) = match route {
+    let (action, target_object, value_name) = match route {
         KernelRegistryRoute::Name { creates } => {
             let base_object = try_get_uint_as_u64(&parser, "BaseObject");
             let base_name = try_get_string(&parser, "BaseName").unwrap_or_default();
@@ -1088,7 +1125,7 @@ fn decode_kernel_registry_record(
             // the disposition check every key open would surface as a
             // `registry_add`.
             refine_registry_create_action(&parser)?;
-            (SensorAction::Create, path?)
+            (SensorAction::Create, path?, None)
         }
         KernelRegistryRoute::Evict => {
             if let Some(object) = key_object {
@@ -1119,7 +1156,7 @@ fn decode_kernel_registry_record(
             });
 
             match path {
-                Some(path) => (action, path),
+                Some(path) => (action, path, value_name),
                 None => {
                     // Counted rather than silently discarded, for the same
                     // reason as the file index: this is the sensor's blind
@@ -1143,9 +1180,7 @@ fn decode_kernel_registry_record(
     let mappings = field_maps::registry_event_mappings();
     let fields = RegistryEventFields {
         target_object: Some(target_object),
-        // The provider reports the value *name*; `CapturedData` holds the data
-        // but is empty unless the session asks for it, so this stays the name.
-        details: try_get_string(&parser, mappings.get_etw_field("Details")?),
+        details: registry_details(&parser, value_name.as_deref()),
         process_id: try_get_uint(&parser, mappings.get_etw_field("ProcessId")?),
         image: try_get_string(&parser, mappings.get_etw_field("Image")?)
             .map(|path| convert_nt_to_dos(&path)),
@@ -1167,6 +1202,26 @@ fn decode_kernel_registry_record(
         process_start_key: None,
         payload: SensorPayload::Registry(fields),
     })
+}
+
+/// `Details` for a registry event: the value *data*, as Sysmon Event ID 13
+/// defines it, falling back to the value name.
+///
+/// The fallback is not dead code. `CapturedData` is only populated because
+/// [`registry_value_data::request_value_data`] asked for it through an
+/// undocumented filter payload, and that request can fail — on a Windows build
+/// that does not honour it, or if the re-enable itself failed and was logged as
+/// a warning. Emitting nothing there would be a regression on the pre-#292
+/// behaviour, so the name is still better than an absent field.
+fn registry_details(parser: &Parser, value_name: Option<&str>) -> Option<String> {
+    let captured = parser
+        .try_parse::<Vec<u8>>(field_maps::registry_event_mappings().get_etw_field("Details")?)
+        .unwrap_or_default();
+    let value_type =
+        try_get_uint_as_u64(parser, registry_value_data::VALUE_TYPE_PROPERTY).unwrap_or(0);
+
+    registry_value_data::format_value_data(value_type as u32, &captured)
+        .or_else(|| value_name.map(str::to_string))
 }
 
 fn decode_network(parser: &Parser, record: &EventRecord) -> Option<DecodedEtwEvent> {
@@ -1503,6 +1558,17 @@ mod tests {
         assert_ne!(
             EtwProviders::FILE_KEYWORDS & EtwProviders::KERNEL_FILE_KEYWORD_FILEIO,
             0
+        );
+    }
+
+    #[test]
+    fn registry_details_reads_the_value_data_property() {
+        // `Details` meant `ValueName` until #292, which made 180 SigmaHQ rules
+        // match the name of the value instead of what was written into it.
+        assert_eq!(
+            field_maps::registry_event_mappings().get_etw_field("Details"),
+            Some("CapturedData"),
+            "Details must map to the value data, with ValueName only as fallback"
         );
     }
 

--- a/src/sensor/windows/field_maps.rs
+++ b/src/sensor/windows/field_maps.rs
@@ -3,6 +3,8 @@
 use std::collections::HashMap;
 use std::sync::LazyLock;
 
+use super::registry_value_data::CAPTURED_DATA_PROPERTY;
+
 /// Field mapping for a specific Sigma category.
 pub struct FieldMapping {
     /// Maps Sigma field name -> ETW property name.
@@ -68,7 +70,10 @@ pub fn file_event_mappings() -> &'static FieldMapping {
 
 static REGISTRY_EVENT_MAP: LazyLock<FieldMapping> = LazyLock::new(|| {
     FieldMapping::new(&[
-        ("Details", "ValueName"),
+        // Sysmon Event ID 13 defines `Details` as the value data, not its
+        // name; `CapturedData` is empty unless the session asks for it, and
+        // `registry_details` falls back to `ValueName` when it is.
+        ("Details", CAPTURED_DATA_PROPERTY),
         ("ProcessId", "ProcessID"),
         ("Image", "ImageName"),
         ("EventType", "EventType"),

--- a/src/sensor/windows/mod.rs
+++ b/src/sensor/windows/mod.rs
@@ -4,5 +4,6 @@ mod field_maps;
 mod file_paths;
 pub mod mapper;
 mod registry_paths;
+mod registry_value_data;
 
 pub use etw::EtwSensor;

--- a/src/sensor/windows/registry_value_data.rs
+++ b/src/sensor/windows/registry_value_data.rs
@@ -223,10 +223,8 @@ fn first_bytes<const N: usize>(data: &[u8]) -> Option<[u8; N]> {
 /// The embedded NULs of a `REG_MULTI_SZ` are kept for the caller to split on;
 /// only the trailing ones go.
 fn decode_utf16(data: &[u8]) -> String {
-    let units: Vec<u16> = data
-        .chunks_exact(2)
-        .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
-        .collect();
+    let (pairs, _odd_trailing_byte) = data.as_chunks::<2>();
+    let units: Vec<u16> = pairs.iter().copied().map(u16::from_le_bytes).collect();
     String::from_utf16_lossy(&units)
         .trim_end_matches('\0')
         .to_string()

--- a/src/sensor/windows/registry_value_data.rs
+++ b/src/sensor/windows/registry_value_data.rs
@@ -1,0 +1,341 @@
+//! Registry value *data*: asking the provider for it, and rendering it.
+//!
+//! `Microsoft-Windows-Kernel-Registry` declares `CapturedData` on `SetValueKey`
+//! but delivers it empty unless the trace session asks for it, so before #292
+//! `Details` carried the value *name* instead. Sysmon Event ID 13 — and the 180
+//! SigmaHQ rules written against it — define `Details` as the value *data*, so
+//! those rules matched the wrong string rather than nothing at all.
+//!
+//! The request is an `EnableTraceEx2` filter descriptor whose four payload
+//! bytes have bit `0x2` set. It is undocumented and unsupported by `ferrisetw`,
+//! which is why the provider is re-enabled by hand here once the session is up;
+//! [`super::etw`] treats a failure as non-fatal and keeps the value-name
+//! behaviour.
+//!
+//! Measured on Windows 11 26200 by enabling the provider once per candidate
+//! payload and writing a known value under each:
+//!
+//! | payload | `CapturedDataSize` |
+//! |---------|--------------------|
+//! | absent  | 0                  |
+//! | `0x0`   | 0                  |
+//! | `0x1`   | 0                  |
+//! | `0x2`   | full value data    |
+//! | `0x3`   | full value data    |
+//! | `0x4`   | 0                  |
+//!
+//! The descriptor `Type` is not validated — `0x1` and `0x2` behave the same as
+//! `EVENT_FILTER_TYPE_NONE`, and only `EVENT_FILTER_TYPE_SCHEMATIZED` is
+//! rejected (`ERROR_INVALID_PARAMETER`), which is what makes this a payload
+//! flag rather than a filter. A 802-byte `REG_SZ` came back whole, so the
+//! provider does not truncate at any small bound.
+
+use std::mem::size_of;
+
+use anyhow::{bail, Result};
+use windows::core::{GUID, PCWSTR};
+use windows::Win32::System::Diagnostics::Etw::{
+    ControlTraceW, EnableTraceEx2, CONTROLTRACE_HANDLE, ENABLE_TRACE_PARAMETERS,
+    ENABLE_TRACE_PARAMETERS_VERSION_2, EVENT_CONTROL_CODE_ENABLE_PROVIDER, EVENT_FILTER_DESCRIPTOR,
+    EVENT_FILTER_TYPE_EVENT_ID, EVENT_TRACE_CONTROL_QUERY, EVENT_TRACE_PROPERTIES,
+};
+
+/// The ETW property that carries the value data, once it is asked for.
+pub(super) const CAPTURED_DATA_PROPERTY: &str = "CapturedData";
+/// The ETW property that carries the `REG_*` type of that data.
+pub(super) const VALUE_TYPE_PROPERTY: &str = "Type";
+
+/// The four filter-payload bytes that turn `CapturedData` on.
+const CAPTURE_VALUE_DATA: u32 = 0x2;
+/// `EVENT_FILTER_TYPE_NONE`. The provider ignores the type of this descriptor
+/// (see the module docs); the neutral value is used so the request cannot be
+/// mistaken for a filter that ETW itself would act on.
+const EVENT_FILTER_TYPE_NONE: u32 = 0;
+
+/// Room for the logger and log-file names `ControlTraceW` writes back, in
+/// bytes. `ControlTraceW` fails with `ERROR_BAD_LENGTH` if either does not fit.
+const TRACE_NAME_BYTES: usize = 2 * 1024;
+
+/// `REG_*` value types, from `winnt.h`. `REG_NONE` (0) and `REG_BINARY` (3)
+/// are deliberately absent: they take the same path as an unrecognised type.
+const REG_SZ: u32 = 1;
+const REG_EXPAND_SZ: u32 = 2;
+const REG_DWORD: u32 = 4;
+const REG_DWORD_BIG_ENDIAN: u32 = 5;
+const REG_LINK: u32 = 6;
+const REG_MULTI_SZ: u32 = 7;
+const REG_QWORD: u32 = 11;
+
+/// Ask an already-started session to include registry value data in
+/// `SetValueKey` events.
+///
+/// Re-enables the provider on the running session, which *replaces* the
+/// enablement `ferrisetw` performed: the level, keywords and event-ID scope
+/// have to be passed again in full, or the session would silently widen to
+/// every registry event.
+pub(super) fn request_value_data(
+    session_name: &str,
+    provider_guid: GUID,
+    level: u8,
+    keywords: u64,
+    event_ids: &[u16],
+) -> Result<()> {
+    let handle = session_handle(session_name)?;
+
+    let capture = CAPTURE_VALUE_DATA;
+    let mut descriptors = vec![EVENT_FILTER_DESCRIPTOR {
+        Ptr: std::ptr::addr_of!(capture) as u64,
+        Size: size_of::<u32>() as u32,
+        Type: EVENT_FILTER_TYPE_NONE,
+    }];
+
+    // Owned outside the `if` so the buffer outlives the `EnableTraceEx2` call.
+    let event_id_filter = event_id_filter(event_ids);
+    if !event_ids.is_empty() {
+        descriptors.push(EVENT_FILTER_DESCRIPTOR {
+            Ptr: event_id_filter.as_ptr() as u64,
+            Size: std::mem::size_of_val(event_id_filter.as_slice()) as u32,
+            Type: EVENT_FILTER_TYPE_EVENT_ID,
+        });
+    }
+
+    let parameters = ENABLE_TRACE_PARAMETERS {
+        Version: ENABLE_TRACE_PARAMETERS_VERSION_2,
+        EnableProperty: 0,
+        ControlFlags: 0,
+        SourceId: GUID::zeroed(),
+        EnableFilterDesc: descriptors.as_mut_ptr(),
+        FilterDescCount: descriptors.len() as u32,
+    };
+
+    // SAFETY: `handle` names a session this process started, the descriptors
+    // and their payloads outlive the call, and `parameters` points at them.
+    let status = unsafe {
+        EnableTraceEx2(
+            handle,
+            &provider_guid,
+            EVENT_CONTROL_CODE_ENABLE_PROVIDER.0,
+            level,
+            keywords,
+            0,
+            0,
+            Some(&parameters),
+        )
+    };
+    if status.is_err() {
+        bail!("EnableTraceEx2 failed: {status:?}");
+    }
+    Ok(())
+}
+
+/// Look up the control handle of a running session by name.
+///
+/// `ControlTraceW` with a null handle returns the session's properties, and the
+/// handle itself in `Wnode.HistoricalContext`. The session was started through
+/// `ferrisetw`, which keeps its handle private, so this is the only way to
+/// reach it.
+fn session_handle(session_name: &str) -> Result<CONTROLTRACE_HANDLE> {
+    let name: Vec<u16> = session_name
+        .encode_utf16()
+        .chain(std::iter::once(0))
+        .collect();
+
+    let total = size_of::<EVENT_TRACE_PROPERTIES>() + 2 * TRACE_NAME_BYTES;
+    let mut buffer = vec![0u8; total];
+    let properties = buffer.as_mut_ptr().cast::<EVENT_TRACE_PROPERTIES>();
+
+    // SAFETY: `buffer` is at least `size_of::<EVENT_TRACE_PROPERTIES>()` bytes
+    // and is allocated with a stricter-than-required alignment by `Vec`, and
+    // both name offsets point inside it.
+    let status = unsafe {
+        (*properties).Wnode.BufferSize = total as u32;
+        (*properties).LoggerNameOffset = size_of::<EVENT_TRACE_PROPERTIES>() as u32;
+        (*properties).LogFileNameOffset =
+            (size_of::<EVENT_TRACE_PROPERTIES>() + TRACE_NAME_BYTES) as u32;
+        ControlTraceW(
+            CONTROLTRACE_HANDLE::default(),
+            PCWSTR(name.as_ptr()),
+            properties,
+            EVENT_TRACE_CONTROL_QUERY,
+        )
+    };
+    if status.is_err() {
+        bail!("ControlTraceW(QUERY) failed for session '{session_name}': {status:?}");
+    }
+
+    // SAFETY: the query succeeded, so the header is initialised.
+    let handle = unsafe { (*properties).Wnode.Anonymous1.HistoricalContext };
+    if handle == 0 {
+        bail!("session '{session_name}' reported no control handle");
+    }
+    Ok(CONTROLTRACE_HANDLE { Value: handle })
+}
+
+/// Build an `EVENT_FILTER_EVENT_ID` payload.
+///
+/// Laid out as `u16`s rather than through the struct so the buffer is aligned
+/// for its `Count` and `Events` members without an unaligned write:
+/// `FilterIn`/`Reserved`, `Count`, then the IDs.
+fn event_id_filter(event_ids: &[u16]) -> Vec<u16> {
+    let mut buffer = vec![0u16; 2 + event_ids.len().max(1)];
+    buffer[0] = 1; // FilterIn = TRUE, Reserved = 0
+    buffer[1] = event_ids.len() as u16;
+    buffer[2..2 + event_ids.len()].copy_from_slice(event_ids);
+    buffer
+}
+
+/// Render captured value data the way Sysmon Event ID 13 renders `Details`.
+///
+/// Rules are written against Sysmon's spelling — `DWORD (0x00000001)`, and
+/// `Binary Data` for anything that is not a string or an integer — so matching
+/// it is what makes the 180 `Details` rules mean what they say.
+///
+/// Returns `None` when there is nothing to render, which is the caller's signal
+/// to fall back to the value name.
+pub(super) fn format_value_data(value_type: u32, data: &[u8]) -> Option<String> {
+    if data.is_empty() {
+        return None;
+    }
+    let rendered = match value_type {
+        REG_SZ | REG_EXPAND_SZ | REG_LINK => decode_utf16(data),
+        REG_MULTI_SZ => decode_utf16(data)
+            .split('\0')
+            .filter(|entry| !entry.is_empty())
+            .collect::<Vec<_>>()
+            .join("\n"),
+        REG_DWORD => format!("DWORD (0x{:08X})", u32::from_le_bytes(first_bytes(data)?)),
+        REG_DWORD_BIG_ENDIAN => {
+            format!("DWORD (0x{:08X})", u32::from_be_bytes(first_bytes(data)?))
+        }
+        REG_QWORD => format!("QWORD (0x{:016X})", u64::from_le_bytes(first_bytes(data)?)),
+        // REG_NONE, REG_BINARY, and any type this build has never heard of.
+        _ => "Binary Data".to_string(),
+    };
+    Some(rendered)
+}
+
+fn first_bytes<const N: usize>(data: &[u8]) -> Option<[u8; N]> {
+    data.get(..N)?.try_into().ok()
+}
+
+/// Decode the UTF-16 payload of a string value, dropping the terminating NUL.
+///
+/// The embedded NULs of a `REG_MULTI_SZ` are kept for the caller to split on;
+/// only the trailing ones go.
+fn decode_utf16(data: &[u8]) -> String {
+    let units: Vec<u16> = data
+        .chunks_exact(2)
+        .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
+        .collect();
+    String::from_utf16_lossy(&units)
+        .trim_end_matches('\0')
+        .to_string()
+}
+
+/// Formatting is pure and the interesting cases are the value types, so it is
+/// tested here; the [`request_value_data`] side needs a live session and is
+/// covered by the `Details` assertion in [`super::etw`]'s test module only in
+/// so far as its fallback is.
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const REG_NONE: u32 = 0;
+    const REG_BINARY: u32 = 3;
+
+    fn utf16(text: &str) -> Vec<u8> {
+        text.encode_utf16()
+            .chain(std::iter::once(0))
+            .flat_map(|unit| unit.to_le_bytes())
+            .collect()
+    }
+
+    #[test]
+    fn string_data_is_the_value_not_the_name() {
+        assert_eq!(
+            format_value_data(REG_SZ, &utf16("powershell -enc SQBFAFgA")).as_deref(),
+            Some("powershell -enc SQBFAFgA"),
+            "a `Details|contains: 'powershell'` rule has to see the payload"
+        );
+    }
+
+    #[test]
+    fn expand_sz_drops_only_the_terminator() {
+        assert_eq!(
+            format_value_data(REG_EXPAND_SZ, &utf16("%SystemRoot%\\system32\\evil.exe")).as_deref(),
+            Some("%SystemRoot%\\system32\\evil.exe")
+        );
+    }
+
+    #[test]
+    fn integers_use_the_sysmon_spelling() {
+        // Rules match this string literally, e.g. `Details: 'DWORD (0x00000001)'`.
+        assert_eq!(
+            format_value_data(REG_DWORD, &1u32.to_le_bytes()).as_deref(),
+            Some("DWORD (0x00000001)")
+        );
+        assert_eq!(
+            format_value_data(REG_DWORD_BIG_ENDIAN, &1u32.to_be_bytes()).as_deref(),
+            Some("DWORD (0x00000001)")
+        );
+        assert_eq!(
+            format_value_data(REG_QWORD, &255u64.to_le_bytes()).as_deref(),
+            Some("QWORD (0x00000000000000FF)")
+        );
+    }
+
+    #[test]
+    fn multi_sz_entries_are_separated() {
+        let mut data = utf16("first");
+        data.extend(utf16("second"));
+        data.extend([0, 0]);
+        assert_eq!(
+            format_value_data(REG_MULTI_SZ, &data).as_deref(),
+            Some("first\nsecond")
+        );
+    }
+
+    #[test]
+    fn binary_matches_sysmon_rather_than_dumping_hex() {
+        assert_eq!(
+            format_value_data(REG_BINARY, &[0xDE, 0xAD, 0xBE, 0xEF]).as_deref(),
+            Some("Binary Data")
+        );
+        assert_eq!(
+            format_value_data(REG_NONE, &[0x00]).as_deref(),
+            Some("Binary Data")
+        );
+        assert_eq!(
+            format_value_data(0xFFFF, &[0x00]).as_deref(),
+            Some("Binary Data"),
+            "an unknown type must still not be reported as a string"
+        );
+    }
+
+    #[test]
+    fn empty_capture_asks_the_caller_to_fall_back() {
+        // The build may not populate `CapturedData` at all; that path has to
+        // keep the pre-#292 value-name behaviour rather than emit nothing.
+        assert_eq!(format_value_data(REG_SZ, &[]), None);
+        assert_eq!(format_value_data(REG_DWORD, &[]), None);
+    }
+
+    #[test]
+    fn truncated_integer_data_is_not_rendered_as_a_number() {
+        assert_eq!(format_value_data(REG_DWORD, &[0x01, 0x00]), None);
+        assert_eq!(
+            format_value_data(REG_QWORD, &[0x01, 0x00, 0x00, 0x00]),
+            None
+        );
+    }
+
+    #[test]
+    fn event_id_filter_has_the_documented_layout() {
+        let filter = event_id_filter(&[1, 2, 5]);
+        assert_eq!(filter, vec![1, 3, 1, 2, 5]);
+        assert_eq!(
+            std::mem::size_of_val(filter.as_slice()),
+            size_of::<u16>() * 5
+        );
+    }
+}


### PR DESCRIPTION
## Summary

`Details` carried the registry value **name**. Sysmon Event ID 13 — and the 180 SigmaHQ rules that reference the field — define it as the value **data**, so those rules matched the wrong string rather than nothing at all. Closes #292.

`Microsoft-Windows-Kernel-Registry` declares `CapturedData` on `SetValueKey` but delivers it empty unless the session asks for it. The request is an `EnableTraceEx2` filter descriptor whose four payload bytes have bit `0x2` set. `ferrisetw` cannot express it, so `src/sensor/windows/registry_value_data.rs` looks the session handle up by name (`ControlTraceW(QUERY)`) and re-enables the provider by hand once the trace is up, passing its level, keywords and event-ID scope again in full.

The data is rendered the way Sysmon renders it, because that is what the rules are written against: the string for `REG_SZ`/`REG_EXPAND_SZ`, `DWORD (0x00000001)` for integers, `Binary Data` for everything else. `TargetObject` keeps the value name appended, unchanged.

**Fallback.** The mechanism is undocumented, so nothing assumes it works: a failed re-enable is logged as a warning and tolerated, and whenever `CapturedData` comes back empty `Details` falls back to the value name — the pre-#292 behaviour.

### Measured on Windows 11 26200

Enabling the provider once per candidate payload and writing a known value under each:

| filter payload | `CapturedDataSize` |
| --- | --- |
| absent | 0 |
| `0x0` | 0 |
| `0x1` | 0 |
| `0x2` | full value data |
| `0x3` | full value data |
| `0x4` | 0 |

The descriptor `Type` is not validated — `0x1` and `0x2` behave the same as `EVENT_FILTER_TYPE_NONE`, and only `EVENT_FILTER_TYPE_SCHEMATIZED` is rejected with `ERROR_INVALID_PARAMETER` — which is what makes this a payload flag rather than a filter. An 802-byte `REG_SZ` came back whole, so the provider does not truncate at any small bound. The capture request and the event-ID scope filter coexist on the same enable call.

## Type of change
- [x] `bug` - bug fix

## Test plan
- [x] Tested on Windows (lab box, Windows 11 26200)
- [x] Existing tests pass (`cargo test` — 324 lib tests + integration suites, `cargo clippy --all-targets -- -D clippy::all` clean)
- [x] New tests added

End to end with `rustinel capture` on this build:

```
{"category":"Registry","event_id":13,"fields":{"TargetObject":"...\\RustinelProbe\\Verify292","Details":"powershell -enc RUSTINEL292PAYLOAD","Image":"C:\\Windows\\System32\\reg.exe"}}
{"category":"Registry","event_id":13,"fields":{"TargetObject":"...\\RustinelProbe\\Verify292Dw","Details":"DWORD (0x00000001)","Image":"C:\\Windows\\System32\\reg.exe"}}
{"category":"Registry","event_id":13,"fields":{"TargetObject":"...\\RustinelProbe\\Verify292Bin","Details":"Binary Data","Image":"C:\\Windows\\System32\\reg.exe"}}
```

487 of 490 `SetValueKey` events in that recording carried data; the three that did not were writes with no value name at all, which is also the only case where the fallback has nothing to fall back to.

Unit tests cover the rendering of each `REG_*` type, the empty-capture fallback signal, truncated integer data, and the `EVENT_FILTER_EVENT_ID` layout; a drift guard asserts `Details` maps to `CapturedData`.

## Checklist
- [x] Label added to this PR
- [x] Docs updated — `docs/limitations.md` no longer lists this as a silent risk, and now documents the undocumented request, its fallback, and `Binary Data`