### PR TITLE
chore: prepare release 1.4.0-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3173,7 +3173,7 @@ dependencies = [
 
 [[package]]
 name = "rustinel"
-version = "1.3.0"
+version = "1.4.0-rc.1"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustinel"
-version = "1.3.0"
+version = "1.4.0-rc.1"
 edition = "2021"
 authors = []
 description = "Open-source EDR for Windows, Linux, and macOS with Sigma, YARA, and IOC detection"


### PR DESCRIPTION
## Summary

Bumps the package version from `1.3.0` to `1.4.0-rc.1` in `Cargo.toml` and `Cargo.lock` for the first 1.4.0 release candidate.

## Type of change

- [x] `maintenance` - release housekeeping

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo test --locked`
- [x] `cargo check --locked --features rsigma-engine`

## Checklist

- [x] Label added to this PR
- [x] No behavior or documentation changes required
