### PR TITLE
perf(windows-etw): size the ETW session buffers explicitly

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -67,6 +67,13 @@ are unavailable.
   rule selecting on `EventID` never matches instead of matching the wrong event.
   Rules keyed on `Operation`, `Query`, `EventNamespace`, `Image` or `User` still
   work.
+- **Extreme process bursts can still be lost in the kernel (silent risk).** The
+  ETW session runs on an explicitly sized buffer pool (256 KB x 64-128, 32 MB
+  ceiling), which absorbs a 4,000-process fork tree with no loss where the
+  library defaults lost 12-60% of process starts. A host that churns processes
+  faster than the lab workload can still overrun that pool, and nothing counts
+  the overrun: a recorded event count is an upper bound, not a total. See
+  [Windows ETW Session Buffers](operations.md#windows-etw-session-buffers).
 - **No injection or driver-load visibility.** No equivalent of CreateRemoteThread,
   ProcessAccess, named-pipe, or driver-load providers - injection-based TTPs leave
   little telemetry.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -323,6 +323,61 @@ for an agent run and reset when it restarts. See
 [Pipeline Telemetry](configuration.md#pipeline-telemetry) and
 [Dropped Events And Full Queues](troubleshooting.md#dropped-events-and-full-queues).
 
+### Windows ETW Session Buffers
+
+Those counters see only Rustinel's own queues. On Windows there is a second,
+earlier place events can be lost: the kernel's buffer pool for the
+`rustinel-etw-trace` session. If the pool fills before the sensor drains it,
+the kernel discards events and the sensor never sees them at all.
+
+Rustinel sets the pool explicitly rather than taking the library defaults:
+
+| Setting | Value | Default it replaces |
+| --- | --- | --- |
+| Buffer size | 256 KB | 32 KB |
+| Minimum buffers | 64 (16 MB committed at start) | kernel-chosen, 2 |
+| Maximum buffers | 128 (32 MB ceiling) | kernel-chosen, 24 (768 KB) |
+| Flush timer | 1 s | 1 s |
+
+The buffers are non-paged pool: 16 MB is committed for the life of the agent
+and the pool grows to at most 32 MB under load. Read the live values back with:
+
+```powershell
+Get-EtwTraceSession -Name rustinel-etw-trace
+```
+
+`logman query -ets` shows the same session, but its output is localized, so
+prefer the cmdlet in scripts.
+
+**What the values were chosen against.** A two-level fork tree on a Windows 11
+lab VM (6 vCPU, 8 GB), 40 parent processes each spawning 100 short-lived
+children. Ground truth is the number of children that actually ran — each one
+creates a uniquely named file — compared against the process-creation events in
+a `rustinel capture` recording of the same run:
+
+| Session sizing | Children ran | Start events delivered | Lost |
+| --- | --- | --- | --- |
+| 32 KB x 2-24 (defaults) | 4,000 | 1,584 | 60.4% |
+| 32 KB x 2-24 (defaults) | 4,000 | 2,178 | 45.6% |
+| 32 KB x 2-24 (defaults) | 3,604 | 1,652 | 54.2% |
+| 32 KB x 2-24 (defaults) | 4,000 | 3,514 | 12.2% |
+| 32 KB x 2-24 (defaults), 50 x 100 | 5,000 | 4,159 | 16.8% |
+| 256 KB x 64-128 | 4,000 | 4,000 | 0% |
+| 256 KB x 64-128 | 4,000 | 4,000 | 0% |
+| 256 KB x 64-128 | 4,000 | 4,000 | 0% |
+| 256 KB x 64-128, 50 x 100 | 5,000 | 5,000 | 0% |
+
+The spread in the default rows is the point as much as the magnitude: identical
+runs lost between 12% and 60% depending on how tightly the burst landed, so a
+single favourable measurement on default sizing proves nothing. A heavier tree
+(60 x 150) exhausted the lab VM's memory before it exhausted the buffer pool,
+so it bounds the *host*, not the sizing.
+
+This is a fixed configuration, not an adaptive one. A host that sustains far
+more process churn than the lab VM can still overrun a 32 MB pool; kernel-side
+loss of that kind is not yet counted anywhere, so treat a recorded event count
+as an upper bound on what happened.
+
 ## Safe Upgrade Checklist
 
 1. Back up `config.toml` and your custom `rules/`.

--- a/src/sensor/windows/etw.rs
+++ b/src/sensor/windows/etw.rs
@@ -8,7 +8,7 @@ use anyhow::Result;
 use ferrisetw::parser::Parser;
 use ferrisetw::provider::{EventFilter, Provider};
 use ferrisetw::schema_locator::SchemaLocator;
-use ferrisetw::trace::{stop_trace_by_name, TraceTrait, UserTrace};
+use ferrisetw::trace::{stop_trace_by_name, TraceProperties, TraceTrait, UserTrace};
 use ferrisetw::{EventRecord, GUID};
 use tokio::sync::mpsc::{error::TrySendError, Sender};
 use tracing::{info, trace, warn};
@@ -32,6 +32,65 @@ use super::{field_maps, mapper};
 /// Fixed trace session name for stopping the trace on shutdown.
 pub(super) const TRACE_SESSION_NAME: &str = "rustinel-etw-trace";
 const WINDOWS_EPOCH_DELTA_100NS: i64 = 116444736000000000;
+
+/// Size of one ETW session buffer, in KB.
+///
+/// `ferrisetw` defaults to 32 KB with the buffer counts left at 0, which lets
+/// the kernel pick them — in practice 2 to 24 buffers, a 768 KB ceiling. That
+/// ceiling cannot absorb a burst. On a Windows 11 lab VM (6 vCPU, 8 GB), a
+/// 4,000-process fork tree lost 12-60% of process starts on the defaults across
+/// four runs, and none at all on the values here; the workload and the full
+/// table are in `docs/operations.md`.
+///
+/// The loss is kernel-side, so no per-field fix reaches it — it degrades
+/// `CommandLine`, `ParentImage` and every other process field at once, and a
+/// lost *parent* start costs `ParentImage` on all of that process's children.
+/// Larger buffers are what helps: the cost of a burst is buffer *turnover*, and
+/// 256 KB holds eight times the events per flush. See [`SESSION_MIN_BUFFERS`]
+/// for the memory this commits.
+const SESSION_BUFFER_SIZE_KB: u32 = 256;
+
+/// Buffers committed when the session starts.
+///
+/// ETW session buffers are non-paged pool, allocated up front for the minimum
+/// and grown on demand to [`SESSION_MAX_BUFFERS`]. 64 x 256 KB is 16 MB
+/// resident — deliberately paid at startup rather than during the burst,
+/// because growing the pool is exactly the work that is too slow when a fork
+/// tree is already filling buffers.
+const SESSION_MIN_BUFFERS: u32 = 64;
+
+/// Upper bound on the buffer pool: 128 x 256 KB = 32 MB.
+///
+/// 42x the default ceiling. This is a fixed configuration on purpose — adaptive
+/// sizing is not warranted until a single configuration is shown not to cover
+/// realistic hosts.
+const SESSION_MAX_BUFFERS: u32 = 128;
+
+/// How often partially filled buffers are flushed to the consumer.
+///
+/// One second is the ETW minimum. It bounds the delay on a *quiet* host, where
+/// buffers would otherwise sit unfilled; under load buffers flush as soon as
+/// they fill, so this does not affect burst behaviour either way.
+const SESSION_FLUSH_TIMER: Duration = Duration::from_secs(1);
+
+/// Buffer configuration for the real-time session.
+///
+/// Everything else is inherited from `ferrisetw`'s defaults, in particular the
+/// logging mode: `EVENT_TRACE_NO_PER_PROCESSOR_BUFFERING` is kept on purpose.
+/// Per-processor buffering would raise raw throughput, but it delivers events
+/// per CPU rather than in timestamp order, and both [`FilePathCache`] and
+/// [`RegistryPathCache`] resolve a path by pairing a naming event with a later
+/// event on the same object — reordering those silently mis-attributes paths.
+/// A wider buffer pool buys the same headroom without touching ordering.
+fn session_properties() -> TraceProperties {
+    TraceProperties {
+        buffer_size: SESSION_BUFFER_SIZE_KB,
+        min_buffer: SESSION_MIN_BUFFERS,
+        max_buffer: SESSION_MAX_BUFFERS,
+        flush_timer: SESSION_FLUSH_TIMER,
+        ..TraceProperties::default()
+    }
+}
 
 /// ETW provider metadata.
 #[derive(Debug, Clone)]
@@ -619,7 +678,19 @@ impl Sensor for EtwSensor {
 
         let _ = stop_trace_by_name(TRACE_SESSION_NAME);
 
-        let mut trace_builder = UserTrace::new().named(TRACE_SESSION_NAME.to_string());
+        let properties = session_properties();
+        info!(
+            "ETW session buffers: {} KB x {}-{} ({} MB ceiling), flush {}s",
+            properties.buffer_size,
+            properties.min_buffer,
+            properties.max_buffer,
+            (properties.buffer_size as u64 * properties.max_buffer as u64) / 1024,
+            properties.flush_timer.as_secs(),
+        );
+
+        let mut trace_builder = UserTrace::new()
+            .named(TRACE_SESSION_NAME.to_string())
+            .set_trace_properties(properties);
         let state = Arc::new(EtwState::new());
 
         for provider_def in EtwProviders::all() {
@@ -1442,6 +1513,44 @@ fn parse_optional_u32(value: Option<&str>) -> Option<u32> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn session_properties_are_set_explicitly() {
+        // The bug this guards is silent: leaving the properties at their
+        // defaults cost 12-60% of process starts under a fork tree, with no
+        // error and no counter (#306). Assert the session is not running on
+        // `ferrisetw`'s defaults, and that the pool it asks for is large
+        // enough to matter.
+        let props = session_properties();
+        let defaults = TraceProperties::default();
+
+        assert!(
+            props.buffer_size > defaults.buffer_size,
+            "buffer size must be raised above the {} KB default",
+            defaults.buffer_size
+        );
+        assert!(
+            props.min_buffer > 0 && props.max_buffer >= props.min_buffer,
+            "buffer counts must be explicit and ordered, got {}-{}",
+            props.min_buffer,
+            props.max_buffer
+        );
+
+        // The default ceiling is 24 x 32 KB; anything close to it is not a fix.
+        let ceiling_kb = props.buffer_size as u64 * props.max_buffer as u64;
+        assert!(
+            ceiling_kb >= 16 * 1024,
+            "buffer pool ceiling is only {ceiling_kb} KB"
+        );
+
+        // Below one second ETW clamps silently, so the value would not be the
+        // configured one.
+        assert!(props.flush_timer >= Duration::from_secs(1));
+
+        // Ordering is load-bearing for the path caches; inheriting the default
+        // logging mode is what keeps it. See `session_properties`.
+        assert_eq!(props.log_file_mode, defaults.log_file_mode);
+    }
 
     #[test]
     fn filter_matches_routing_allowlist() {


### PR DESCRIPTION
Closes #306.

## What

The ETW session was built as a bare `UserTrace::new().named(...)`, inheriting `ferrisetw`'s defaults — 32 KB buffers, kernel-chosen counts (2–24), a 768 KB ceiling. It now sets buffer size, minimum and maximum buffer count, and the flush timer explicitly:

| Setting | Value | Default it replaces |
| --- | --- | --- |
| Buffer size | 256 KB | 32 KB |
| Minimum buffers | 64 (16 MB committed at start) | 2 |
| Maximum buffers | 128 (32 MB ceiling) | 24 (768 KB) |
| Flush timer | 1 s | 1 s |

The logging mode is deliberately left at the default, keeping `EVENT_TRACE_NO_PER_PROCESSOR_BUFFERING`. Per-processor buffering would raise raw throughput, but it delivers events per CPU rather than in timestamp order, and both `FilePathCache` and `RegistryPathCache` resolve a path by pairing a naming event with a later event on the same object — reordering those would silently mis-attribute paths. A wider pool buys the headroom without touching ordering.

## Measurement

Windows 11 lab VM, 6 vCPU / 8 GB. Workload is a two-level fork tree: N parent processes each spawning 100 short-lived children. Ground truth is the number of children that **actually ran** — each one creates a uniquely named file — compared against process-creation events in a `rustinel capture` recording of the same run. Both binaries are release builds of this branch and of its merge base, run alternately on the same idle box.

| Session sizing | Workload | Children ran | Start events delivered | Lost |
| --- | --- | --- | --- | --- |
| 32 KB x 2-24 (defaults) | 40 x 100 | 4,000 | 1,584 | 60.4% |
| 32 KB x 2-24 (defaults) | 40 x 100 | 4,000 | 2,178 | 45.6% |
| 32 KB x 2-24 (defaults) | 40 x 100 | 3,604 | 1,652 | 54.2% |
| 32 KB x 2-24 (defaults) | 40 x 100 | 4,000 | 3,514 | 12.2% |
| 32 KB x 2-24 (defaults) | 50 x 100 | 5,000 | 4,159 | 16.8% |
| **256 KB x 64-128** | 40 x 100 | 4,000 | 4,000 | **0%** |
| **256 KB x 64-128** | 40 x 100 | 4,000 | 4,000 | **0%** |
| **256 KB x 64-128** | 40 x 100 | 4,000 | 4,000 | **0%** |
| **256 KB x 64-128** | 50 x 100 | 5,000 | 5,000 | **0%** |

The spread in the default rows matters as much as the magnitude: identical runs lost between 12% and 60% depending on how tightly the burst landed, which is why a single favourable measurement on default sizing proves nothing.

Sizing is read back live from `Get-EtwTraceSession -Name rustinel-etw-trace` in every run, so the table reflects what the kernel actually granted, not what was requested.

## Scope and caveats

- A heavier tree (60 x 150) exhausted the lab VM's memory — the agent itself hit an allocation failure — before it exhausted the buffer pool. That run bounds the *host*, not the sizing, and is excluded.
- This is a fixed configuration, not adaptive sizing, per the issue.
- Kernel-side loss is still not *counted* anywhere; that is #305, and this change makes its effect measurable rather than replacing it. `docs/limitations.md` says so explicitly.

## Verification

Everything below ran on the Windows lab box (this code cannot compile on macOS):

- `cargo build --release` — clean
- `cargo clippy --all-targets -- -D clippy::all` — clean
- `cargo test --lib sensor::windows::etw` — 16 passed, including the new `session_properties_are_set_explicitly`

## Acceptance criteria

- [x] Session buffer parameters are set explicitly.
- [x] A fork-tree workload shows materially reduced loss (12–60% → 0%).
- [x] The chosen values are documented with the workload they were tested against ([`docs/operations.md`](docs/operations.md), "Windows ETW Session Buffers").