### PR TITLE
chore: prepare release 1.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3173,7 +3173,7 @@ dependencies = [
 
 [[package]]
 name = "rustinel"
-version = "1.4.0-rc.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustinel"
-version = "1.4.0-rc.1"
+version = "1.4.0"
 edition = "2021"
 authors = []
 description = "Open-source EDR for Windows, Linux, and macOS with Sigma, YARA, and IOC detection"


### PR DESCRIPTION
## Summary

Bumps the package version from `1.4.0-rc.1` to `1.4.0` in `Cargo.toml` and `Cargo.lock` for the stable release.

## Type of change

- [x] `maintenance` - release housekeeping

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo test --locked`

## Checklist

- [x] Label added to this PR
- [x] No behavior or documentation changes required
