### PR TITLE
perf(windows-etw): cut quiet-host alert latency

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -109,6 +109,13 @@ directory = "captures"      # default parent for rustinel-capture-<UTC timestamp
 enabled = true
 snapshot_interval_secs = 30 # a snapshot is also written at shutdown
 
+# 6c. Windows ETW Delivery
+#   ETW's native flush timer has a one-second minimum. Rustinel requests an
+#   earlier handoff for partially filled buffers so isolated events reach the
+#   detector promptly. Set to 0 to use only ETW's native timer.
+[windows]
+etw_flush_interval_ms = 100
+
 # 7. Atomic IOC Detection (Hashes, IPs, Domains, Path Regex)
 [ioc]
 enabled = true

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -93,6 +93,9 @@ directory = "captures"
 enabled = true
 snapshot_interval_secs = 30
 
+[windows]
+etw_flush_interval_ms = 100
+
 [response]
 enabled = false
 prevention_enabled = false
@@ -293,6 +296,21 @@ nothing was dropped and warns with per-channel totals when something was;
 `--json` carries the raw numbers under `telemetry`. Setting `enabled = false`
 leaves drop totals visible only in the operational log, and `doctor` reports
 that reduced visibility as a warning.
+
+### Windows ETW delivery
+
+ETW's real-time session timer hands partially filled buffers to consumers once
+per second. Rustinel requests an earlier handoff without changing the session's
+buffer size or pool limits.
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `etw_flush_interval_ms` | `100` | Partial-buffer handoff interval in milliseconds; `0` disables it |
+
+Values below 20 ms are clamped to 20 ms. Rustinel pauses requests while the
+`sensor_events` queue is at least half full, when downstream queueing controls
+latency. ETW continues its normal full-buffer and timer-based delivery. Override
+the setting with `EDR__WINDOWS__ETW_FLUSH_INTERVAL_MS`.
 
 ### Active response
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -183,6 +183,12 @@ Rustinel sets the pool explicitly rather than inheriting library defaults:
 | Minimum buffers | 64 (16 MB committed at start) | 2 |
 | Maximum buffers | 128 (32 MB ceiling) | 24 (768 KB) |
 | Flush timer | 1 s | 1 s |
+| Forced partial-buffer handoff | 100 ms | disabled |
+
+The forced handoff controls quiet-host delivery latency without changing the
+buffer pool. Configure it with `windows.etw_flush_interval_ms`; `0` disables it.
+Rustinel pauses requests while its sensor queue is at least half full, when
+queueing controls latency instead.
 
 The buffers are non-paged pool: 16 MB is committed for the life of the agent and
 grows to at most 32 MB under load. Read the live values back with:

--- a/scripts/bench/windows.ps1
+++ b/scripts/bench/windows.ps1
@@ -323,7 +323,7 @@ function Measure-AlertLatency {
 
     $before = Get-AlertLineCount -RuleName $AlertRuleName
     $sw = [System.Diagnostics.Stopwatch]::StartNew()
-    & whoami | Out-Null
+    & whoami /all | Out-Null
     while ($sw.Elapsed.TotalSeconds -lt 15) {
         Start-Sleep -Milliseconds 100
         $after = Get-AlertLineCount -RuleName $AlertRuleName

--- a/src/config.rs
+++ b/src/config.rs
@@ -300,6 +300,7 @@ pub struct AppConfig {
     pub dedup: DedupConfig,
     pub capture: CaptureConfig,
     pub telemetry: TelemetryConfig,
+    pub windows: WindowsConfig,
 }
 
 /// Scanner configuration (Sigma and YARA rules)
@@ -447,6 +448,15 @@ pub struct TelemetryConfig {
     pub snapshot_interval_secs: u64,
 }
 
+/// Windows telemetry configuration. It is present on every platform so one
+/// managed configuration can be distributed to a mixed fleet.
+#[derive(Debug, Clone, Deserialize)]
+pub struct WindowsConfig {
+    /// Periodically hand partially filled ETW buffers to the consumer. Zero
+    /// disables forced flushing and restores ETW's one-second timer.
+    pub etw_flush_interval_ms: u64,
+}
+
 impl AppConfig {
     /// Load configuration from defaults, config.toml, and environment variables
     pub fn new() -> Result<Self, config::ConfigError> {
@@ -555,7 +565,9 @@ impl AppConfig {
             .set_default("capture.directory", "captures")?
             // Telemetry
             .set_default("telemetry.enabled", true)?
-            .set_default("telemetry.snapshot_interval_secs", 30i64)?;
+            .set_default("telemetry.snapshot_interval_secs", 30i64)?
+            // Windows ETW delivery latency
+            .set_default("windows.etw_flush_interval_ms", 100i64)?;
 
         let builder = match selected_config {
             Some(path) => builder.add_source(config::File::from(path).required(true)),
@@ -811,6 +823,9 @@ impl Default for AppConfig {
             telemetry: TelemetryConfig {
                 enabled: true,
                 snapshot_interval_secs: 30,
+            },
+            windows: WindowsConfig {
+                etw_flush_interval_ms: 100,
             },
         };
 
@@ -1149,6 +1164,12 @@ paths_regex_path = "explicit-ioc/paths_regex.txt"
         assert!(cfg.dedup.enabled);
         assert_eq!(cfg.dedup.window_secs, 60);
         assert_eq!(cfg.dedup.max_entries, 10_000);
+    }
+
+    #[test]
+    fn test_windows_etw_flush_default() {
+        let cfg = AppConfig::default();
+        assert_eq!(cfg.windows.etw_flush_interval_ms, 100);
     }
 
     #[test]

--- a/src/runtime/capture.rs
+++ b/src/runtime/capture.rs
@@ -77,6 +77,11 @@ impl CaptureContext {
         })
     }
 
+    #[cfg_attr(not(windows), allow(dead_code))]
+    pub(crate) fn config(&self) -> &AppConfig {
+        &self.config
+    }
+
     /// Open the recording and build the record-only event pipeline.
     pub(crate) fn start_recording(
         self,

--- a/src/runtime/windows.rs
+++ b/src/runtime/windows.rs
@@ -212,6 +212,7 @@ pub fn run_capture(options: CaptureOptions) -> anyhow::Result<()> {
     runtime.block_on(async move {
         let context = CaptureContext::load(&options, "Windows ETW")?;
         ensure_administrator_privileges()?;
+        let flush_interval_ms = context.config().windows.etw_flush_interval_ms;
         let session = context.start_recording(&options, Platform::Windows)?;
 
         // Cold start: seed the process cache so early events resolve parents.
@@ -227,7 +228,7 @@ pub fn run_capture(options: CaptureOptions) -> anyhow::Result<()> {
         }
 
         let (sensor_tx, sensor_worker) = session.sensor_channel();
-        let sensor = Arc::new(EtwSensor::new());
+        let sensor = Arc::new(EtwSensor::with_flush_interval(flush_interval_ms));
         let sensor_for_trace = Arc::clone(&sensor);
         let mut trace_handle =
             tokio::task::spawn_blocking(move || sensor_for_trace.start(sensor_tx));
@@ -364,7 +365,9 @@ async fn run_edr(
         info!("Process snapshot not available on non-Windows platforms");
     }
 
-    let sensor = Arc::new(EtwSensor::new());
+    let sensor = Arc::new(EtwSensor::with_flush_interval(
+        cfg.windows.etw_flush_interval_ms,
+    ));
 
     // Initialize Sigma engine
     let engine_kind =

--- a/src/sensor/windows/etw.rs
+++ b/src/sensor/windows/etw.rs
@@ -649,12 +649,18 @@ struct DecodedEtwEvent {
 /// Windows ETW sensor implementation.
 pub struct EtwSensor {
     shutdown: Arc<AtomicBool>,
+    flush_interval_ms: u64,
 }
 
 impl EtwSensor {
     pub fn new() -> Self {
+        Self::with_flush_interval(super::flush::DEFAULT_INTERVAL_MS)
+    }
+
+    pub fn with_flush_interval(flush_interval_ms: u64) -> Self {
         Self {
             shutdown: Arc::new(AtomicBool::new(false)),
+            flush_interval_ms,
         }
     }
 
@@ -776,7 +782,17 @@ impl Sensor for EtwSensor {
 
                 request_registry_value_data();
 
-                match trace.process() {
+                // Decouples delivery latency from the session `FlushTimer`,
+                // whose floor is one second. It pauses when downstream
+                // queueing, rather than ETW buffering, controls latency.
+                let flusher = super::flush::spawn(
+                    TRACE_SESSION_NAME,
+                    self.flush_interval_ms,
+                    Arc::clone(&self.shutdown),
+                    tx.clone(),
+                );
+
+                let processed = match trace.process() {
                     Ok(()) => {
                         info!("ETW sensor stopped");
                         Ok(())
@@ -794,7 +810,15 @@ impl Sensor for EtwSensor {
                             Err(anyhow::anyhow!("ETW trace processing failed: {:?}", err))
                         }
                     }
+                };
+
+                // The thread parks on the shutdown flag, which `process()`
+                // returning means is either already set or about to be.
+                self.shutdown.store(true, Ordering::Relaxed);
+                if let Some(flusher) = flusher {
+                    let _ = flusher.join();
                 }
+                processed
             }
             Err(err) => Err(anyhow::anyhow!("Failed to start ETW trace: {:?}", err)),
         };

--- a/src/sensor/windows/flush.rs
+++ b/src/sensor/windows/flush.rs
@@ -1,0 +1,170 @@
+//! Periodic handoff of partially filled ETW buffers.
+//!
+//! ETW flushes a real-time session when a buffer fills or the session's
+//! one-second `FlushTimer` expires. A lone event can therefore wait almost one
+//! second before the consumer sees it. `ControlTraceW(EVENT_TRACE_CONTROL_FLUSH)`
+//! requests the same handoff without changing the session buffer sizing.
+//!
+//! Forced flushing pauses while Rustinel's sensor queue is at least half full.
+//! At that point buffers already fill quickly and downstream queueing, rather
+//! than ETW's timer, controls alert latency.
+
+use std::mem::size_of;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+use tokio::sync::mpsc::Sender;
+use tracing::{info, warn};
+use windows::core::PCWSTR;
+use windows::Win32::System::Diagnostics::Etw::{
+    ControlTraceW, CONTROLTRACE_HANDLE, EVENT_TRACE_CONTROL_FLUSH, EVENT_TRACE_PROPERTIES,
+};
+
+use super::registry_value_data::session_handle;
+use crate::sensor::SensorEvent;
+
+pub(super) const DEFAULT_INTERVAL_MS: u64 = 100;
+const MIN_INTERVAL: Duration = Duration::from_millis(20);
+const MAX_QUEUE_PERCENT_FOR_FLUSH: usize = 50;
+const TRACE_NAME_BYTES: usize = 2 * 1024;
+
+/// An explicitly aligned header followed by the name storage `ControlTraceW`
+/// expects. The header gives the allocation the API's required alignment.
+#[repr(C)]
+struct PropertiesBuffer {
+    properties: EVENT_TRACE_PROPERTIES,
+    names: [u8; 2 * TRACE_NAME_BYTES],
+}
+
+impl PropertiesBuffer {
+    fn new() -> Box<Self> {
+        Box::new(Self {
+            properties: EVENT_TRACE_PROPERTIES::default(),
+            names: [0; 2 * TRACE_NAME_BYTES],
+        })
+    }
+}
+
+fn configured_interval(interval_ms: u64) -> Option<Duration> {
+    if interval_ms == 0 {
+        return None;
+    }
+    Some(Duration::from_millis(interval_ms).max(MIN_INTERVAL))
+}
+
+pub(super) fn spawn(
+    session_name: &str,
+    interval_ms: u64,
+    shutdown: Arc<AtomicBool>,
+    sensor_tx: Sender<SensorEvent>,
+) -> Option<JoinHandle<()>> {
+    let interval = configured_interval(interval_ms)?;
+
+    let handle = match session_handle(session_name) {
+        Ok(handle) => handle,
+        Err(err) => {
+            warn!(
+                "Forced ETW flush disabled: could not resolve control handle for '{session_name}': {err:#}"
+            );
+            return None;
+        }
+    };
+
+    info!(
+        "Forced ETW flush enabled: every {} ms while the sensor queue is below {}% (session '{}')",
+        interval.as_millis(),
+        MAX_QUEUE_PERCENT_FOR_FLUSH,
+        session_name
+    );
+
+    let name = session_name.to_string();
+    thread::Builder::new()
+        .name("etw-flush".into())
+        .spawn(move || run(handle, interval, shutdown, sensor_tx, &name))
+        .map_err(|err| warn!("Failed to spawn ETW flush thread: {err}"))
+        .ok()
+}
+
+fn queue_is_backed_up<T>(sensor_tx: &Sender<T>) -> bool {
+    let capacity = sensor_tx.max_capacity();
+    let depth = capacity.saturating_sub(sensor_tx.capacity());
+    depth.saturating_mul(100) >= capacity.saturating_mul(MAX_QUEUE_PERCENT_FOR_FLUSH)
+}
+
+fn run(
+    handle: CONTROLTRACE_HANDLE,
+    interval: Duration,
+    shutdown: Arc<AtomicBool>,
+    sensor_tx: Sender<SensorEvent>,
+    name: &str,
+) {
+    let mut warned = false;
+
+    while !shutdown.load(Ordering::Relaxed) {
+        thread::sleep(interval);
+        if shutdown.load(Ordering::Relaxed) {
+            break;
+        }
+        if queue_is_backed_up(&sensor_tx) {
+            continue;
+        }
+
+        let mut buffer = PropertiesBuffer::new();
+        let properties = &mut buffer.properties as *mut EVENT_TRACE_PROPERTIES;
+        let total = size_of::<EVENT_TRACE_PROPERTIES>() + 2 * TRACE_NAME_BYTES;
+
+        // SAFETY: `properties` points to the aligned header in `buffer`, the
+        // allocation is at least `total` bytes, and both name offsets point
+        // into its trailing storage. The API may write throughout that block.
+        let status = unsafe {
+            (*properties).Wnode.BufferSize = total as u32;
+            (*properties).LoggerNameOffset = size_of::<EVENT_TRACE_PROPERTIES>() as u32;
+            (*properties).LogFileNameOffset =
+                (size_of::<EVENT_TRACE_PROPERTIES>() + TRACE_NAME_BYTES) as u32;
+            ControlTraceW(
+                handle,
+                PCWSTR::null(),
+                properties,
+                EVENT_TRACE_CONTROL_FLUSH,
+            )
+        };
+
+        if status.is_err() && !warned {
+            warned = true;
+            warn!("Forced ETW flush failed for session '{name}': {status:?}; buffers still flush on the session timer");
+        }
+    }
+
+    info!("ETW flush thread stopped");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zero_disables_forced_flushing() {
+        assert!(configured_interval(0).is_none());
+    }
+
+    #[test]
+    fn interval_is_clamped_to_twenty_milliseconds() {
+        assert_eq!(configured_interval(1), Some(MIN_INTERVAL));
+        assert_eq!(
+            configured_interval(DEFAULT_INTERVAL_MS),
+            Some(Duration::from_millis(DEFAULT_INTERVAL_MS))
+        );
+    }
+
+    #[test]
+    fn queue_guard_activates_at_half_capacity() {
+        let (tx, _rx) = tokio::sync::mpsc::channel(4);
+        assert!(!queue_is_backed_up(&tx));
+        tx.try_send(()).expect("first event fits");
+        assert!(!queue_is_backed_up(&tx));
+        tx.try_send(()).expect("second event fits");
+        assert!(queue_is_backed_up(&tx));
+    }
+}

--- a/src/sensor/windows/mod.rs
+++ b/src/sensor/windows/mod.rs
@@ -2,6 +2,7 @@ pub mod etw;
 mod event_log;
 mod field_maps;
 mod file_paths;
+mod flush;
 pub mod mapper;
 mod registry_paths;
 mod registry_value_data;

--- a/src/sensor/windows/registry_value_data.rs
+++ b/src/sensor/windows/registry_value_data.rs
@@ -56,6 +56,22 @@ const EVENT_FILTER_TYPE_NONE: u32 = 0;
 /// bytes. `ControlTraceW` fails with `ERROR_BAD_LENGTH` if either does not fit.
 const TRACE_NAME_BYTES: usize = 2 * 1024;
 
+/// Aligned storage for the variable-length `ControlTraceW` properties block.
+#[repr(C)]
+struct PropertiesBuffer {
+    properties: EVENT_TRACE_PROPERTIES,
+    names: [u8; 2 * TRACE_NAME_BYTES],
+}
+
+impl PropertiesBuffer {
+    fn new() -> Box<Self> {
+        Box::new(Self {
+            properties: EVENT_TRACE_PROPERTIES::default(),
+            names: [0; 2 * TRACE_NAME_BYTES],
+        })
+    }
+}
+
 /// `REG_*` value types, from `winnt.h`. `REG_NONE` (0) and `REG_BINARY` (3)
 /// are deliberately absent: they take the same path as an unrecognised type.
 const REG_SZ: u32 = 1;
@@ -134,19 +150,19 @@ pub(super) fn request_value_data(
 /// handle itself in `Wnode.HistoricalContext`. The session was started through
 /// `ferrisetw`, which keeps its handle private, so this is the only way to
 /// reach it.
-fn session_handle(session_name: &str) -> Result<CONTROLTRACE_HANDLE> {
+pub(super) fn session_handle(session_name: &str) -> Result<CONTROLTRACE_HANDLE> {
     let name: Vec<u16> = session_name
         .encode_utf16()
         .chain(std::iter::once(0))
         .collect();
 
     let total = size_of::<EVENT_TRACE_PROPERTIES>() + 2 * TRACE_NAME_BYTES;
-    let mut buffer = vec![0u8; total];
-    let properties = buffer.as_mut_ptr().cast::<EVENT_TRACE_PROPERTIES>();
+    let mut buffer = PropertiesBuffer::new();
+    let properties = &mut buffer.properties as *mut EVENT_TRACE_PROPERTIES;
 
-    // SAFETY: `buffer` is at least `size_of::<EVENT_TRACE_PROPERTIES>()` bytes
-    // and is allocated with a stricter-than-required alignment by `Vec`, and
-    // both name offsets point inside it.
+    // SAFETY: `properties` points to the aligned header in `buffer`, the
+    // allocation is at least `total` bytes, and both name offsets point into
+    // its trailing storage.
     let status = unsafe {
         (*properties).Wnode.BufferSize = total as u32;
         (*properties).LoggerNameOffset = size_of::<EVENT_TRACE_PROPERTIES>() as u32;


### PR DESCRIPTION
## Summary

- request an ETW partial-buffer handoff every 100 ms by default, configurable with `windows.etw_flush_interval_ms`
- pause forced handoffs when the 8,192-event sensor queue reaches 50%, where downstream queueing controls latency
- keep the existing 256 KB x 64-128 ETW buffer pool unchanged
- use aligned storage for the variable-length `ControlTraceW` properties blocks
- fix the Windows benchmark trigger to run `whoami /all`, matching its generated Sigma rule
- document the setting against the consolidated documentation from current `main`

Set `windows.etw_flush_interval_ms = 0` to restore ETW's native one-second timer. Values from 1 to 19 ms are clamped to 20 ms.

## Windows lab results

Windows 11 VM, 6 vCPU, 8 GB. Latency is measured from immediately before `whoami /all` to Rustinel's timestamped `Detection triggered` record, avoiding the harness's 100 ms alert-file polling granularity.

15 quiet-host runs per setting with 11 Sigma rules:

| Forced handoff | Median | Mean | p95 / max |
| --- | ---: | ---: | ---: |
| disabled | 483 ms | 604 ms | 1,013 ms |
| 250 ms | 125 ms | 124 ms | 238 ms |
| 100 ms | 77 ms | 66 ms | 101 ms |
| 50 ms | 27 ms | 24 ms | 45 ms |
| 20 ms | 10 ms | 11 ms | 22 ms |

With 2,599 Sigma rules after 500 sequential process launches, 100 ms flushing produced a 61 ms median versus 259 ms disabled. The sensor queue high-water mark was 64, so this case was not queue-bound.

A 2,000-file burst raised the queue high-water mark to 4,801/8,192 with zero drops and showed no clear flush benefit, as expected. A deliberately excessive 5,000-file burst saturated the queue and confirmed that forced flushing does not solve downstream backpressure. The 50% guard stops explicit flush requests in that state.

Idle process CPU over 60 seconds remained below 0.4% of one core at every tested interval, with no monotonic increase attributable to flushing.

## Validation

- `cargo test --locked --lib` (309 passed)
- `cargo clippy --locked --all-targets -- -D warnings`
- Windows: `cargo test --locked --no-run`
- Windows: `cargo test --locked sensor::windows::flush::tests` (3 passed)
- Windows: `cargo build --locked --release`
- Windows default-config smoke test: 20-70 ms across five runs
- Windows disabled smoke test: 133-1,001 ms across five runs
