### PR TITLE
feat(windows-eventlog): add a Security channel source

### DIFF
--- a/.github/workflows/privileged-smoke.yml
+++ b/.github/workflows/privileged-smoke.yml
@@ -60,3 +60,5 @@ jobs:
         run: cargo test --locked --test active_response -- --include-ignored
       - name: Run ignored service event log smoke test
         run: cargo test --locked --test windows_service_event_log -- --include-ignored
+      - name: Run ignored security event log smoke test
+        run: cargo test --locked --test windows_security_event_log -- --include-ignored

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -74,8 +74,8 @@ The key split in the codebase is between the hot event path and the control plan
 
 ### Windows
 
-The Windows sensor uses ETW for realtime providers and a filtered Windows Event
-Log subscription for Service Control Manager event 7045. It currently covers:
+The Windows sensor uses ETW for realtime providers and filtered Windows Event
+Log subscriptions for the System and Security channels. It currently covers:
 
 - Process
 - Image load
@@ -87,6 +87,7 @@ Log subscription for Service Control Manager event 7045. It currently covers:
 - WMI
 - Service creation
 - Task creation
+- Security channel audit events
 
 The ETW providers include:
 
@@ -102,6 +103,15 @@ The ETW providers include:
 Service creation comes from the System event log rather than the classic
 Service Control Manager provider, which does not deliver event 7045 to realtime
 user ETW sessions.
+
+The Event Log side is source-agnostic: a source is a channel, an XPath query,
+and a decoder, and the subscription lifecycle is shared. Two sources exist
+today, the System channel's 7045 and the Security channel's audit events, and
+both deliver into the same sensor channel as ETW. The Security source is scoped
+by its query to the event IDs it decodes, so the channel's full volume is
+filtered in the kernel rather than in the agent. What it collects depends on the
+host's audit policy — see
+[Windows audit policy](operations.md#windows-audit-policy).
 
 ### Linux
 

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -42,14 +42,22 @@ Dominated by two Event Log channels and a few Sysmon categories:
 | 17 | `windefend` |
 | 15 | `create_remote_thread` |
 
-**Since this measurement:** the 34 `ps_module` rules are no longer blocked.
-Event 4103 is collected from the PowerShell provider
-([#322](https://github.com/Karib0u/rustinel/issues/322)), and all 34 reference
-only `ContextInfo` and `Payload`, which the decoder populates — so they move to
-"can fire" (Windows 2,172 / 75.5%, blocked-on-collector 414 / 14.4%) once the
-host has Module Logging enabled. See
-[Detection](detection.md#powershell-logsources). The table itself is left as
-measured; the next full run will absorb it.
+**Since this measurement**, two of these rows have moved. The table itself is
+left as measured; the next full run will absorb both.
+
+- The 34 `ps_module` rules are no longer blocked. Event 4103 is collected from
+  the PowerShell provider
+  ([#322](https://github.com/Karib0u/rustinel/issues/322)), and all 34 reference
+  only `ContextInfo` and `Payload`, which the decoder populates — so they move
+  to "can fire" (Windows 2,172 / 75.5%, blocked-on-collector 414 / 14.4%) once
+  the host has Module Logging enabled. See
+  [Detection](detection.md#powershell-logsources).
+- The `security` row predates the Security channel collector
+  ([#315](https://github.com/Karib0u/rustinel/issues/315)), which covers six
+  audit event families in that channel. It has not been re-measured, and what
+  the collector delivers depends on the host's
+  [audit policy](operations.md#windows-audit-policy), so treat 177 as an upper
+  bound on what is still blocked rather than a current count.
 
 ### Windows: unavailable fields (289 rules)
 

--- a/docs/detection.md
+++ b/docs/detection.md
@@ -115,6 +115,33 @@ tracked by [#195](https://github.com/Karib0u/rustinel/issues/195).
 | `service_creation` | Yes | No | No | Windows only |
 | `task_creation` | Yes | No | No | Windows only |
 
+The Windows Security channel is a family of its own. Rules for it carry no
+`category` — `product: windows`, `service: security`, and an `EventID`
+selection — so they are routed by channel rather than by category:
+
+| Event ID | Event | Key fields |
+| --- | --- | --- |
+| 4624 | An account was successfully logged on | `LogonType`, `AuthenticationPackageName`, `LogonProcessName`, `TargetUserName`, `WorkstationName`, `IpAddress` |
+| 4656 | A handle to an object was requested | `ObjectType`, `ObjectName`, `AccessMask`, `AccessList`, `ProcessName` |
+| 4663 | An attempt was made to access an object | `ObjectType`, `ObjectName`, `AccessMask`, `AccessList`, `ProcessName` |
+| 4697 | A service was installed in the system | `ServiceName`, `ServiceFileName`, `ServiceType`, `ServiceStartType`, `ServiceAccount` |
+| 5136 | A directory service object was modified | `ObjectDN`, `ObjectClass`, `AttributeLDAPDisplayName`, `AttributeValue`, `OperationType` |
+| 5145 | A network share object was checked | `ShareName`, `ShareLocalPath`, `RelativeTargetName`, `AccessMask`, `AccessList`, `IpAddress` |
+
+Every one of them also carries the `Subject*` identity block
+(`SubjectUserSid`, `SubjectUserName`, `SubjectDomainName`, `SubjectLogonId`).
+An event ID outside this list is not subscribed to, so a rule selecting on one
+loads and never matches. The authoritative list is `SUPPORTED_EVENTS` in
+`src/sensor/windows/event_log/security.rs`.
+
+Values are kept exactly as Windows renders them, because that is what rules for
+this channel are written against: `SubjectLogonId` matches `0x3e4`, not `996`,
+and `AccessList` matches the raw `%%4417` access-right codes. `ProcessId` is
+likewise the channel's own hex.
+
+Five of the six need audit policy that is off by default — see
+[Windows audit policy](operations.md#windows-audit-policy).
+
 macOS telemetry has two sources: Endpoint Security for process and file events
 (`provider: esf`), and `/dev/bpf` capture for network and DNS (`provider: bpf`).
 Its coverage mirrors Linux.

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -18,13 +18,14 @@ full rather than hide them.
 | No stateful correlation or filter evaluation | Engine |
 | Telemetry is dropped under burst load (counted, not prevented) | Pipeline |
 | Writes through handles or keys opened before startup are invisible | Windows |
+| Security channel events depend on audit policy Rustinel does not set | Windows |
 | Image paths are truncated, and truncation is unmarked on process events | Linux |
 
 ## Windows (ETW and Event Log)
 
-Telemetry comes from ETW plus a Windows Event Log subscription for System event
-7045, rather than a kernel driver. Coverage is the broadest of the three
-platforms, but several Sysmon-style fields are unavailable.
+Telemetry comes from ETW plus Windows Event Log subscriptions on the System and
+Security channels, rather than a kernel driver. Coverage is the broadest of the
+three platforms, but several Sysmon-style fields are unavailable.
 
 - **No process or image-load hashes (silent risk).** There is no
   `Hashes`/`Imphash` on process or image-load events, so the many Sigma rules
@@ -74,6 +75,20 @@ platforms, but several Sysmon-style fields are unavailable.
   operations in that range. Nothing is remapped and the two colliding IDs are
   dropped, so a `wmi_event` rule selecting on `EventID` never matches rather
   than matching the wrong event. WMI persistence telemetry is not collected.
+- **Security channel coverage depends on the host's audit policy (silent
+  risk).** Rustinel subscribes to the Security channel and decodes six audit
+  event families, but only 4624 (logon) is audited by default. The other five
+  need their audit subcategory enabled, and 4656/4663 additionally need a SACL
+  on the object being watched. Nothing about this is visible from inside the
+  agent: the subscription succeeds, the rules load against an active collector,
+  and no event ever arrives. The policy each needs is in
+  [Windows audit policy](operations.md#windows-audit-policy); Rustinel never
+  changes it.
+- **Only six Security event IDs are subscribed to (silent risk).** The
+  subscription is scoped in the kernel to 4624, 4656, 4663, 4697, 5136 and 5145.
+  A `windows/security` rule selecting on any other `EventID` loads, is counted
+  as backed by an active collector, and can never match. The list is
+  `SUPPORTED_EVENTS` in `src/sensor/windows/event_log/security.rs`.
 - **No injection, driver-load, or named-pipe visibility.** There is no
   equivalent of CreateRemoteThread, ProcessAccess, pipe, or driver-load
   telemetry, so injection-based TTPs leave little trace.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -151,6 +151,71 @@ The Service Control Manager runs the managed binary directly. Note that Windows
 services start with `C:\Windows\System32` as the working directory, which is why
 managed installs use an absolute managed config path.
 
+## Windows Audit Policy
+
+Rustinel subscribes to the Security channel, but Windows only writes to it what
+the host's audit policy tells it to. Every event below is subscribed to and
+decoded; the ones whose policy is off simply never occur, so the rules that
+need them load and stay silent. **Enabling this policy is the operator's
+decision, not Rustinel's** — the agent never changes it.
+
+| Event | Subcategory | Subcategory GUID | On by default |
+| --- | --- | --- | --- |
+| 4624 logon | Logon | `{0CCE9215-…}` | Yes |
+| 4697 service installed | Security System Extension | `{0CCE9211-…}` | No |
+| 4656 handle requested | File System, Registry, Kernel Object, SAM | `{0CCE921D-…}`, `{0CCE921E-…}`, `{0CCE921F-…}`, `{0CCE9220-…}` | No |
+| 4663 object access | File System, Registry, Kernel Object | `{0CCE921D-…}`, `{0CCE921E-…}`, `{0CCE921F-…}` | No |
+| 5145 network share object checked | Detailed File Share | `{0CCE9244-…}` | No |
+| 5136 directory service object modified | Directory Service Changes | `{0CCE923C-…}` | No (domain controllers) |
+
+All GUIDs end in `-69AE-11D9-BED3-505054503030`.
+
+Turn a subcategory on with `auditpol`, from an elevated prompt:
+
+```bat
+auditpol /set /subcategory:"Security System Extension" /success:enable
+```
+
+```bat
+auditpol /set /subcategory:"Detailed File Share" /success:enable /failure:enable
+```
+
+Check what is currently enabled:
+
+```bat
+auditpol /get /category:*
+```
+
+**`auditpol` takes the *localized* subcategory name.** On a non-English Windows
+the commands above fail with *the parameter is incorrect*; use the GUID, which
+is the same on every locale:
+
+```bat
+auditpol /set /subcategory:{0CCE9211-69AE-11D9-BED3-505054503030} /success:enable
+```
+
+`auditpol /list /subcategory:* /v` prints the local names next to their GUIDs.
+Before changing policy on a host you do not own, take a copy you can put back:
+
+```bat
+auditpol /backup /file:C:\auditpol-before.csv
+```
+
+Two caveats worth knowing before turning these on:
+
+- **4656 and 4663 additionally need a SACL on the object.** The subcategory only
+  enables the *mechanism*; nothing is logged until an audit entry is placed on
+  the file, key, or object of interest (its **Properties → Security → Advanced →
+  Auditing** tab). Enabling the subcategory alone produces no events.
+- **Detailed File Share and Kernel Object auditing are high volume.** 5145 fires
+  once per share access check. On a file server this can dominate the Security
+  channel. Enable it deliberately, and size the channel accordingly
+  (`wevtutil sl Security /ms:<bytes>`).
+
+Group Policy configures the same settings at
+*Computer Configuration → Windows Settings → Security Settings → Advanced Audit
+Policy Configuration*.
+
 ## Monitoring Telemetry Loss
 
 Sensor channels are bounded and shed events under burst load, which produces a

--- a/docs/output.md
+++ b/docs/output.md
@@ -131,8 +131,17 @@ Format:
 | WMI | `edr.wmi` |
 | Service | `edr.service` |
 | Task | `edr.task` |
+| Security channel | `edr.security` |
 
 The full field set depends on event type and platform. Windows alerts can include PE metadata, registry details, PowerShell content, and service or task context. Linux and macOS alerts currently focus on process, network, file, and DNS fields.
+
+Windows Security channel alerts additionally carry `edr.security`, a nested
+object holding the decoded audit record under its own Windows field names
+(`ObjectName`, `ShareName`, `AttributeValue`, ...). The fields that map onto ECS
+— identity, source address, process, service — are also lifted into the standard
+ECS fields, so `edr.security` is the lossless copy rather than the only one. It
+is nested rather than flattened so a Windows field name can never collide with
+an ECS one.
 
 ## Behavioral Recordings
 

--- a/src/engine/alert.rs
+++ b/src/engine/alert.rs
@@ -612,6 +612,15 @@ impl Engine {
                     Some("task_creation"),
                 ));
             }
+            // The Security channel is addressed by channel alone: its Sigma
+            // rules carry no category and select on `EventID` instead.
+            EventCategory::Security => {
+                aliases.push(LogSourceKey::from_parts(
+                    Some("windows"),
+                    Some("security"),
+                    None,
+                ));
+            }
         }
 
         aliases

--- a/src/engine/logsource.rs
+++ b/src/engine/logsource.rs
@@ -282,6 +282,7 @@ impl Engine {
                 ),
                 LogSourceKey::from_parts(Some("windows"), Some("wmi"), Some("wmi_event")),
                 LogSourceKey::from_parts(Some("windows"), Some("system"), Some("service_creation")),
+                LogSourceKey::from_parts(Some("windows"), Some("security"), None),
                 LogSourceKey::from_parts(
                     Some("windows"),
                     Some("taskscheduler"),

--- a/src/engine/rsigma_adapter.rs
+++ b/src/engine/rsigma_adapter.rs
@@ -106,7 +106,9 @@ impl Event for RsigmaEvent<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::models::{EventCategory, EventFields, NormalizedEvent, ProcessCreationFields};
+    use crate::models::{
+        EventCategory, EventFields, NormalizedEvent, ProcessCreationFields, SecurityAuditFields,
+    };
     use crate::sensor::Platform;
     use std::collections::HashMap;
 
@@ -207,5 +209,26 @@ mod tests {
         let values = adapter.all_string_values();
         assert!(values.iter().any(|value| value.as_ref() == "/usr/bin/curl"));
         assert!(values.iter().any(|value| value.contains("example.test")));
+    }
+
+    #[test]
+    fn security_audit_fields_serialize_flat_like_the_typed_variants() {
+        // The Security payload is a map rather than a struct of named options.
+        // The cold paths here read the fields through serde, so a nested
+        // representation would produce `fields.ObjectName`-style keys that no
+        // rule field name could ever match.
+        let mut fields = SecurityAuditFields::default();
+        fields.insert("ObjectName", r"C:\Windows\NTDS\ntds.dit");
+        fields.insert("SubjectLogonId", "0x3e4");
+
+        let mut event = generic_event(&[]);
+        event.category = EventCategory::Security;
+        event.fields = EventFields::SecurityAudit(fields);
+        let adapter = RsigmaEvent::new(&event);
+
+        let keys = adapter.field_keys();
+        assert!(keys.iter().any(|key| key.as_ref() == "ObjectName"));
+        assert!(keys.iter().any(|key| key.as_ref() == "SubjectLogonId"));
+        assert!(adapter.any_string_value(&|value| value.ends_with("ntds.dit")));
     }
 }

--- a/src/models/ecs/alert.rs
+++ b/src/models/ecs/alert.rs
@@ -2,6 +2,7 @@ use super::helpers::{basename, parse_u64};
 use super::user::apply_user_fields;
 use crate::models::{MatchDetails, ProcessContext};
 use serde::Serialize;
+use std::collections::BTreeMap;
 
 #[derive(Serialize)]
 pub struct DnsAnswer {
@@ -434,6 +435,18 @@ pub struct EcsAlert {
         skip_serializing_if = "Option::is_none"
     )]
     pub edr_process_target_image: Option<String>,
+
+    // ========================================================================
+    // Windows Security Channel Fields
+    // ========================================================================
+    /// The decoded Security audit record, under its own Windows field names.
+    ///
+    /// The channel's event families have almost no fields in common, so the
+    /// ones that map onto ECS are lifted into the standard fields above and the
+    /// whole record is carried here as well. Nested rather than flattened so a
+    /// Windows field name can never collide with an ECS one.
+    #[serde(rename = "edr.security", skip_serializing_if = "Option::is_none")]
+    pub edr_security: Option<BTreeMap<String, String>>,
 
     // ========================================================================
     // Related Fields

--- a/src/models/ecs/event.rs
+++ b/src/models/ecs/event.rs
@@ -11,7 +11,7 @@ pub(super) fn alert_severity_to_event_severity(severity: AlertSeverity) -> u8 {
     }
 }
 
-pub(super) fn ecs_event_category(category: EventCategory) -> Vec<String> {
+pub(super) fn ecs_event_category(category: EventCategory, event_id: u16) -> Vec<String> {
     match category {
         EventCategory::Process => vec!["process".to_string()],
         EventCategory::Network => vec!["network".to_string()],
@@ -24,7 +24,38 @@ pub(super) fn ecs_event_category(category: EventCategory) -> Vec<String> {
         EventCategory::Wmi => vec!["api".to_string()],
         EventCategory::Service => vec!["configuration".to_string()],
         EventCategory::Task => vec!["configuration".to_string()],
+        // The Security channel is one logsource carrying unrelated event
+        // families, so its ECS mapping is driven by the audit event ID rather
+        // than by the category. Object-access events name the kind of object
+        // they touched in `ObjectType`, which the field mapper reads to refine
+        // this default.
+        EventCategory::Security => match event_id {
+            4624 => vec!["authentication".to_string(), "session".to_string()],
+            4697 => vec!["configuration".to_string()],
+            5136 => vec!["iam".to_string()],
+            _ => vec!["file".to_string()],
+        },
     }
+}
+
+/// ECS `event.category` for an object-access audit event, from its `ObjectType`.
+///
+/// Windows names the object kind rather than the ECS category, and audits the
+/// same event ID over files, registry keys and process tokens alike.
+pub(super) fn ecs_object_access_category(object_type: Option<&str>) -> Vec<String> {
+    let category = match object_type {
+        Some("Key") => "registry",
+        Some("Process") | Some("Thread") | Some("Token") => "process",
+        Some("SAM")
+        | Some("SAM_DOMAIN")
+        | Some("SAM_USER")
+        | Some("SAM_GROUP")
+        | Some("SAM_ALIAS")
+        | Some("SAM_SERVER")
+        | Some("directoryService") => "iam",
+        _ => "file",
+    };
+    vec![category.to_string()]
 }
 
 pub(super) fn ecs_event_type(category: EventCategory, opcode: u8, event_id: u16) -> Vec<String> {
@@ -66,6 +97,12 @@ pub(super) fn ecs_event_type(category: EventCategory, opcode: u8, event_id: u16)
                 vec!["change".to_string()]
             }
         }
+        EventCategory::Security => match event_id {
+            4624 => vec!["start".to_string()],
+            4697 => vec!["creation".to_string()],
+            5136 => vec!["change".to_string()],
+            _ => vec!["access".to_string()],
+        },
     }
 }
 
@@ -112,6 +149,15 @@ pub(super) fn ecs_event_action(
                 "task-change"
             }
         }
+        EventCategory::Security => match event_id {
+            4624 => "logged-in",
+            4656 => "handle-requested",
+            4663 => "object-access-attempted",
+            4697 => "service-installed",
+            5136 => "directory-service-object-modified",
+            5145 => "network-share-object-checked",
+            _ => "security-audit",
+        },
     };
     Some(action.to_string())
 }
@@ -129,6 +175,7 @@ pub(super) fn event_dataset(category: EventCategory) -> String {
         EventCategory::Wmi => "wmi",
         EventCategory::Service => "service",
         EventCategory::Task => "task",
+        EventCategory::Security => "security",
     };
     format!("{}.{}", EVENT_MODULE, suffix)
 }

--- a/src/models/ecs/mod.rs
+++ b/src/models/ecs/mod.rs
@@ -16,7 +16,8 @@ pub use alert::{DnsAnswer, EcsAlert, ReplayProvenance};
 use crate::models::{Alert, EventFields};
 use event::{
     alert_severity_to_event_severity, ecs_event_action, ecs_event_category, ecs_event_type,
-    event_dataset, event_provider, host_os_family, host_os_type, network_direction_from_category,
+    ecs_object_access_category, event_dataset, event_provider, host_os_family, host_os_type,
+    network_direction_from_category,
 };
 use helpers::{basename, file_extension_from_path, parse_bool, parse_u16, parse_u64};
 use network::{extract_ips, network_transport_from_opcode, network_type_from_ip};
@@ -30,7 +31,7 @@ impl From<&Alert> for EcsAlert {
     fn from(alert: &Alert) -> Self {
         let opcode = alert.event.opcode;
         let event_id = alert.event.event_id;
-        let event_category = ecs_event_category(alert.event.category);
+        let event_category = ecs_event_category(alert.event.category, event_id);
         let event_type = ecs_event_type(alert.event.category, opcode, event_id);
         let event_action = ecs_event_action(alert.event.category, opcode, event_id);
         let event_code = if !alert.event.event_id_string.is_empty() {
@@ -132,6 +133,7 @@ impl From<&Alert> for EcsAlert {
             edr_remote_thread_start_module: None,
             edr_remote_thread_start_function: None,
             edr_process_target_image: None,
+            edr_security: None,
             related_ip: None,
             related_user: None,
             edr_match: alert.match_details.clone(),
@@ -285,6 +287,48 @@ impl From<&Alert> for EcsAlert {
                 ecs.edr_remote_thread_start_module = f.start_module.clone();
                 ecs.edr_remote_thread_start_function = f.start_function.clone();
                 apply_user_fields(&mut ecs, f.user.as_deref());
+            }
+            EventFields::SecurityAudit(f) => {
+                // Windows names the acting identity in three separate fields;
+                // the rest of the model carries one `DOMAIN\\user` string, so
+                // recompose it before handing it to the shared user mapping.
+                let subject = match (f.get("SubjectDomainName"), f.get("SubjectUserName")) {
+                    (Some(domain), Some(name)) => Some(format!("{domain}\\{name}")),
+                    (None, Some(name)) => Some(name.to_string()),
+                    _ => None,
+                };
+                apply_user_fields(&mut ecs, subject.as_deref());
+                if ecs.user_id.is_none() {
+                    ecs.user_id = f.get("SubjectUserSid").map(str::to_string);
+                }
+                ecs.winlog_logon_id = f.get("SubjectLogonId").map(str::to_string);
+
+                // 4624 and 5145 name the machine the request came *from*.
+                ecs.source_ip = f.get("IpAddress").map(str::to_string);
+                ecs.source_port = parse_u16(&f.get("IpPort").map(str::to_string));
+
+                ecs.process_executable = f.get("ProcessName").map(str::to_string);
+                ecs.process_pid = f.process_id().map(u64::from);
+
+                ecs.service_name = f.get("ServiceName").map(str::to_string);
+                ecs.edr_service_executable = f.get("ServiceFileName").map(str::to_string);
+                ecs.edr_service_type = f.get("ServiceType").map(str::to_string);
+                ecs.edr_service_start_type = f.get("ServiceStartType").map(str::to_string);
+                ecs.edr_service_account_name = f.get("ServiceAccount").map(str::to_string);
+
+                if matches!(f.get("ObjectType"), Some("File") | Some("Directory")) {
+                    ecs.file_path = f.get("ObjectName").map(str::to_string);
+                }
+                if matches!(f.get("ObjectType"), Some("Key")) {
+                    ecs.registry_path = f.get("ObjectName").map(str::to_string);
+                }
+                if matches!(event_id, 4656 | 4663 | 5145) {
+                    ecs.event_category = ecs_object_access_category(f.get("ObjectType"));
+                }
+
+                if !f.fields.is_empty() {
+                    ecs.edr_security = Some(f.fields.clone());
+                }
             }
             EventFields::Generic(_) => {
                 // Generic events don't have structured field mapping

--- a/src/models/event.rs
+++ b/src/models/event.rs
@@ -269,6 +269,7 @@ impl NormalizedEvent {
                 "Image" => f.image.as_deref(),
                 _ => None,
             },
+            EventFields::SecurityAudit(f) => f.get(key),
             EventFields::Generic(map) => map.get(key).map(|s| s.as_str()),
         }
     }
@@ -582,6 +583,11 @@ impl NormalizedEvent {
                     values.push(v.as_str());
                 }
                 if let Some(v) = &f.image {
+                    values.push(v.as_str());
+                }
+            }
+            EventFields::SecurityAudit(f) => {
+                for v in f.fields.values() {
                     values.push(v.as_str());
                 }
             }
@@ -919,6 +925,11 @@ impl NormalizedEvent {
                     values.push(("Image", v.as_str()));
                 }
             }
+            EventFields::SecurityAudit(f) => {
+                for (key, value) in &f.fields {
+                    values.push((key.as_str(), value.as_str()));
+                }
+            }
             EventFields::Generic(map) => {
                 for (key, value) in map {
                     values.push((key.as_str(), value.as_str()));
@@ -944,6 +955,7 @@ pub enum EventCategory {
     Wmi,
     Service,
     Task,
+    Security,
 }
 
 #[cfg(test)]
@@ -1105,6 +1117,9 @@ mod round_trip_tests {
             }),
             (EventCategory::Task, "Image", |f| {
                 matches!(f, EventFields::TaskCreation(_))
+            }),
+            (EventCategory::Security, "ObjectName", |f| {
+                matches!(f, EventFields::SecurityAudit(_))
             }),
         ];
 

--- a/src/models/fields.rs
+++ b/src/models/fields.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use super::EventCategory;
 
@@ -25,6 +25,7 @@ pub enum EventFields {
     WmiEvent(WmiEventFields),
     ServiceCreation(ServiceCreationFields),
     TaskCreation(TaskCreationFields),
+    SecurityAudit(SecurityAuditFields),
     Generic(HashMap<String, String>),
 }
 
@@ -59,6 +60,7 @@ impl EventFields {
             EventCategory::Wmi => serde_json::from_value(payload).map(Self::WmiEvent),
             EventCategory::Service => serde_json::from_value(payload).map(Self::ServiceCreation),
             EventCategory::Task => serde_json::from_value(payload).map(Self::TaskCreation),
+            EventCategory::Security => serde_json::from_value(payload).map(Self::SecurityAudit),
         }
     }
 }
@@ -422,4 +424,72 @@ pub struct TaskCreationFields {
 
     #[serde(rename = "Image", skip_serializing_if = "Option::is_none")]
     pub image: Option<String>,
+}
+
+/// Windows Security channel audit fields (Sigma: `windows/security`).
+///
+/// Every other category is a single event shape, so a struct of named options
+/// models it exactly. The Security channel is not: one logsource carries event
+/// families whose field sets barely overlap — a logon (4624), a handle request
+/// (4656), a share access (5145) and a directory service change (5136) share
+/// only the `Subject*` identity block — and each family the collector grows
+/// brings its own. Keeping the record as the event's own field names avoids a
+/// union struct that would be `None` in almost every slot on every event.
+///
+/// The names and the values are Windows' own, exactly as the channel renders
+/// them, because that is what Sigma rules for this logsource are written
+/// against: `SubjectLogonId` matches `0x3e4`, not `996`, and `AccessList`
+/// matches the raw `%%4417` access-right codes.
+///
+/// The set is not open-ended. `sensor::windows::event_log::security` holds one
+/// allowlist per supported event ID, and that table is the single statement of
+/// which fields this collector populates.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct SecurityAuditFields {
+    pub fields: BTreeMap<String, String>,
+}
+
+impl SecurityAuditFields {
+    /// Read a decoded field by its Windows name.
+    pub fn get(&self, name: &str) -> Option<&str> {
+        self.fields.get(name).map(String::as_str)
+    }
+
+    /// Record a decoded field, ignoring empty values.
+    ///
+    /// The channel writes `-` for a property that does not apply to the
+    /// instance of the event, which is not a value a rule should be able to
+    /// match on, so it is dropped like an empty one.
+    pub fn insert(&mut self, name: &str, value: &str) {
+        if value.is_empty() || value == "-" {
+            return;
+        }
+        self.fields.insert(name.to_string(), value.to_string());
+    }
+
+    /// The process this event is attributed to, if it carries one.
+    ///
+    /// The Security channel renders process IDs in hex (`0x4d8`), unlike every
+    /// other field in the model that holds a decimal PID string. The raw
+    /// rendering stays in [`Self::fields`] for rules to match; this is the
+    /// parse the pipeline itself needs for process-cache lookups.
+    pub fn process_id(&self) -> Option<u32> {
+        parse_windows_process_id(self.get("ProcessId")?)
+    }
+}
+
+/// Parse a process ID as the Windows Security channel renders it.
+///
+/// Accepts the hex form the channel emits and a plain decimal, so a value that
+/// arrives already normalized is not rejected.
+pub fn parse_windows_process_id(value: &str) -> Option<u32> {
+    let value = value.trim();
+    match value
+        .strip_prefix("0x")
+        .or_else(|| value.strip_prefix("0X"))
+    {
+        Some(hex) => u32::from_str_radix(hex, 16).ok(),
+        None => value.parse::<u32>().ok(),
+    }
 }

--- a/src/normalizer/mod.rs
+++ b/src/normalizer/mod.rs
@@ -58,6 +58,7 @@ impl Normalizer {
             SensorPayload::Wmi(fields) => self.normalize_wmi(fields.clone()),
             SensorPayload::Service(fields) => self.normalize_service(event, fields.clone()),
             SensorPayload::Task(fields) => self.normalize_task(event, fields.clone()),
+            SensorPayload::Security(fields) => Some(EventFields::SecurityAudit(fields.clone())),
         }?;
 
         Some(NormalizedEvent {
@@ -366,6 +367,7 @@ impl Normalizer {
             EventFields::WmiEvent(f) => f.process_id.as_deref(),
             EventFields::ServiceCreation(f) => f.process_id.as_deref(),
             EventFields::TaskCreation(f) => f.process_id.as_deref(),
+            EventFields::SecurityAudit(f) => f.get("ProcessId"),
             EventFields::RemoteThread(f) => f.source_process_id.as_deref(),
             EventFields::ProcessCreation(_) | EventFields::Generic(_) => None,
         };

--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -461,6 +461,10 @@ fn extract_process_info(alert: &Alert) -> (Option<u32>, Option<String>) {
                 image = f.source_image.clone();
             }
         }
+        EventFields::SecurityAudit(f) => {
+            pid = f.process_id();
+            image = f.get("ProcessName").map(str::to_string);
+        }
         EventFields::Generic(_) => {}
     }
 

--- a/src/sensor/mod.rs
+++ b/src/sensor/mod.rs
@@ -24,7 +24,8 @@ use tokio::sync::mpsc::Sender;
 use crate::models::{
     DnsQueryFields, EventCategory, EventFields, FileEventFields, ImageLoadFields,
     NetworkConnectionFields, PowerShellModuleFields, PowerShellScriptFields, ProcessCreationFields,
-    RegistryEventFields, ServiceCreationFields, TaskCreationFields, WmiEventFields,
+    RegistryEventFields, SecurityAuditFields, ServiceCreationFields, TaskCreationFields,
+    WmiEventFields,
 };
 
 /// Cross-platform sensor interface.
@@ -79,6 +80,8 @@ pub enum SensorAction {
     Load,
     Execute,
     Register,
+    /// A subject asked for, or exercised, access to a securable object.
+    Access,
 }
 
 /// Stable process identity used to avoid PID reuse collisions.
@@ -242,6 +245,7 @@ pub enum SensorPayload {
     Wmi(WmiEventFields),
     Service(ServiceCreationFields),
     Task(TaskCreationFields),
+    Security(SecurityAuditFields),
 }
 
 impl SensorPayload {
@@ -259,6 +263,7 @@ impl SensorPayload {
             Self::Wmi(_) => EventCategory::Wmi,
             Self::Service(_) => EventCategory::Service,
             Self::Task(_) => EventCategory::Task,
+            Self::Security(_) => EventCategory::Security,
         }
     }
 
@@ -277,6 +282,7 @@ impl SensorPayload {
             Self::Wmi(fields) => EventFields::WmiEvent(fields),
             Self::Service(fields) => EventFields::ServiceCreation(fields),
             Self::Task(fields) => EventFields::TaskCreation(fields),
+            Self::Security(fields) => EventFields::SecurityAudit(fields),
         }
     }
 }
@@ -297,6 +303,7 @@ impl TryFrom<EventFields> for SensorPayload {
             EventFields::WmiEvent(fields) => Ok(Self::Wmi(fields)),
             EventFields::ServiceCreation(fields) => Ok(Self::Service(fields)),
             EventFields::TaskCreation(fields) => Ok(Self::Task(fields)),
+            EventFields::SecurityAudit(fields) => Ok(Self::Security(fields)),
             other => Err(other),
         }
     }

--- a/src/sensor/windows/etw.rs
+++ b/src/sensor/windows/etw.rs
@@ -673,7 +673,9 @@ impl EtwRouting {
             EventCategory::Dns => SensorAction::Query,
             EventCategory::Wmi => SensorAction::Execute,
             EventCategory::Task => SensorAction::Register,
-            EventCategory::Service => unreachable!("service events use the event log source"),
+            EventCategory::Service | EventCategory::Security => {
+                unreachable!("event log categories use the event log sources")
+            }
             EventCategory::Process
             | EventCategory::ImageLoad
             | EventCategory::Scripting
@@ -923,7 +925,9 @@ fn decode_record(
         EventCategory::Scripting => decode_powershell(&parser, record),
         EventCategory::PowerShellModule => decode_powershell_module(&parser, record),
         EventCategory::Wmi => decode_wmi(&parser, record),
-        EventCategory::Service => unreachable!("service events use the event log source"),
+        EventCategory::Service | EventCategory::Security => {
+            unreachable!("event log categories use the event log sources")
+        }
         EventCategory::Task => decode_task(&parser, record),
     }?;
 

--- a/src/sensor/windows/event_log/mod.rs
+++ b/src/sensor/windows/event_log/mod.rs
@@ -4,6 +4,7 @@
 //! subscription lifecycle, native handles, shutdown, and sensor-channel
 //! delivery stay shared across System, Security, and Application sources.
 
+mod security;
 mod service;
 
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -62,7 +63,7 @@ pub(super) struct EventLogSubscriptions {
 
 impl EventLogSubscriptions {
     pub(super) fn start(tx: Sender<SensorEvent>, shutdown: Arc<AtomicBool>) -> Result<Self> {
-        let sources = [service::source()];
+        let sources = [service::source(), security::source()];
         let mut workers = Vec::with_capacity(sources.len());
 
         for source in sources {

--- a/src/sensor/windows/event_log/security.rs
+++ b/src/sensor/windows/event_log/security.rs
@@ -1,0 +1,514 @@
+//! Windows Security channel audit event decoding.
+//!
+//! The Security channel is one Sigma logsource (`windows/security`) carrying
+//! unrelated event families. Rules address them by `EventID` and by the field
+//! names Windows itself writes, so the decoder keeps both: the subscription is
+//! scoped to the supported IDs, and each ID has an allowlist of the properties
+//! decoded from it.
+//!
+//! [`SUPPORTED_EVENTS`] is therefore the single statement of what this
+//! collector populates. Adding an event family is adding a row to it, and
+//! nothing else in the pipeline needs to change.
+//!
+//! Only 4624 is audited by default. The other five need their audit
+//! subcategory enabled, and the two object-access families additionally need a
+//! SACL on the object; the required policy is in `docs/operations.md`.
+
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use anyhow::{anyhow, Context, Result};
+use chrono::DateTime;
+
+use crate::models::SecurityAuditFields;
+use crate::sensor::{Platform, SensorAction, SensorEvent, SensorNormalization, SensorPayload};
+
+use super::EventLogSource;
+
+const PROVIDER: &str = "Microsoft-Windows-Security-Auditing";
+
+/// The identity block every audited event carries: who did it, and in which
+/// logon session.
+const SUBJECT_FIELDS: &[&str] = &[
+    "SubjectUserSid",
+    "SubjectUserName",
+    "SubjectDomainName",
+    "SubjectLogonId",
+];
+
+/// Supported audit events, and the properties decoded from each.
+///
+/// The lists are the event's own schema, restricted to the properties that
+/// carry detection value. A property Windows emits but that is absent here is
+/// dropped rather than passed through, which keeps the field model closed and
+/// reviewable.
+const SUPPORTED_EVENTS: &[(u16, &[&str])] = &[
+    // An account was successfully logged on.
+    (
+        4624,
+        &[
+            "TargetUserSid",
+            "TargetUserName",
+            "TargetDomainName",
+            "TargetLogonId",
+            "LogonType",
+            "LogonProcessName",
+            "AuthenticationPackageName",
+            "WorkstationName",
+            "LogonGuid",
+            "LmPackageName",
+            "KeyLength",
+            "ProcessId",
+            "ProcessName",
+            "IpAddress",
+            "IpPort",
+            "ImpersonationLevel",
+            "RestrictedAdminMode",
+            "TargetOutboundUserName",
+            "TargetOutboundDomainName",
+            "VirtualAccount",
+            "TargetLinkedLogonId",
+            "ElevatedToken",
+        ],
+    ),
+    // A handle to an object was requested.
+    (
+        4656,
+        &[
+            "ObjectServer",
+            "ObjectType",
+            "ObjectName",
+            "HandleId",
+            "AccessList",
+            "AccessMask",
+            "AccessReason",
+            "PrivilegeList",
+            "ProcessId",
+            "ProcessName",
+        ],
+    ),
+    // An attempt was made to access an object.
+    (
+        4663,
+        &[
+            "ObjectServer",
+            "ObjectType",
+            "ObjectName",
+            "HandleId",
+            "AccessList",
+            "AccessMask",
+            "ProcessId",
+            "ProcessName",
+        ],
+    ),
+    // A service was installed in the system.
+    (
+        4697,
+        &[
+            "ServiceName",
+            "ServiceFileName",
+            "ServiceType",
+            "ServiceStartType",
+            "ServiceAccount",
+        ],
+    ),
+    // A directory service object was modified.
+    (
+        5136,
+        &[
+            "DSName",
+            "DSType",
+            "ObjectDN",
+            "ObjectGUID",
+            "ObjectClass",
+            "AttributeLDAPDisplayName",
+            "AttributeSyntaxOID",
+            "AttributeValue",
+            "OperationType",
+        ],
+    ),
+    // A network share object was checked to see whether the client can be
+    // granted the desired access.
+    (
+        5145,
+        &[
+            "ObjectType",
+            "IpAddress",
+            "IpPort",
+            "ShareName",
+            "ShareLocalPath",
+            "RelativeTargetName",
+            "AccessMask",
+            "AccessList",
+            "AccessReason",
+        ],
+    ),
+];
+
+/// XPath filter scoping the subscription to [`SUPPORTED_EVENTS`].
+///
+/// Written out rather than built at runtime: the query is what the kernel
+/// filters on, so an event family is only reachable if it appears both here and
+/// in the table above, and a reviewer can see the two agree.
+const QUERY: &str = "*[System[Provider[@Name='Microsoft-Windows-Security-Auditing'] \
+     and (EventID=4624 or EventID=4656 or EventID=4663 or EventID=4697 \
+     or EventID=5136 or EventID=5145)]]";
+
+pub(super) const fn source() -> EventLogSource {
+    EventLogSource::new("security-audit", "Security", QUERY, decode)
+}
+
+/// The action an audit event reports, for logging and downstream routing.
+fn action_for_event(event_id: u16) -> SensorAction {
+    match event_id {
+        4624 => SensorAction::Start,
+        4697 => SensorAction::Register,
+        5136 => SensorAction::Modify,
+        _ => SensorAction::Access,
+    }
+}
+
+fn decode(xml: &str) -> Result<SensorEvent> {
+    let document = roxmltree::Document::parse(xml).context("invalid security event XML")?;
+    let system = document
+        .descendants()
+        .find(|node| node.has_tag_name("System"))
+        .context("security event XML has no System element")?;
+
+    let event_id = child_text(system, "EventID")
+        .context("security event XML has no EventID")?
+        .parse::<u16>()
+        .context("security event XML has an invalid EventID")?;
+
+    let provider = system
+        .children()
+        .find(|node| node.has_tag_name("Provider"))
+        .and_then(|node| node.attribute("Name"));
+    if provider != Some(PROVIDER) {
+        return Err(anyhow!("unexpected Security event provider {provider:?}"));
+    }
+
+    let allowed = SUPPORTED_EVENTS
+        .iter()
+        .find_map(|(id, fields)| (*id == event_id).then_some(*fields))
+        .ok_or_else(|| anyhow!("unsupported Security event ID {event_id}"))?;
+
+    let mut fields = SecurityAuditFields::default();
+    for node in document.descendants() {
+        if !node.has_tag_name("Data") {
+            continue;
+        }
+        let Some(name) = node.attribute("Name") else {
+            continue;
+        };
+        if !SUBJECT_FIELDS.contains(&name) && !allowed.contains(&name) {
+            continue;
+        }
+        fields.insert(name, node.text().unwrap_or_default());
+    }
+
+    if fields.fields.is_empty() {
+        return Err(anyhow!("Security event {event_id} carried no decoded data"));
+    }
+
+    let timestamp = system
+        .children()
+        .find(|node| node.has_tag_name("TimeCreated"))
+        .and_then(|node| node.attribute("SystemTime"))
+        .and_then(parse_system_time)
+        .unwrap_or_else(SystemTime::now);
+
+    // The `ProcessId` in the payload stays as Windows renders it, in hex, for
+    // rules to match. The pipeline needs a number to reach the process cache,
+    // so the parsed value rides along on the event instead.
+    let pid = fields.process_id();
+
+    Ok(SensorEvent {
+        platform: Platform::Windows,
+        provider: "windows_event_log",
+        action: action_for_event(event_id),
+        normalization: SensorNormalization {
+            event_id,
+            action_code: 0,
+        },
+        pid,
+        timestamp,
+        process_start_key: None,
+        payload: SensorPayload::Security(fields),
+    })
+}
+
+fn child_text<'a, 'input>(node: roxmltree::Node<'a, 'input>, name: &str) -> Option<&'a str> {
+    node.children()
+        .find(|child| child.has_tag_name(name))
+        .and_then(|child| child.text())
+}
+
+fn parse_system_time(value: &str) -> Option<SystemTime> {
+    let timestamp = DateTime::parse_from_rfc3339(value).ok()?;
+    let seconds = timestamp.timestamp();
+    let nanos = timestamp.timestamp_subsec_nanos();
+    if seconds < 0 {
+        return None;
+    }
+    Some(UNIX_EPOCH + Duration::new(seconds as u64, nanos))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{decode, PROVIDER, QUERY, SUPPORTED_EVENTS};
+    use crate::sensor::{SensorAction, SensorPayload};
+
+    fn security_event(event_id: u16, event_data: &str) -> String {
+        format!(
+            r#"
+<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+  <System>
+    <Provider Name="Microsoft-Windows-Security-Auditing" Guid="{{54849625-5478-4994-a5ba-3e3b0328c30d}}"/>
+    <EventID>{event_id}</EventID>
+    <TimeCreated SystemTime="2026-08-25T12:34:56.1234567Z"/>
+    <Channel>Security</Channel>
+    <Computer>lab-windows</Computer>
+  </System>
+  <EventData>
+{event_data}
+  </EventData>
+</Event>"#
+        )
+    }
+
+    fn fields(xml: &str) -> crate::models::SecurityAuditFields {
+        let event = decode(xml).expect("event should decode");
+        let SensorPayload::Security(fields) = event.payload else {
+            panic!("expected a security payload");
+        };
+        fields
+    }
+
+    const SUBJECT: &str = r#"    <Data Name="SubjectUserSid">S-1-5-21-1-2-3-1001</Data>
+    <Data Name="SubjectUserName">alice</Data>
+    <Data Name="SubjectDomainName">ACME</Data>
+    <Data Name="SubjectLogonId">0x3e4</Data>"#;
+
+    #[test]
+    fn decodes_a_service_installation() {
+        let xml = security_event(
+            4697,
+            &format!(
+                r#"{SUBJECT}
+    <Data Name="ServiceName">RustinelIssue315</Data>
+    <Data Name="ServiceFileName">C:\Windows\Temp\payload.exe</Data>
+    <Data Name="ServiceType">0x10</Data>
+    <Data Name="ServiceStartType">3</Data>
+    <Data Name="ServiceAccount">LocalSystem</Data>"#
+            ),
+        );
+
+        let event = decode(&xml).expect("4697 should decode");
+        assert_eq!(event.action, SensorAction::Register);
+        assert_eq!(event.normalization.event_id, 4697);
+        assert_eq!(event.provider, "windows_event_log");
+
+        let SensorPayload::Security(fields) = event.payload else {
+            panic!("expected a security payload");
+        };
+        assert_eq!(fields.get("ServiceName"), Some("RustinelIssue315"));
+        assert_eq!(
+            fields.get("ServiceFileName"),
+            Some(r"C:\Windows\Temp\payload.exe")
+        );
+        assert_eq!(fields.get("ServiceStartType"), Some("3"));
+        assert_eq!(fields.get("ServiceAccount"), Some("LocalSystem"));
+        assert_eq!(fields.get("SubjectUserName"), Some("alice"));
+        assert_eq!(fields.get("SubjectLogonId"), Some("0x3e4"));
+    }
+
+    #[test]
+    fn decodes_a_successful_logon() {
+        let xml = security_event(
+            4624,
+            &format!(
+                r#"{SUBJECT}
+    <Data Name="TargetUserName">bob</Data>
+    <Data Name="TargetDomainName">ACME</Data>
+    <Data Name="TargetLogonId">0x1a2b3c</Data>
+    <Data Name="LogonType">3</Data>
+    <Data Name="LogonProcessName">NtLmSsp</Data>
+    <Data Name="AuthenticationPackageName">NTLM</Data>
+    <Data Name="WorkstationName">WKSTN01</Data>
+    <Data Name="IpAddress">10.0.0.9</Data>
+    <Data Name="IpPort">49512</Data>
+    <Data Name="ProcessId">0x0</Data>
+    <Data Name="ProcessName">-</Data>"#
+            ),
+        );
+
+        let event = decode(&xml).expect("4624 should decode");
+        assert_eq!(event.action, SensorAction::Start);
+
+        let SensorPayload::Security(fields) = event.payload else {
+            panic!("expected a security payload");
+        };
+        assert_eq!(fields.get("LogonType"), Some("3"));
+        assert_eq!(fields.get("AuthenticationPackageName"), Some("NTLM"));
+        assert_eq!(fields.get("IpAddress"), Some("10.0.0.9"));
+        assert_eq!(fields.get("TargetUserName"), Some("bob"));
+        // `-` is how the channel spells "does not apply to this event", not a
+        // value a rule should be able to match on.
+        assert_eq!(fields.get("ProcessName"), None);
+    }
+
+    #[test]
+    fn decodes_an_object_access_attempt() {
+        let xml = security_event(
+            4663,
+            &format!(
+                r#"{SUBJECT}
+    <Data Name="ObjectServer">Security</Data>
+    <Data Name="ObjectType">File</Data>
+    <Data Name="ObjectName">C:\Users\alice\Documents\secrets.docx</Data>
+    <Data Name="HandleId">0x8f4</Data>
+    <Data Name="AccessList">%%4416
+				</Data>
+    <Data Name="AccessMask">0x1</Data>
+    <Data Name="ProcessId">0x4d8</Data>
+    <Data Name="ProcessName">C:\Windows\System32\notepad.exe</Data>"#
+            ),
+        );
+
+        let event = decode(&xml).expect("4663 should decode");
+        assert_eq!(event.action, SensorAction::Access);
+        // Hex in the payload for rules, parsed for the pipeline.
+        assert_eq!(event.pid, Some(0x4d8));
+
+        let SensorPayload::Security(fields) = event.payload else {
+            panic!("expected a security payload");
+        };
+        assert_eq!(fields.get("ProcessId"), Some("0x4d8"));
+        assert_eq!(fields.get("ObjectType"), Some("File"));
+        assert_eq!(
+            fields.get("ObjectName"),
+            Some(r"C:\Users\alice\Documents\secrets.docx")
+        );
+        assert!(fields.get("AccessList").unwrap().contains("%%4416"));
+    }
+
+    #[test]
+    fn decodes_a_handle_request() {
+        let xml = security_event(
+            4656,
+            &format!(
+                r#"{SUBJECT}
+    <Data Name="ObjectServer">Security</Data>
+    <Data Name="ObjectType">Key</Data>
+    <Data Name="ObjectName">\REGISTRY\MACHINE\SECURITY</Data>
+    <Data Name="AccessMask">0x20019</Data>
+    <Data Name="ProcessName">C:\Windows\System32\reg.exe</Data>"#
+            ),
+        );
+
+        let fields = fields(&xml);
+        assert_eq!(fields.get("ObjectType"), Some("Key"));
+        assert_eq!(
+            fields.get("ObjectName"),
+            Some(r"\REGISTRY\MACHINE\SECURITY")
+        );
+        assert_eq!(fields.get("AccessMask"), Some("0x20019"));
+    }
+
+    #[test]
+    fn decodes_a_network_share_check() {
+        let xml = security_event(
+            5145,
+            &format!(
+                r#"{SUBJECT}
+    <Data Name="ObjectType">File</Data>
+    <Data Name="IpAddress">10.0.0.9</Data>
+    <Data Name="IpPort">50123</Data>
+    <Data Name="ShareName">\\*\ADMIN$</Data>
+    <Data Name="ShareLocalPath">\??\C:\Windows</Data>
+    <Data Name="RelativeTargetName">PSEXESVC.exe</Data>
+    <Data Name="AccessMask">0x100081</Data>"#
+            ),
+        );
+
+        let fields = fields(&xml);
+        assert_eq!(fields.get("ShareName"), Some(r"\\*\ADMIN$"));
+        assert_eq!(fields.get("RelativeTargetName"), Some("PSEXESVC.exe"));
+        assert_eq!(fields.get("IpAddress"), Some("10.0.0.9"));
+    }
+
+    #[test]
+    fn decodes_a_directory_service_change() {
+        let xml = security_event(
+            5136,
+            &format!(
+                r#"{SUBJECT}
+    <Data Name="DSName">acme.test</Data>
+    <Data Name="DSType">%%14676</Data>
+    <Data Name="ObjectDN">CN=svc-backup,CN=Users,DC=acme,DC=test</Data>
+    <Data Name="ObjectClass">user</Data>
+    <Data Name="AttributeLDAPDisplayName">msDS-AllowedToDelegateTo</Data>
+    <Data Name="AttributeValue">cifs/dc01.acme.test</Data>
+    <Data Name="OperationType">%%14674</Data>"#
+            ),
+        );
+
+        let event = decode(&xml).expect("5136 should decode");
+        assert_eq!(event.action, SensorAction::Modify);
+
+        let SensorPayload::Security(fields) = event.payload else {
+            panic!("expected a security payload");
+        };
+        assert_eq!(
+            fields.get("AttributeLDAPDisplayName"),
+            Some("msDS-AllowedToDelegateTo")
+        );
+        assert_eq!(fields.get("AttributeValue"), Some("cifs/dc01.acme.test"));
+        assert_eq!(fields.get("ObjectClass"), Some("user"));
+    }
+
+    #[test]
+    fn drops_properties_outside_the_event_allowlist() {
+        let xml = security_event(
+            4697,
+            &format!(
+                r#"{SUBJECT}
+    <Data Name="ServiceName">RustinelIssue315</Data>
+    <Data Name="ServiceFileName">C:\Windows\Temp\payload.exe</Data>
+    <Data Name="ObjectName">C:\not-a-4697-property</Data>"#
+            ),
+        );
+
+        let fields = fields(&xml);
+        assert_eq!(fields.get("ServiceName"), Some("RustinelIssue315"));
+        assert_eq!(fields.get("ObjectName"), None);
+    }
+
+    #[test]
+    fn rejects_an_unsupported_event_id() {
+        let xml = security_event(4688, r#"    <Data Name="SubjectUserName">alice</Data>"#);
+        assert!(decode(&xml).is_err());
+    }
+
+    #[test]
+    fn rejects_a_different_provider() {
+        let xml = security_event(4697, r#"    <Data Name="ServiceName">svc</Data>"#)
+            .replace(PROVIDER, "Other Provider");
+        assert!(decode(&xml).is_err());
+    }
+
+    #[test]
+    fn the_subscription_query_covers_exactly_the_supported_events() {
+        for (event_id, _) in SUPPORTED_EVENTS {
+            assert!(
+                QUERY.contains(&format!("EventID={event_id}")),
+                "event {event_id} is decoded but not subscribed to"
+            );
+        }
+        assert_eq!(
+            QUERY.matches("EventID=").count(),
+            SUPPORTED_EVENTS.len(),
+            "the subscription query and the decoder table must agree"
+        );
+    }
+}

--- a/src/sensor/windows/mapper.rs
+++ b/src/sensor/windows/mapper.rs
@@ -49,6 +49,9 @@ fn action_code_for_record(
         EventCategory::Wmi => 0,
         EventCategory::Service => 0,
         EventCategory::Task => 0,
+        // Event Log sources decode their own normalization; no ETW record
+        // reaches this mapping with a Security category.
+        EventCategory::Security => 0,
     }
 }
 
@@ -86,6 +89,7 @@ fn raw_event_id_for_record(category: EventCategory, action_code: u8, record: &Ev
         EventCategory::Wmi => record.event_id(),
         EventCategory::Service => record.event_id(),
         EventCategory::Task => record.event_id(),
+        EventCategory::Security => record.event_id(),
     }
 }
 
@@ -124,7 +128,8 @@ pub fn map_to_sysmon_id(category: EventCategory, action_code: u8, raw_event_id: 
         | EventCategory::Scripting
         | EventCategory::PowerShellModule
         | EventCategory::Service
-        | EventCategory::Task => raw_event_id,
+        | EventCategory::Task
+        | EventCategory::Security => raw_event_id,
     }
 }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -606,6 +606,7 @@ pub fn event_fields_from_payload(event: SensorEvent) -> EventFields {
         SensorPayload::Wmi(fields) => EventFields::WmiEvent(fields),
         SensorPayload::Service(fields) => EventFields::ServiceCreation(fields),
         SensorPayload::Task(fields) => EventFields::TaskCreation(fields),
+        SensorPayload::Security(fields) => EventFields::SecurityAudit(fields),
     }
 }
 

--- a/tests/ecs_contract.rs
+++ b/tests/ecs_contract.rs
@@ -11,10 +11,18 @@ use rustinel::models::{
     Alert, AlertSeverity, DetectionEngine, DnsQueryFields, EventCategory, EventFields,
     FileEventFields, ImageLoadFields, NetworkConnectionFields, NormalizedEvent,
     PowerShellModuleFields, PowerShellScriptFields, ProcessCreationFields, RegistryEventFields,
-    ServiceCreationFields, TaskCreationFields, WmiEventFields,
+    SecurityAuditFields, ServiceCreationFields, TaskCreationFields, WmiEventFields,
 };
 use rustinel::sensor::Platform;
 use serde_json::json;
+
+fn security_audit_fields(pairs: &[(&str, &str)]) -> SecurityAuditFields {
+    let mut fields = SecurityAuditFields::default();
+    for (name, value) in pairs {
+        fields.insert(name, value);
+    }
+    fields
+}
 
 fn alert(category: EventCategory, event_id: u16, opcode: u8, fields: EventFields) -> Alert {
     Alert {
@@ -335,6 +343,26 @@ fn ecs_category_coverage_maps_event_contract_fields() {
             json!(["creation"]),
             "task-create",
             "edr.task.name",
+        ),
+        (
+            alert(
+                EventCategory::Security,
+                4624,
+                0,
+                EventFields::SecurityAudit(security_audit_fields(&[
+                    ("SubjectUserName", "alice"),
+                    ("SubjectDomainName", "ACME"),
+                    ("TargetUserName", "bob"),
+                    ("LogonType", "3"),
+                    ("AuthenticationPackageName", "NTLM"),
+                    ("IpAddress", "10.0.0.9"),
+                ])),
+            ),
+            "edr.security",
+            json!(["authentication", "session"]),
+            json!(["start"]),
+            "logged-in",
+            "edr.security",
         ),
     ];
 

--- a/tests/windows_security_channel.rs
+++ b/tests/windows_security_channel.rs
@@ -1,0 +1,455 @@
+//! `windows/security` logsource routing, from a decoded audit record to a
+//! Sigma match and its ECS alert.
+//!
+//! The decoder itself is Windows-only and covered by its unit tests. What this
+//! file protects is the part every platform builds: that a Security audit
+//! payload normalizes, reaches rules written against the `windows/security`
+//! logsource, and lands in the right ECS fields.
+
+#[cfg(test)]
+mod common;
+
+use std::time::SystemTime;
+
+use common::{assert_ecs_field_eq, ecs_json, SigmaFixture, TestNormalizer};
+use rustinel::{
+    engine::{Engine, LogSource, LogSourceStatus},
+    models::{EventCategory, EventFields, NormalizedEvent, SecurityAuditFields},
+    sensor::{Platform, SensorAction, SensorEvent, SensorNormalization, SensorPayload},
+};
+
+fn audit_fields(pairs: &[(&str, &str)]) -> SecurityAuditFields {
+    let mut fields = SecurityAuditFields::default();
+    for (name, value) in pairs {
+        fields.insert(name, value);
+    }
+    fields
+}
+
+fn security_event(event_id: u16, action: SensorAction, pairs: &[(&str, &str)]) -> SensorEvent {
+    let fields = audit_fields(pairs);
+    let pid = fields.process_id();
+
+    SensorEvent {
+        platform: Platform::Windows,
+        provider: "windows_event_log",
+        action,
+        normalization: SensorNormalization {
+            event_id,
+            action_code: 0,
+        },
+        pid,
+        timestamp: SystemTime::now(),
+        process_start_key: None,
+        payload: SensorPayload::Security(fields),
+    }
+}
+
+fn normalize(event: &SensorEvent) -> NormalizedEvent {
+    TestNormalizer::new(false)
+        .normalizer
+        .normalize(event)
+        .expect("a security audit event should normalize")
+}
+
+fn windows_security_engine(fixture: &SigmaFixture) -> Engine {
+    let mut engine = Engine::new_for_platform(Platform::Windows);
+    engine
+        .load_rules(fixture.rules_dir())
+        .expect("sigma rules should load");
+    assert_eq!(engine.stats().failed_rules, Vec::<(String, String)>::new());
+    engine
+}
+
+#[test]
+fn windows_security_is_an_active_logsource() {
+    let engine = Engine::new_for_platform(Platform::Windows);
+    let classification = engine.classify_logsource(&LogSource {
+        product: Some("windows".to_string()),
+        service: Some("security".to_string()),
+        category: None,
+    });
+
+    assert_eq!(classification.status, LogSourceStatus::Supported);
+    assert_eq!(
+        classification.collector_active,
+        Some(true),
+        "windows/security rules must load against a live collector"
+    );
+}
+
+#[test]
+fn security_audit_events_normalize_under_their_own_field_names() {
+    let event = security_event(
+        4697,
+        SensorAction::Register,
+        &[
+            ("SubjectUserName", "alice"),
+            ("SubjectDomainName", "ACME"),
+            ("SubjectLogonId", "0x3e4"),
+            ("ServiceName", "RustinelIssue315"),
+            ("ServiceFileName", r"C:\Windows\Temp\payload.exe"),
+        ],
+    );
+
+    let normalized = normalize(&event);
+    assert_eq!(normalized.category, EventCategory::Security);
+    assert_eq!(normalized.event_id, 4697);
+    assert_eq!(normalized.get_field("EventID"), Some("4697"));
+    assert_eq!(normalized.get_field("SubjectLogonId"), Some("0x3e4"));
+    assert_eq!(
+        normalized.get_field("ServiceFileName"),
+        Some(r"C:\Windows\Temp\payload.exe")
+    );
+    assert!(matches!(normalized.fields, EventFields::SecurityAudit(_)));
+}
+
+/// One rule per supported event family, each written the way SigmaHQ writes
+/// them for this channel: `product: windows`, `service: security`, no category,
+/// and an `EventID` selection.
+#[test]
+fn each_supported_event_family_matches_a_windows_security_rule() {
+    let cases: Vec<(&str, &str, SensorEvent)> = vec![
+        (
+            "service.yml",
+            "Security Service Installation",
+            security_event(
+                4697,
+                SensorAction::Register,
+                &[
+                    ("ServiceName", "RustinelIssue315"),
+                    ("ServiceFileName", r"C:\Windows\Temp\payload.exe"),
+                ],
+            ),
+        ),
+        (
+            "share.yml",
+            "Security Admin Share Write",
+            security_event(
+                5145,
+                SensorAction::Access,
+                &[
+                    ("ShareName", r"\\*\ADMIN$"),
+                    ("RelativeTargetName", "PSEXESVC.exe"),
+                    ("IpAddress", "10.0.0.9"),
+                ],
+            ),
+        ),
+        (
+            "object_access.yml",
+            "Security Credential File Access",
+            security_event(
+                4663,
+                SensorAction::Access,
+                &[
+                    ("ObjectType", "File"),
+                    ("ObjectName", r"C:\Windows\NTDS\ntds.dit"),
+                    ("ProcessId", "0x4d8"),
+                    ("ProcessName", r"C:\Windows\System32\ntdsutil.exe"),
+                ],
+            ),
+        ),
+        (
+            "logon.yml",
+            "Security Network Logon From Host",
+            security_event(
+                4624,
+                SensorAction::Start,
+                &[
+                    ("LogonType", "3"),
+                    ("AuthenticationPackageName", "NTLM"),
+                    ("TargetUserName", "bob"),
+                    ("IpAddress", "10.0.0.9"),
+                ],
+            ),
+        ),
+        (
+            "handle.yml",
+            "Security SAM Handle Request",
+            security_event(
+                4656,
+                SensorAction::Access,
+                &[
+                    ("ObjectType", "Key"),
+                    ("ObjectName", r"\REGISTRY\MACHINE\SECURITY"),
+                    ("AccessMask", "0x20019"),
+                ],
+            ),
+        ),
+        (
+            "directory.yml",
+            "Security Delegation Attribute Change",
+            security_event(
+                5136,
+                SensorAction::Modify,
+                &[
+                    ("AttributeLDAPDisplayName", "msDS-AllowedToDelegateTo"),
+                    ("AttributeValue", "cifs/dc01.acme.test"),
+                    ("ObjectClass", "user"),
+                ],
+            ),
+        ),
+    ];
+
+    let rules = [
+        (
+            "service.yml",
+            r#"title: Security Service Installation
+logsource:
+  product: windows
+  service: security
+detection:
+  selection:
+    EventID: 4697
+    ServiceFileName|contains: '\Temp\'
+  condition: selection
+level: high
+"#,
+        ),
+        (
+            "share.yml",
+            r#"title: Security Admin Share Write
+logsource:
+  product: windows
+  service: security
+detection:
+  selection:
+    EventID: 5145
+    ShareName|contains: 'ADMIN$'
+    RelativeTargetName|endswith: '.exe'
+  condition: selection
+level: high
+"#,
+        ),
+        (
+            "object_access.yml",
+            r#"title: Security Credential File Access
+logsource:
+  product: windows
+  service: security
+detection:
+  selection:
+    EventID: 4663
+    ObjectName|endswith: '\ntds.dit'
+  condition: selection
+level: critical
+"#,
+        ),
+        (
+            "logon.yml",
+            r#"title: Security Network Logon From Host
+logsource:
+  product: windows
+  service: security
+detection:
+  selection:
+    EventID: 4624
+    LogonType: 3
+    AuthenticationPackageName: 'NTLM'
+  condition: selection
+level: medium
+"#,
+        ),
+        (
+            "handle.yml",
+            r#"title: Security SAM Handle Request
+logsource:
+  product: windows
+  service: security
+detection:
+  selection:
+    EventID: 4656
+    ObjectName|endswith: '\SECURITY'
+  condition: selection
+level: high
+"#,
+        ),
+        (
+            "directory.yml",
+            r#"title: Security Delegation Attribute Change
+logsource:
+  product: windows
+  service: security
+detection:
+  selection:
+    EventID: 5136
+    AttributeLDAPDisplayName: 'msDS-AllowedToDelegateTo'
+  condition: selection
+level: high
+"#,
+        ),
+    ];
+
+    let fixture = SigmaFixture::new();
+    for (filename, yaml) in rules {
+        fixture.write_rule(filename, yaml);
+    }
+    let engine = windows_security_engine(&fixture);
+    assert_eq!(engine.stats().total_rules, 6);
+    assert_eq!(engine.stats().inactive_collector_rules, 0);
+
+    for (filename, expected_rule, event) in cases {
+        let normalized = normalize(&event);
+        let alert = engine
+            .check_event(&normalized)
+            .unwrap_or_else(|| panic!("{filename} should match {expected_rule}"));
+        assert_eq!(alert.rule_name, expected_rule);
+        assert_ecs_field_eq(&ecs_json(&alert), "event.dataset", "edr.security");
+    }
+}
+
+/// A rule keyed on a different event ID in the same channel must not fire: the
+/// channel is one logsource, so `EventID` is the only thing separating the
+/// families.
+#[test]
+fn a_rule_for_another_event_id_does_not_match() {
+    let fixture = SigmaFixture::new();
+    fixture.write_rule(
+        "other.yml",
+        r#"title: Security Logon
+logsource:
+  product: windows
+  service: security
+detection:
+  selection:
+    EventID: 4624
+  condition: selection
+level: low
+"#,
+    );
+    let engine = windows_security_engine(&fixture);
+
+    let event = security_event(
+        4697,
+        SensorAction::Register,
+        &[("ServiceName", "RustinelIssue315")],
+    );
+    assert!(engine.check_event(&normalize(&event)).is_none());
+}
+
+#[test]
+fn security_alerts_map_identity_network_and_object_fields_to_ecs() {
+    let fixture = SigmaFixture::new();
+    fixture.write_rule(
+        "share.yml",
+        r#"title: Security Admin Share Write
+logsource:
+  product: windows
+  service: security
+detection:
+  selection:
+    EventID: 5145
+    ShareName|contains: 'ADMIN$'
+  condition: selection
+level: high
+"#,
+    );
+    let engine = windows_security_engine(&fixture);
+
+    let event = security_event(
+        5145,
+        SensorAction::Access,
+        &[
+            ("SubjectUserSid", "S-1-5-21-1-2-3-1001"),
+            ("SubjectUserName", "alice"),
+            ("SubjectDomainName", "ACME"),
+            ("SubjectLogonId", "0x3e4"),
+            ("ObjectType", "File"),
+            ("ShareName", r"\\*\ADMIN$"),
+            ("RelativeTargetName", "PSEXESVC.exe"),
+            ("IpAddress", "10.0.0.9"),
+            ("IpPort", "50123"),
+        ],
+    );
+    let alert = engine
+        .check_event(&normalize(&event))
+        .expect("the share rule should match");
+    let json = ecs_json(&alert);
+
+    assert_ecs_field_eq(&json, "event.dataset", "edr.security");
+    assert_ecs_field_eq(&json, "event.code", "5145");
+    assert_ecs_field_eq(&json, "event.action", "network-share-object-checked");
+    assert_ecs_field_eq(&json, "event.category", serde_json::json!(["file"]));
+    assert_ecs_field_eq(&json, "user.name", "alice");
+    assert_ecs_field_eq(&json, "user.domain", "ACME");
+    assert_ecs_field_eq(&json, "user.id", "S-1-5-21-1-2-3-1001");
+    assert_ecs_field_eq(&json, "winlog.logon.id", "0x3e4");
+    assert_ecs_field_eq(&json, "source.ip", "10.0.0.9");
+    assert_ecs_field_eq(&json, "source.port", 50123);
+
+    // The whole decoded record travels with the alert, under Windows' own
+    // names, so nothing the rule matched on is lost on the way to a SIEM.
+    let record = json
+        .get("edr.security")
+        .expect("the decoded audit record should be present");
+    assert_eq!(
+        record.get("ShareName").and_then(|v| v.as_str()),
+        Some(r"\\*\ADMIN$")
+    );
+    assert_eq!(
+        record.get("RelativeTargetName").and_then(|v| v.as_str()),
+        Some("PSEXESVC.exe")
+    );
+}
+
+#[test]
+fn object_access_ecs_category_follows_the_audited_object_type() {
+    let fixture = SigmaFixture::new();
+    fixture.write_rule(
+        "handle.yml",
+        r#"title: Security Handle Request
+logsource:
+  product: windows
+  service: security
+detection:
+  selection:
+    EventID: 4656
+  condition: selection
+level: low
+"#,
+    );
+    let engine = windows_security_engine(&fixture);
+
+    let cases = [
+        ("Key", "registry", r"\REGISTRY\MACHINE\SECURITY"),
+        ("File", "file", r"C:\Windows\NTDS\ntds.dit"),
+        ("Process", "process", "lsass.exe"),
+    ];
+
+    for (object_type, expected_category, object_name) in cases {
+        let event = security_event(
+            4656,
+            SensorAction::Access,
+            &[("ObjectType", object_type), ("ObjectName", object_name)],
+        );
+        let alert = engine
+            .check_event(&normalize(&event))
+            .expect("the handle rule should match");
+        let json = ecs_json(&alert);
+        assert_ecs_field_eq(
+            &json,
+            "event.category",
+            serde_json::json!([expected_category]),
+        );
+    }
+}
+
+/// A Security-channel process ID is hex. The raw value stays matchable and the
+/// pipeline still gets a number it can use.
+#[test]
+fn hex_process_ids_stay_raw_for_rules_and_parse_for_the_pipeline() {
+    let event = security_event(
+        4663,
+        SensorAction::Access,
+        &[
+            ("ProcessId", "0x4d8"),
+            ("ProcessName", r"C:\Windows\System32\notepad.exe"),
+            ("ObjectType", "File"),
+            ("ObjectName", r"C:\Temp\secrets.txt"),
+        ],
+    );
+
+    assert_eq!(event.pid, Some(0x4d8));
+    let normalized = normalize(&event);
+    assert_eq!(normalized.get_field("ProcessId"), Some("0x4d8"));
+}

--- a/tests/windows_security_event_log.rs
+++ b/tests/windows_security_event_log.rs
@@ -1,0 +1,161 @@
+#![cfg(windows)]
+
+//! Privileged smoke test for the Security channel source.
+//!
+//! Unlike System 7045, nothing in the Security channel is audited by default
+//! except logons, so the test turns the *Security System Extension*
+//! subcategory on, produces a service installation, and restores whatever the
+//! host had before. That restore is what keeps the test safe to run on a lab
+//! box that is also used for other work.
+
+use std::path::PathBuf;
+use std::process::{self, Command};
+use std::sync::Arc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use rustinel::sensor::windows::EtwSensor;
+use rustinel::sensor::{Sensor, SensorPayload};
+
+/// The *Security System Extension* audit subcategory, which is what makes
+/// Windows log event 4697.
+///
+/// Addressed by GUID rather than by name: `auditpol` takes the subcategory's
+/// *localized* name, so `"Security System Extension"` is not a valid argument
+/// on a non-English Windows. The GUID is the same everywhere.
+const SUBCATEGORY: &str = "{0CCE9211-69AE-11D9-BED3-505054503030}";
+
+struct TemporaryService(String);
+
+impl Drop for TemporaryService {
+    fn drop(&mut self) {
+        let _ = Command::new("sc.exe").args(["delete", &self.0]).status();
+    }
+}
+
+/// Enables the subcategory for the duration of the test and puts the host's
+/// audit policy back exactly as it was afterwards, however the test ends.
+///
+/// The restore is a full `auditpol` backup rather than an inverse `/set`, so
+/// nothing is inferred about what the setting was: the file holds the whole
+/// policy, and applying it is exact.
+struct AuditPolicy {
+    backup: PathBuf,
+}
+
+impl AuditPolicy {
+    fn enable_success() -> Self {
+        let backup = std::env::temp_dir().join(format!("rustinel-auditpol-{}.csv", process::id()));
+
+        let status = Command::new("auditpol.exe")
+            .arg("/backup")
+            .arg(format!("/file:{}", backup.display()))
+            .status()
+            .expect("auditpol.exe must be available");
+        assert!(
+            status.success(),
+            "failed to back up the audit policy; the test needs Administrator"
+        );
+
+        let policy = Self { backup };
+        let status = Command::new("auditpol.exe")
+            .arg("/set")
+            .arg(format!("/subcategory:{SUBCATEGORY}"))
+            .arg("/success:enable")
+            .status()
+            .expect("auditpol.exe must be available");
+        assert!(status.success(), "failed to enable the 4697 audit");
+
+        policy
+    }
+}
+
+impl Drop for AuditPolicy {
+    fn drop(&mut self) {
+        let _ = Command::new("auditpol.exe")
+            .arg("/restore")
+            .arg(format!("/file:{}", self.backup.display()))
+            .status();
+        let _ = std::fs::remove_file(&self.backup);
+    }
+}
+
+#[test]
+#[ignore = "requires Administrator privileges and changes audit policy; runs in the Windows privileged smoke job"]
+fn a_service_installation_reaches_the_sensor_as_security_event_4697() {
+    let _audit_policy = AuditPolicy::enable_success();
+
+    let (tx, mut rx) = tokio::sync::mpsc::channel(256);
+    let sensor = Arc::new(EtwSensor::new());
+    let worker_sensor = Arc::clone(&sensor);
+    let worker = thread::spawn(move || worker_sensor.start(tx));
+
+    // Both Event Log subscriptions start on the sensor's worker thread; give
+    // them a window to become ready before producing the one-shot event.
+    thread::sleep(Duration::from_secs(2));
+
+    let service_name = format!("Rustinel4697Test{}", process::id());
+    let temporary_service = TemporaryService(service_name.clone());
+    let create = Command::new("sc.exe")
+        .args([
+            "create",
+            &service_name,
+            "binPath=",
+            r"C:\Windows\System32\cmd.exe /c exit 0",
+            "start=",
+            "demand",
+            "obj=",
+            "LocalSystem",
+        ])
+        .output()
+        .expect("sc.exe must be available");
+    assert!(
+        create.status.success(),
+        "failed to create test service: {}",
+        String::from_utf8_lossy(&create.stderr)
+    );
+
+    let deadline = Instant::now() + Duration::from_secs(20);
+    let mut matched = None;
+    while Instant::now() < deadline {
+        match rx.try_recv() {
+            Ok(event) => {
+                if event.normalization.event_id != 4697 {
+                    continue;
+                }
+                if let SensorPayload::Security(fields) = &event.payload {
+                    if fields.get("ServiceName") == Some(service_name.as_str()) {
+                        matched = Some(event.clone());
+                        break;
+                    }
+                }
+            }
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty) => {
+                thread::sleep(Duration::from_millis(25));
+            }
+            Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => break,
+        }
+    }
+
+    sensor.shutdown();
+    let sensor_result = worker.join().expect("sensor worker must not panic");
+    drop(temporary_service);
+    sensor_result.expect("sensor must stop cleanly");
+
+    let event = matched.expect("Security event 4697 must reach the sensor channel");
+    assert_eq!(event.provider, "windows_event_log");
+    let SensorPayload::Security(fields) = event.payload else {
+        unreachable!();
+    };
+    assert_eq!(fields.get("ServiceName"), Some(service_name.as_str()));
+    assert!(
+        fields
+            .get("ServiceFileName")
+            .is_some_and(|path| path.contains("cmd.exe")),
+        "ServiceFileName should name the service binary: {fields:?}"
+    );
+    // The identity block is what separates a Security audit record from the
+    // System channel's account-less 7045.
+    assert!(fields.get("SubjectUserName").is_some());
+    assert!(fields.get("SubjectLogonId").is_some());
+}


### PR DESCRIPTION
## Summary

Adds a Security channel `EventLogSource`, so the `windows/security` Sigma
logsource has a collector behind it for the first time. Rules targeting it
previously loaded, counted as backed by nothing, and could never match.

- New Security source on the existing source-agnostic Event Log infrastructure,
  registered alongside the System 7045 one. The XPath query scopes the
  subscription **in the kernel** to the six event families from the issue
  (4624, 4656, 4663, 4697, 5136, 5145), and each ID carries an allowlist of the
  properties decoded from it. `SUPPORTED_EVENTS` is the single statement of what
  the collector populates; a unit test asserts the query and that table agree.
- New `EventCategory::Security` / `SensorPayload::Security` /
  `EventFields::SecurityAudit`, backed by `SecurityAuditFields`.
- Routing: Security events alias to `(windows, security)` **by channel**, since
  rules for this logsource carry no category and select on `EventID`. The tuple
  joins the Windows active set, so those rules now load collector-backed.
- ECS: `event.dataset: edr.security`, with `event.category`/`type`/`action`
  driven by the audit event ID and object access refined from `ObjectType`.
  Identity, source address, process and service fields lift into standard ECS,
  and the whole decoded record also travels as a nested `edr.security` object.

### Two design notes worth a reviewer's attention

**The payload is a map, not a union struct.** Every other category is one event
shape. This channel is one logsource carrying families whose field sets barely
overlap — a logon, a handle request, a share access and a directory change share
only the `Subject*` block — so a struct covering them would be ~50 `Option`s that
are `None` on every event, and each new family would add more. The set is still
closed: the per-event allowlists bound it, and they are the same table the
coverage audit reads field availability from.

**Values are kept exactly as Windows renders them**, because that is what rules
for this logsource are written against — SigmaHQ has `SubjectLogonId: '0x3e4'`
and `AccessList|contains: '%%4417'`. `ProcessId` therefore stays hex in the
payload; the parsed value rides on `SensorEvent.pid` so process-cache lookups
and active response still work.

### Coverage caveat, documented as a silent risk

Only 4624 is audited by default. 4697/5145/5136 need an audit subcategory
enabled, and 4656/4663 additionally need a SACL on the object. Nothing about
this is visible from inside the agent — the subscription succeeds, the rules
load as active, and no event ever arrives. `limitations.md` tags it, and
`operations.md` gains a **Windows audit policy** section with the required
policy per event.

Lab validation surfaced a portability trap worth flagging: **`auditpol` takes
the *localized* subcategory name**, so `/subcategory:"Security System Extension"`
fails with *the parameter is incorrect* on a non-English Windows. The smoke test
addresses subcategories by GUID and restores via `auditpol /backup` + `/restore`
rather than an inferred inverse `/set`; the docs give both forms.

`docs/coverage.md`'s 177-rule `security` row is deliberately **not** re-measured
here — it is a point-in-time figure and re-running that audit is its own job. It
is annotated as an upper bound, folded into the "Since this measurement" block
#334 introduced.

Fixes #315

## Type of change

- [x] `feat` / `enhancement` - new feature
- [ ] `bug` - bug fix
- [ ] `refactor` - refactoring, no behaviour change
- [ ] `documentation` - docs only
- [ ] `ci` - CI and release changes
- [ ] `dependencies` - dependency update

## Test plan

- [x] Tested on Windows
- [ ] Tested on Linux
- [x] Existing tests pass (`cargo test`) — 417 on macOS, full suite on Windows
- [x] New tests added
- [x] Windows `cargo clippy --locked --all-targets -- -D clippy::all`

Verified on a real Windows 11 host, on the rebased tree:

- **Decoder unit tests** (Windows-only): one per event family, plus allowlist
  enforcement, provider rejection, unsupported-ID rejection, and query/table
  agreement.
- **`tests/windows_security_channel.rs`** (all platforms): `windows/security`
  classifies as supported with `collector_active: true`; each of the six
  families matches a rule written the way SigmaHQ writes them; a rule for a
  different `EventID` in the same channel does *not* match; ECS identity /
  network / object mapping; `ObjectType` → `event.category`; hex PID handling.
- **`tests/windows_security_event_log.rs`** (privileged smoke, wired into
  `privileged-smoke.yml`): enables the 4697 subcategory, installs a service,
  asserts the decoded record reaches the sensor channel, restores the host's
  audit policy. Passed as SYSTEM.
- **Live agent runs**, alerts read back from `alerts.json`:
  - 4697 — rule loaded with `inactive_collector_rules=0`, both subscriptions
    started, `Detection triggered … category=Security`, alert carried
    `service.name`, `user.id: S-1-5-18`, `winlog.logon.id: 0x3e7`.
  - 5145 — matched on `ShareName`/`RelativeTargetName`, with `source.ip`,
    `source.port`, raw `%%4423` access codes, and `event.category: ["file"]`
    derived from `ObjectType`.
  - Audit policy confirmed restored after both runs; test service removed.

## Checklist

- [x] Label added to this PR
- [x] Docs updated — `architecture.md`, `detection.md`, `limitations.md`,
      `operations.md`, `output.md`, `coverage.md`
