### PR TITLE
fix(ci): ignore unreachable wasmtime WASI advisory

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -3,6 +3,7 @@ ignore = [
     { id = "RUSTSEC-2023-0071", reason = "rsa is pulled transitively by yara-x. No fixed rsa release is available, and rustinel does not use yara-x for attacker observable private key RSA operations." },
     { id = "RUSTSEC-2025-0141", reason = "bincode is pulled transitively by yara-x. This is tracked as an upstream maintenance advisory until yara-x removes or replaces it." },
   { id = "RUSTSEC-2026-0222", reason = "yara-x 1.19.0 creates a single Wasmtime engine, so the cross-engine type-index mix-up described by this advisory is not reachable. See https://github.com/VirusTotal/yara-x/issues/726." },
+    { id = "RUSTSEC-2026-0269", reason = "Wasmtime is pulled transitively by yara-x, which uses it only to JIT compiled rule conditions. This advisory is a WASI filesystem sandbox escape and wasmtime-wasi is not in the dependency tree, so it is not reachable. No fixed release is available on the 43.x line that yara-x 1.19 requires (nor 45.x, required by yara-x 1.20)." },
 ]
 
 [licenses]


### PR DESCRIPTION
## Summary

The `Supply Chain` job is red on every open PR. Nothing in the repo changed — **RUSTSEC-2026-0269** was published on 2026-08-20 against `wasmtime`, which `yara-x 1.19.0` pulls in transitively. `main` was green four days ago and fails today.

This adds a fourth `deny.toml` ignore, following the pattern of the three existing yara-x transitive entries.

**Why an ignore rather than an upgrade.** The patched ranges are `>=24.0.13 <25`, `>=36.0.14 <37`, `>=46.0.3 <47`, `>=47.0.4`. We are on 43.0.2, which is not covered, and `yara-x 1.20.0` (newest, released 2026-08-24) requires `wasmtime ^45.0.3` — also unpatched. Both `cargo update -p wasmtime` and a yara-x bump leave the check red. There is no upgrade path today.

**Why it is not reachable here.** The advisory is a WASI filesystem sandbox escape via trailing slashes in paths and symlinks. `wasmtime-wasi` is not in the dependency tree at all — only the JIT crates (`wasmtime-internal-core`, `-cranelift`, and friends) are present. yara-x uses wasmtime solely to JIT compiled rule conditions, so no filesystem sandbox is in play.

Worth revisiting when yara-x moves to a wasmtime release inside a patched range.

## Type of change
- [x] `ci` - CI and release changes

## Test plan
Both steps the `Supply Chain` job runs were verified locally:

- `cargo deny --locked check` → `advisories ok, bans ok, licenses ok, sources ok`
- `cargo deny --locked --manifest-path ebpf/Cargo.toml --config ebpf/deny.toml check` → `advisories ok, bans ok, licenses ok, sources ok`

The lingering `spin 0.9.8` yanked-crate line is a pre-existing warning, not a failure. No other job was affected, so no platform testing applies to this change.

- [ ] Tested on Windows
- [ ] Tested on Linux
- [x] Existing tests pass (`cargo test`) — unaffected; no code change
- [ ] New tests added (if applicable)

## Checklist
- [x] Label added to this PR
- [x] Docs updated (if behaviour changed) — no behaviour change