### PR TITLE
fix(logging): reduce default console noise

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -37,6 +37,10 @@ debounce_ms = 2000          # debounces real-time filesystem events; fallback po
 [logging]
 level = "info"              # trace, debug, info, warn, error
 # Optional target-aware filter (takes precedence over level when set)
+# Interactive commands use a compact console view at info; the operational
+# file keeps the configured detail. Use --log-level debug for console details.
+# Path-resolution drops are counted by the sensors; detailed notices are
+# debug-level and hidden by the default info level.
 # filter = "info,engine=info,scanner=info,ioc=info,rustinel::normalizer=info"
 directory = "logs"
 filename = "rustinel.log"

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -46,6 +46,11 @@ sudo ./rustinel run --config /etc/rustinel/config.toml
 Notes:
 
 - `rustinel run` enables console output by default on every platform.
+- At the default `info` level, the console shows startup milestones, detections,
+  actionable warnings and errors, and the final pipeline summary. The
+  operational log keeps the detailed stream.
+- Use `--log-level debug` or `--log-level trace` when the detailed console
+  stream is needed for troubleshooting.
 - `--config <PATH>` selects the config file and overrides `RUSTINEL_CONFIG`, managed platform paths, executable-directory config, and current-directory config.
 - `--no-console` suppresses console output, for example when redirecting logs.
 - `--console` is kept as a compatibility alias and has the same effect as the default.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -72,6 +72,10 @@ debounce_ms = 2000
 
 [logging]
 level = "info"
+# Interactive commands use a compact console view at info; the operational
+# file keeps the configured detail. Use --log-level debug for console details.
+# Path-resolution drops are counted by the sensors; detailed notices are
+# debug-level and hidden by the default info level.
 directory = "logs"
 filename = "rustinel.log"
 console_output = false
@@ -216,10 +220,10 @@ software and is a common location for macOS malware.
 | Option | Default | Description |
 | --- | --- | --- |
 | `level` | `info` | `trace`, `debug`, `info`, `warn`, or `error` |
-| `filter` | `null` | Optional `tracing_subscriber` filter expression; overrides `level` when valid |
+| `filter` | `null` | Optional `tracing_subscriber` filter expression; overrides `level` when valid for both file and console. Path-resolution drops are counted by the sensors; detailed notices are debug-level |
 | `directory` | `logs` | Operational log directory |
 | `filename` | `rustinel.log` | Operational log filename, rotated daily |
-| `console_output` | `false` | Console mirroring when the runtime does not override it. Interactive `rustinel run` enables console output regardless; use `--no-console` to suppress. On Windows, colored output needs [Windows Terminal](https://aka.ms/terminal) |
+| `console_output` | `false` | Console mirroring when the runtime does not override it. Interactive `rustinel run` enables console output regardless; at info it uses a compact view, while the operational file keeps configured detail. Use `--no-console` to suppress. On Windows, colored output needs [Windows Terminal](https://aka.ms/terminal) |
 
 ### Alerts
 

--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -12,7 +12,7 @@ use arc_swap::ArcSwap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use tokio::sync::mpsc;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 const TARGET_RESPONSE: &str = "response";
 static IDENTITY_MISMATCH_SKIPS: AtomicU64 = AtomicU64::new(0);
@@ -71,7 +71,7 @@ impl ResponseEngine {
 
         let handle = tokio::spawn(async move {
             let initial = worker_cfg.load();
-            info!(
+            debug!(
                 target: TARGET_RESPONSE,
                 enabled = initial.enabled,
                 prevention_enabled = initial.prevention_enabled,
@@ -98,7 +98,7 @@ impl ResponseEngine {
                 );
             }
 
-            info!(target: TARGET_RESPONSE, "Active response worker shutting down");
+            debug!(target: TARGET_RESPONSE, "Active response worker shutting down");
         });
 
         (

--- a/src/runtime/ioc.rs
+++ b/src/runtime/ioc.rs
@@ -106,6 +106,7 @@ pub fn spawn_ioc_hash_worker(
             let matches = ioc_engine.match_hashes(&hashes);
             if !matches.is_empty() {
                 info!(
+                    target: "engine",
                     pid = pid,
                     file = %path,
                     matches = matches.len(),

--- a/src/runtime/linux.rs
+++ b/src/runtime/linux.rs
@@ -6,7 +6,7 @@ use crate::normalizer::Normalizer;
 use crate::reload::DetectorStore;
 use crate::response::ResponseEngine;
 use crate::runtime::capture::{CaptureContext, CaptureOptions, CaptureSession};
-use crate::runtime::logging::{init_logging, log_startup_banner};
+use crate::runtime::logging::{init_logging, log_startup_banner, TARGET_CONSOLE};
 use crate::runtime::telemetry::TelemetryReporter;
 use crate::runtime::{ioc as runtime_ioc, yara as runtime_yara};
 use crate::scanner::{YaraEventHandler, YaraMemoryJob};
@@ -45,7 +45,7 @@ pub fn run_capture(options: CaptureOptions) -> anyhow::Result<()> {
         let (sensor_tx, sensor_worker) = session.sensor_channel();
 
         let sensor = Arc::new(EbpfSensor::new());
-        info!("Starting eBPF sensor...");
+        info!(target: TARGET_CONSOLE, "Starting eBPF sensor...");
         if let Err(e) = sensor.start(sensor_tx) {
             error!("eBPF sensor failed to start: {:#}", e);
             session.abandon(sensor_worker).await;
@@ -125,7 +125,7 @@ async fn run_linux_edr(
     // 5. Sigma engine
     let engine_kind =
         crate::engine::SigmaEngineKind::resolve(sigma_engine_override, &cfg.scanner.sigma_engine)?;
-    info!(engine = engine_kind.as_str(), "Selected Sigma engine");
+    info!(target: TARGET_CONSOLE, engine = engine_kind.as_str(), "Selected Sigma engine");
     let mut sigma_engine = Engine::new_for_platform_with_logging_level_and_match_debug(
         Platform::Linux,
         &cfg.logging.level,
@@ -140,6 +140,7 @@ async fn run_linux_edr(
         } else {
             let stats = sigma_engine.stats();
             info!(
+                target: TARGET_CONSOLE,
                 total_rules = stats.total_rules,
                 skipped_deferred_rules = stats.skipped_deferred_rules,
                 skipped_unknown_logsource_rules = stats.skipped_unknown_logsource_rules,
@@ -154,6 +155,8 @@ async fn run_linux_edr(
                 info!(logsource = %logsource, count, "Sigma rules loaded");
             }
         }
+    } else {
+        info!(target: TARGET_CONSOLE, "Sigma detection disabled by configuration");
     }
     let sigma_engine = Arc::new(sigma_engine);
 
@@ -163,7 +166,7 @@ async fn run_linux_edr(
             .map(|s| s.with_limits(cfg.scanner.yara_scan_limits()))
         {
             Ok(s) => {
-                info!("YARA scanner initialized");
+                info!(target: TARGET_CONSOLE, "YARA scanner initialized");
                 Arc::new(s)
             }
             Err(e) => {
@@ -172,6 +175,7 @@ async fn run_linux_edr(
             }
         }
     } else {
+        info!(target: TARGET_CONSOLE, "YARA scanning disabled by configuration");
         Arc::new(scanner::Scanner::empty())
     };
 
@@ -180,6 +184,23 @@ async fn run_linux_edr(
 
     // 7. IOC engine
     let ioc_engine = Arc::new(IocEngine::load(&cfg.ioc));
+    if ioc_engine.is_enabled() {
+        let stats = ioc_engine.stats();
+        info!(
+            target: TARGET_CONSOLE,
+            md5 = stats.md5,
+            sha1 = stats.sha1,
+            sha256 = stats.sha256,
+            ip = stats.ip,
+            cidr = stats.cidr,
+            domain_exact = stats.domain_exact,
+            domain_suffix = stats.domain_suffix,
+            path_regex = stats.path_regex,
+            "IOC engine initialized"
+        );
+    } else {
+        info!(target: TARGET_CONSOLE, "IOC detection disabled by configuration");
+    }
 
     // 8. Detector store + hot-reload
     let detectors = DetectorStore::new(
@@ -323,8 +344,10 @@ async fn run_linux_edr(
     // 13. eBPF sensor
     let sensor = Arc::new(EbpfSensor::new());
 
-    info!("Starting eBPF sensor...");
-    info!("Press Ctrl+C to stop gracefully");
+    info!(
+        target: TARGET_CONSOLE,
+        "Starting eBPF sensor; press Ctrl+C to stop gracefully"
+    );
 
     let (sensor_tx, mut sensor_rx) = mpsc::channel::<SensorEvent>(8192);
     let router_for_worker = Arc::clone(&router);
@@ -342,7 +365,7 @@ async fn run_linux_edr(
 
     // 14. Wait for Ctrl+C
     match tokio::signal::ctrl_c().await {
-        Ok(()) => info!("Received Ctrl+C, shutting down"),
+        Ok(()) => info!(target: TARGET_CONSOLE, "Received Ctrl+C, shutting down"),
         Err(e) => error!("Failed to listen for Ctrl+C: {}", e),
     }
     sensor.shutdown();
@@ -382,6 +405,6 @@ async fn run_linux_edr(
         reporter.finish().await;
     }
 
-    info!("Shutdown complete");
+    info!(target: TARGET_CONSOLE, "Shutdown complete");
     Ok(())
 }

--- a/src/runtime/logging.rs
+++ b/src/runtime/logging.rs
@@ -9,6 +9,9 @@ use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, Env
 
 const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
 const STARTUP_BANNER_INNER_WIDTH: usize = 49;
+/// Tracing target for messages intended for an interactive console.
+pub const TARGET_CONSOLE: &str = "console";
+const DEFAULT_CONSOLE_FILTER: &str = "warn,console=info,engine=info,response=info";
 
 struct RestrictedFileAppender {
     inner: rolling::RollingFileAppender,
@@ -63,21 +66,52 @@ pub fn build_log_filter(logging: &config::LogConfig) -> EnvFilter {
     }
 }
 
+/// Build the filter for an interactive console layer.
+///
+/// The operational file keeps the configured stream. With the default info
+/// level, the console shows milestones and detections while suppressing
+/// component internals. Explicit debug or trace levels opt into the full
+/// stream for troubleshooting. A custom filter remains authoritative for
+/// both outputs.
+fn build_console_log_filter(logging: &config::LogConfig, base_filter: &EnvFilter) -> EnvFilter {
+    let has_custom_filter = logging
+        .filter
+        .as_deref()
+        .map(str::trim)
+        .is_some_and(|filter| !filter.is_empty());
+    if has_custom_filter {
+        return base_filter.clone();
+    }
+
+    let level = logging.level.trim().to_ascii_lowercase();
+    let filter = match level.as_str() {
+        "debug" | "trace" => logging.level.trim(),
+        "warn" => "warn",
+        "error" => "error",
+        _ => DEFAULT_CONSOLE_FILTER,
+    };
+
+    EnvFilter::try_new(filter).unwrap_or_else(|_| {
+        EnvFilter::try_new(DEFAULT_CONSOLE_FILTER)
+            .expect("hardcoded console filter should always parse")
+    })
+}
+
 pub fn log_startup_banner(runtime: &str) {
-    info!(target: "rustinel", "╔═══════════════════════════════════════════════════╗");
+    info!(target: TARGET_CONSOLE, "╔═══════════════════════════════════════════════════╗");
     info!(
-        target: "rustinel",
+        target: TARGET_CONSOLE,
         "║ {:^width$} ║",
         format!("Rustinel v{} ({})", APP_VERSION, runtime),
         width = STARTUP_BANNER_INNER_WIDTH
     );
     info!(
-        target: "rustinel",
+        target: TARGET_CONSOLE,
         "║ {:^width$} ║",
         "High-Performance Endpoint Detection Agent",
         width = STARTUP_BANNER_INNER_WIDTH
     );
-    info!(target: "rustinel", "╚═══════════════════════════════════════════════════╝");
+    info!(target: TARGET_CONSOLE, "╚═══════════════════════════════════════════════════╝");
 }
 
 /// Initialize dual-pipeline logging system.
@@ -93,6 +127,7 @@ pub fn init_logging(
     let (app_writer, app_guard) =
         build_daily_writer("operational", &cfg.logging.directory, &cfg.logging.filename);
     let base_filter = build_log_filter(&cfg.logging);
+    let console_filter = build_console_log_filter(&cfg.logging, &base_filter);
 
     let app_layer = fmt::layer()
         .with_writer(app_writer)
@@ -112,7 +147,7 @@ pub fn init_logging(
                 .compact()
                 .with_ansi(ansi_supported)
                 .with_target(false)
-                .with_filter(base_filter),
+                .with_filter(console_filter),
         )
     } else {
         None
@@ -137,6 +172,7 @@ pub fn init_logging(
     let (app_writer, app_guard) =
         build_daily_writer("operational", &cfg.logging.directory, &cfg.logging.filename);
     let base_filter = build_log_filter(&cfg.logging);
+    let console_filter = build_console_log_filter(&cfg.logging, &base_filter);
 
     let app_layer = fmt::layer()
         .with_writer(app_writer)
@@ -152,8 +188,8 @@ pub fn init_logging(
         let console_layer = fmt::layer()
             .compact()
             .with_ansi(true)
-            .with_target(true)
-            .with_filter(base_filter);
+            .with_target(false)
+            .with_filter(console_filter);
         tracing_subscriber::registry()
             .with(app_layer)
             .with(console_layer)
@@ -176,6 +212,7 @@ pub fn init_operational_logging(
     let (app_writer, app_guard) =
         build_daily_writer("operational", &cfg.logging.directory, &cfg.logging.filename);
     let base_filter = build_log_filter(&cfg.logging);
+    let console_filter = build_console_log_filter(&cfg.logging, &base_filter);
 
     let app_layer = fmt::layer()
         .with_writer(app_writer)
@@ -189,8 +226,8 @@ pub fn init_operational_logging(
             fmt::layer()
                 .compact()
                 .with_ansi(console_ansi_supported())
-                .with_target(true)
-                .with_filter(base_filter),
+                .with_target(false)
+                .with_filter(console_filter),
         )
     } else {
         None
@@ -212,12 +249,13 @@ pub fn init_operational_logging(
 /// keeps diagnostics — a rule that failed to compile, say — out of the replay
 /// report on stdout.
 pub fn init_replay_logging(cfg: &config::AppConfig) {
+    let base_filter = build_log_filter(&cfg.logging);
     let layer = fmt::layer()
         .with_writer(std::io::stderr)
         .compact()
         .with_ansi(console_ansi_supported())
-        .with_target(true)
-        .with_filter(build_log_filter(&cfg.logging));
+        .with_target(false)
+        .with_filter(build_console_log_filter(&cfg.logging, &base_filter));
 
     // A replay running inside a process that already has a subscriber keeps
     // that one; this is best-effort diagnostics, not a reason to fail.
@@ -385,5 +423,94 @@ mod permission_tests {
             fs::metadata(&unrelated_file).unwrap().permissions().mode() & 0o777,
             0o644
         );
+    }
+}
+
+#[cfg(test)]
+mod filter_tests {
+    use super::{build_console_log_filter, build_log_filter, TARGET_CONSOLE};
+    use crate::config;
+    use std::sync::{Arc, Mutex};
+    use tracing_subscriber::{fmt, layer::SubscriberExt, Layer};
+
+    struct SharedWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl std::io::Write for SharedWriter {
+        fn write(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buffer);
+            Ok(buffer.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn logging(level: &str, filter: Option<&str>) -> config::LogConfig {
+        let mut logging = config::AppConfig::default().logging;
+        logging.level = level.to_owned();
+        logging.filter = filter.map(str::to_owned);
+        logging
+    }
+
+    #[test]
+    fn default_info_console_filter_is_compact() {
+        let logging = logging("info", None);
+        let file_filter = build_log_filter(&logging);
+        let console_filter = build_console_log_filter(&logging, &file_filter);
+        let rendered = console_filter.to_string();
+
+        for directive in ["warn", "console=info", "engine=info", "response=info"] {
+            assert!(rendered.split(',').any(|item| item == directive));
+        }
+    }
+
+    #[test]
+    fn debug_console_filter_follows_the_requested_level() {
+        let logging = logging("debug", None);
+        let file_filter = build_log_filter(&logging);
+        let console_filter = build_console_log_filter(&logging, &file_filter);
+
+        assert_eq!(console_filter.to_string(), "debug");
+    }
+
+    #[test]
+    fn custom_filter_applies_to_the_console_as_well() {
+        let logging = logging("info", Some("info,scanner=debug"));
+        let file_filter = build_log_filter(&logging);
+        let console_filter = build_console_log_filter(&logging, &file_filter);
+        let rendered = console_filter.to_string();
+
+        assert!(rendered.split(',').any(|item| item == "info"));
+        assert!(rendered.split(',').any(|item| item == "scanner=debug"));
+    }
+
+    #[test]
+    fn default_info_console_output_keeps_user_facing_events() {
+        let logging = logging("info", None);
+        let file_filter = build_log_filter(&logging);
+        let console_filter = build_console_log_filter(&logging, &file_filter);
+        let output = Arc::new(Mutex::new(Vec::new()));
+        let writer_output = Arc::clone(&output);
+        let subscriber = tracing_subscriber::registry().with(
+            fmt::layer()
+                .compact()
+                .with_ansi(false)
+                .with_writer(move || SharedWriter(Arc::clone(&writer_output)))
+                .with_filter(console_filter),
+        );
+
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::info!(target: "rustinel", "internal info");
+            tracing::info!(target: TARGET_CONSOLE, "startup milestone");
+            tracing::info!(target: "engine", "detection event");
+            tracing::warn!(target: "rustinel", "actionable warning");
+        });
+
+        let output = String::from_utf8(output.lock().unwrap().clone()).unwrap();
+        assert!(!output.contains("internal info"));
+        assert!(output.contains("startup milestone"));
+        assert!(output.contains("detection event"));
+        assert!(output.contains("actionable warning"));
     }
 }

--- a/src/runtime/macos.rs
+++ b/src/runtime/macos.rs
@@ -6,7 +6,7 @@ use crate::normalizer::Normalizer;
 use crate::reload::DetectorStore;
 use crate::response::ResponseEngine;
 use crate::runtime::capture::{CaptureContext, CaptureOptions, CaptureSession};
-use crate::runtime::logging::{init_logging, log_startup_banner};
+use crate::runtime::logging::{init_logging, log_startup_banner, TARGET_CONSOLE};
 use crate::runtime::telemetry::TelemetryReporter;
 use crate::runtime::{ioc as runtime_ioc, yara as runtime_yara};
 use crate::scanner::{YaraEventHandler, YaraMemoryJob};
@@ -46,7 +46,7 @@ pub fn run_capture(options: CaptureOptions) -> anyhow::Result<()> {
 
         let esf_sensor = Arc::new(EsfSensor::new());
         let bpf_sensor = Arc::new(BpfSensor::new());
-        info!("Starting macOS sensors...");
+        info!(target: TARGET_CONSOLE, "Starting macOS sensors...");
 
         // Endpoint Security is the primary source; failing to start it is fatal.
         if let Err(e) = esf_sensor.start(sensor_tx.clone()) {
@@ -141,7 +141,7 @@ async fn run_macos_edr(
     // 5. Sigma engine
     let engine_kind =
         crate::engine::SigmaEngineKind::resolve(sigma_engine_override, &cfg.scanner.sigma_engine)?;
-    info!(engine = engine_kind.as_str(), "Selected Sigma engine");
+    info!(target: TARGET_CONSOLE, engine = engine_kind.as_str(), "Selected Sigma engine");
     let mut sigma_engine = Engine::new_for_platform_with_logging_level_and_match_debug(
         Platform::MacOS,
         &cfg.logging.level,
@@ -156,6 +156,7 @@ async fn run_macos_edr(
         } else {
             let stats = sigma_engine.stats();
             info!(
+                target: TARGET_CONSOLE,
                 total_rules = stats.total_rules,
                 skipped_deferred_rules = stats.skipped_deferred_rules,
                 skipped_unknown_logsource_rules = stats.skipped_unknown_logsource_rules,
@@ -170,6 +171,8 @@ async fn run_macos_edr(
                 info!(logsource = %logsource, count, "Sigma rules loaded");
             }
         }
+    } else {
+        info!(target: TARGET_CONSOLE, "Sigma detection disabled by configuration");
     }
     let sigma_engine = Arc::new(sigma_engine);
 
@@ -179,7 +182,7 @@ async fn run_macos_edr(
             .map(|s| s.with_limits(cfg.scanner.yara_scan_limits()))
         {
             Ok(s) => {
-                info!("YARA scanner initialized");
+                info!(target: TARGET_CONSOLE, "YARA scanner initialized");
                 Arc::new(s)
             }
             Err(e) => {
@@ -188,6 +191,7 @@ async fn run_macos_edr(
             }
         }
     } else {
+        info!(target: TARGET_CONSOLE, "YARA scanning disabled by configuration");
         Arc::new(scanner::Scanner::empty())
     };
 
@@ -196,6 +200,23 @@ async fn run_macos_edr(
 
     // 7. IOC engine
     let ioc_engine = Arc::new(IocEngine::load(&cfg.ioc));
+    if ioc_engine.is_enabled() {
+        let stats = ioc_engine.stats();
+        info!(
+            target: TARGET_CONSOLE,
+            md5 = stats.md5,
+            sha1 = stats.sha1,
+            sha256 = stats.sha256,
+            ip = stats.ip,
+            cidr = stats.cidr,
+            domain_exact = stats.domain_exact,
+            domain_suffix = stats.domain_suffix,
+            path_regex = stats.path_regex,
+            "IOC engine initialized"
+        );
+    } else {
+        info!(target: TARGET_CONSOLE, "IOC detection disabled by configuration");
+    }
 
     // 8. Detector store + hot-reload
     let detectors = DetectorStore::new(
@@ -340,8 +361,10 @@ async fn run_macos_edr(
     let esf_sensor = Arc::new(EsfSensor::new());
     let bpf_sensor = Arc::new(BpfSensor::new());
 
-    info!("Starting macOS sensors...");
-    info!("Press Ctrl+C to stop gracefully");
+    info!(
+        target: TARGET_CONSOLE,
+        "Starting macOS sensors; press Ctrl+C to stop gracefully"
+    );
 
     let (sensor_tx, mut sensor_rx) = mpsc::channel::<SensorEvent>(8192);
     let router_for_worker = Arc::clone(&router);
@@ -369,7 +392,7 @@ async fn run_macos_edr(
 
     // 14. Wait for Ctrl+C
     match tokio::signal::ctrl_c().await {
-        Ok(()) => info!("Received Ctrl+C, shutting down"),
+        Ok(()) => info!(target: TARGET_CONSOLE, "Received Ctrl+C, shutting down"),
         Err(e) => error!("Failed to listen for Ctrl+C: {}", e),
     }
     esf_sensor.shutdown();
@@ -410,6 +433,6 @@ async fn run_macos_edr(
         reporter.finish().await;
     }
 
-    info!("Shutdown complete");
+    info!(target: TARGET_CONSOLE, "Shutdown complete");
     Ok(())
 }

--- a/src/runtime/windows.rs
+++ b/src/runtime/windows.rs
@@ -6,7 +6,7 @@ use crate::normalizer::Normalizer;
 use crate::reload::DetectorStore;
 use crate::response::ResponseEngine;
 use crate::runtime::capture::{CaptureContext, CaptureOptions, CaptureSession};
-use crate::runtime::logging::{init_logging, log_startup_banner};
+use crate::runtime::logging::{init_logging, log_startup_banner, TARGET_CONSOLE};
 use crate::runtime::telemetry::TelemetryReporter;
 use crate::runtime::{ioc as runtime_ioc, yara as runtime_yara};
 use crate::scanner::{YaraEventHandler, YaraMemoryJob};
@@ -146,7 +146,7 @@ fn spawn_shutdown_handler(
         match shutdown_mode {
             ShutdownMode::Console => match tokio::signal::ctrl_c().await {
                 Ok(()) => {
-                    info!("Received Ctrl+C signal");
+                    info!(target: TARGET_CONSOLE, "Received Ctrl+C signal");
                     sensor.shutdown();
                 }
                 Err(err) => {
@@ -155,7 +155,7 @@ fn spawn_shutdown_handler(
             },
             ShutdownMode::Service(mut shutdown_rx) => {
                 if shutdown_rx.changed().await.is_ok() {
-                    info!("Received service stop signal");
+                    info!(target: TARGET_CONSOLE, "Received service stop signal");
                 } else {
                     warn!("Service shutdown channel dropped");
                 }
@@ -196,7 +196,7 @@ fn ensure_administrator_privileges() -> anyhow::Result<()> {
                         "Insufficient privileges - Administrator access required"
                     ));
                 } else {
-                    info!("✓ Running with Administrator privileges");
+                    info!(target: TARGET_CONSOLE, "✓ Running with Administrator privileges");
                 }
             }
         }
@@ -218,6 +218,7 @@ pub fn run_capture(options: CaptureOptions) -> anyhow::Result<()> {
         // Cold start: seed the process cache so early events resolve parents.
         match crate::platform::windows::snapshot_processes(session.process_cache()) {
             Ok(count) => info!(
+                target: TARGET_CONSOLE,
                 "✓ Process Cache initialized with {} existing processes",
                 count
             ),
@@ -324,6 +325,7 @@ async fn run_edr(
         alerts_dir = ?cfg.alerts.directory,
         "Agent started with dual-pipeline logging"
     );
+    info!(target: TARGET_CONSOLE, "Agent started");
 
     // Verify running with appropriate privileges
     ensure_administrator_privileges()?;
@@ -347,6 +349,7 @@ async fn run_edr(
         match crate::platform::windows::snapshot_processes(&process_cache) {
             Ok(count) => {
                 info!(
+                    target: TARGET_CONSOLE,
                     "✓ Process Cache initialized with {} existing processes",
                     count
                 );
@@ -372,7 +375,7 @@ async fn run_edr(
     // Initialize Sigma engine
     let engine_kind =
         crate::engine::SigmaEngineKind::resolve(sigma_engine_override, &cfg.scanner.sigma_engine)?;
-    info!(target: "rustinel", engine = engine_kind.as_str(), "Selected Sigma engine");
+    info!(target: TARGET_CONSOLE, engine = engine_kind.as_str(), "Selected Sigma engine");
     let mut sigma_engine = Engine::new_for_platform_with_logging_level_and_match_debug(
         Platform::Windows,
         &cfg.logging.level,
@@ -392,7 +395,7 @@ async fn run_edr(
         } else {
             let stats = sigma_engine.stats();
             info!(
-                target: "rustinel",
+                target: TARGET_CONSOLE,
                 total_rules = stats.total_rules,
                 skipped_deferred_rules = stats.skipped_deferred_rules,
                 skipped_unknown_logsource_rules = stats.skipped_unknown_logsource_rules,
@@ -408,7 +411,7 @@ async fn run_edr(
             }
         }
     } else {
-        info!(target: "rustinel", "Sigma detection disabled by configuration");
+        info!(target: TARGET_CONSOLE, "Sigma detection disabled by configuration");
     }
     let sigma_engine = Arc::new(sigma_engine);
 
@@ -424,7 +427,7 @@ async fn run_edr(
             .map(|s| s.with_limits(cfg.scanner.yara_scan_limits()))
         {
             Ok(s) => {
-                info!(target: "rustinel", "YARA Scanner initialized successfully");
+                info!(target: TARGET_CONSOLE, "YARA Scanner initialized successfully");
                 Arc::new(s)
             }
             Err(e) => {
@@ -434,7 +437,7 @@ async fn run_edr(
             }
         }
     } else {
-        info!(target: "rustinel", "YARA scanning disabled by configuration");
+        info!(target: TARGET_CONSOLE, "YARA scanning disabled by configuration");
         Arc::new(scanner::Scanner::empty())
     };
 
@@ -442,7 +445,7 @@ async fn run_edr(
         scanner::normalize_allowlist_paths(&cfg.scanner.yara_allowlist_paths);
     if !yara_allowlist_paths.is_empty() {
         info!(
-            target: "rustinel",
+            target: TARGET_CONSOLE,
             count = yara_allowlist_paths.len(),
             "YARA allowlist paths loaded (files under these paths will NOT be scanned)"
         );
@@ -453,7 +456,7 @@ async fn run_edr(
     if ioc_engine.is_enabled() {
         let stats = ioc_engine.stats();
         info!(
-            target: "rustinel",
+            target: TARGET_CONSOLE,
             md5 = stats.md5,
             sha1 = stats.sha1,
             sha256 = stats.sha256,
@@ -465,7 +468,7 @@ async fn run_edr(
             "IOC engine initialized"
         );
     } else {
-        info!(target: "rustinel", "IOC detection disabled by configuration");
+        info!(target: TARGET_CONSOLE, "IOC detection disabled by configuration");
     }
 
     let detectors = DetectorStore::new(
@@ -586,7 +589,7 @@ async fn run_edr(
         cfg.network.aggregation_enabled,
     ));
 
-    info!("✓ ETW sensor initialized");
+    info!(target: TARGET_CONSOLE, "✓ ETW sensor initialized");
     info!("✓ Normalizer initialized");
 
     // Create the normalized-event handler in live detection mode
@@ -631,7 +634,7 @@ async fn run_edr(
     info!("✓ Signal handlers configured");
     info!("");
     info!("Starting ETW trace session...");
-    info!("Press Ctrl+C to stop gracefully");
+    info!(target: TARGET_CONSOLE, "ETW sensor starting; press Ctrl+C to stop gracefully");
     info!("");
 
     // Start shared sensor event pipeline
@@ -766,6 +769,7 @@ async fn run_edr(
     }
 
     info!("");
+    info!(target: TARGET_CONSOLE, "Shutdown complete");
     info!("╔═══════════════════════════════════════════════════╗");
     info!("║           Shutdown Complete                       ║");
     info!("║        Thank you for using Rustinel!              ║");

--- a/src/sensor/linux/ebpf.rs
+++ b/src/sensor/linux/ebpf.rs
@@ -22,7 +22,7 @@ use aya::programs::{KProbe, TracePoint};
 use aya::Ebpf;
 use tokio::io::unix::AsyncFd;
 use tokio::sync::mpsc::Sender;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::models::{
     DnsQueryFields, FileEventFields, NetworkConnectionFields, ProcessCreationFields,
@@ -630,7 +630,7 @@ fn build_file_event(
     else {
         *unresolved += 1;
         if *unresolved == 1 || unresolved.is_multiple_of(1000) {
-            warn!(
+            debug!(
                 unresolved_file_events = *unresolved,
                 raw_path = %raw_path,
                 "Dropping file event whose path could not be resolved"

--- a/src/sensor/windows/etw.rs
+++ b/src/sensor/windows/etw.rs
@@ -11,7 +11,7 @@ use ferrisetw::schema_locator::SchemaLocator;
 use ferrisetw::trace::{stop_trace_by_name, TraceProperties, TraceTrait, UserTrace};
 use ferrisetw::{EventRecord, GUID};
 use tokio::sync::mpsc::{error::TrySendError, Sender};
-use tracing::{info, trace, warn};
+use tracing::{debug, info, trace, warn};
 
 use crate::models::{
     DnsQueryFields, EventCategory, FileEventFields, ImageLoadFields, NetworkConnectionFields,
@@ -1127,7 +1127,7 @@ fn decode_kernel_file_record(
                 // endpoint is quiet or unobserved.
                 let unresolved = state.unresolved_file_events.fetch_add(1, Ordering::Relaxed) + 1;
                 if unresolved == 1 || unresolved.is_multiple_of(1000) {
-                    warn!(
+                    debug!(
                         unresolved_file_events = unresolved,
                         "Dropping file event whose path could not be resolved"
                     );
@@ -1268,7 +1268,7 @@ fn decode_kernel_registry_record(
                         .fetch_add(1, Ordering::Relaxed)
                         + 1;
                     if unresolved == 1 || unresolved.is_multiple_of(10_000) {
-                        warn!(
+                        debug!(
                             unresolved_registry_events = unresolved,
                             "Dropping registry event whose key path could not be resolved"
                         );

--- a/src/telemetry/snapshot.rs
+++ b/src/telemetry/snapshot.rs
@@ -17,6 +17,7 @@ use tokio::task::JoinHandle;
 use tracing::{debug, info, warn};
 
 use super::{ChannelId, PROCESS_START, TARGET_TELEMETRY};
+use crate::runtime::logging::TARGET_CONSOLE;
 use crate::utils::fs::restrict_file_permissions;
 
 /// File name of the snapshot, written inside the configured log directory.
@@ -201,8 +202,19 @@ pub fn spawn_reporter(path: PathBuf, interval: Duration) -> JoinHandle<()> {
 /// even if the snapshot cannot be written.
 pub fn write_final_snapshot(path: &Path) {
     let snapshot = TelemetrySnapshot::capture();
+    let active_channels = snapshot.active_channels();
 
-    for channel in snapshot.active_channels() {
+    if !active_channels.is_empty() {
+        info!(
+            target: TARGET_CONSOLE,
+            channels = active_channels.len(),
+            accepted = snapshot.total_accepted(),
+            dropped = snapshot.total_dropped(),
+            "Pipeline summary"
+        );
+    }
+
+    for channel in active_channels {
         info!(
             target: TARGET_TELEMETRY,
             channel = %channel.channel,


### PR DESCRIPTION
## Summary
This PR makes the default interactive console output concise without reducing operational visibility.

- Keeps the configured detailed stream in the operational log.
- Shows startup milestones, detections, actionable warnings, errors, and the final pipeline summary at the default `info` level.
- Keeps `debug` and `trace` available for troubleshooting.
- Demotes repetitive unresolved-path notices to `debug` while retaining sensor-side counters.
- Centralizes the console tracing target and adds a real subscriber-output test for the filtering behavior.
- Updates the CLI and configuration documentation.

## Type of change
- [ ] `feat` / `enhancement` - new feature
- [x] `bug` - bug fix
- [ ] `refactor` - refactoring, no behaviour change
- [ ] `documentation` - docs only
- [ ] `ci` - CI and release changes
- [ ] `dependencies` - dependency update

## Test plan
- [x] Tested on Windows
- [x] Tested on Linux
- [x] Existing tests pass (`cargo test`)
- [x] New tests added (if applicable)

Validation:
- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets -- -D clippy::all`
- Local Linux suite: 313 passed
- Windows lab suite: 334 passed
- Ubuntu lab eBPF smoke: detection triggered, 0 pipeline drops, clean shutdown, and 0 unresolved-path warning lines

## Checklist
- [x] Label added to this PR
- [x] Docs updated (if behaviour changed)