### PR TITLE
fix(ci): update workflow action version pins

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,5 +42,5 @@ jobs:
       pages: write # publish to GitHub Pages
       id-token: write # OIDC token consumed by deploy-pages
     steps:
-      - uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5
+      - uses: actions/deploy-pages@368f82528645a54fb793d4d04e342629a3f51346 # v5.0.1
         id: deployment

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -546,7 +546,7 @@ jobs:
             rustinel-${{ steps.version.outputs.version }}-checksums-sha256.txt
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
         with:
           files: |
             rustinel-${{ steps.version.outputs.version }}-x86_64-unknown-linux-musl.tar.gz


### PR DESCRIPTION
## Summary

- update `actions/deploy-pages` to the commit for v5.0.1
- update `softprops/action-gh-release` to the commit for v3.0.3
- use exact version comments matching both pinned commits

## Validation

- workflow security scan reports no `ref-version-mismatch` findings
- `git diff --check` passes