### PR TITLE
fix(ci): validate Windows PE stack reserve at correct offset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,8 +126,8 @@ jobs:
             exit 1
           }
           $peOffset = [BitConverter]::ToInt32($bytes, 0x3c)
-          if ($peOffset -lt 0 -or $peOffset + 24 + 56 -gt $bytes.Length) {
-            Write-Error "Binary has an invalid PE header offset"
+          if ($peOffset -lt 0 -or $peOffset + 24 + 80 -gt $bytes.Length) {
+            Write-Error "Binary has an invalid PE header offset or truncated optional header"
             exit 1
           }
           if ($bytes[$peOffset] -ne 0x50 -or $bytes[$peOffset + 1] -ne 0x45 -or $bytes[$peOffset + 2] -ne 0x00 -or $bytes[$peOffset + 3] -ne 0x00) {
@@ -139,8 +139,8 @@ jobs:
             Write-Error "Binary is not a 64-bit PE executable"
             exit 1
           }
-          # PE32+ stores SizeOfStackReserve 48 bytes into the optional header.
-          $stackReserve = [BitConverter]::ToUInt64($bytes, $optionalHeaderOffset + 48)
+          # PE32+ stores SizeOfStackReserve 72 bytes into the optional header.
+          $stackReserve = [BitConverter]::ToUInt64($bytes, $optionalHeaderOffset + 72)
           $expectedStackReserve = [uint64]0x1000000
           Write-Output ("SizeOfStackReserve: 0x{0:X}" -f $stackReserve)
           if ($stackReserve -ne $expectedStackReserve) {


### PR DESCRIPTION
## Summary

Fixes the Windows release binary verification step that rejected the `v1.4.0-rc.1` build.

The check read `SizeOfStackReserve` 48 bytes into the PE32+ optional header. The field starts at offset 72 and is 8 bytes wide, so the check read `0x6` from the subsystem version fields instead of the configured `0x1000000` stack reserve. The bounds check now covers the complete field too.

Failure: https://github.com/Karib0u/rustinel/actions/runs/33099209766/job/98613963790

## Type of change

- [x] `bug` - bug fix
- [x] `ci` - CI and release changes

## Test plan

- [x] `git diff --check`
- [x] Verified the corrected PE32+ offsets against the Microsoft PE format
- [ ] Windows release workflow validation after merge

## Checklist

- [x] Labels added to this PR
- [x] No application behavior changed

After this merges, the existing `v1.4.0-rc.1` tag must be recreated on the fixed commit so the release workflow uses the corrected verification step.
