### PR TITLE
fix(windows-etw): preserve CommandLine for short-lived processes

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -118,7 +118,7 @@ snapshot_interval_secs = 30 # a snapshot is also written at shutdown
 #   earlier handoff for partially filled buffers so isolated events reach the
 #   detector promptly. Set to 0 to use only ETW's native timer.
 [windows]
-etw_flush_interval_ms = 100
+etw_flush_interval_ms = 20
 
 # 7. Atomic IOC Detection (Hashes, IPs, Domains, Path Regex)
 [ioc]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -98,7 +98,7 @@ enabled = true
 snapshot_interval_secs = 30
 
 [windows]
-etw_flush_interval_ms = 100
+etw_flush_interval_ms = 20
 
 [response]
 enabled = false
@@ -309,12 +309,15 @@ buffer size or pool limits.
 
 | Option | Default | Description |
 | --- | --- | --- |
-| `etw_flush_interval_ms` | `100` | Partial-buffer handoff interval in milliseconds; `0` disables it |
+| `etw_flush_interval_ms` | `20` | Partial-buffer handoff interval in milliseconds; `0` disables it |
 
 Values below 20 ms are clamped to 20 ms. Rustinel pauses requests while the
 `sensor_events` queue is at least half full, when downstream queueing controls
-latency. ETW continues its normal full-buffer and timer-based delivery. Override
-the setting with `EDR__WINDOWS__ETW_FLUSH_INTERVAL_MS`.
+latency. The 20 ms default narrows the race for short-lived process command
+lines, but cannot recover a process that exits before the live-PEB back-fill;
+it also adds a small periodic flush cost. ETW continues its normal full-buffer
+and timer-based delivery. Override the setting with
+`EDR__WINDOWS__ETW_FLUSH_INTERVAL_MS`.
 
 ### Active response
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -40,11 +40,11 @@ three platforms, but several Sysmon-style fields are unavailable.
   do not carry it, and a mandatory label whose level Windows has not defined is
   reported as the raw `S-1-16-...` SID rather than dropped.
 - **Command line is back-filled, and can be lost.** No Kernel-Process event
-  carries `CommandLine`; it is obtained by querying the live process. Measured
-  at 100% on realistic workloads and 99.8% under process churn, the gap appears
-  only for processes killed before they execute. When the back-fill loses the
-  race it returns nothing rather than another process's command line, but the
-  failure is currently uncounted
+  carries `CommandLine`; it is obtained by querying the live process. The
+  default 20 ms ETW handoff narrows the race for short-lived processes, but a
+  process that exits before the back-fill still has no command line. When the
+  back-fill loses the race it returns nothing rather than another process's
+  command line, but the failure is currently uncounted
   ([#304](https://github.com/Karib0u/rustinel/issues/304)).
 - **Registry value data depends on an undocumented request (silent risk).**
   `Details` carries the value data, as Sysmon Event ID 13 defines it, because

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -248,12 +248,15 @@ Rustinel sets the pool explicitly rather than inheriting library defaults:
 | Minimum buffers | 64 (16 MB committed at start) | 2 |
 | Maximum buffers | 128 (32 MB ceiling) | 24 (768 KB) |
 | Flush timer | 1 s | 1 s |
-| Forced partial-buffer handoff | 100 ms | disabled |
+| Forced partial-buffer handoff | 20 ms | disabled |
 
 The forced handoff controls quiet-host delivery latency without changing the
 buffer pool. Configure it with `windows.etw_flush_interval_ms`; `0` disables it.
 Rustinel pauses requests while its sensor queue is at least half full, when
-queueing controls latency instead.
+queueing controls latency instead. The 20 ms default reduces the command-line
+back-fill race for short-lived processes at the cost of more frequent flush
+requests; a process that exits before the back-fill can still have no
+`CommandLine`.
 
 The buffers are non-paged pool: 16 MB is committed for the life of the agent and
 grows to at most 32 MB under load. Read the live values back with:

--- a/src/config.rs
+++ b/src/config.rs
@@ -567,7 +567,7 @@ impl AppConfig {
             .set_default("telemetry.enabled", true)?
             .set_default("telemetry.snapshot_interval_secs", 30i64)?
             // Windows ETW delivery latency
-            .set_default("windows.etw_flush_interval_ms", 100i64)?;
+            .set_default("windows.etw_flush_interval_ms", 20i64)?;
 
         let builder = match selected_config {
             Some(path) => builder.add_source(config::File::from(path).required(true)),
@@ -825,7 +825,7 @@ impl Default for AppConfig {
                 snapshot_interval_secs: 30,
             },
             windows: WindowsConfig {
-                etw_flush_interval_ms: 100,
+                etw_flush_interval_ms: 20,
             },
         };
 
@@ -1169,7 +1169,25 @@ paths_regex_path = "explicit-ioc/paths_regex.txt"
     #[test]
     fn test_windows_etw_flush_default() {
         let cfg = AppConfig::default();
-        assert_eq!(cfg.windows.etw_flush_interval_ms, 100);
+        assert_eq!(cfg.windows.etw_flush_interval_ms, 20);
+    }
+
+    #[test]
+    fn config_builder_uses_windows_etw_flush_default() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let cfg = AppConfig::from_options_with_environment(
+            ConfigLoadOptions {
+                explicit_config: None,
+                env_config: None,
+                managed_config: temp.path().join("missing-managed.toml"),
+                exe_config: None,
+                cwd_config: temp.path().join("missing-cwd.toml"),
+            },
+            Some(config::Map::new()),
+        )
+        .expect("load default config");
+
+        assert_eq!(cfg.windows.etw_flush_interval_ms, 20);
     }
 
     #[test]

--- a/src/sensor/windows/flush.rs
+++ b/src/sensor/windows/flush.rs
@@ -25,7 +25,7 @@ use windows::Win32::System::Diagnostics::Etw::{
 use super::registry_value_data::session_handle;
 use crate::sensor::SensorEvent;
 
-pub(super) const DEFAULT_INTERVAL_MS: u64 = 100;
+pub(super) const DEFAULT_INTERVAL_MS: u64 = 20;
 const MIN_INTERVAL: Duration = Duration::from_millis(20);
 const MAX_QUEUE_PERCENT_FOR_FLUSH: usize = 50;
 const TRACE_NAME_BYTES: usize = 2 * 1024;
@@ -151,6 +151,7 @@ mod tests {
 
     #[test]
     fn interval_is_clamped_to_twenty_milliseconds() {
+        assert_eq!(DEFAULT_INTERVAL_MS, 20);
         assert_eq!(configured_interval(1), Some(MIN_INTERVAL));
         assert_eq!(
             configured_interval(DEFAULT_INTERVAL_MS),


### PR DESCRIPTION
## Summary
Reduce the default Windows ETW forced-flush interval from 100 ms to 20 ms. This narrows the live-PEB back-fill race for short-lived process creation events while keeping the existing 256 KB ETW buffer sizing and 20 ms minimum clamp.

The bundled configuration and operator documentation now use the same default and document the residual race and periodic flush cost.

## Type of change
- [x] `bug` - bug fix

## Test plan
- [x] Tested on Windows
- [x] Tested on Linux/macOS host
- [x] Existing tests pass (`cargo test --locked`)
- [x] New tests added for both config default paths and the runtime default

Validation results:
- Windows test suite: 360 passed
- Windows lab probe at 100 ms: 6/15 short-lived command lines, 3/3 long-lived
- Windows lab probe at the 20 ms default: 71/75 short-lived command lines across five runs, including two 15/15 runs; 3/3 long-lived

## Checklist
- [x] Docs updated

Fixes #340