### PR TITLE
docs(security): route vulnerability reports privately

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/Karib0u/rustinel/security/advisories/new
+    about: Privately report a security vulnerability to the maintainers.


### PR DESCRIPTION
## Summary

- Enable private vulnerability reporting in the repository settings so the link in `SECURITY.md` opens the private report form
- Add a security contact link to the issue chooser to steer vulnerability reports away from public issues

Fixes #311

## Type of change

- [ ] `feat` / `enhancement` - new feature
- [x] `bug` - bug fix
- [ ] `refactor` - refactoring, no behaviour change
- [x] `documentation` - docs only
- [ ] `ci` - CI and release changes
- [ ] `dependencies` - dependency update

## Test plan

- [ ] Tested on Windows
- [ ] Tested on Linux
- [ ] Existing tests pass (`cargo test`)
- [ ] New tests added (if applicable)
- [x] Confirmed private vulnerability reporting is enabled through the GitHub API
- [x] Confirmed the advisory URL resolves to GitHub's authenticated private-report flow
- [x] Parsed the issue chooser configuration as valid YAML

## Checklist

- [x] Label added to this PR
- [x] Docs updated (if behaviour changed)
