### PR TITLE
fix(windows-etw): give Kernel-Process its own low-latency ETW session

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -117,8 +117,24 @@ snapshot_interval_secs = 30 # a snapshot is also written at shutdown
 #   ETW's native flush timer has a one-second minimum. Rustinel requests an
 #   earlier handoff for partially filled buffers so isolated events reach the
 #   detector promptly. Set to 0 to use only ETW's native timer.
+#
+#   Rustinel runs two ETW sessions and they are tuned separately.
+#
+#   `etw_flush_interval_ms` is the main session (file, registry, network, DNS,
+#   PowerShell, WMI, tasks). It trades alert latency against one periodic
+#   syscall; 0 is a reasonable choice. Values below 20 are clamped to 20.
+#
+#   `etw_process_flush_interval_ms` is the Kernel-Process session, and it is
+#   NOT a latency preference. `CommandLine` is not carried by any ETW process
+#   event - it is read back out of the live process, so the event has to reach
+#   Rustinel before the process exits. Measured over 2,000 `cmd /c echo` runs:
+#   5 ms captured 99.9% of their command lines, 20 ms only 61.5%.
+#   SETTING THIS TO 0 GIVES UP ROUGHLY 40% OF SHORT-LIVED COMMAND LINES, and
+#   with them every Sigma process_creation rule that matches on CommandLine
+#   (78% of them). Raise it only if you have measured that you can afford to.
 [windows]
 etw_flush_interval_ms = 20
+etw_process_flush_interval_ms = 5
 
 # 7. Atomic IOC Detection (Hashes, IPs, Domains, Path Regex)
 [ioc]

--- a/config.toml
+++ b/config.toml
@@ -129,8 +129,9 @@ snapshot_interval_secs = 30 # a snapshot is also written at shutdown
 #   event - it is read back out of the live process, so the event has to reach
 #   Rustinel before the process exits. Measured over 2,000 `cmd /c echo` runs:
 #   5 ms captured 99.9% of their command lines, 20 ms only 61.5%.
-#   SETTING THIS TO 0 GIVES UP ROUGHLY 40% OF SHORT-LIVED COMMAND LINES, and
-#   with them every Sigma process_creation rule that matches on CommandLine
+#   SETTING THIS TO 0 GIVES UP ~83% OF SHORT-LIVED COMMAND LINES (measured:
+#   16.6% captured, because the session falls back to ETW's one-second timer),
+#   and with them every Sigma process_creation rule that matches on CommandLine
 #   (78% of them). Raise it only if you have measured that you can afford to.
 [windows]
 etw_flush_interval_ms = 20

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -304,18 +304,23 @@ that reduced visibility as a warning.
 ### Windows ETW delivery
 
 ETW's real-time session timer hands partially filled buffers to consumers once
-per second. Rustinel requests an earlier handoff without changing the session's
-buffer size or pool limits.
+per second. Rustinel requests an earlier handoff without changing either
+session's buffer size or pool limits.
 
 | Option | Default | Description |
 | --- | --- | --- |
 | `etw_flush_interval_ms` | `20` | Partial-buffer handoff interval in milliseconds; `0` disables it |
 
-Values below 20 ms are clamped to 20 ms. Rustinel pauses requests while the
-`sensor_events` queue is at least half full, when downstream queueing controls
-latency. The 20 ms default narrows the race for short-lived process command
-lines, but cannot recover a process that exits before the live-PEB back-fill;
-it also adds a small periodic flush cost. ETW continues its normal full-buffer
+This sets the interval for the main session, `rustinel-etw-trace`. Values below
+20 ms are clamped to 20 ms. The dedicated `rustinel-etw-process` session is
+flushed every 5 ms regardless — that interval is set by how long a short-lived
+process lives, not by a latency preference, and a longer one loses command lines
+(see [Windows ETW session buffers](operations.md#windows-etw-session-buffers)).
+Setting this option to `0` disables forced flushing on both sessions; setting it
+below 5 ms speeds up both.
+
+Rustinel pauses requests while the `sensor_events` queue is at least half full,
+when downstream queueing controls latency. ETW continues its normal full-buffer
 and timer-based delivery. Override the setting with
 `EDR__WINDOWS__ETW_FLUSH_INTERVAL_MS`.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -307,22 +307,34 @@ ETW's real-time session timer hands partially filled buffers to consumers once
 per second. Rustinel requests an earlier handoff without changing either
 session's buffer size or pool limits.
 
-| Option | Default | Description |
-| --- | --- | --- |
-| `etw_flush_interval_ms` | `20` | Partial-buffer handoff interval in milliseconds; `0` disables it |
+Rustinel runs two ETW sessions and each has its own interval, because they are
+flushed for different reasons.
 
-This sets the interval for the main session, `rustinel-etw-trace`. Values below
-20 ms are clamped to 20 ms. The dedicated `rustinel-etw-process` session is
-flushed every 5 ms regardless — that interval is set by how long a short-lived
-process lives, not by a latency preference, and a longer one loses command lines
-(see [Windows ETW session buffers](operations.md#windows-etw-session-buffers)).
-Setting this option to `0` disables forced flushing on both sessions; setting it
-below 5 ms speeds up both.
+| Option | Default | Session | Description |
+| --- | --- | --- | --- |
+| `etw_flush_interval_ms` | `20` | `rustinel-etw-trace` | Partial-buffer handoff interval in milliseconds; `0` disables it. Values below 20 ms are clamped to 20 ms |
+| `etw_process_flush_interval_ms` | `5` | `rustinel-etw-process` | The same for the process session; `0` disables it. Values below 1 ms are clamped to 1 ms |
+
+On the main session the interval trades alert latency against one periodic
+syscall, and `0` is a reasonable choice.
+
+**On the process session it is not a latency preference — it decides whether
+`CommandLine` is collected at all.** No ETW process event carries the field; it
+is read back out of the live process, so the event has to reach Rustinel before
+that process exits. Over 2,000 `cmd /c echo` runs on the lab VM, 5 ms captured
+99.9% of their command lines and 20 ms only 61.5%. **Setting
+`etw_process_flush_interval_ms = 0` gives up roughly 40% of short-lived command
+lines, and with them every Sigma `process_creation` rule that matches on
+`CommandLine` — 78% of them.** The two options are deliberately independent so
+that turning the main session's handoff off does not silently do this. See
+[Windows ETW session buffers](operations.md#windows-etw-session-buffers) for the
+full sweep.
 
 Rustinel pauses requests while the `sensor_events` queue is at least half full,
 when downstream queueing controls latency. ETW continues its normal full-buffer
-and timer-based delivery. Override the setting with
-`EDR__WINDOWS__ETW_FLUSH_INTERVAL_MS`.
+and timer-based delivery. Override the settings with
+`EDR__WINDOWS__ETW_FLUSH_INTERVAL_MS` and
+`EDR__WINDOWS__ETW_PROCESS_FLUSH_INTERVAL_MS`.
 
 ### Active response
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -323,10 +323,14 @@ syscall, and `0` is a reasonable choice.
 is read back out of the live process, so the event has to reach Rustinel before
 that process exits. Over 2,000 `cmd /c echo` runs on the lab VM, 5 ms captured
 99.9% of their command lines and 20 ms only 61.5%. **Setting
-`etw_process_flush_interval_ms = 0` gives up roughly 40% of short-lived command
-lines, and with them every Sigma `process_creation` rule that matches on
-`CommandLine` — 78% of them.** The two options are deliberately independent so
-that turning the main session's handoff off does not silently do this. See
+`etw_process_flush_interval_ms = 0` captured 16.6% — it gives up about 83% of
+short-lived command lines, and with them every Sigma `process_creation` rule
+that matches on `CommandLine`, 78% of them.** Zero is worse than a slow interval
+because the session then falls all the way back to ETW's one-second timer. The
+two options are deliberately independent so that turning the main session's
+handoff off does not silently do this — measured with
+`etw_flush_interval_ms = 0` and the process option left at 5 ms, command-line
+capture stayed at 100%. See
 [Windows ETW session buffers](operations.md#windows-etw-session-buffers) for the
 full sweep.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -318,17 +318,17 @@ flushed for different reasons.
 On the main session the interval trades alert latency against one periodic
 syscall, and `0` is a reasonable choice.
 
-**On the process session it is not a latency preference — it decides whether
+**On the process session it is not a latency preference - it decides whether
 `CommandLine` is collected at all.** No ETW process event carries the field; it
 is read back out of the live process, so the event has to reach Rustinel before
 that process exits. Over 2,000 `cmd /c echo` runs on the lab VM, 5 ms captured
 99.9% of their command lines and 20 ms only 61.5%. **Setting
-`etw_process_flush_interval_ms = 0` captured 16.6% — it gives up about 83% of
+`etw_process_flush_interval_ms = 0` captured 16.6% - it gives up about 83% of
 short-lived command lines, and with them every Sigma `process_creation` rule
 that matches on `CommandLine`, 78% of them.** Zero is worse than a slow interval
 because the session then falls all the way back to ETW's one-second timer. The
 two options are deliberately independent so that turning the main session's
-handoff off does not silently do this — measured with
+handoff off does not silently do this - measured with
 `etw_flush_interval_ms = 0` and the process option left at 5 ms, command-line
 capture stayed at 100%. See
 [Windows ETW session buffers](operations.md#windows-etw-session-buffers) for the

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -42,9 +42,11 @@ three platforms, but several Sysmon-style fields are unavailable.
 - **Command line is back-filled, and can be lost.** No Kernel-Process event
   carries `CommandLine`; it is obtained by querying the live process. Process
   events are collected on their own ETW session, flushed every 5 ms so they
-  reach the sensor while the process is still alive, but a process that exits
-  first still has no command line. Measured at 99.85% on 2,000 `cmd /c echo`
-  runs and 4000/4000 on a 4,000-process fork tree.
+  reach the sensor while the process is still alive, and the back-fill runs
+  before any other decoding work, but a process that exits first still has no
+  command line. Measured at 99.9% on 2,000 `cmd /c echo` runs and 4000/4000 on
+  a 4,000-process fork tree. Setting `windows.etw_process_flush_interval_ms`
+  to `0` gives the loss back.
   When the back-fill loses the race it returns nothing rather than another
   process's command line, but the failure is currently uncounted
   ([#304](https://github.com/Karib0u/rustinel/issues/304)).

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -46,7 +46,7 @@ three platforms, but several Sysmon-style fields are unavailable.
   before any other decoding work, but a process that exits first still has no
   command line. Measured at 99.9% on 2,000 `cmd /c echo` runs and 4000/4000 on
   a 4,000-process fork tree. Setting `windows.etw_process_flush_interval_ms`
-  to `0` gives the loss back.
+  to `0` drops that to 16.6%.
   When the back-fill loses the race it returns nothing rather than another
   process's command line, but the failure is currently uncounted
   ([#304](https://github.com/Karib0u/rustinel/issues/304)).

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -71,9 +71,9 @@ three platforms, but several Sysmon-style fields are unavailable.
   for some services means until reboot. Counted as `unresolved_file_events` and
   `unresolved_registry_events`.
 - **Extreme process bursts can still be lost in the kernel (silent risk).** Both
-  ETW sessions use an explicitly sized buffer pool — 256 KB × 64-128 (32 MB
+  ETW sessions use an explicitly sized buffer pool - 256 KB × 64-128 (32 MB
   ceiling) for the main session, 32 KB × 64-512 (16 MB ceiling) for the process
-  session — where the pool that absorbed a 4,000-process fork tree with no loss
+  session - where the pool that absorbed a 4,000-process fork tree with no loss
   was the former and the library defaults lost 12-60%. A host that churns harder
   can still overrun them, and nothing counts the overrun
   ([#305](https://github.com/Karib0u/rustinel/issues/305)), so a recorded event

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -41,9 +41,10 @@ three platforms, but several Sysmon-style fields are unavailable.
   reported as the raw `S-1-16-...` SID rather than dropped.
 - **Command line is back-filled, and can be lost.** No Kernel-Process event
   carries `CommandLine`; it is obtained by querying the live process. Process
-  events are collected on their own small-buffer ETW session so they reach the
-  sensor while the process is still alive, and the 20 ms handoff narrows the
-  window further, but a process that exits first still has no command line.
+  events are collected on their own ETW session, flushed every 5 ms so they
+  reach the sensor while the process is still alive, but a process that exits
+  first still has no command line. Measured at 99.85% on 2,000 `cmd /c echo`
+  runs and 4000/4000 on a 4,000-process fork tree.
   When the back-fill loses the race it returns nothing rather than another
   process's command line, but the failure is currently uncounted
   ([#304](https://github.com/Karib0u/rustinel/issues/304)).

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -40,11 +40,12 @@ three platforms, but several Sysmon-style fields are unavailable.
   do not carry it, and a mandatory label whose level Windows has not defined is
   reported as the raw `S-1-16-...` SID rather than dropped.
 - **Command line is back-filled, and can be lost.** No Kernel-Process event
-  carries `CommandLine`; it is obtained by querying the live process. The
-  default 20 ms ETW handoff narrows the race for short-lived processes, but a
-  process that exits before the back-fill still has no command line. When the
-  back-fill loses the race it returns nothing rather than another process's
-  command line, but the failure is currently uncounted
+  carries `CommandLine`; it is obtained by querying the live process. Process
+  events are collected on their own small-buffer ETW session so they reach the
+  sensor while the process is still alive, and the 20 ms handoff narrows the
+  window further, but a process that exits first still has no command line.
+  When the back-fill loses the race it returns nothing rather than another
+  process's command line, but the failure is currently uncounted
   ([#304](https://github.com/Karib0u/rustinel/issues/304)).
 - **Registry value data depends on an undocumented request (silent risk).**
   `Details` carries the value data, as Sysmon Event ID 13 defines it, because
@@ -66,11 +67,12 @@ three platforms, but several Sysmon-style fields are unavailable.
   and service logs stay unobserved until the handle is closed and reopened, which
   for some services means until reboot. Counted as `unresolved_file_events` and
   `unresolved_registry_events`.
-- **Extreme process bursts can still be lost in the kernel (silent risk).** The
-  ETW session uses an explicitly sized buffer pool (256 KB × 64-128, 32 MB
-  ceiling) that absorbed a 4,000-process fork tree with no loss, where the
-  library defaults lost 12-60%. A host that churns harder can still overrun it,
-  and nothing counts the overrun
+- **Extreme process bursts can still be lost in the kernel (silent risk).** Both
+  ETW sessions use an explicitly sized buffer pool — 256 KB × 64-128 (32 MB
+  ceiling) for the main session, 32 KB × 64-512 (16 MB ceiling) for the process
+  session — where the pool that absorbed a 4,000-process fork tree with no loss
+  was the former and the library defaults lost 12-60%. A host that churns harder
+  can still overrun them, and nothing counts the overrun
   ([#305](https://github.com/Karib0u/rustinel/issues/305)), so a recorded event
   count is an upper bound. See
   [Windows ETW session buffers](operations.md#windows-etw-session-buffers).

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -256,23 +256,40 @@ Both set the pool explicitly rather than inheriting library defaults:
 | Minimum buffers | 64 (16 MB committed) | 64 (2 MB committed) | 2 |
 | Maximum buffers | 128 (32 MB ceiling) | 512 (16 MB ceiling) | 24 (768 KB) |
 | Flush timer | 1 s | 1 s | 1 s |
-| Forced partial-buffer handoff | 20 ms | 20 ms | disabled |
+| Forced partial-buffer handoff | 20 ms | 5 ms | disabled |
 
-A buffer is handed to the consumer when it fills. A 256 KB buffer carrying only
-process events takes a long time to fill on a quiet host — long enough that
-`cmd /c echo` has exited before the sensor can read its command line, which is
-the regression a single 256 KB session introduced in 1.4.0
-([#349](https://github.com/Karib0u/rustinel/issues/349)). The process session
-keeps the 32 KB buffer that fills quickly, and raises the buffer *count*
-instead, so it has burst headroom without the latency.
+A buffer is handed to the consumer when it fills, or when a flush is forced.
+Neither buffer size on its own gets a low-volume stream out quickly — a session
+carrying only process events does not fill a buffer of *any* size fast enough to
+beat a process that lives 20 ms, which is why the split had to come with a
+faster forced handoff (below). What the split buys is that the faster handoff is
+affordable: it applies to a small session rather than to the 256 KB pool sized
+to absorb bursts, where flushing 200 times a second would hand over mostly empty
+buffers and give back what
+[#312](https://github.com/Karib0u/rustinel/pull/312) bought. The process session
+keeps the 32 KB buffer and raises the buffer *count* instead, so it has burst
+headroom without committing 32 MB to it.
 
 The forced handoff controls quiet-host delivery latency without changing the
 buffer pools, and runs on both sessions. Configure it with
-`windows.etw_flush_interval_ms`; `0` disables it. Rustinel pauses requests while
-its sensor queue is at least half full, when queueing controls latency instead.
-The 20 ms default reduces the command-line back-fill race for short-lived
-processes at the cost of more frequent flush requests; a process that exits
-before the back-fill can still have no `CommandLine`.
+`windows.etw_flush_interval_ms`; `0` disables it on both. Rustinel pauses
+requests while its sensor queue is at least half full, when queueing controls
+latency instead.
+
+The process session is flushed at a fixed 5 ms rather than at the configured
+interval, because what sets it is how long a short-lived process lives, not a
+latency preference. Over 2,000 `cmd /c echo` runs on the lab VM:
+
+| Process-session handoff | Command lines captured |
+| --- | --- |
+| 20 ms (the main session's interval) | 61.5% |
+| 10 ms | 99.9% |
+| 5 ms | 99.85% |
+| 1 ms | 99.8% |
+
+Agent CPU was indistinguishable across that range. A process that exits before
+the back-fill can still have no `CommandLine`; the race is structural, and only
+its width is under Rustinel's control.
 
 The buffers are non-paged pool: 18 MB is committed for the life of the agent
 across both sessions and grows to at most 48 MB under load. Read the live values
@@ -288,9 +305,19 @@ the cmdlet in scripts.
 
 This sizing absorbed a 4,000-process fork tree with no loss on a Windows 11 lab
 VM, where the library defaults lost 12-60% of process starts across identical
-runs ([#312](https://github.com/Karib0u/rustinel/pull/312)). It is a fixed
-configuration, not an adaptive one: a host that churns processes harder than
-that can still overrun either pool, and kernel-side loss is not counted
+runs ([#312](https://github.com/Karib0u/rustinel/pull/312)). Re-measured on the
+same fork tree after the session split, with the pre-#312 configuration rebuilt
+on current code for comparison:
+
+| Configuration | Kernel loss | Command lines |
+| --- | --- | --- |
+| Pre-#312 (one 32 KB session, no handoff) | 51.4% | 1877 / 4000 |
+| 1.4.0 (one 256 KB session, 20 ms) | 0% | 3878 / 4000 |
+| Split sessions, 5 ms process handoff | 0% | 4000 / 4000 |
+
+It is a fixed configuration, not an adaptive one: a host that churns processes
+harder than that can still overrun either pool, and kernel-side loss is not
+counted
 anywhere yet ([#305](https://github.com/Karib0u/rustinel/issues/305)). Treat a
 recorded event count as an upper bound on what happened.
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -271,14 +271,14 @@ keeps the 32 KB buffer and raises the buffer *count* instead, so it has burst
 headroom without committing 32 MB to it.
 
 The forced handoff controls quiet-host delivery latency without changing the
-buffer pools, and runs on both sessions. Configure it with
-`windows.etw_flush_interval_ms`; `0` disables it on both. Rustinel pauses
-requests while its sensor queue is at least half full, when queueing controls
-latency instead.
+buffer pools, and runs on both sessions — each from its own option,
+`windows.etw_flush_interval_ms` and `windows.etw_process_flush_interval_ms`.
+Rustinel pauses requests while its sensor queue is at least half full, when
+queueing controls latency instead.
 
-The process session is flushed at a fixed 5 ms rather than at the configured
-interval, because what sets it is how long a short-lived process lives, not a
-latency preference. Over 2,000 `cmd /c echo` runs on the lab VM:
+The process session defaults to 5 ms rather than the main session's 20 ms,
+because what sets it is how long a short-lived process lives, not a latency
+preference. Over 2,000 `cmd /c echo` runs on the lab VM:
 
 | Process-session handoff | Command lines captured |
 | --- | --- |
@@ -287,9 +287,15 @@ latency preference. Over 2,000 `cmd /c echo` runs on the lab VM:
 | 5 ms | 99.85% |
 | 1 ms | 99.8% |
 
-Agent CPU was indistinguishable across that range. A process that exits before
-the back-fill can still have no `CommandLine`; the race is structural, and only
-its width is under Rustinel's control.
+Agent CPU was indistinguishable across that range. Setting
+`etw_process_flush_interval_ms = 0` disables the handoff and returns the process
+session to ETW's one-second timer, which is the 20 ms row and worse — treat it
+as giving up short-lived command lines deliberately. A process that exits before
+the back-fill can still have no `CommandLine` even at 5 ms; the race is
+structural, and only its width is under Rustinel's control. Rustinel narrows it
+on the decode side too: the back-fill runs as soon as the PID is parsed, ahead
+of PE version-resource parsing and every path conversion, so no avoidable work
+sits between the event arriving and the live-process read.
 
 The buffers are non-paged pool: 18 MB is committed for the life of the agent
 across both sessions and grows to at most 48 MB under load. Read the live values

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -236,43 +236,61 @@ for what to do about it.
 ### Windows ETW session buffers
 
 Those counters see only Rustinel's own queues. On Windows there is an earlier
-place events can be lost: the kernel's buffer pool for the `rustinel-etw-trace`
-session. If the pool fills before the sensor drains it, the kernel discards
-events and the sensor never sees them.
+place events can be lost: the kernel's buffer pool for Rustinel's ETW sessions.
+If a pool fills before the sensor drains it, the kernel discards events and the
+sensor never sees them.
 
-Rustinel sets the pool explicitly rather than inheriting library defaults:
+Rustinel runs **two** real-time sessions, because process events and everything
+else want opposite buffer sizing:
 
-| Setting | Value | Default it replaces |
+| Session | Providers | Why |
 | --- | --- | --- |
-| Buffer size | 256 KB | 32 KB |
-| Minimum buffers | 64 (16 MB committed at start) | 2 |
-| Maximum buffers | 128 (32 MB ceiling) | 24 (768 KB) |
-| Flush timer | 1 s | 1 s |
-| Forced partial-buffer handoff | 20 ms | disabled |
+| `rustinel-etw-trace` | File, Registry, Network, DNS, PowerShell, WMI, Task Scheduler | Burst headroom — these are the high-volume providers |
+| `rustinel-etw-process` | Kernel-Process | Latency — `CommandLine` is read from the live process, which must still exist |
+
+Both set the pool explicitly rather than inheriting library defaults:
+
+| Setting | `rustinel-etw-trace` | `rustinel-etw-process` | Default it replaces |
+| --- | --- | --- | --- |
+| Buffer size | 256 KB | 32 KB | 32 KB |
+| Minimum buffers | 64 (16 MB committed) | 64 (2 MB committed) | 2 |
+| Maximum buffers | 128 (32 MB ceiling) | 512 (16 MB ceiling) | 24 (768 KB) |
+| Flush timer | 1 s | 1 s | 1 s |
+| Forced partial-buffer handoff | 20 ms | 20 ms | disabled |
+
+A buffer is handed to the consumer when it fills. A 256 KB buffer carrying only
+process events takes a long time to fill on a quiet host — long enough that
+`cmd /c echo` has exited before the sensor can read its command line, which is
+the regression a single 256 KB session introduced in 1.4.0
+([#349](https://github.com/Karib0u/rustinel/issues/349)). The process session
+keeps the 32 KB buffer that fills quickly, and raises the buffer *count*
+instead, so it has burst headroom without the latency.
 
 The forced handoff controls quiet-host delivery latency without changing the
-buffer pool. Configure it with `windows.etw_flush_interval_ms`; `0` disables it.
-Rustinel pauses requests while its sensor queue is at least half full, when
-queueing controls latency instead. The 20 ms default reduces the command-line
-back-fill race for short-lived processes at the cost of more frequent flush
-requests; a process that exits before the back-fill can still have no
-`CommandLine`.
+buffer pools, and runs on both sessions. Configure it with
+`windows.etw_flush_interval_ms`; `0` disables it. Rustinel pauses requests while
+its sensor queue is at least half full, when queueing controls latency instead.
+The 20 ms default reduces the command-line back-fill race for short-lived
+processes at the cost of more frequent flush requests; a process that exits
+before the back-fill can still have no `CommandLine`.
 
-The buffers are non-paged pool: 16 MB is committed for the life of the agent and
-grows to at most 32 MB under load. Read the live values back with:
+The buffers are non-paged pool: 18 MB is committed for the life of the agent
+across both sessions and grows to at most 48 MB under load. Read the live values
+back with:
 
 ```powershell
 Get-EtwTraceSession -Name rustinel-etw-trace
+Get-EtwTraceSession -Name rustinel-etw-process
 ```
 
-`logman query -ets` shows the same session but localizes its output, so prefer
+`logman query -ets` shows the same sessions but localizes its output, so prefer
 the cmdlet in scripts.
 
 This sizing absorbed a 4,000-process fork tree with no loss on a Windows 11 lab
 VM, where the library defaults lost 12-60% of process starts across identical
 runs ([#312](https://github.com/Karib0u/rustinel/pull/312)). It is a fixed
 configuration, not an adaptive one: a host that churns processes harder than
-that can still overrun a 32 MB pool, and kernel-side loss is not counted
+that can still overrun either pool, and kernel-side loss is not counted
 anywhere yet ([#305](https://github.com/Karib0u/rustinel/issues/305)). Treat a
 recorded event count as an upper bound on what happened.
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -286,11 +286,14 @@ preference. Over 2,000 `cmd /c echo` runs on the lab VM:
 | 10 ms | 99.9% |
 | 5 ms | 99.85% |
 | 1 ms | 99.8% |
+| `0` (disabled — falls back to ETW's 1 s timer) | 16.6% |
 
-Agent CPU was indistinguishable across that range. Setting
-`etw_process_flush_interval_ms = 0` disables the handoff and returns the process
-session to ETW's one-second timer, which is the 20 ms row and worse — treat it
-as giving up short-lived command lines deliberately. A process that exits before
+Agent CPU was indistinguishable across the 1-20 ms range. Note that `0` is much
+worse than a slow interval, not equivalent to one: it returns the session to
+ETW's one-second timer. Treat it as giving up short-lived command lines
+deliberately. The main session's `etw_flush_interval_ms` is a separate option
+precisely so that setting *it* to `0` does not do this — measured that way,
+command-line capture stayed at 100%. A process that exits before
 the back-fill can still have no `CommandLine` even at 5 ms; the race is
 structural, and only its width is under Rustinel's control. Rustinel narrows it
 on the decode side too: the back-fill runs as soon as the PID is parsed, ahead

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -245,8 +245,8 @@ else want opposite buffer sizing:
 
 | Session | Providers | Why |
 | --- | --- | --- |
-| `rustinel-etw-trace` | File, Registry, Network, DNS, PowerShell, WMI, Task Scheduler | Burst headroom — these are the high-volume providers |
-| `rustinel-etw-process` | Kernel-Process | Latency — `CommandLine` is read from the live process, which must still exist |
+| `rustinel-etw-trace` | File, Registry, Network, DNS, PowerShell, WMI, Task Scheduler | Burst headroom - these are the high-volume providers |
+| `rustinel-etw-process` | Kernel-Process | Latency - `CommandLine` is read from the live process, which must still exist |
 
 Both set the pool explicitly rather than inheriting library defaults:
 
@@ -259,7 +259,7 @@ Both set the pool explicitly rather than inheriting library defaults:
 | Forced partial-buffer handoff | 20 ms | 5 ms | disabled |
 
 A buffer is handed to the consumer when it fills, or when a flush is forced.
-Neither buffer size on its own gets a low-volume stream out quickly — a session
+Neither buffer size on its own gets a low-volume stream out quickly - a session
 carrying only process events does not fill a buffer of *any* size fast enough to
 beat a process that lives 20 ms, which is why the split had to come with a
 faster forced handoff (below). What the split buys is that the faster handoff is
@@ -271,7 +271,7 @@ keeps the 32 KB buffer and raises the buffer *count* instead, so it has burst
 headroom without committing 32 MB to it.
 
 The forced handoff controls quiet-host delivery latency without changing the
-buffer pools, and runs on both sessions — each from its own option,
+buffer pools, and runs on both sessions - each from its own option,
 `windows.etw_flush_interval_ms` and `windows.etw_process_flush_interval_ms`.
 Rustinel pauses requests while its sensor queue is at least half full, when
 queueing controls latency instead.
@@ -286,13 +286,13 @@ preference. Over 2,000 `cmd /c echo` runs on the lab VM:
 | 10 ms | 99.9% |
 | 5 ms | 99.85% |
 | 1 ms | 99.8% |
-| `0` (disabled — falls back to ETW's 1 s timer) | 16.6% |
+| `0` (disabled - falls back to ETW's 1 s timer) | 16.6% |
 
 Agent CPU was indistinguishable across the 1-20 ms range. Note that `0` is much
 worse than a slow interval, not equivalent to one: it returns the session to
 ETW's one-second timer. Treat it as giving up short-lived command lines
 deliberately. The main session's `etw_flush_interval_ms` is a separate option
-precisely so that setting *it* to `0` does not do this — measured that way,
+precisely so that setting *it* to `0` does not do this - measured that way,
 command-line capture stayed at 100%. A process that exits before
 the back-fill can still have no `CommandLine` even at 5 ms; the race is
 structural, and only its width is under Rustinel's control. Rustinel narrows it

--- a/src/config.rs
+++ b/src/config.rs
@@ -452,9 +452,21 @@ pub struct TelemetryConfig {
 /// managed configuration can be distributed to a mixed fleet.
 #[derive(Debug, Clone, Deserialize)]
 pub struct WindowsConfig {
-    /// Periodically hand partially filled ETW buffers to the consumer. Zero
-    /// disables forced flushing and restores ETW's one-second timer.
+    /// Periodically hand partially filled ETW buffers to the consumer on the
+    /// main session. Zero disables forced flushing there and restores ETW's
+    /// one-second timer.
     pub etw_flush_interval_ms: u64,
+    /// The same, for the dedicated Kernel-Process session.
+    ///
+    /// Deliberately a separate option rather than a share of
+    /// [`Self::etw_flush_interval_ms`]: on the main session the interval trades
+    /// alert latency against a periodic syscall, and either answer is
+    /// defensible. On the process session it decides whether `CommandLine` is
+    /// collected at all — the field is read from the live process, and the
+    /// default 5 ms captured 99.9% of short-lived processes against 61.5% at
+    /// the main session's 20 ms. Zero disables it, and gives up roughly 40% of
+    /// short-lived command lines with it.
+    pub etw_process_flush_interval_ms: u64,
 }
 
 impl AppConfig {
@@ -567,7 +579,8 @@ impl AppConfig {
             .set_default("telemetry.enabled", true)?
             .set_default("telemetry.snapshot_interval_secs", 30i64)?
             // Windows ETW delivery latency
-            .set_default("windows.etw_flush_interval_ms", 20i64)?;
+            .set_default("windows.etw_flush_interval_ms", 20i64)?
+            .set_default("windows.etw_process_flush_interval_ms", 5i64)?;
 
         let builder = match selected_config {
             Some(path) => builder.add_source(config::File::from(path).required(true)),
@@ -826,6 +839,7 @@ impl Default for AppConfig {
             },
             windows: WindowsConfig {
                 etw_flush_interval_ms: 20,
+                etw_process_flush_interval_ms: 5,
             },
         };
 
@@ -1170,6 +1184,16 @@ paths_regex_path = "explicit-ioc/paths_regex.txt"
     fn test_windows_etw_flush_default() {
         let cfg = AppConfig::default();
         assert_eq!(cfg.windows.etw_flush_interval_ms, 20);
+        assert_eq!(cfg.windows.etw_process_flush_interval_ms, 5);
+    }
+
+    #[test]
+    fn process_flush_is_independent_of_the_main_interval() {
+        // Disabling the main session's handoff must not silently disable the
+        // process session's, which is what collects `CommandLine` at all.
+        let mut cfg = AppConfig::default();
+        cfg.windows.etw_flush_interval_ms = 0;
+        assert_eq!(cfg.windows.etw_process_flush_interval_ms, 5);
     }
 
     #[test]
@@ -1188,6 +1212,7 @@ paths_regex_path = "explicit-ioc/paths_regex.txt"
         .expect("load default config");
 
         assert_eq!(cfg.windows.etw_flush_interval_ms, 20);
+        assert_eq!(cfg.windows.etw_process_flush_interval_ms, 5);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -462,9 +462,9 @@ pub struct WindowsConfig {
     /// [`Self::etw_flush_interval_ms`]: on the main session the interval trades
     /// alert latency against a periodic syscall, and either answer is
     /// defensible. On the process session it decides whether `CommandLine` is
-    /// collected at all — the field is read from the live process, and the
+    /// collected at all - the field is read from the live process, and the
     /// default 5 ms captured 99.9% of short-lived processes against 61.5% at
-    /// the main session's 20 ms. Zero disables it, and gives up roughly 40% of
+    /// the main session's 20 ms. Zero disables it, and gives up roughly 83% of
     /// short-lived command lines with it.
     pub etw_process_flush_interval_ms: u64,
 }

--- a/src/runtime/windows.rs
+++ b/src/runtime/windows.rs
@@ -213,6 +213,7 @@ pub fn run_capture(options: CaptureOptions) -> anyhow::Result<()> {
         let context = CaptureContext::load(&options, "Windows ETW")?;
         ensure_administrator_privileges()?;
         let flush_interval_ms = context.config().windows.etw_flush_interval_ms;
+        let process_flush_interval_ms = context.config().windows.etw_process_flush_interval_ms;
         let session = context.start_recording(&options, Platform::Windows)?;
 
         // Cold start: seed the process cache so early events resolve parents.
@@ -229,7 +230,10 @@ pub fn run_capture(options: CaptureOptions) -> anyhow::Result<()> {
         }
 
         let (sensor_tx, sensor_worker) = session.sensor_channel();
-        let sensor = Arc::new(EtwSensor::with_flush_interval(flush_interval_ms));
+        let sensor = Arc::new(EtwSensor::with_flush_intervals(
+            flush_interval_ms,
+            process_flush_interval_ms,
+        ));
         let sensor_for_trace = Arc::clone(&sensor);
         let mut trace_handle =
             tokio::task::spawn_blocking(move || sensor_for_trace.start(sensor_tx));
@@ -368,8 +372,9 @@ async fn run_edr(
         info!("Process snapshot not available on non-Windows platforms");
     }
 
-    let sensor = Arc::new(EtwSensor::with_flush_interval(
+    let sensor = Arc::new(EtwSensor::with_flush_intervals(
         cfg.windows.etw_flush_interval_ms,
+        cfg.windows.etw_process_flush_interval_ms,
     ));
 
     // Initialize Sigma engine

--- a/src/sensor/windows/etw.rs
+++ b/src/sensor/windows/etw.rs
@@ -780,17 +780,24 @@ struct DecodedEtwEvent {
 pub struct EtwSensor {
     shutdown: Arc<AtomicBool>,
     flush_interval_ms: u64,
+    process_flush_interval_ms: u64,
 }
 
 impl EtwSensor {
     pub fn new() -> Self {
-        Self::with_flush_interval(super::flush::DEFAULT_INTERVAL_MS)
+        Self::with_flush_intervals(
+            super::flush::DEFAULT_INTERVAL_MS,
+            super::flush::DEFAULT_PROCESS_INTERVAL_MS,
+        )
     }
 
-    pub fn with_flush_interval(flush_interval_ms: u64) -> Self {
+    /// The two sessions are configured separately on purpose; see
+    /// [`super::flush::process_interval`].
+    pub fn with_flush_intervals(flush_interval_ms: u64, process_flush_interval_ms: u64) -> Self {
         Self {
             shutdown: Arc::new(AtomicBool::new(false)),
             flush_interval_ms,
+            process_flush_interval_ms,
         }
     }
 
@@ -987,7 +994,7 @@ impl EtwSensor {
             ),
             (
                 PROCESS_TRACE_SESSION_NAME,
-                super::flush::process_interval(self.flush_interval_ms),
+                super::flush::process_interval(self.process_flush_interval_ms),
             ),
         ]
         .map(|(name, interval)| {
@@ -1217,6 +1224,28 @@ fn decode_process(
     action: SensorAction,
 ) -> Option<DecodedEtwEvent> {
     let mappings = field_maps::process_creation_mappings();
+
+    // The PID and the command line come first, and nothing is allowed between
+    // them and the back-fill below. Everything else this function does is
+    // reading a property out of a buffer that is already in memory; the
+    // back-fill is the one step racing a live process, and `parse_metadata`
+    // in particular opens and maps the image off disk. Decoding in field order
+    // put that read, and every path conversion, ahead of the race for no
+    // reason. See `PROCESS_TRACE_SESSION_NAME`.
+    let process_id = try_get_uint(parser, mappings.get_etw_field("ProcessId")?)
+        .or_else(|| Some(record.process_id().to_string()));
+    let pid = process_id
+        .as_deref()
+        .and_then(|value| value.parse::<u32>().ok())
+        .unwrap_or_else(|| record.process_id());
+
+    // No Kernel-Process event version carries `CommandLine`, so this is a read
+    // of the live process's PEB and only succeeds while it still exists.
+    let mut command_line = try_get_string(parser, mappings.get_etw_field("CommandLine")?);
+    if action == SensorAction::Start && command_line.is_none() {
+        command_line = query_process_command_line(pid);
+    }
+
     let creation_time_opt = try_get_uint_as_u64(parser, "CreateTime")
         .or_else(|| try_get_uint_as_u64(parser, "ProcessStartTime"));
     let creation_time_with_fallback =
@@ -1249,7 +1278,7 @@ fn decode_process(
     let (original_file_name, product, description, company, file_version) =
         pe::version_fields(pe_metadata);
 
-    let mut fields = ProcessCreationFields {
+    let fields = ProcessCreationFields {
         image: image.clone(),
         original_file_name,
         product,
@@ -1258,9 +1287,8 @@ fn decode_process(
         file_version,
         target_image: try_get_string(parser, mappings.get_etw_field("TargetImage")?)
             .map(|path| convert_nt_to_dos(&path)),
-        command_line: try_get_string(parser, mappings.get_etw_field("CommandLine")?),
-        process_id: try_get_uint(parser, mappings.get_etw_field("ProcessId")?)
-            .or_else(|| Some(record.process_id().to_string())),
+        command_line,
+        process_id,
         process_start_time: creation_time_with_fallback,
         parent_process_id: try_get_uint(parser, mappings.get_etw_field("ParentProcessId")?),
         parent_image,
@@ -1272,18 +1300,6 @@ fn decode_process(
             .and_then(|sid| integrity_level_from_sid(&sid)),
         user: try_get_string(parser, mappings.get_etw_field("User")?),
     };
-
-    let pid = fields
-        .process_id
-        .as_deref()
-        .and_then(|value| value.parse::<u32>().ok())
-        .unwrap_or_else(|| record.process_id());
-
-    if action == SensorAction::Start && fields.command_line.is_none() {
-        if let Some(command_line) = query_process_command_line(pid) {
-            fields.command_line = Some(command_line);
-        }
-    }
 
     let process_start_key = match action {
         SensorAction::Start => {

--- a/src/sensor/windows/etw.rs
+++ b/src/sensor/windows/etw.rs
@@ -43,7 +43,8 @@ pub(super) const TRACE_SESSION_NAME: &str = "rustinel-etw-trace";
 /// alive. `cmd /c echo` lives 10-30 ms. Every other provider needs the
 /// opposite — the wide buffer pool of [`session_properties`], which is what
 /// makes a buffer take a long time to fill and be handed over. One session
-/// cannot satisfy both; two can. See [`process_session_properties`].
+/// cannot satisfy both; two can. See [`process_session_properties`] and
+/// [`super::flush`], which flushes this session four times as often.
 pub(super) const PROCESS_TRACE_SESSION_NAME: &str = "rustinel-etw-process";
 const WINDOWS_EPOCH_DELTA_100NS: i64 = 116444736000000000;
 
@@ -975,17 +976,22 @@ impl EtwSensor {
         info!("ETW trace session '{PROCESS_TRACE_SESSION_NAME}' started successfully");
 
         // Decouples delivery latency from the session `FlushTimer`, whose floor
-        // is one second. Both sessions get one: the process session because the
-        // back-fill race is measured in tens of milliseconds, the main session
-        // because alert latency is dominated by it. Each pauses when downstream
+        // is one second. Both sessions get one, at different intervals: the
+        // main session's bounds alert latency, the process session's has to
+        // beat process exit. See `super::flush`. Each pauses when downstream
         // queueing, rather than ETW buffering, controls latency.
-        let flushers = [TRACE_SESSION_NAME, PROCESS_TRACE_SESSION_NAME].map(|name| {
-            super::flush::spawn(
-                name,
-                self.flush_interval_ms,
-                Arc::clone(&self.shutdown),
-                tx.clone(),
-            )
+        let flushers = [
+            (
+                TRACE_SESSION_NAME,
+                super::flush::main_interval(self.flush_interval_ms),
+            ),
+            (
+                PROCESS_TRACE_SESSION_NAME,
+                super::flush::process_interval(self.flush_interval_ms),
+            ),
+        ]
+        .map(|(name, interval)| {
+            super::flush::spawn(name, interval, Arc::clone(&self.shutdown), tx.clone())
         });
 
         let process_worker = self.spawn_process_trace_worker(process_handle);

--- a/src/sensor/windows/etw.rs
+++ b/src/sensor/windows/etw.rs
@@ -41,7 +41,7 @@ pub(super) const TRACE_SESSION_NAME: &str = "rustinel-etw-trace";
 /// Kernel-Process event version, so it is read back out of the PEB in
 /// [`decode_process`], and that read only succeeds while the process is still
 /// alive. `cmd /c echo` lives 10-30 ms. Every other provider needs the
-/// opposite — the wide buffer pool of [`session_properties`], which is what
+/// opposite - the wide buffer pool of [`session_properties`], which is what
 /// makes a buffer take a long time to fill and be handed over. One session
 /// cannot satisfy both; two can. See [`process_session_properties`] and
 /// [`super::flush`], which flushes this session four times as often.
@@ -111,7 +111,7 @@ fn session_properties() -> TraceProperties {
 ///
 /// The small buffer is the point of the second session. A buffer is handed to
 /// the consumer when it fills, and a 256 KB buffer carrying only process and
-/// image-load events takes far longer to fill than a 32 KB one — on a quiet
+/// image-load events takes far longer to fill than a 32 KB one - on a quiet
 /// host it never does, and delivery falls back on the flush timer. That is the
 /// regression #349 describes: the back-fill race window went from ~8-16 ms to
 /// ~100 ms-1 s when #312 widened the shared session, and a `cmd /c echo` exits
@@ -127,8 +127,8 @@ const PROCESS_SESSION_MIN_BUFFERS: u32 = 64;
 /// The buffer counts are set explicitly for the same reason [`session_properties`]
 /// sets them: left at `0` the kernel picks at most 24 buffers, a 768 KB ceiling
 /// that lost 12-60% of process starts under a fork tree (#312). Small buffers
-/// and a deep pool are not in tension — the first bounds latency, the second
-/// bounds burst loss — so this session keeps 1.3.0's latency without giving up
+/// and a deep pool are not in tension - the first bounds latency, the second
+/// bounds burst loss - so this session keeps 1.3.0's latency without giving up
 /// #312's headroom for the events that matter most to it.
 const PROCESS_SESSION_MAX_BUFFERS: u32 = 512;
 
@@ -137,7 +137,7 @@ const PROCESS_SESSION_MAX_BUFFERS: u32 = 512;
 /// Deliberately close to `ferrisetw`'s defaults, which is what Rustinel ran on
 /// before #312: the same 32 KB buffer and the same one-second flush timer, with
 /// only the pool depth raised. The logging mode is inherited for the same
-/// reason as the main session — event order within a session is load-bearing —
+/// reason as the main session - event order within a session is load-bearing -
 /// though nothing on this session pairs events the way the path caches do.
 fn process_session_properties() -> TraceProperties {
     TraceProperties {
@@ -342,7 +342,7 @@ impl EtwProviders {
     /// stay with the others: [`RegistryPathCache`] resolves a write's key by
     /// pairing it with the earlier `OpenKey` that named it, and that pairing
     /// only holds within one session's ordering. Process events are the one
-    /// stream nothing else is paired against — arriving *earlier* than the rest
+    /// stream nothing else is paired against - arriving *earlier* than the rest
     /// is strictly better for `ProcessCache` enrichment, never worse.
     fn process_session() -> Vec<EtwProvider> {
         vec![Self::kernel_process()]
@@ -921,7 +921,7 @@ fn build_session(
 ///
 /// Stopping a trace from `shutdown()` makes `process()` return an error by
 /// design; only a failure while the sensor is supposed to keep running is a
-/// real one, and it must reach the caller — logging alone buries the ETW error
+/// real one, and it must reach the caller - logging alone buries the ETW error
 /// code in the operational log (#256).
 fn interpret_process_result(
     session_name: &str,
@@ -982,26 +982,41 @@ impl EtwSensor {
             .map_err(|err| anyhow::anyhow!("Failed to start ETW process trace: {err:?}"))?;
         info!("ETW trace session '{PROCESS_TRACE_SESSION_NAME}' started successfully");
 
-        // Decouples delivery latency from the session `FlushTimer`, whose floor
-        // is one second. Both sessions get one, at different intervals: the
-        // main session's bounds alert latency, the process session's has to
-        // beat process exit. See `super::flush`. Each pauses when downstream
-        // queueing, rather than ETW buffering, controls latency.
-        let flushers = [
-            (
-                TRACE_SESSION_NAME,
-                super::flush::main_interval(self.flush_interval_ms),
-            ),
-            (
-                PROCESS_TRACE_SESSION_NAME,
-                super::flush::process_interval(self.process_flush_interval_ms),
-            ),
-        ]
-        .map(|(name, interval)| {
-            super::flush::spawn(name, interval, Arc::clone(&self.shutdown), tx.clone())
-        });
+        // Check the worker before blocking on the main session. Otherwise a
+        // thread-creation failure would leave the sensor running forever with
+        // no consumer for process events.
+        let process_worker = self.spawn_process_trace_worker(process_handle)?;
 
-        let process_worker = self.spawn_process_trace_worker(process_handle);
+        // The process flusher is required whenever its interval is enabled:
+        // without it, short-lived command-line capture falls back to 16.6%.
+        let process_flusher = match super::flush::spawn(
+            PROCESS_TRACE_SESSION_NAME,
+            super::flush::process_interval(self.process_flush_interval_ms),
+            Arc::clone(&self.shutdown),
+            tx.clone(),
+        ) {
+            Ok(flusher) => flusher,
+            Err(err) => {
+                self.shutdown.store(true, Ordering::Relaxed);
+                drop(process_trace);
+                let _ = process_worker.join();
+                return Err(err);
+            }
+        };
+
+        // Failure of the main session's optional latency optimization keeps
+        // the existing behavior: ETW's native timer still delivers events.
+        let main_flusher = super::flush::spawn(
+            TRACE_SESSION_NAME,
+            super::flush::main_interval(self.flush_interval_ms),
+            Arc::clone(&self.shutdown),
+            tx.clone(),
+        )
+        .unwrap_or_else(|err| {
+            warn!("Forced ETW flush disabled for main session: {err:#}");
+            None
+        });
+        let flushers = [main_flusher, process_flusher];
 
         let main_result = interpret_process_result(
             TRACE_SESSION_NAME,
@@ -1016,12 +1031,9 @@ impl EtwSensor {
         self.shutdown.store(true, Ordering::Relaxed);
         let _ = stop_trace_by_name(PROCESS_TRACE_SESSION_NAME);
 
-        let process_result = match process_worker {
-            Ok(worker) => worker
-                .join()
-                .unwrap_or_else(|_| Err(anyhow::anyhow!("ETW process trace thread panicked"))),
-            Err(err) => Err(err),
-        };
+        let process_result = process_worker
+            .join()
+            .unwrap_or_else(|_| Err(anyhow::anyhow!("ETW process trace thread panicked")));
 
         for flusher in flushers.into_iter().flatten() {
             let _ = flusher.join();
@@ -1033,7 +1045,7 @@ impl EtwSensor {
 
     /// Run the Kernel-Process session on its own thread.
     ///
-    /// A second `process()` cannot share the main thread — the call blocks
+    /// A second `process()` cannot share the main thread - the call blocks
     /// until its session stops. The handle is processed rather than the trace
     /// itself so the `UserTrace` stays with the caller, which is what stops the
     /// session when this function's caller returns.
@@ -1054,7 +1066,7 @@ impl EtwSensor {
                 // The main session's `process()` is blocking, so a failure here
                 // would otherwise sit unnoticed until the agent is stopped by
                 // hand, with every process event missing in the meantime. Stop
-                // the main session to make the failure reach the caller — the
+                // the main session to make the failure reach the caller - the
                 // same contract `run_subscription` uses for the event logs.
                 if result.is_err() && !shutdown.swap(true, Ordering::Relaxed) {
                     let _ = stop_trace_by_name(TRACE_SESSION_NAME);

--- a/src/sensor/windows/etw.rs
+++ b/src/sensor/windows/etw.rs
@@ -8,7 +8,7 @@ use anyhow::Result;
 use ferrisetw::parser::Parser;
 use ferrisetw::provider::{EventFilter, Provider};
 use ferrisetw::schema_locator::SchemaLocator;
-use ferrisetw::trace::{stop_trace_by_name, TraceProperties, TraceTrait, UserTrace};
+use ferrisetw::trace::{stop_trace_by_name, TraceBuilder, TraceProperties, TraceTrait, UserTrace};
 use ferrisetw::{EventRecord, GUID};
 use tokio::sync::mpsc::{error::TrySendError, Sender};
 use tracing::{debug, info, trace, warn};
@@ -33,6 +33,18 @@ use super::{field_maps, mapper, registry_value_data};
 
 /// Fixed trace session name for stopping the trace on shutdown.
 pub(super) const TRACE_SESSION_NAME: &str = "rustinel-etw-trace";
+
+/// Session name for the dedicated `Microsoft-Windows-Kernel-Process` trace.
+///
+/// Process events are collected in their own session because they are the only
+/// ones with a *latency* requirement: `CommandLine` is not carried by any
+/// Kernel-Process event version, so it is read back out of the PEB in
+/// [`decode_process`], and that read only succeeds while the process is still
+/// alive. `cmd /c echo` lives 10-30 ms. Every other provider needs the
+/// opposite — the wide buffer pool of [`session_properties`], which is what
+/// makes a buffer take a long time to fill and be handed over. One session
+/// cannot satisfy both; two can. See [`process_session_properties`].
+pub(super) const PROCESS_TRACE_SESSION_NAME: &str = "rustinel-etw-process";
 const WINDOWS_EPOCH_DELTA_100NS: i64 = 116444736000000000;
 
 /// Size of one ETW session buffer, in KB.
@@ -89,6 +101,48 @@ fn session_properties() -> TraceProperties {
         buffer_size: SESSION_BUFFER_SIZE_KB,
         min_buffer: SESSION_MIN_BUFFERS,
         max_buffer: SESSION_MAX_BUFFERS,
+        flush_timer: SESSION_FLUSH_TIMER,
+        ..TraceProperties::default()
+    }
+}
+
+/// Size of one buffer on the Kernel-Process session, in KB.
+///
+/// The small buffer is the point of the second session. A buffer is handed to
+/// the consumer when it fills, and a 256 KB buffer carrying only process and
+/// image-load events takes far longer to fill than a 32 KB one — on a quiet
+/// host it never does, and delivery falls back on the flush timer. That is the
+/// regression #349 describes: the back-fill race window went from ~8-16 ms to
+/// ~100 ms-1 s when #312 widened the shared session, and a `cmd /c echo` exits
+/// inside it. 32 KB is the value that measured 15/15 short-lived command lines
+/// in 1.3.0.
+const PROCESS_SESSION_BUFFER_SIZE_KB: u32 = 32;
+
+/// Buffers committed when the Kernel-Process session starts: 2 MB.
+const PROCESS_SESSION_MIN_BUFFERS: u32 = 64;
+
+/// Upper bound on the Kernel-Process buffer pool: 512 x 32 KB = 16 MB.
+///
+/// The buffer counts are set explicitly for the same reason [`session_properties`]
+/// sets them: left at `0` the kernel picks at most 24 buffers, a 768 KB ceiling
+/// that lost 12-60% of process starts under a fork tree (#312). Small buffers
+/// and a deep pool are not in tension — the first bounds latency, the second
+/// bounds burst loss — so this session keeps 1.3.0's latency without giving up
+/// #312's headroom for the events that matter most to it.
+const PROCESS_SESSION_MAX_BUFFERS: u32 = 512;
+
+/// Buffer configuration for the dedicated Kernel-Process session.
+///
+/// Deliberately close to `ferrisetw`'s defaults, which is what Rustinel ran on
+/// before #312: the same 32 KB buffer and the same one-second flush timer, with
+/// only the pool depth raised. The logging mode is inherited for the same
+/// reason as the main session — event order within a session is load-bearing —
+/// though nothing on this session pairs events the way the path caches do.
+fn process_session_properties() -> TraceProperties {
+    TraceProperties {
+        buffer_size: PROCESS_SESSION_BUFFER_SIZE_KB,
+        min_buffer: PROCESS_SESSION_MIN_BUFFERS,
+        max_buffer: PROCESS_SESSION_MAX_BUFFERS,
         flush_timer: SESSION_FLUSH_TIMER,
         ..TraceProperties::default()
     }
@@ -281,6 +335,32 @@ impl EtwProviders {
         }
     }
 
+    /// Providers on the dedicated low-latency session.
+    ///
+    /// Kernel-Process only, and deliberately so. Registry in particular must
+    /// stay with the others: [`RegistryPathCache`] resolves a write's key by
+    /// pairing it with the earlier `OpenKey` that named it, and that pairing
+    /// only holds within one session's ordering. Process events are the one
+    /// stream nothing else is paired against — arriving *earlier* than the rest
+    /// is strictly better for `ProcessCache` enrichment, never worse.
+    fn process_session() -> Vec<EtwProvider> {
+        vec![Self::kernel_process()]
+    }
+
+    /// Providers on the main, burst-tolerant session.
+    fn main_session() -> Vec<EtwProvider> {
+        vec![
+            Self::kernel_network(),
+            Self::kernel_file(),
+            Self::kernel_registry(),
+            Self::dns_client(),
+            Self::powershell(),
+            Self::wmi_activity(),
+            Self::task_scheduler(),
+        ]
+    }
+
+    #[cfg(test)]
     fn all() -> Vec<EtwProvider> {
         vec![
             Self::kernel_process(),
@@ -759,6 +839,220 @@ impl Default for EtwSensor {
     }
 }
 
+/// Attach `providers` to a named session and return the builder.
+///
+/// Every provider gets the same callback: routing is by provider GUID inside
+/// [`decode_record`], not by which session delivered the record, so the split
+/// is invisible below this point.
+fn build_session(
+    session_name: &str,
+    properties: TraceProperties,
+    providers: Vec<EtwProvider>,
+    state: &Arc<EtwState>,
+    tx: &Sender<SensorEvent>,
+) -> TraceBuilder<UserTrace> {
+    info!(
+        "ETW session '{}' buffers: {} KB x {}-{} ({} MB ceiling), flush {}s",
+        session_name,
+        properties.buffer_size,
+        properties.min_buffer,
+        properties.max_buffer,
+        (properties.buffer_size as u64 * properties.max_buffer as u64) / 1024,
+        properties.flush_timer.as_secs(),
+    );
+
+    let mut trace_builder = UserTrace::new()
+        .named(session_name.to_string())
+        .set_trace_properties(properties);
+
+    for provider_def in providers {
+        info!(
+            "Enabling ETW provider: {} ({:?}) with level {} and keywords: 0x{:X} on session '{}'",
+            provider_def.name,
+            provider_def.guid,
+            provider_def.level,
+            provider_def.keywords,
+            session_name
+        );
+
+        let state = Arc::clone(state);
+        let tx = tx.clone();
+        let mut provider_builder = Provider::by_guid(provider_def.guid)
+            .level(provider_def.level)
+            .any(provider_def.keywords)
+            .add_callback(move |record, schema_locator| {
+                let Some(event) = decode_record(record, schema_locator, &state) else {
+                    return;
+                };
+
+                // Blocking inside an ETW callback stalls the trace
+                // session and loses events in the kernel buffer instead,
+                // so overflow is shed. The telemetry counters record both
+                // outcomes and emit the rate-limited cumulative warning.
+                if let Err(TrySendError::Closed(_)) = crate::telemetry::try_send(
+                    crate::telemetry::ChannelId::SensorEvents,
+                    &tx,
+                    event,
+                ) {
+                    trace!("Sensor event channel closed; dropping ETW event");
+                }
+            });
+
+        if !provider_def.event_ids.is_empty() {
+            provider_builder = provider_builder
+                .add_filter(EventFilter::ByEventIds(provider_def.event_ids.to_vec()));
+        }
+
+        trace_builder = trace_builder.enable(provider_builder.build());
+    }
+
+    trace_builder
+}
+
+/// Interpret the return of a blocking `process()` call.
+///
+/// Stopping a trace from `shutdown()` makes `process()` return an error by
+/// design; only a failure while the sensor is supposed to keep running is a
+/// real one, and it must reach the caller — logging alone buries the ETW error
+/// code in the operational log (#256).
+fn interpret_process_result(
+    session_name: &str,
+    result: std::result::Result<(), ferrisetw::trace::TraceError>,
+    shutting_down: bool,
+) -> Result<()> {
+    match result {
+        Ok(()) => {
+            info!("ETW trace session '{session_name}' stopped");
+            Ok(())
+        }
+        Err(err) if shutting_down => {
+            info!("ETW trace session '{session_name}' stopped with result: {err:?}");
+            Ok(())
+        }
+        Err(err) => Err(anyhow::anyhow!(
+            "ETW trace processing failed for session '{session_name}': {err:?}"
+        )),
+    }
+}
+
+impl EtwSensor {
+    /// Start both sessions and block on the main one until shutdown.
+    ///
+    /// The two sessions are started before either is processed, so a failure to
+    /// create the second one is reported as a startup error rather than as a
+    /// sensor that silently runs without process events.
+    fn run_sessions(&self, tx: &Sender<SensorEvent>) -> Result<()> {
+        let state = Arc::new(EtwState::new());
+
+        let main_builder = build_session(
+            TRACE_SESSION_NAME,
+            session_properties(),
+            EtwProviders::main_session(),
+            &state,
+            tx,
+        );
+        let process_builder = build_session(
+            PROCESS_TRACE_SESSION_NAME,
+            process_session_properties(),
+            EtwProviders::process_session(),
+            &state,
+            tx,
+        );
+
+        let (mut main_trace, _main_handle) = main_builder
+            .start()
+            .map_err(|err| anyhow::anyhow!("Failed to start ETW trace: {err:?}"))?;
+        info!("ETW trace session '{TRACE_SESSION_NAME}' started successfully");
+
+        request_registry_value_data();
+
+        // Dropping `main_trace` on this path stops the session it created, so
+        // a half-started pair cannot be left behind for the next run to trip
+        // over.
+        let (process_trace, process_handle) = process_builder
+            .start()
+            .map_err(|err| anyhow::anyhow!("Failed to start ETW process trace: {err:?}"))?;
+        info!("ETW trace session '{PROCESS_TRACE_SESSION_NAME}' started successfully");
+
+        // Decouples delivery latency from the session `FlushTimer`, whose floor
+        // is one second. Both sessions get one: the process session because the
+        // back-fill race is measured in tens of milliseconds, the main session
+        // because alert latency is dominated by it. Each pauses when downstream
+        // queueing, rather than ETW buffering, controls latency.
+        let flushers = [TRACE_SESSION_NAME, PROCESS_TRACE_SESSION_NAME].map(|name| {
+            super::flush::spawn(
+                name,
+                self.flush_interval_ms,
+                Arc::clone(&self.shutdown),
+                tx.clone(),
+            )
+        });
+
+        let process_worker = self.spawn_process_trace_worker(process_handle);
+
+        let main_result = interpret_process_result(
+            TRACE_SESSION_NAME,
+            main_trace.process(),
+            self.shutdown.load(Ordering::Relaxed),
+        );
+
+        // Whatever ended the main session ends the sensor. The process session
+        // is stopped by name so its blocking `process_from_handle` returns and
+        // the worker can be joined; `process_trace` would do the same on drop,
+        // but only after the join has already deadlocked.
+        self.shutdown.store(true, Ordering::Relaxed);
+        let _ = stop_trace_by_name(PROCESS_TRACE_SESSION_NAME);
+
+        let process_result = match process_worker {
+            Ok(worker) => worker
+                .join()
+                .unwrap_or_else(|_| Err(anyhow::anyhow!("ETW process trace thread panicked"))),
+            Err(err) => Err(err),
+        };
+
+        for flusher in flushers.into_iter().flatten() {
+            let _ = flusher.join();
+        }
+
+        drop(process_trace);
+        main_result.and(process_result)
+    }
+
+    /// Run the Kernel-Process session on its own thread.
+    ///
+    /// A second `process()` cannot share the main thread — the call blocks
+    /// until its session stops. The handle is processed rather than the trace
+    /// itself so the `UserTrace` stays with the caller, which is what stops the
+    /// session when this function's caller returns.
+    fn spawn_process_trace_worker(
+        &self,
+        handle: ferrisetw::native::TraceHandle,
+    ) -> Result<std::thread::JoinHandle<Result<()>>> {
+        let shutdown = Arc::clone(&self.shutdown);
+        std::thread::Builder::new()
+            .name("etw-process-trace".into())
+            .spawn(move || {
+                let result = interpret_process_result(
+                    PROCESS_TRACE_SESSION_NAME,
+                    UserTrace::process_from_handle(handle),
+                    shutdown.load(Ordering::Relaxed),
+                );
+
+                // The main session's `process()` is blocking, so a failure here
+                // would otherwise sit unnoticed until the agent is stopped by
+                // hand, with every process event missing in the meantime. Stop
+                // the main session to make the failure reach the caller — the
+                // same contract `run_subscription` uses for the event logs.
+                if result.is_err() && !shutdown.swap(true, Ordering::Relaxed) {
+                    let _ = stop_trace_by_name(TRACE_SESSION_NAME);
+                }
+
+                result
+            })
+            .map_err(|err| anyhow::anyhow!("Failed to spawn ETW process trace thread: {err}"))
+    }
+}
+
 impl Sensor for EtwSensor {
     fn start(&self, tx: Sender<SensorEvent>) -> Result<()> {
         info!("Starting ETW sensor...");
@@ -766,111 +1060,12 @@ impl Sensor for EtwSensor {
         self.shutdown.store(false, Ordering::Relaxed);
         let event_logs = EventLogSubscriptions::start(tx.clone(), Arc::clone(&self.shutdown))?;
 
+        // A session left running by a previous process keeps its old buffer
+        // sizing and its old providers, and `start` would then bind to it.
         let _ = stop_trace_by_name(TRACE_SESSION_NAME);
+        let _ = stop_trace_by_name(PROCESS_TRACE_SESSION_NAME);
 
-        let properties = session_properties();
-        info!(
-            "ETW session buffers: {} KB x {}-{} ({} MB ceiling), flush {}s",
-            properties.buffer_size,
-            properties.min_buffer,
-            properties.max_buffer,
-            (properties.buffer_size as u64 * properties.max_buffer as u64) / 1024,
-            properties.flush_timer.as_secs(),
-        );
-
-        let mut trace_builder = UserTrace::new()
-            .named(TRACE_SESSION_NAME.to_string())
-            .set_trace_properties(properties);
-        let state = Arc::new(EtwState::new());
-
-        for provider_def in EtwProviders::all() {
-            info!(
-                "Enabling ETW provider: {} ({:?}) with level {} and keywords: 0x{:X}",
-                provider_def.name, provider_def.guid, provider_def.level, provider_def.keywords
-            );
-
-            let state = Arc::clone(&state);
-            let tx = tx.clone();
-            let mut provider_builder = Provider::by_guid(provider_def.guid)
-                .level(provider_def.level)
-                .any(provider_def.keywords)
-                .add_callback(move |record, schema_locator| {
-                    let Some(event) = decode_record(record, schema_locator, &state) else {
-                        return;
-                    };
-
-                    // Blocking inside an ETW callback stalls the trace
-                    // session and loses events in the kernel buffer instead,
-                    // so overflow is shed. The telemetry counters record both
-                    // outcomes and emit the rate-limited cumulative warning.
-                    if let Err(TrySendError::Closed(_)) = crate::telemetry::try_send(
-                        crate::telemetry::ChannelId::SensorEvents,
-                        &tx,
-                        event,
-                    ) {
-                        trace!("Sensor event channel closed; dropping ETW event");
-                    }
-                });
-
-            if !provider_def.event_ids.is_empty() {
-                provider_builder = provider_builder
-                    .add_filter(EventFilter::ByEventIds(provider_def.event_ids.to_vec()));
-            }
-
-            let provider = provider_builder.build();
-
-            trace_builder = trace_builder.enable(provider);
-        }
-
-        let trace_result = match trace_builder.start() {
-            Ok((mut trace, _handle)) => {
-                info!(
-                    "ETW trace session '{}' started successfully",
-                    TRACE_SESSION_NAME
-                );
-
-                request_registry_value_data();
-
-                // Decouples delivery latency from the session `FlushTimer`,
-                // whose floor is one second. It pauses when downstream
-                // queueing, rather than ETW buffering, controls latency.
-                let flusher = super::flush::spawn(
-                    TRACE_SESSION_NAME,
-                    self.flush_interval_ms,
-                    Arc::clone(&self.shutdown),
-                    tx.clone(),
-                );
-
-                let processed = match trace.process() {
-                    Ok(()) => {
-                        info!("ETW sensor stopped");
-                        Ok(())
-                    }
-                    Err(err) => {
-                        // Stopping the trace from `shutdown()` makes `process()`
-                        // return an error by design; only a failure while the
-                        // sensor is supposed to keep running is a real one, and
-                        // it must reach the caller — logging alone buries the
-                        // ETW error code in the operational log (#256).
-                        if self.shutdown.load(Ordering::Relaxed) {
-                            info!("ETW sensor stopped with result: {:?}", err);
-                            Ok(())
-                        } else {
-                            Err(anyhow::anyhow!("ETW trace processing failed: {:?}", err))
-                        }
-                    }
-                };
-
-                // The thread parks on the shutdown flag, which `process()`
-                // returning means is either already set or about to be.
-                self.shutdown.store(true, Ordering::Relaxed);
-                if let Some(flusher) = flusher {
-                    let _ = flusher.join();
-                }
-                processed
-            }
-            Err(err) => Err(anyhow::anyhow!("Failed to start ETW trace: {:?}", err)),
-        };
+        let trace_result = self.run_sessions(&tx);
 
         self.shutdown.store(true, Ordering::Relaxed);
         event_logs.join().and(trace_result)
@@ -880,12 +1075,11 @@ impl Sensor for EtwSensor {
         info!("Initiating graceful shutdown of ETW sensor...");
         self.shutdown.store(true, Ordering::Relaxed);
 
-        info!("Stopping ETW trace session '{}'...", TRACE_SESSION_NAME);
-        if let Err(err) = stop_trace_by_name(TRACE_SESSION_NAME) {
-            warn!(
-                "Failed to stop trace session '{}': {:?}",
-                TRACE_SESSION_NAME, err
-            );
+        for session in [TRACE_SESSION_NAME, PROCESS_TRACE_SESSION_NAME] {
+            info!("Stopping ETW trace session '{session}'...");
+            if let Err(err) = stop_trace_by_name(session) {
+                warn!("Failed to stop trace session '{session}': {err:?}");
+            }
         }
     }
 }
@@ -1697,6 +1891,99 @@ mod tests {
         // Ordering is load-bearing for the path caches; inheriting the default
         // logging mode is what keeps it. See `session_properties`.
         assert_eq!(props.log_file_mode, defaults.log_file_mode);
+    }
+
+    #[test]
+    fn process_session_trades_buffer_size_for_pool_depth() {
+        // The two properties this session exists for, and they pull in
+        // opposite directions if only one number is available to tune: a
+        // *small* buffer so it fills and is handed over before a short-lived
+        // process exits (#349), and a *deep* pool so a fork tree does not
+        // overrun it the way `ferrisetw`'s defaults did (#312).
+        let props = process_session_properties();
+        let main = session_properties();
+        let defaults = TraceProperties::default();
+
+        assert!(
+            props.buffer_size <= defaults.buffer_size,
+            "process buffers must not be larger than the {} KB default that measured 15/15",
+            defaults.buffer_size
+        );
+        assert!(
+            props.buffer_size < main.buffer_size,
+            "a process session sized like the main session is not a fix"
+        );
+
+        assert!(
+            props.min_buffer > 0 && props.max_buffer >= props.min_buffer,
+            "buffer counts must be explicit and ordered, got {}-{}",
+            props.min_buffer,
+            props.max_buffer
+        );
+        let ceiling_kb = props.buffer_size as u64 * props.max_buffer as u64;
+        assert!(
+            ceiling_kb >= 16 * 1024,
+            "process buffer pool ceiling is only {ceiling_kb} KB"
+        );
+
+        assert!(props.flush_timer >= Duration::from_secs(1));
+        assert_eq!(props.log_file_mode, defaults.log_file_mode);
+    }
+
+    #[test]
+    fn sessions_partition_the_providers() {
+        // A provider dropped from both lists is silent telemetry loss, and one
+        // enabled on both is a duplicate of every event it carries.
+        let mut split: Vec<&str> = EtwProviders::process_session()
+            .iter()
+            .chain(EtwProviders::main_session().iter())
+            .map(|provider| provider.name)
+            .collect();
+        let mut all: Vec<&str> = EtwProviders::all()
+            .iter()
+            .map(|provider| provider.name)
+            .collect();
+        split.sort_unstable();
+        all.sort_unstable();
+
+        assert_eq!(split, all, "provider split does not cover every provider");
+        let unique = {
+            let mut names = split.clone();
+            names.dedup();
+            names
+        };
+        assert_eq!(unique, split, "a provider is enabled on both sessions");
+    }
+
+    #[test]
+    fn only_kernel_process_is_split_off() {
+        // Registry must stay on the main session: `RegistryPathCache` pairs a
+        // write with the `OpenKey` that named its key, and that pairing only
+        // holds within one session's ordering. Kernel-File has the same
+        // constraint through `FilePathCache`.
+        let names: Vec<&str> = EtwProviders::process_session()
+            .iter()
+            .map(|provider| provider.name)
+            .collect();
+        assert_eq!(names, vec!["Microsoft-Windows-Kernel-Process"]);
+    }
+
+    #[test]
+    fn sessions_have_distinct_names() {
+        assert_ne!(TRACE_SESSION_NAME, PROCESS_TRACE_SESSION_NAME);
+    }
+
+    #[test]
+    fn shutdown_is_not_treated_as_a_processing_failure() {
+        // `stop_trace_by_name` makes the blocking `process()` return an error;
+        // reporting that as a sensor failure would make every clean stop look
+        // like a crash, and swallowing it unconditionally would hide a real one
+        // (#256).
+        let err = || Err(ferrisetw::trace::TraceError::InvalidTraceName);
+
+        assert!(interpret_process_result(TRACE_SESSION_NAME, err(), true).is_ok());
+        assert!(interpret_process_result(TRACE_SESSION_NAME, err(), false).is_err());
+        assert!(interpret_process_result(TRACE_SESSION_NAME, Ok(()), false).is_ok());
     }
 
     #[test]

--- a/src/sensor/windows/event_log/mod.rs
+++ b/src/sensor/windows/event_log/mod.rs
@@ -27,7 +27,7 @@ use windows::Win32::System::Threading::{CreateEventW, ResetEvent, WaitForSingleO
 
 use crate::sensor::SensorEvent;
 
-use super::etw::TRACE_SESSION_NAME;
+use super::etw::{PROCESS_TRACE_SESSION_NAME, TRACE_SESSION_NAME};
 
 const EVENT_LOG_WAIT: Duration = Duration::from_millis(250);
 
@@ -145,8 +145,12 @@ fn run_subscription(
 
     if result.is_err() && !shutdown.swap(true, Ordering::Relaxed) {
         // ETW processing is blocking. Stop it so an event log failure reaches
-        // the sensor caller instead of silently removing telemetry.
-        let _ = ferrisetw::trace::stop_trace_by_name(TRACE_SESSION_NAME);
+        // the sensor caller instead of silently removing telemetry. Both
+        // sessions are stopped: each has a thread parked in `process()`, and
+        // leaving either running holds the sensor open.
+        for session in [TRACE_SESSION_NAME, PROCESS_TRACE_SESSION_NAME] {
+            let _ = ferrisetw::trace::stop_trace_by_name(session);
+        }
     }
 
     result

--- a/src/sensor/windows/flush.rs
+++ b/src/sensor/windows/flush.rs
@@ -21,8 +21,9 @@
 //!
 //! The two intervals are separate configuration options. `0` on the main
 //! session is a latency-for-syscalls trade an operator may reasonably want;
-//! `0` on the process session gives up roughly 40% of short-lived command
-//! lines, and has to be asked for on its own.
+//! `0` on the process session drops short-lived command-line capture to 16.6%,
+//! since that session then falls back to the one-second timer, and has to be
+//! asked for on its own.
 
 use std::mem::size_of;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -98,7 +99,8 @@ pub(super) fn main_interval(interval_ms: u64) -> Option<Duration> {
 /// `etw_flush_interval_ms = 0` is a reasonable thing for an operator to want —
 /// it trades alert latency for one less periodic syscall — and it must not
 /// silently take `CommandLine` collection down with it. Zero here disables the
-/// process handoff explicitly, at the documented cost.
+/// process handoff explicitly, and measures 16.6% short-lived command-line
+/// capture against 99.9% at the 5 ms default.
 pub(super) fn process_interval(interval_ms: u64) -> Option<Duration> {
     if interval_ms == 0 {
         return None;

--- a/src/sensor/windows/flush.rs
+++ b/src/sensor/windows/flush.rs
@@ -18,6 +18,11 @@
 //! affordable because the process session is small — flushing the 256 KB
 //! burst-absorbing session 200 times a second would hand over mostly empty
 //! buffers and give back what #312 bought.
+//!
+//! The two intervals are separate configuration options. `0` on the main
+//! session is a latency-for-syscalls trade an operator may reasonably want;
+//! `0` on the process session gives up roughly 40% of short-lived command
+//! lines, and has to be asked for on its own.
 
 use std::mem::size_of;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -38,19 +43,20 @@ use crate::sensor::SensorEvent;
 pub(super) const DEFAULT_INTERVAL_MS: u64 = 20;
 const MIN_INTERVAL: Duration = Duration::from_millis(20);
 
-/// Handoff interval for the dedicated Kernel-Process session.
+/// Default handoff interval for the dedicated Kernel-Process session, in
+/// milliseconds.
 ///
-/// Not a tuning knob: it is set by how long a short-lived process lives, not by
-/// a latency preference. Measured on the Windows 11 lab VM over 2,000
+/// Barely a tuning knob: it is set by how long a short-lived process lives, not
+/// by a latency preference. Measured on the Windows 11 lab VM over 2,000
 /// `cmd /c echo` runs — 20 ms captured 61.5% of their command lines, 10 ms
 /// 99.9%, 5 ms 99.85%, 1 ms 99.8%, against 100% for the pre-#312 session. 5 ms
 /// is chosen over 10 ms for margin on a faster host: the sweep shows the cost
 /// is flat below 10 ms, with the agent's CPU indistinguishable across the whole
 /// range.
-const PROCESS_INTERVAL: Duration = Duration::from_millis(5);
+pub(super) const DEFAULT_PROCESS_INTERVAL_MS: u64 = 5;
 
-/// Floor for the process session, for an operator who configures a shorter
-/// interval than [`PROCESS_INTERVAL`] for the main one.
+/// Floor for the process session, so a misconfigured interval cannot turn the
+/// flush thread into a spin on the syscall.
 const PROCESS_MIN_INTERVAL: Duration = Duration::from_millis(1);
 
 const MAX_QUEUE_PERCENT_FOR_FLUSH: usize = 50;
@@ -85,21 +91,19 @@ pub(super) fn main_interval(interval_ms: u64) -> Option<Duration> {
     Some(Duration::from_millis(interval_ms).max(MIN_INTERVAL))
 }
 
-/// Handoff interval for the Kernel-Process session.
+/// Handoff interval for the Kernel-Process session, from
+/// `windows.etw_process_flush_interval_ms`.
 ///
-/// Fixed at [`PROCESS_INTERVAL`] rather than configured, because it is the
-/// back-fill race that sets it. The one thing the configuration still decides
-/// is whether forced flushing happens at all, and an operator who asks for a
-/// *faster* main session gets at least that on the process session too.
+/// Read from its own option rather than from the main session's, because
+/// `etw_flush_interval_ms = 0` is a reasonable thing for an operator to want —
+/// it trades alert latency for one less periodic syscall — and it must not
+/// silently take `CommandLine` collection down with it. Zero here disables the
+/// process handoff explicitly, at the documented cost.
 pub(super) fn process_interval(interval_ms: u64) -> Option<Duration> {
     if interval_ms == 0 {
         return None;
     }
-    Some(
-        Duration::from_millis(interval_ms)
-            .min(PROCESS_INTERVAL)
-            .max(PROCESS_MIN_INTERVAL),
-    )
+    Some(Duration::from_millis(interval_ms).max(PROCESS_MIN_INTERVAL))
 }
 
 pub(super) fn spawn(
@@ -212,26 +216,40 @@ mod tests {
     fn process_session_is_flushed_faster_than_the_main_one() {
         // The measured cliff: at the main session's 20 ms interval the
         // command-line back-fill captured 61.5% of `cmd /c echo` runs, and
-        // 99.85% at 5 ms. A process interval that tracked the main one would
+        // 99.85% at 5 ms. A process default that tracked the main one would
         // reintroduce #349.
-        assert!(PROCESS_INTERVAL < MIN_INTERVAL);
-        assert_eq!(
-            process_interval(DEFAULT_INTERVAL_MS),
-            Some(PROCESS_INTERVAL),
-            "the default configuration must not slow the process session down"
+        const { assert!(DEFAULT_PROCESS_INTERVAL_MS < DEFAULT_INTERVAL_MS) };
+        assert!(
+            process_interval(DEFAULT_PROCESS_INTERVAL_MS) < main_interval(DEFAULT_INTERVAL_MS),
+            "the process session must be handed its buffers sooner than the main one"
         );
         assert_eq!(
-            process_interval(10_000),
-            Some(PROCESS_INTERVAL),
-            "a relaxed main interval must not relax the back-fill race"
+            process_interval(DEFAULT_PROCESS_INTERVAL_MS),
+            Some(Duration::from_millis(DEFAULT_PROCESS_INTERVAL_MS))
         );
     }
 
     #[test]
-    fn a_faster_main_interval_is_honoured_by_the_process_session() {
-        assert_eq!(process_interval(2), Some(Duration::from_millis(2)));
-        // Still floored, so a misconfiguration cannot spin on the syscall.
+    fn the_two_intervals_are_configured_independently() {
+        // `etw_flush_interval_ms = 0` is a reasonable operator choice, and it
+        // must not take `CommandLine` collection down with it: the process
+        // session reads its own option, so nothing here consults the main one.
+        assert_eq!(
+            process_interval(DEFAULT_PROCESS_INTERVAL_MS),
+            Some(Duration::from_millis(5)),
+            "the process interval must not depend on the main session's"
+        );
+        // Only the main session is clamped to 20 ms; clamping the process
+        // session there is exactly the bug.
+        assert_eq!(main_interval(5), Some(MIN_INTERVAL));
+        assert_eq!(process_interval(5), Some(Duration::from_millis(5)));
+    }
+
+    #[test]
+    fn the_process_interval_is_floored_but_not_capped() {
         assert_eq!(process_interval(1), Some(PROCESS_MIN_INTERVAL));
+        assert_eq!(process_interval(2), Some(Duration::from_millis(2)));
+        assert_eq!(process_interval(50), Some(Duration::from_millis(50)));
     }
 
     #[test]

--- a/src/sensor/windows/flush.rs
+++ b/src/sensor/windows/flush.rs
@@ -15,7 +15,7 @@
 //! a race against process exit: `CommandLine` is read out of the live process,
 //! and on this lab VM a `cmd /c echo` is gone often enough that a 20 ms handoff
 //! captured only 60% of them, against 99.9% at 5 ms. That rate is only
-//! affordable because the process session is small — flushing the 256 KB
+//! affordable because the process session is small - flushing the 256 KB
 //! burst-absorbing session 200 times a second would hand over mostly empty
 //! buffers and give back what #312 bought.
 //!
@@ -31,6 +31,7 @@ use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
+use anyhow::{Context, Result};
 use tokio::sync::mpsc::Sender;
 use tracing::{info, warn};
 use windows::core::PCWSTR;
@@ -49,7 +50,7 @@ const MIN_INTERVAL: Duration = Duration::from_millis(20);
 ///
 /// Barely a tuning knob: it is set by how long a short-lived process lives, not
 /// by a latency preference. Measured on the Windows 11 lab VM over 2,000
-/// `cmd /c echo` runs — 20 ms captured 61.5% of their command lines, 10 ms
+/// `cmd /c echo` runs - 20 ms captured 61.5% of their command lines, 10 ms
 /// 99.9%, 5 ms 99.85%, 1 ms 99.8%, against 100% for the pre-#312 session. 5 ms
 /// is chosen over 10 ms for margin on a faster host: the sweep shows the cost
 /// is flat below 10 ms, with the agent's CPU indistinguishable across the whole
@@ -96,8 +97,8 @@ pub(super) fn main_interval(interval_ms: u64) -> Option<Duration> {
 /// `windows.etw_process_flush_interval_ms`.
 ///
 /// Read from its own option rather than from the main session's, because
-/// `etw_flush_interval_ms = 0` is a reasonable thing for an operator to want —
-/// it trades alert latency for one less periodic syscall — and it must not
+/// `etw_flush_interval_ms = 0` is a reasonable thing for an operator to want -
+/// it trades alert latency for one less periodic syscall - and it must not
 /// silently take `CommandLine` collection down with it. Zero here disables the
 /// process handoff explicitly, and measures 16.6% short-lived command-line
 /// capture against 99.9% at the 5 ms default.
@@ -113,18 +114,14 @@ pub(super) fn spawn(
     interval: Option<Duration>,
     shutdown: Arc<AtomicBool>,
     sensor_tx: Sender<SensorEvent>,
-) -> Option<JoinHandle<()>> {
-    let interval = interval?;
-
-    let handle = match session_handle(session_name) {
-        Ok(handle) => handle,
-        Err(err) => {
-            warn!(
-                "Forced ETW flush disabled: could not resolve control handle for '{session_name}': {err:#}"
-            );
-            return None;
-        }
+) -> Result<Option<JoinHandle<()>>> {
+    let Some(interval) = interval else {
+        return Ok(None);
     };
+
+    let handle = session_handle(session_name).with_context(|| {
+        format!("could not resolve forced ETW flush handle for session '{session_name}'")
+    })?;
 
     info!(
         "Forced ETW flush enabled: every {} ms while the sensor queue is below {}% (session '{}')",
@@ -134,11 +131,13 @@ pub(super) fn spawn(
     );
 
     let name = session_name.to_string();
-    thread::Builder::new()
+    let worker = thread::Builder::new()
         .name("etw-flush".into())
         .spawn(move || run(handle, interval, shutdown, sensor_tx, &name))
-        .map_err(|err| warn!("Failed to spawn ETW flush thread: {err}"))
-        .ok()
+        .with_context(|| {
+            format!("failed to spawn ETW flush thread for session '{session_name}'")
+        })?;
+    Ok(Some(worker))
 }
 
 fn queue_is_backed_up<T>(sensor_tx: &Sender<T>) -> bool {

--- a/src/sensor/windows/flush.rs
+++ b/src/sensor/windows/flush.rs
@@ -8,6 +8,16 @@
 //! Forced flushing pauses while Rustinel's sensor queue is at least half full.
 //! At that point buffers already fill quickly and downstream queueing, rather
 //! than ETW's timer, controls alert latency.
+//!
+//! The two sessions are flushed at different rates, because they are flushed
+//! for different reasons. The main session is flushed to bound *alert* latency,
+//! which the 20 ms default covers. The Kernel-Process session is flushed to win
+//! a race against process exit: `CommandLine` is read out of the live process,
+//! and on this lab VM a `cmd /c echo` is gone often enough that a 20 ms handoff
+//! captured only 60% of them, against 99.9% at 5 ms. That rate is only
+//! affordable because the process session is small — flushing the 256 KB
+//! burst-absorbing session 200 times a second would hand over mostly empty
+//! buffers and give back what #312 bought.
 
 use std::mem::size_of;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -27,6 +37,22 @@ use crate::sensor::SensorEvent;
 
 pub(super) const DEFAULT_INTERVAL_MS: u64 = 20;
 const MIN_INTERVAL: Duration = Duration::from_millis(20);
+
+/// Handoff interval for the dedicated Kernel-Process session.
+///
+/// Not a tuning knob: it is set by how long a short-lived process lives, not by
+/// a latency preference. Measured on the Windows 11 lab VM over 2,000
+/// `cmd /c echo` runs — 20 ms captured 61.5% of their command lines, 10 ms
+/// 99.9%, 5 ms 99.85%, 1 ms 99.8%, against 100% for the pre-#312 session. 5 ms
+/// is chosen over 10 ms for margin on a faster host: the sweep shows the cost
+/// is flat below 10 ms, with the agent's CPU indistinguishable across the whole
+/// range.
+const PROCESS_INTERVAL: Duration = Duration::from_millis(5);
+
+/// Floor for the process session, for an operator who configures a shorter
+/// interval than [`PROCESS_INTERVAL`] for the main one.
+const PROCESS_MIN_INTERVAL: Duration = Duration::from_millis(1);
+
 const MAX_QUEUE_PERCENT_FOR_FLUSH: usize = 50;
 const TRACE_NAME_BYTES: usize = 2 * 1024;
 
@@ -47,20 +73,42 @@ impl PropertiesBuffer {
     }
 }
 
-fn configured_interval(interval_ms: u64) -> Option<Duration> {
+/// Handoff interval for the main session, from `windows.etw_flush_interval_ms`.
+///
+/// `0` disables forced flushing altogether; anything else is raised to
+/// [`MIN_INTERVAL`], below which the syscall cost is not worth paying for
+/// providers with no deadline of their own.
+pub(super) fn main_interval(interval_ms: u64) -> Option<Duration> {
     if interval_ms == 0 {
         return None;
     }
     Some(Duration::from_millis(interval_ms).max(MIN_INTERVAL))
 }
 
+/// Handoff interval for the Kernel-Process session.
+///
+/// Fixed at [`PROCESS_INTERVAL`] rather than configured, because it is the
+/// back-fill race that sets it. The one thing the configuration still decides
+/// is whether forced flushing happens at all, and an operator who asks for a
+/// *faster* main session gets at least that on the process session too.
+pub(super) fn process_interval(interval_ms: u64) -> Option<Duration> {
+    if interval_ms == 0 {
+        return None;
+    }
+    Some(
+        Duration::from_millis(interval_ms)
+            .min(PROCESS_INTERVAL)
+            .max(PROCESS_MIN_INTERVAL),
+    )
+}
+
 pub(super) fn spawn(
     session_name: &str,
-    interval_ms: u64,
+    interval: Option<Duration>,
     shutdown: Arc<AtomicBool>,
     sensor_tx: Sender<SensorEvent>,
 ) -> Option<JoinHandle<()>> {
-    let interval = configured_interval(interval_ms)?;
+    let interval = interval?;
 
     let handle = match session_handle(session_name) {
         Ok(handle) => handle,
@@ -146,17 +194,44 @@ mod tests {
 
     #[test]
     fn zero_disables_forced_flushing() {
-        assert!(configured_interval(0).is_none());
+        assert!(main_interval(0).is_none());
+        assert!(process_interval(0).is_none());
     }
 
     #[test]
     fn interval_is_clamped_to_twenty_milliseconds() {
         assert_eq!(DEFAULT_INTERVAL_MS, 20);
-        assert_eq!(configured_interval(1), Some(MIN_INTERVAL));
+        assert_eq!(main_interval(1), Some(MIN_INTERVAL));
         assert_eq!(
-            configured_interval(DEFAULT_INTERVAL_MS),
+            main_interval(DEFAULT_INTERVAL_MS),
             Some(Duration::from_millis(DEFAULT_INTERVAL_MS))
         );
+    }
+
+    #[test]
+    fn process_session_is_flushed_faster_than_the_main_one() {
+        // The measured cliff: at the main session's 20 ms interval the
+        // command-line back-fill captured 61.5% of `cmd /c echo` runs, and
+        // 99.85% at 5 ms. A process interval that tracked the main one would
+        // reintroduce #349.
+        assert!(PROCESS_INTERVAL < MIN_INTERVAL);
+        assert_eq!(
+            process_interval(DEFAULT_INTERVAL_MS),
+            Some(PROCESS_INTERVAL),
+            "the default configuration must not slow the process session down"
+        );
+        assert_eq!(
+            process_interval(10_000),
+            Some(PROCESS_INTERVAL),
+            "a relaxed main interval must not relax the back-fill race"
+        );
+    }
+
+    #[test]
+    fn a_faster_main_interval_is_honoured_by_the_process_session() {
+        assert_eq!(process_interval(2), Some(Duration::from_millis(2)));
+        // Still floored, so a misconfiguration cannot spin on the syscall.
+        assert_eq!(process_interval(1), Some(PROCESS_MIN_INTERVAL));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Give `Microsoft-Windows-Kernel-Process` its own ETW session and flush it every
5 ms, restoring `CommandLine` on short-lived processes without giving back the
burst headroom from #312.

**The issue's diagnosis was half right, and measuring it changed the fix.** #349
attributes the regression to buffer *size* — that a 256 KB buffer never fills on
a quiet host. Splitting Kernel-Process onto its own 32 KB session and leaving the
flush at the shared 20 ms moved short-lived capture from **60.2% to 61.5%**, i.e.
nothing. The binding constraint is the **forced-flush interval**: a session
carrying only process events does not fill a buffer of *any* size fast enough to
beat a process that lives ~20 ms. Buffer size only mattered before #312 because
Kernel-File's `FILEIO` keyword shared the session and filled the 32 KB buffer in
milliseconds — co-tenancy, not sizing, is what made 1.3.0 fast.

So the split stays, but for a different reason than the issue gives: it is what
makes a 5 ms interval *affordable*. Flushing the 256 KB burst-absorbing pool
200 times a second would hand over mostly empty buffers and undo #312.

Three changes:

1. **Two sessions.** `rustinel-etw-process` (32 KB x 64-512, 16 MB ceiling)
   carries Kernel-Process; `rustinel-etw-trace` keeps #312's 256 KB x 64-128 for
   everything else. Registry and File must stay together — `RegistryPathCache`
   and `FilePathCache` pair a write with the earlier event that named its target,
   and that only holds within one session's ordering. Both sessions are stopped
   on shutdown and reclaimed if left behind, and a failure on either takes the
   other down so it reaches the caller instead of silently removing telemetry.
2. **The back-fill runs first.** `decode_process` built its fields in template
   order, which put `parse_metadata` — an open and map of the image off disk —
   and every `convert_nt_to_dos` ahead of `query_process_command_line`. That work
   sat between the event arriving and the one step racing a live process. The PID
   and command line are now read first.
3. **`windows.etw_process_flush_interval_ms`** (default 5) is its own option.
   Previously the process interval was derived from `etw_flush_interval_ms`, so
   setting that to `0` — a reasonable latency-for-syscalls trade on the main
   session — silently disabled the handoff that collects `CommandLine` at all.

## Type of change
- [x] `bug` - bug fix

## Test plan
- [x] Tested on Windows (lab VM, Win11 26100, 6 vCPU)
- [x] Existing tests pass (`cargo test --locked`) — 28 test binaries, 0 failures
- [x] `cargo clippy --all-targets -- -D warnings` clean on Windows
- [x] New tests: session/provider partition, the two flush intervals and their
      independence, `interpret_process_result`'s shutdown-vs-failure contract,
      process-session buffer geometry, config defaults

### Short-lived command lines — 2,000 `cmd /c echo` runs per configuration

Measured with `rustinel capture`, counting `Process`/`event_id=1` events whose
`Image` ends in `\cmd.exe`. The 29-test atomic suite cannot resolve this; it
takes thousands of samples to tell 60% from 99%.

| Configuration | Captured |
| --- | --- |
| pre-#312 rebuilt on current code (32 KB/0/0, no handoff) | 100.0% |
| 1.4.0 baseline (one 256 KB session, 20 ms) | 60.2% |
| split sessions, 20 ms on both | 61.5% |
| single 256 KB session, 5 ms | 99.45% |
| **this PR (split, 5 ms process handoff)** | **99.90%** |

Interval sweep on the split session: 20 ms → 61.5%, 10 ms → 99.9%, 5 ms →
99.85%, 1 ms → 99.8%. Sharp cliff between 20 and 10 ms; 5 ms is chosen for
margin on a faster host. Agent CPU indistinguishable across the whole range.

### Burst — 4,000-process fork tree (#312's harness)

Eight parallel launchers, processes identified by a uniquely named copy of
`cmd.exe` so the denominator does not depend on `CommandLine`.

| Configuration | Kernel loss | Command lines |
| --- | --- | --- |
| pre-#312 rebuilt on current code | **51.4%** | 1877 / 4000 |
| 1.4.0 baseline | 0% | 3878 / 4000 |
| split + 5 ms | 0% | 3987 / 4000 |
| **this PR (+ back-fill first)** | **0%** | **4000 / 4000** (two consecutive runs) |

This is the configuration that is best on both axes; no single-session
configuration is.

### Config independence

- `etw_flush_interval_ms = 0`, process left at 5 ms → **100%** capture, and
  exactly one flush thread starts (the process session's). Before this PR that
  configuration silently collected 16.6%.
- `etw_process_flush_interval_ms = 0` → **16.6%**, an explicit opt-out. Note this
  is much worse than a slow interval, because the session then falls back to
  ETW's one-second timer.

### Other
- Restart over a **stale session pair** — agent hard-killed leaving both sessions
  running, then restarted without stopping them by hand: both reclaimed, 51/51
  command lines captured. This was the risk #349 flags about doubling exposure to
  the #312 teardown trap.
- rustinel-rules Windows atomic suite: **28/29**, only the allowed
  `windows_eicar_ioc` failing.

## Checklist
- [x] Docs updated — `docs/operations.md` (both sessions, the sweep, the burst
      table), `docs/configuration.md` (the two options and the cost of `0`),
      `docs/limitations.md`, `config.toml`

Fixes #349
