### PR TITLE
fix(windows-etw): omit unavailable registry details

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -54,7 +54,7 @@ three platforms, but several Sysmon-style fields are unavailable.
   `Details` carries the value data, as Sysmon Event ID 13 defines it, because
   the session asks Kernel-Registry for it with an undocumented filter payload.
   That is not contractual: if a future Windows build stops honouring it,
-  `Details` falls back to the value *name* and a warning is logged at startup.
+  `Details` is absent and a warning is logged at startup.
   Binary values render as `Binary Data`, matching Sysmon, so their content is
   not searchable.
 - **Registry `TargetObject` is not always a full path (silent risk).** The path

--- a/src/sensor/windows/etw.rs
+++ b/src/sensor/windows/etw.rs
@@ -1485,7 +1485,7 @@ fn decode_kernel_registry_record(
 
     let key_object = try_get_uint_as_u64(&parser, "KeyObject");
 
-    let (action, target_object, value_name) = match route {
+    let (action, target_object) = match route {
         KernelRegistryRoute::Name { creates } => {
             let base_object = try_get_uint_as_u64(&parser, "BaseObject");
             let base_name = try_get_string(&parser, "BaseName").unwrap_or_default();
@@ -1507,7 +1507,7 @@ fn decode_kernel_registry_record(
             // the disposition check every key open would surface as a
             // `registry_add`.
             refine_registry_create_action(&parser)?;
-            (SensorAction::Create, path?, None)
+            (SensorAction::Create, path?)
         }
         KernelRegistryRoute::Evict => {
             if let Some(object) = key_object {
@@ -1538,7 +1538,7 @@ fn decode_kernel_registry_record(
             });
 
             match path {
-                Some(path) => (action, path, value_name),
+                Some(path) => (action, path),
                 None => {
                     // Counted rather than silently discarded, for the same
                     // reason as the file index: this is the sensor's blind

--- a/src/sensor/windows/etw.rs
+++ b/src/sensor/windows/etw.rs
@@ -810,8 +810,7 @@ impl EtwSensor {
 ///
 /// This cannot be part of building the provider: `ferrisetw` has no way to
 /// express the filter payload it needs, so the provider is re-enabled by hand
-/// on the running session. A failure is logged and tolerated — `Details` then
-/// falls back to the value name, exactly as before #292 — because the
+/// on the running session. A failure is logged and tolerated because the
 /// mechanism is undocumented and may not hold on every Windows build.
 fn request_registry_value_data() {
     let provider = EtwProviders::kernel_registry();
@@ -825,7 +824,7 @@ fn request_registry_value_data() {
         Ok(()) => info!("Registry value data capture enabled"),
         Err(err) => warn!(
             "Could not enable registry value data capture ({err:#}); \
-             registry Details will carry the value name"
+             registry Details will be unavailable"
         ),
     }
 }
@@ -1563,7 +1562,7 @@ fn decode_kernel_registry_record(
     let mappings = field_maps::registry_event_mappings();
     let fields = RegistryEventFields {
         target_object: Some(target_object),
-        details: registry_details(&parser, value_name.as_deref()),
+        details: registry_details(&parser),
         process_id: try_get_uint(&parser, mappings.get_etw_field("ProcessId")?),
         image: try_get_string(&parser, mappings.get_etw_field("Image")?)
             .map(|path| convert_nt_to_dos(&path)),
@@ -1588,15 +1587,10 @@ fn decode_kernel_registry_record(
 }
 
 /// `Details` for a registry event: the value *data*, as Sysmon Event ID 13
-/// defines it, falling back to the value name.
-///
-/// The fallback is not dead code. `CapturedData` is only populated because
-/// [`registry_value_data::request_value_data`] asked for it through an
-/// undocumented filter payload, and that request can fail — on a Windows build
-/// that does not honour it, or if the re-enable itself failed and was logged as
-/// a warning. Emitting nothing there would be a regression on the pre-#292
-/// behaviour, so the name is still better than an absent field.
-fn registry_details(parser: &Parser, value_name: Option<&str>) -> Option<String> {
+/// defines it. If captured data is unavailable or cannot be rendered, the
+/// field stays absent rather than carrying the semantically different value
+/// name.
+fn registry_details(parser: &Parser) -> Option<String> {
     let captured = parser
         .try_parse::<Vec<u8>>(field_maps::registry_event_mappings().get_etw_field("Details")?)
         .unwrap_or_default();
@@ -1604,7 +1598,6 @@ fn registry_details(parser: &Parser, value_name: Option<&str>) -> Option<String>
         try_get_uint_as_u64(parser, registry_value_data::VALUE_TYPE_PROPERTY).unwrap_or(0);
 
     registry_value_data::format_value_data(value_type as u32, &captured)
-        .or_else(|| value_name.map(str::to_string))
 }
 
 fn decode_network(parser: &Parser, record: &EventRecord) -> Option<DecodedEtwEvent> {
@@ -2091,13 +2084,13 @@ mod tests {
     }
 
     #[test]
-    fn registry_details_reads_the_value_data_property() {
+    fn registry_details_maps_only_to_the_value_data_property() {
         // `Details` meant `ValueName` until #292, which made 180 SigmaHQ rules
         // match the name of the value instead of what was written into it.
         assert_eq!(
             field_maps::registry_event_mappings().get_etw_field("Details"),
             Some("CapturedData"),
-            "Details must map to the value data, with ValueName only as fallback"
+            "Details must map only to the value data"
         );
     }
 

--- a/src/sensor/windows/field_maps.rs
+++ b/src/sensor/windows/field_maps.rs
@@ -74,8 +74,7 @@ pub fn file_event_mappings() -> &'static FieldMapping {
 static REGISTRY_EVENT_MAP: LazyLock<FieldMapping> = LazyLock::new(|| {
     FieldMapping::new(&[
         // Sysmon Event ID 13 defines `Details` as the value data, not its
-        // name; `CapturedData` is empty unless the session asks for it, and
-        // `registry_details` falls back to `ValueName` when it is.
+        // name. When `CapturedData` is unavailable, `Details` stays absent.
         ("Details", CAPTURED_DATA_PROPERTY),
         ("ProcessId", "ProcessID"),
         ("Image", "ImageName"),

--- a/src/sensor/windows/registry_value_data.rs
+++ b/src/sensor/windows/registry_value_data.rs
@@ -9,8 +9,7 @@
 //! The request is an `EnableTraceEx2` filter descriptor whose four payload
 //! bytes have bit `0x2` set. It is undocumented and unsupported by `ferrisetw`,
 //! which is why the provider is re-enabled by hand here once the session is up;
-//! [`super::etw`] treats a failure as non-fatal and keeps the value-name
-//! behaviour.
+//! [`super::etw`] treats a failure as non-fatal and leaves `Details` absent.
 //!
 //! Measured on Windows 11 26200 by enabling the provider once per candidate
 //! payload and writing a known value under each:
@@ -206,8 +205,8 @@ fn event_id_filter(event_ids: &[u16]) -> Vec<u16> {
 /// `Binary Data` for anything that is not a string or an integer — so matching
 /// it is what makes the 180 `Details` rules mean what they say.
 ///
-/// Returns `None` when there is nothing to render, which is the caller's signal
-/// to fall back to the value name.
+/// Returns `None` when there is nothing to render, so the decoder can leave
+/// `Details` absent.
 pub(super) fn format_value_data(value_type: u32, data: &[u8]) -> Option<String> {
     if data.is_empty() {
         return None;
@@ -327,9 +326,9 @@ mod tests {
     }
 
     #[test]
-    fn empty_capture_asks_the_caller_to_fall_back() {
-        // The build may not populate `CapturedData` at all; that path has to
-        // keep the pre-#292 value-name behaviour rather than emit nothing.
+    fn empty_capture_leaves_details_absent() {
+        // The build may not populate `CapturedData` at all. In that case the
+        // decoder must not substitute the semantically different value name.
         assert_eq!(format_value_data(REG_SZ, &[]), None);
         assert_eq!(format_value_data(REG_DWORD, &[]), None);
     }


### PR DESCRIPTION
## Summary

- leave registry `Details` absent when `CapturedData` is unavailable or cannot be rendered
- keep `ValueName` limited to constructing `TargetObject`
- update warnings, documentation, and regression expectations

## Testing

- `cargo fmt --check`
- `cargo test`
- `git diff --check`

Windows cross-compilation was also attempted, but the macOS host lacks the Windows C headers required by `ring` (`assert.h`).

Closes #325