### PR TITLE
fix(windows-etw): report kernel-side event loss

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -70,14 +70,14 @@ three platforms, but several Sysmon-style fields are unavailable.
   and service logs stay unobserved until the handle is closed and reopened, which
   for some services means until reboot. Counted as `unresolved_file_events` and
   `unresolved_registry_events`.
-- **Extreme process bursts can still be lost in the kernel (silent risk).** Both
+- **Extreme process bursts can still be lost in the kernel.** Both
   ETW sessions use an explicitly sized buffer pool - 256 KB × 64-128 (32 MB
   ceiling) for the main session, 32 KB × 64-512 (16 MB ceiling) for the process
   session - where the pool that absorbed a 4,000-process fork tree with no loss
   was the former and the library defaults lost 12-60%. A host that churns harder
-  can still overrun them, and nothing counts the overrun
-  ([#305](https://github.com/Karib0u/rustinel/issues/305)), so a recorded event
-  count is an upper bound. See
+  can still overrun them. The sensor polls ETW's cumulative loss counters and
+  warns when they increase; behavioral capture also records the combined count
+  as `events.source_lost` and marks the recording incomplete. See
   [Windows ETW session buffers](operations.md#windows-etw-session-buffers).
 - **WMI event IDs are not Sysmon's (silent risk).** `Microsoft-Windows-WMI-Activity`
   has no equivalent of Sysmon's `wmi_event` 19/20/21, and numbers its own

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -325,10 +325,10 @@ on current code for comparison:
 | Split sessions, 5 ms process handoff | 0% | 4000 / 4000 |
 
 It is a fixed configuration, not an adaptive one: a host that churns processes
-harder than that can still overrun either pool, and kernel-side loss is not
-counted
-anywhere yet ([#305](https://github.com/Karib0u/rustinel/issues/305)). Treat a
-recorded event count as an upper bound on what happened.
+harder than that can still overrun either pool. Rustinel polls each session's
+cumulative `EventsLost` counter once per second and emits a rate-limited warning
+when it increases. Behavioral recordings also store the combined value as
+`events.source_lost` and are marked incomplete when it is non-zero.
 
 ## Upgrades
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -188,7 +188,7 @@ The manifest records what the payload contains and whether it can be trusted:
   "started_at": "2026-08-16T09:12:40Z",
   "ended_at": "2026-08-16T09:14:02Z",
   "status": "complete",
-  "events": { "received": 1841, "written": 1841, "lost": 0 },
+  "events": { "received": 1841, "written": 1841, "lost": 0, "source_lost": 0 },
   "payload_bytes": 612884,
   "payload_sha256": "9f2c…"
 }
@@ -197,9 +197,11 @@ The manifest records what the payload contains and whether it can be trusted:
 `status` is the field that matters. The manifest is written as `incomplete` when
 the session starts and is only rewritten as `complete` at clean shutdown with
 every received event accounted for. A recording is therefore `incomplete`
-whenever the process was killed before it could finalize, or events were lost
-because the writer could not keep up. `received` always equals
-`written + lost`, so loss is visible rather than implied.
+whenever the process was killed before it could finalize, events were lost
+because the writer could not keep up, or the source reported loss before the
+events reached the sensor. `received` always equals `written + lost`;
+`source_lost` is separate because those events were never received. On Windows,
+`source_lost` is the cumulative `EventsLost` count across both ETW sessions.
 
 Recordings are as sensitive as alerts, and often more so: they contain full
 command lines, file paths, network destinations, and user names for *all*

--- a/src/capture/manifest.rs
+++ b/src/capture/manifest.rs
@@ -64,6 +64,10 @@ pub struct CaptureEventCounts {
     /// Events dropped because the queue was full, or that failed to serialize
     /// or write.
     pub lost: u64,
+    /// Events dropped before reaching the sensor, such as Windows ETW kernel
+    /// buffer loss.
+    #[serde(default)]
+    pub source_lost: u64,
 }
 
 /// Sidecar describing a behavioral recording.
@@ -179,6 +183,7 @@ mod tests {
             received: 3,
             written: 3,
             lost: 0,
+            source_lost: 0,
         };
         manifest.payload_bytes = 128;
         manifest.payload_sha256 = Some("abc123".to_string());
@@ -202,5 +207,18 @@ mod tests {
         manifest.schema_version = CAPTURE_SCHEMA_VERSION + 1;
 
         assert!(!manifest.is_replayable());
+    }
+
+    #[test]
+    fn older_manifests_default_source_loss_to_zero() {
+        let json = r#"{
+            "received": 10,
+            "written": 9,
+            "lost": 1
+        }"#;
+
+        let events: CaptureEventCounts = serde_json::from_str(json).expect("events deserialize");
+
+        assert_eq!(events.source_lost, 0);
     }
 }

--- a/src/capture/writer.rs
+++ b/src/capture/writer.rs
@@ -62,6 +62,7 @@ impl CaptureCounters {
             received: self.received.load(Ordering::Relaxed),
             written: self.written.load(Ordering::Relaxed),
             lost: self.lost.load(Ordering::Relaxed),
+            source_lost: 0,
         }
     }
 }
@@ -238,7 +239,15 @@ impl CaptureRecorder {
     ///
     /// The recording is marked [`CaptureStatus::Complete`] only when every
     /// received event reached the payload.
-    pub async fn finish(mut self) -> anyhow::Result<CaptureManifest> {
+    pub async fn finish(self) -> anyhow::Result<CaptureManifest> {
+        self.finish_with_source_loss(0).await
+    }
+
+    /// Finalize the recording with loss reported by the event source itself.
+    pub async fn finish_with_source_loss(
+        mut self,
+        source_lost: u64,
+    ) -> anyhow::Result<CaptureManifest> {
         // Dropping every sender ends the writer loop once the queue drains.
         drop(self.tx.take());
         drop(self.sink);
@@ -248,8 +257,10 @@ impl CaptureRecorder {
             .await
             .context("capture writer task failed to complete")?;
 
-        let events = self.counters.snapshot();
+        let mut events = self.counters.snapshot();
+        events.source_lost = source_lost;
         let status = if events.lost == 0
+            && events.source_lost == 0
             && !digest.write_failed
             && !self.forced_incomplete.load(Ordering::Relaxed)
         {
@@ -465,9 +476,25 @@ mod tests {
                 received: 3,
                 written: 3,
                 lost: 0,
+                source_lost: 0,
             }
         );
         assert_eq!(manifest.status, CaptureStatus::Complete);
+    }
+
+    #[tokio::test]
+    async fn source_loss_marks_the_manifest_incomplete() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let payload = temp.path().join("session.ndjson");
+        let recorder = CaptureRecorder::start(payload, Platform::Windows).expect("capture starts");
+
+        let manifest = recorder
+            .finish_with_source_loss(7)
+            .await
+            .expect("capture finalizes");
+
+        assert_eq!(manifest.events.source_lost, 7);
+        assert_eq!(manifest.status, CaptureStatus::Incomplete);
     }
 
     #[tokio::test]

--- a/src/replay/recording.rs
+++ b/src/replay/recording.rs
@@ -158,11 +158,13 @@ fn verify(
 
     if manifest.status != CaptureStatus::Complete {
         bail!(
-            "recording {} is incomplete: the capture session was interrupted or lost {} of {} \
-             events, so replaying it would report detections over a stream with holes in it",
+            "recording {} is incomplete: the capture session was interrupted, lost {} of {} \
+             received events, or lost {} events at the source, so replaying it would report \
+             detections over a stream with holes in it",
             payload_path.display(),
             manifest.events.lost,
-            manifest.events.received
+            manifest.events.received,
+            manifest.events.source_lost
         );
     }
 
@@ -299,6 +301,7 @@ mod tests {
                 received: 3,
                 written: 2,
                 lost: 1,
+                source_lost: 0,
             };
         });
 

--- a/src/runtime/capture.rs
+++ b/src/runtime/capture.rs
@@ -200,7 +200,11 @@ impl CaptureSession {
     /// Drain queued events, finalize the manifest, and report final counts.
     ///
     /// Call after the sensors have been shut down.
-    pub(crate) async fn finish(self, sensor_worker: JoinHandle<()>) -> anyhow::Result<()> {
+    pub(crate) async fn finish(
+        self,
+        sensor_worker: JoinHandle<()>,
+        source_lost: u64,
+    ) -> anyhow::Result<()> {
         drop(self.router);
         let _ = sensor_worker.await;
         self.progress.abort();
@@ -208,7 +212,7 @@ impl CaptureSession {
 
         let payload_path = self.recorder.payload_path().to_path_buf();
         let manifest_path = self.recorder.manifest_path().to_path_buf();
-        let manifest = self.recorder.finish().await?;
+        let manifest = self.recorder.finish_with_source_loss(source_lost).await?;
 
         info!(
             target: "capture",
@@ -216,6 +220,7 @@ impl CaptureSession {
             received = manifest.events.received,
             written = manifest.events.written,
             lost = manifest.events.lost,
+            source_lost = manifest.events.source_lost,
             "Capture finished"
         );
 
@@ -223,15 +228,15 @@ impl CaptureSession {
         eprintln!("Recording: {}", payload_path.display());
         eprintln!("Manifest:  {}", manifest_path.display());
         eprintln!(
-            "Events:    {} recorded, {} lost",
-            manifest.events.written, manifest.events.lost
+            "Events:    {} recorded, {} writer lost, {} source lost",
+            manifest.events.written, manifest.events.lost, manifest.events.source_lost
         );
         eprintln!("Status:    {}", manifest.status.as_str());
         if manifest.status != CaptureStatus::Complete {
             eprintln!(
                 "This recording is incomplete and will be rejected by replay. \
-                 {} events could not be written.",
-                manifest.events.lost
+                 {} events could not be written and {} were lost at the source.",
+                manifest.events.lost, manifest.events.source_lost
             );
         }
 

--- a/src/runtime/linux.rs
+++ b/src/runtime/linux.rs
@@ -54,7 +54,7 @@ pub fn run_capture(options: CaptureOptions) -> anyhow::Result<()> {
 
         CaptureSession::wait_for_shutdown().await;
         sensor.shutdown();
-        session.finish(sensor_worker).await
+        session.finish(sensor_worker, 0).await
     })
 }
 

--- a/src/runtime/macos.rs
+++ b/src/runtime/macos.rs
@@ -70,7 +70,7 @@ pub fn run_capture(options: CaptureOptions) -> anyhow::Result<()> {
         CaptureSession::wait_for_shutdown().await;
         esf_sensor.shutdown();
         bpf_sensor.shutdown();
-        session.finish(sensor_worker).await
+        session.finish(sensor_worker, 0).await
     })
 }
 

--- a/src/runtime/windows.rs
+++ b/src/runtime/windows.rs
@@ -262,7 +262,7 @@ pub fn run_capture(options: CaptureOptions) -> anyhow::Result<()> {
             }
         }
 
-        session.finish(sensor_worker).await?;
+        session.finish(sensor_worker, sensor.events_lost()).await?;
 
         match sensor_failure {
             Some(err) => Err(err),

--- a/src/sensor/windows/etw.rs
+++ b/src/sensor/windows/etw.rs
@@ -779,6 +779,7 @@ struct DecodedEtwEvent {
 /// Windows ETW sensor implementation.
 pub struct EtwSensor {
     shutdown: Arc<AtomicBool>,
+    loss_counters: Arc<super::loss::LossCounters>,
     flush_interval_ms: u64,
     process_flush_interval_ms: u64,
 }
@@ -796,6 +797,7 @@ impl EtwSensor {
     pub fn with_flush_intervals(flush_interval_ms: u64, process_flush_interval_ms: u64) -> Self {
         Self {
             shutdown: Arc::new(AtomicBool::new(false)),
+            loss_counters: Arc::new(super::loss::LossCounters::new()),
             flush_interval_ms,
             process_flush_interval_ms,
         }
@@ -803,6 +805,11 @@ impl EtwSensor {
 
     pub fn is_shutdown(&self) -> bool {
         self.shutdown.load(Ordering::Relaxed)
+    }
+
+    /// Cumulative kernel-buffer loss across both ETW sessions.
+    pub fn events_lost(&self) -> u64 {
+        self.loss_counters.total()
     }
 }
 
@@ -987,6 +994,33 @@ impl EtwSensor {
         // no consumer for process events.
         let process_worker = self.spawn_process_trace_worker(process_handle)?;
 
+        let loss_monitor = match super::loss::spawn(
+            [
+                (TRACE_SESSION_NAME, super::loss::Session::Main),
+                (PROCESS_TRACE_SESSION_NAME, super::loss::Session::Process),
+            ],
+            Arc::clone(&self.shutdown),
+            Arc::clone(&self.loss_counters),
+        ) {
+            Ok(worker) => worker,
+            Err(err) => {
+                self.shutdown.store(true, Ordering::Relaxed);
+                let _ = super::loss::stop_and_record(
+                    TRACE_SESSION_NAME,
+                    super::loss::Session::Main,
+                    &self.loss_counters,
+                );
+                let _ = super::loss::stop_and_record(
+                    PROCESS_TRACE_SESSION_NAME,
+                    super::loss::Session::Process,
+                    &self.loss_counters,
+                );
+                let _ = process_worker.join();
+                drop(process_trace);
+                return Err(err);
+            }
+        };
+
         // The process flusher is required whenever its interval is enabled:
         // without it, short-lived command-line capture falls back to 16.6%.
         let process_flusher = match super::flush::spawn(
@@ -998,8 +1032,19 @@ impl EtwSensor {
             Ok(flusher) => flusher,
             Err(err) => {
                 self.shutdown.store(true, Ordering::Relaxed);
-                drop(process_trace);
+                let _ = super::loss::stop_and_record(
+                    TRACE_SESSION_NAME,
+                    super::loss::Session::Main,
+                    &self.loss_counters,
+                );
+                let _ = super::loss::stop_and_record(
+                    PROCESS_TRACE_SESSION_NAME,
+                    super::loss::Session::Process,
+                    &self.loss_counters,
+                );
                 let _ = process_worker.join();
+                let _ = loss_monitor.join();
+                drop(process_trace);
                 return Err(err);
             }
         };
@@ -1029,7 +1074,16 @@ impl EtwSensor {
         // the worker can be joined; `process_trace` would do the same on drop,
         // but only after the join has already deadlocked.
         self.shutdown.store(true, Ordering::Relaxed);
-        let _ = stop_trace_by_name(PROCESS_TRACE_SESSION_NAME);
+        let _ = super::loss::stop_and_record(
+            TRACE_SESSION_NAME,
+            super::loss::Session::Main,
+            &self.loss_counters,
+        );
+        let _ = super::loss::stop_and_record(
+            PROCESS_TRACE_SESSION_NAME,
+            super::loss::Session::Process,
+            &self.loss_counters,
+        );
 
         let process_result = process_worker
             .join()
@@ -1038,6 +1092,7 @@ impl EtwSensor {
         for flusher in flushers.into_iter().flatten() {
             let _ = flusher.join();
         }
+        let _ = loss_monitor.join();
 
         drop(process_trace);
         main_result.and(process_result)
@@ -1054,6 +1109,7 @@ impl EtwSensor {
         handle: ferrisetw::native::TraceHandle,
     ) -> Result<std::thread::JoinHandle<Result<()>>> {
         let shutdown = Arc::clone(&self.shutdown);
+        let loss_counters = Arc::clone(&self.loss_counters);
         std::thread::Builder::new()
             .name("etw-process-trace".into())
             .spawn(move || {
@@ -1069,7 +1125,11 @@ impl EtwSensor {
                 // the main session to make the failure reach the caller - the
                 // same contract `run_subscription` uses for the event logs.
                 if result.is_err() && !shutdown.swap(true, Ordering::Relaxed) {
-                    let _ = stop_trace_by_name(TRACE_SESSION_NAME);
+                    let _ = super::loss::stop_and_record(
+                        TRACE_SESSION_NAME,
+                        super::loss::Session::Main,
+                        &loss_counters,
+                    );
                 }
 
                 result
@@ -1083,6 +1143,7 @@ impl Sensor for EtwSensor {
         info!("Starting ETW sensor...");
 
         self.shutdown.store(false, Ordering::Relaxed);
+        self.loss_counters.reset();
         let event_logs = EventLogSubscriptions::start(tx.clone(), Arc::clone(&self.shutdown))?;
 
         // A session left running by a previous process keeps its old buffer
@@ -1102,7 +1163,12 @@ impl Sensor for EtwSensor {
 
         for session in [TRACE_SESSION_NAME, PROCESS_TRACE_SESSION_NAME] {
             info!("Stopping ETW trace session '{session}'...");
-            if let Err(err) = stop_trace_by_name(session) {
+            let kind = if session == TRACE_SESSION_NAME {
+                super::loss::Session::Main
+            } else {
+                super::loss::Session::Process
+            };
+            if let Err(err) = super::loss::stop_and_record(session, kind, &self.loss_counters) {
                 warn!("Failed to stop trace session '{session}': {err:?}");
             }
         }

--- a/src/sensor/windows/loss.rs
+++ b/src/sensor/windows/loss.rs
@@ -1,0 +1,197 @@
+//! Windows ETW kernel-buffer loss accounting.
+//!
+//! Queue telemetry starts at the provider callback, so it cannot see events
+//! discarded by ETW before that callback runs. `EventsLost` is cumulative for
+//! each trace session and is read both periodically and when the session is
+//! stopped.
+
+use std::mem::size_of;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+use anyhow::{bail, Context, Result};
+use tracing::{info, warn};
+use windows::core::PCWSTR;
+use windows::Win32::System::Diagnostics::Etw::{
+    ControlTraceW, CONTROLTRACE_HANDLE, EVENT_TRACE_CONTROL, EVENT_TRACE_CONTROL_QUERY,
+    EVENT_TRACE_CONTROL_STOP, EVENT_TRACE_PROPERTIES,
+};
+
+use crate::utils::LogRateLimiter;
+
+const POLL_INTERVAL: Duration = Duration::from_secs(1);
+const LOSS_LOG_WINDOW: Duration = Duration::from_secs(10);
+const TRACE_NAME_BYTES: usize = 2 * 1024;
+
+#[repr(C)]
+struct PropertiesBuffer {
+    properties: EVENT_TRACE_PROPERTIES,
+    names: [u8; 2 * TRACE_NAME_BYTES],
+}
+
+impl PropertiesBuffer {
+    fn new() -> Box<Self> {
+        Box::new(Self {
+            properties: EVENT_TRACE_PROPERTIES::default(),
+            names: [0; 2 * TRACE_NAME_BYTES],
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(super) enum Session {
+    Main,
+    Process,
+}
+
+#[derive(Debug)]
+pub(super) struct LossCounters {
+    main: AtomicU64,
+    process: AtomicU64,
+    warnings: Mutex<LogRateLimiter>,
+}
+
+impl LossCounters {
+    pub(super) fn new() -> Self {
+        Self {
+            main: AtomicU64::new(0),
+            process: AtomicU64::new(0),
+            warnings: Mutex::new(LogRateLimiter::new(LOSS_LOG_WINDOW)),
+        }
+    }
+
+    pub(super) fn total(&self) -> u64 {
+        self.main
+            .load(Ordering::Relaxed)
+            .saturating_add(self.process.load(Ordering::Relaxed))
+    }
+
+    pub(super) fn reset(&self) {
+        self.main.store(0, Ordering::Relaxed);
+        self.process.store(0, Ordering::Relaxed);
+        match self.warnings.lock() {
+            Ok(mut limiter) => *limiter = LogRateLimiter::new(LOSS_LOG_WINDOW),
+            Err(poisoned) => {
+                *poisoned.into_inner() = LogRateLimiter::new(LOSS_LOG_WINDOW);
+            }
+        }
+    }
+
+    fn record(&self, session: Session, session_name: &str, events_lost: u64) {
+        let counter = match session {
+            Session::Main => &self.main,
+            Session::Process => &self.process,
+        };
+        let previous = counter.fetch_max(events_lost, Ordering::Relaxed);
+        if events_lost <= previous {
+            return;
+        }
+
+        let decision = match self.warnings.lock() {
+            Ok(mut limiter) => limiter.should_emit("etw_events_lost"),
+            Err(poisoned) => poisoned.into_inner().should_emit("etw_events_lost"),
+        };
+        if decision.should_emit {
+            warn!(
+                session = session_name,
+                session_lost = events_lost,
+                lost_total = self.total(),
+                suppressed_warnings = decision.suppressed_since_last_emit,
+                "ETW discarded events because its kernel buffer pool was exhausted"
+            );
+        }
+    }
+}
+
+pub(super) fn spawn(
+    sessions: [(&'static str, Session); 2],
+    shutdown: Arc<AtomicBool>,
+    counters: Arc<LossCounters>,
+) -> Result<JoinHandle<()>> {
+    thread::Builder::new()
+        .name("etw-loss".into())
+        .spawn(move || {
+            let mut query_warned = [false; 2];
+            while !shutdown.load(Ordering::Relaxed) {
+                thread::sleep(POLL_INTERVAL);
+                if shutdown.load(Ordering::Relaxed) {
+                    break;
+                }
+                for (index, (name, session)) in sessions.iter().copied().enumerate() {
+                    match query(name, EVENT_TRACE_CONTROL_QUERY) {
+                        Ok(events_lost) => counters.record(session, name, events_lost),
+                        Err(err) if !query_warned[index] => {
+                            query_warned[index] = true;
+                            warn!(
+                                session = name,
+                                "Could not query ETW kernel loss; retrying: {err:#}"
+                            );
+                        }
+                        Err(_) => {}
+                    }
+                }
+            }
+            info!(lost_total = counters.total(), "ETW loss monitor stopped");
+        })
+        .context("failed to spawn ETW loss monitor")
+}
+
+/// Stop a session and retain the final `EventsLost` value returned by ETW.
+pub(super) fn stop_and_record(
+    session_name: &str,
+    session: Session,
+    counters: &LossCounters,
+) -> Result<()> {
+    let events_lost = query(session_name, EVENT_TRACE_CONTROL_STOP)?;
+    counters.record(session, session_name, events_lost);
+    Ok(())
+}
+
+fn query(session_name: &str, control: EVENT_TRACE_CONTROL) -> Result<u64> {
+    let name: Vec<u16> = session_name
+        .encode_utf16()
+        .chain(std::iter::once(0))
+        .collect();
+    let total = size_of::<EVENT_TRACE_PROPERTIES>() + 2 * TRACE_NAME_BYTES;
+    let mut buffer = PropertiesBuffer::new();
+    let properties = &mut buffer.properties as *mut EVENT_TRACE_PROPERTIES;
+
+    // SAFETY: `properties` points to the aligned header of an allocation large
+    // enough for both name buffers, and the offsets point into that storage.
+    let status = unsafe {
+        (*properties).Wnode.BufferSize = total as u32;
+        (*properties).LoggerNameOffset = size_of::<EVENT_TRACE_PROPERTIES>() as u32;
+        (*properties).LogFileNameOffset =
+            (size_of::<EVENT_TRACE_PROPERTIES>() + TRACE_NAME_BYTES) as u32;
+        ControlTraceW(
+            CONTROLTRACE_HANDLE::default(),
+            PCWSTR(name.as_ptr()),
+            properties,
+            control,
+        )
+    };
+    if status.is_err() {
+        bail!("ControlTraceW failed for session '{session_name}': {status:?}");
+    }
+
+    // ETW exposes a 32-bit per-session counter. Widen before combining the two
+    // sessions so their cumulative total cannot overflow at the addition site.
+    Ok(unsafe { (*properties).EventsLost as u64 })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn totals_are_monotonic_and_sum_both_sessions() {
+        let counters = LossCounters::new();
+        counters.record(Session::Main, "main", 3);
+        counters.record(Session::Process, "process", 5);
+        counters.record(Session::Main, "main", 2);
+
+        assert_eq!(counters.total(), 8);
+    }
+}

--- a/src/sensor/windows/mod.rs
+++ b/src/sensor/windows/mod.rs
@@ -3,6 +3,7 @@ mod event_log;
 mod field_maps;
 mod file_paths;
 mod flush;
+mod loss;
 pub mod mapper;
 mod registry_paths;
 mod registry_value_data;


### PR DESCRIPTION
Closes #305.

## What

- Polls `EventsLost` once per second for both ETW sessions.
- Emits rate-limited warnings with the per-session count and combined cumulative total.
- Reads the final counter from `EVENT_TRACE_CONTROL_STOP`, so shutdown loss is not missed.
- Adds `events.source_lost` to capture manifests and marks recordings incomplete when it is non-zero. Older manifests remain compatible and default the field to zero.
- Updates operations, limitations, output, and replay diagnostics.

## Post-buffer-fix measurement

The documented Windows 11 fork-tree measurement remains the basis for the current sizing:

| Configuration | Kernel loss | Command lines |
| --- | --- | --- |
| Pre-#312, one 32 KB session, no forced handoff | 51.4% | 1877 / 4000 |
| 1.4.0, one 256 KB session, 20 ms handoff | 0% | 3878 / 4000 |
| Current split sessions, 5 ms process handoff | 0% | 4000 / 4000 |

This change makes that outcome measurable on every Windows host instead of relying on the lab result.

## Verification

- `cargo test --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- Capture unit and integration tests, including source loss marking the manifest incomplete and old manifests defaulting `source_lost` to zero

A local Windows cross-check could not pass the native dependency build on macOS because the Windows C SDK headers are unavailable; the Windows CI job provides the platform build and test result.