### PR TITLE
fix(windows-etw): omit TargetImage from process creation

### DIFF
--- a/src/models/ecs/mod.rs
+++ b/src/models/ecs/mod.rs
@@ -479,6 +479,10 @@ mod tests {
         assert_eq!(ecs.process_pid, Some(1234));
         assert_eq!(ecs.process_name.as_deref(), Some("cmd.exe"));
         assert_eq!(ecs.user_name.as_deref(), Some("SYSTEM"));
+        assert!(ecs.edr_process_target_image.is_none());
+
+        let json = serde_json::to_value(&ecs).expect("ECS alert serializes");
+        assert!(json.get("edr.process.target_image").is_none());
     }
 
     #[test]

--- a/src/models/event.rs
+++ b/src/models/event.rs
@@ -1363,7 +1363,7 @@ mod round_trip_tests {
             process_context: None,
         };
 
-        for field in ["ProcessId", "ParentProcessId", "User"] {
+        for field in ["ProcessId", "ParentProcessId", "User", "TargetImage"] {
             assert_eq!(event.get_field(field), None, "{field} should stay absent");
             assert!(
                 event
@@ -1373,6 +1373,14 @@ mod round_trip_tests {
                 "{field} should not appear in flattened fields"
             );
         }
+
+        let json = serde_json::to_value(&event).expect("event serializes");
+        assert!(
+            json.get("fields")
+                .and_then(|fields| fields.get("TargetImage"))
+                .is_none(),
+            "recorded process creation must omit TargetImage"
+        );
     }
 
     #[test]

--- a/src/sensor/windows/etw.rs
+++ b/src/sensor/windows/etw.rs
@@ -1297,8 +1297,8 @@ fn decode_process(
         description,
         company,
         file_version,
-        target_image: try_get_string(parser, mappings.get_etw_field("TargetImage")?)
-            .map(|path| convert_nt_to_dos(&path)),
+        // Process creation describes one image and has no target process.
+        target_image: None,
         command_line,
         process_id,
         process_start_time: creation_time_with_fallback,

--- a/src/sensor/windows/field_maps.rs
+++ b/src/sensor/windows/field_maps.rs
@@ -35,7 +35,6 @@ static PROCESS_CREATION_MAP: LazyLock<FieldMapping> = LazyLock::new(|| {
     FieldMapping::new(&[
         ("Image", "ImageName"),
         ("OriginalFileName", "OriginalFileName"),
-        ("TargetImage", "ImageName"),
         ("CommandLine", "CommandLine"),
         ("ProcessId", "ProcessID"),
         ("ParentProcessId", "ParentProcessID"),
@@ -220,6 +219,11 @@ mod tests {
         // event. An entry here would only advertise a field nothing can fill.
         assert_eq!(mappings.get_etw_field("LogonId"), None);
         assert_eq!(mappings.get_etw_field("LogonGuid"), None);
+
+        // Process creation has no target process. Mapping this to ImageName
+        // duplicated Image and gave TargetImage a meaning it does not have.
+        assert_eq!(mappings.get_etw_field("Image"), Some("ImageName"));
+        assert_eq!(mappings.get_etw_field("TargetImage"), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- remove the invalid process-creation mapping from `TargetImage` to `ImageName`
- leave `target_image` absent when decoding Kernel-Process events
- verify field lookup, recorded output, and ECS output omit the absent field

## Testing

- `cargo fmt --all -- --check`
- `cargo test --all-targets`
- `cargo clippy --locked --all-targets -- -D clippy::all`

Closes #326