### PR TITLE
ci: skip duplicate atomic tests on releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [master, main]
   workflow_call:
+    inputs:
+      skip_atomics:
+        description: Skip source-built atomic tests when release artifacts will be tested
+        required: false
+        type: boolean
+        default: false
 
 env:
   CARGO_TERM_COLOR: always
@@ -196,6 +202,7 @@ jobs:
   # branch is only green when the atomic suite passes.
   atomic:
     name: Atomic (${{ matrix.platform }})
+    if: ${{ !inputs.skip_atomics }}
     continue-on-error: ${{ github.event_name == 'pull_request' }}
     runs-on: ${{ matrix.os }}
     needs: ebpf-build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ jobs:
   ci:
     name: CI Gates
     uses: ./.github/workflows/ci.yml
+    with:
+      skip_atomics: true
     permissions:
       contents: read
 


### PR DESCRIPTION
## Summary

- add a `skip_atomics` input to the reusable CI workflow
- skip source-built Linux and Windows atomic tests when invoked by the release workflow
- retain the full artifact-based release matrix across Linux, Windows, and macOS

## Why

Release runs currently execute atomic tests once through the shared CI gates and again against the built release artifacts. The artifact tests are the stronger release gate because they exercise the exact binaries and packages that will be published.

Direct CI runs keep atomics enabled by default.

## Validation

- `git diff --check`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/ci.yml .github/workflows/release.yml`