### PR TITLE
fix(windows): preserve detection fidelity under burst load

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -122,13 +122,15 @@ snapshot_interval_secs = 30 # a snapshot is also written at shutdown
 #
 #   `etw_flush_interval_ms` is the main session (file, registry, network, DNS,
 #   PowerShell, WMI, tasks). It trades alert latency against one periodic
-#   syscall; 0 is a reasonable choice. Values below 20 are clamped to 20.
+#   syscall; 0 is a reasonable choice. Values below 20 are clamped to 20. Its
+#   forced flush pauses when the shared sensor queue is at least half full.
 #
 #   `etw_process_flush_interval_ms` is the Kernel-Process session, and it is
 #   NOT a latency preference. `CommandLine` is not carried by any ETW process
 #   event - it is read back out of the live process, so the event has to reach
 #   Rustinel before the process exits. Measured over 2,000 `cmd /c echo` runs:
 #   5 ms captured 99.9% of their command lines, 20 ms only 61.5%.
+#   This session keeps flushing under queue pressure to preserve that lookup.
 #   SETTING THIS TO 0 GIVES UP ~83% OF SHORT-LIVED COMMAND LINES (measured:
 #   16.6% captured, because the session falls back to ETW's one-second timer),
 #   and with them every Sigma process_creation rule that matches on CommandLine

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -301,6 +301,12 @@ nothing was dropped and warns with per-channel totals when something was;
 leaves drop totals visible only in the operational log, and `doctor` reports
 that reduced visibility as a warning.
 
+`sensor_events_by_category` splits accepted and dropped ingress events into
+process, network, file, registry, DNS, image-load, scripting, PowerShell
+module, WMI, service, task, and security categories. On Windows,
+`windows_process_command_line` reports attempted, captured, and missed command
+lines after the normalizer has tried its final live-process fallback.
+
 On Windows the snapshot also carries a `registry` section, because a registry
 write can be lost *before* any channel sees it: `SetValueKey` carries no key
 path, so a write whose key cannot be named is discarded inside the sensor and
@@ -337,7 +343,8 @@ flushed for different reasons.
 | `etw_process_flush_interval_ms` | `5` | `rustinel-etw-process` | The same for the process session; `0` disables it. Values below 1 ms are clamped to 1 ms |
 
 On the main session the interval trades alert latency against one periodic
-syscall, and `0` is a reasonable choice.
+syscall, and `0` is a reasonable choice. Forced main-session flushes pause when
+the shared sensor queue is at least half full.
 
 **On the process session it is not a latency preference - it decides whether
 `CommandLine` is collected at all.** No ETW process event carries the field; it
@@ -351,7 +358,8 @@ because the session then falls all the way back to ETW's one-second timer. The
 two options are deliberately independent so that turning the main session's
 handoff off does not silently do this - measured with
 `etw_flush_interval_ms = 0` and the process option left at 5 ms, command-line
-capture stayed at 100%. See
+capture stayed at 100%. Process-session flushes continue under shared queue
+pressure so the live lookup is not delayed until after process exit. See
 [Windows ETW session buffers](operations.md#windows-etw-session-buffers) for the
 full sweep.
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -273,8 +273,14 @@ headroom without committing 32 MB to it.
 The forced handoff controls quiet-host delivery latency without changing the
 buffer pools, and runs on both sessions - each from its own option,
 `windows.etw_flush_interval_ms` and `windows.etw_process_flush_interval_ms`.
-Rustinel pauses requests while its sensor queue is at least half full, when
-queueing controls latency instead.
+The main session pauses requests while its sensor queue is at least half full,
+when queueing controls latency instead. The process session does not pause:
+delaying that callback also delays the live-process `CommandLine` lookup and
+can lose the field when a short-lived process exits.
+
+The Windows sensor queue holds up to 32,768 events. Its telemetry snapshot
+reports the peak depth plus accepted and dropped events by category, so burst
+headroom and any detection gap can be measured directly.
 
 The process session defaults to 5 ms rather than the main session's 20 ms,
 because what sets it is how long a short-lived process lives, not a latency

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -467,7 +467,7 @@ These messages mean the agent is under backpressure somewhere in the pipeline.
 Each bounded channel logs a cumulative line at most once a minute:
 
 ```text
-Pipeline channel full; shedding telemetry channel="sensor_events" capacity=8192 dropped_total=1204 accepted_total=1841204 suppressed_warnings=1202
+Pipeline channel full; shedding telemetry channel="sensor_events" capacity=32768 dropped_total=1204 accepted_total=1841204 suppressed_warnings=1202
 YARA queue full; dropping scan job
 IOC hash queue full; dropping job
 Active response queue full, dropping task

--- a/src/doctor/telemetry.rs
+++ b/src/doctor/telemetry.rs
@@ -148,6 +148,8 @@ mod tests {
             captured_at: "2026-08-24T12:00:00Z".to_string(),
             uptime_secs: 3600,
             channels,
+            sensor_events_by_category: Vec::new(),
+            windows_process_command_line: None,
             registry: None,
         }
     }

--- a/src/engine/handler.rs
+++ b/src/engine/handler.rs
@@ -10,7 +10,7 @@
 use std::sync::Arc;
 
 use tokio::sync::mpsc;
-use tracing::{debug, info};
+use tracing::debug;
 
 use crate::alerts::AlertSink;
 use crate::capture::CaptureSink;
@@ -146,7 +146,7 @@ impl SensorEventHandler for NormalizedEventHandler {
                     self.normalizer
                         .enrich_process_context(&mut alert.event, event.pid.unwrap_or(0));
 
-                    info!(
+                    debug!(
                         target: TARGET_ENGINE,
                         engine = ?alert.engine,
                         rule = %alert.rule_name,

--- a/src/normalizer/mod.rs
+++ b/src/normalizer/mod.rs
@@ -11,7 +11,7 @@ use std::time::SystemTime;
 use chrono::{DateTime, SecondsFormat, Utc};
 
 use crate::models::*;
-use crate::sensor::{SensorAction, SensorEvent, SensorPayload};
+use crate::sensor::{Platform, SensorAction, SensorEvent, SensorPayload};
 use crate::state::{ConnectionAggregator, DnsCache, ProcessCache, Protocol, SidCache};
 use crate::utils::{convert_nt_to_dos, query_process_command_line};
 
@@ -109,6 +109,10 @@ impl Normalizer {
             if let Some(command_line) = query_process_command_line(pid) {
                 fields.command_line = Some(command_line);
             }
+        }
+
+        if event.platform == Platform::Windows && event.action == SensorAction::Start {
+            crate::telemetry::WINDOWS_PROCESS_COMMAND_LINE.record(fields.command_line.is_some());
         }
 
         if event.action == SensorAction::Start {

--- a/src/runtime/windows.rs
+++ b/src/runtime/windows.rs
@@ -14,6 +14,8 @@ use crate::sensor::windows::EtwSensor;
 use crate::sensor::{Platform, Sensor, SensorEvent, SensorEventRouter};
 use crate::state::{ConnectionAggregator, DnsCache, ProcessCache, SidCache};
 use crate::{config, reload, scanner};
+
+const SENSOR_EVENT_CHANNEL_CAPACITY: usize = 32_768;
 use arc_swap::ArcSwap;
 use std::sync::Arc;
 use tokio::runtime::Builder;
@@ -643,7 +645,7 @@ async fn run_edr(
     info!("");
 
     // Start shared sensor event pipeline
-    let (sensor_tx, mut sensor_rx) = mpsc::channel::<SensorEvent>(8192);
+    let (sensor_tx, mut sensor_rx) = mpsc::channel::<SensorEvent>(SENSOR_EVENT_CHANNEL_CAPACITY);
     let router_clone = Arc::clone(&router);
     let sensor_worker_handle = tokio::task::spawn_blocking(move || {
         info!(target: "sensor", "Sensor event worker thread started");

--- a/src/sensor/linux/ebpf.rs
+++ b/src/sensor/linux/ebpf.rs
@@ -731,7 +731,7 @@ fn parse_dns_query_name(ev: &DnsEvent) -> Option<String> {
 fn try_send(tx: &Sender<SensorEvent>, event: SensorEvent) {
     // Both the full and closed cases are already counted; the reason is in the
     // rate-limited warning the telemetry module emits.
-    let _ = crate::telemetry::try_send(crate::telemetry::ChannelId::SensorEvents, tx, event);
+    let _ = crate::telemetry::try_send_sensor_event(tx, event);
 }
 
 fn resolved_linux_user(uid: u32) -> String {

--- a/src/sensor/macos/bpf.rs
+++ b/src/sensor/macos/bpf.rs
@@ -643,7 +643,7 @@ fn record_type_name(qtype: u16) -> Option<&'static str> {
 /// overflow that buffer instead. Overflow is shed and counted — see
 /// [`crate::telemetry`].
 fn try_send(tx: &Sender<SensorEvent>, event: SensorEvent) {
-    let _ = crate::telemetry::try_send(crate::telemetry::ChannelId::SensorEvents, tx, event);
+    let _ = crate::telemetry::try_send_sensor_event(tx, event);
 }
 
 fn read_u32(buf: &[u8], at: usize) -> u32 {

--- a/src/sensor/macos/esf.rs
+++ b/src/sensor/macos/esf.rs
@@ -578,7 +578,7 @@ fn system_time_nanos(time: SystemTime) -> u64 {
 /// The ESF message handler runs on the client's own queue and must return
 /// promptly, so overflow is shed and counted — see [`crate::telemetry`].
 fn try_send(tx: &Sender<SensorEvent>, event: SensorEvent) {
-    let _ = crate::telemetry::try_send(crate::telemetry::ChannelId::SensorEvents, tx, event);
+    let _ = crate::telemetry::try_send_sensor_event(tx, event);
 }
 
 #[cfg(test)]

--- a/src/sensor/windows/etw.rs
+++ b/src/sensor/windows/etw.rs
@@ -1118,11 +1118,9 @@ fn build_session(
                     // session and loses events in the kernel buffer instead,
                     // so overflow is shed. The telemetry counters record both
                     // outcomes and emit the rate-limited cumulative warning.
-                    if let Err(TrySendError::Closed(_)) = crate::telemetry::try_send(
-                        crate::telemetry::ChannelId::SensorEvents,
-                        &tx,
-                        event,
-                    ) {
+                    if let Err(TrySendError::Closed(_)) =
+                        crate::telemetry::try_send_sensor_event(&tx, event)
+                    {
                         trace!("Sensor event channel closed; dropping ETW event");
                     }
                 }
@@ -1244,6 +1242,7 @@ impl EtwSensor {
             super::flush::process_interval(self.process_flush_interval_ms),
             Arc::clone(&self.shutdown),
             tx.clone(),
+            false,
         ) {
             Ok(flusher) => flusher,
             Err(err) => {
@@ -1272,6 +1271,7 @@ impl EtwSensor {
             super::flush::main_interval(self.flush_interval_ms),
             Arc::clone(&self.shutdown),
             tx.clone(),
+            true,
         )
         .unwrap_or_else(|err| {
             warn!("Forced ETW flush disabled for main session: {err:#}");

--- a/src/sensor/windows/event_log/mod.rs
+++ b/src/sensor/windows/event_log/mod.rs
@@ -261,11 +261,9 @@ fn drain_events(
 
             match decoded {
                 Ok(event) => {
-                    if let Err(TrySendError::Closed(_)) = crate::telemetry::try_send(
-                        crate::telemetry::ChannelId::SensorEvents,
-                        tx,
-                        event,
-                    ) {
+                    if let Err(TrySendError::Closed(_)) =
+                        crate::telemetry::try_send_sensor_event(tx, event)
+                    {
                         trace!(
                             source = source.name,
                             "Sensor event channel closed; dropping event"

--- a/src/sensor/windows/flush.rs
+++ b/src/sensor/windows/flush.rs
@@ -5,9 +5,10 @@
 //! second before the consumer sees it. `ControlTraceW(EVENT_TRACE_CONTROL_FLUSH)`
 //! requests the same handoff without changing the session buffer sizing.
 //!
-//! Forced flushing pauses while Rustinel's sensor queue is at least half full.
-//! At that point buffers already fill quickly and downstream queueing, rather
-//! than ETW's timer, controls alert latency.
+//! The main session pauses forced flushing while Rustinel's sensor queue is at
+//! least half full. The process session keeps flushing because delaying its
+//! callback also delays the live-process `CommandLine` lookup, and short-lived
+//! processes may exit before that lookup runs.
 //!
 //! The two sessions are flushed at different rates, because they are flushed
 //! for different reasons. The main session is flushed to bound *alert* latency,
@@ -114,6 +115,7 @@ pub(super) fn spawn(
     interval: Option<Duration>,
     shutdown: Arc<AtomicBool>,
     sensor_tx: Sender<SensorEvent>,
+    pause_on_backpressure: bool,
 ) -> Result<Option<JoinHandle<()>>> {
     let Some(interval) = interval else {
         return Ok(None);
@@ -123,17 +125,34 @@ pub(super) fn spawn(
         format!("could not resolve forced ETW flush handle for session '{session_name}'")
     })?;
 
-    info!(
-        "Forced ETW flush enabled: every {} ms while the sensor queue is below {}% (session '{}')",
-        interval.as_millis(),
-        MAX_QUEUE_PERCENT_FOR_FLUSH,
-        session_name
-    );
+    if pause_on_backpressure {
+        info!(
+            "Forced ETW flush enabled: every {} ms while the sensor queue is below {}% (session '{}')",
+            interval.as_millis(),
+            MAX_QUEUE_PERCENT_FOR_FLUSH,
+            session_name
+        );
+    } else {
+        info!(
+            "Forced ETW flush enabled: every {} ms without queue pausing (session '{}')",
+            interval.as_millis(),
+            session_name
+        );
+    }
 
     let name = session_name.to_string();
     let worker = thread::Builder::new()
         .name("etw-flush".into())
-        .spawn(move || run(handle, interval, shutdown, sensor_tx, &name))
+        .spawn(move || {
+            run(
+                handle,
+                interval,
+                shutdown,
+                sensor_tx,
+                pause_on_backpressure,
+                &name,
+            )
+        })
         .with_context(|| {
             format!("failed to spawn ETW flush thread for session '{session_name}'")
         })?;
@@ -146,11 +165,16 @@ fn queue_is_backed_up<T>(sensor_tx: &Sender<T>) -> bool {
     depth.saturating_mul(100) >= capacity.saturating_mul(MAX_QUEUE_PERCENT_FOR_FLUSH)
 }
 
+fn should_pause_flush<T>(sensor_tx: &Sender<T>, pause_on_backpressure: bool) -> bool {
+    pause_on_backpressure && queue_is_backed_up(sensor_tx)
+}
+
 fn run(
     handle: CONTROLTRACE_HANDLE,
     interval: Duration,
     shutdown: Arc<AtomicBool>,
     sensor_tx: Sender<SensorEvent>,
+    pause_on_backpressure: bool,
     name: &str,
 ) {
     let mut warned = false;
@@ -160,7 +184,7 @@ fn run(
         if shutdown.load(Ordering::Relaxed) {
             break;
         }
-        if queue_is_backed_up(&sensor_tx) {
+        if should_pause_flush(&sensor_tx, pause_on_backpressure) {
             continue;
         }
 
@@ -261,5 +285,7 @@ mod tests {
         assert!(!queue_is_backed_up(&tx));
         tx.try_send(()).expect("second event fits");
         assert!(queue_is_backed_up(&tx));
+        assert!(should_pause_flush(&tx, true));
+        assert!(!should_pause_flush(&tx, false));
     }
 }

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -25,9 +25,13 @@ use tracing::warn;
 use crate::utils::LogRateLimiter;
 
 pub use snapshot::{
-    snapshot_path, spawn_reporter, write_final_snapshot, ChannelSnapshot, RegistrySnapshot,
-    TelemetrySnapshot, SNAPSHOT_FILE_NAME,
+    snapshot_path, spawn_reporter, write_final_snapshot, ChannelSnapshot,
+    ProcessCommandLineSnapshot, RegistrySnapshot, SensorEventCategorySnapshot, TelemetrySnapshot,
+    SNAPSHOT_FILE_NAME,
 };
+
+use crate::models::EventCategory;
+use crate::sensor::SensorEvent;
 
 /// Tracing target for pipeline telemetry accounting.
 pub const TARGET_TELEMETRY: &str = "telemetry";
@@ -277,6 +281,134 @@ impl RegistryCounters {
     }
 }
 
+/// Windows process command-line collection after every available fallback.
+#[derive(Debug, Default)]
+pub struct ProcessCommandLineCounters {
+    attempted: AtomicU64,
+    captured: AtomicU64,
+    missed: AtomicU64,
+}
+
+/// Process-wide command-line accounting. It remains idle outside Windows.
+pub static WINDOWS_PROCESS_COMMAND_LINE: ProcessCommandLineCounters =
+    ProcessCommandLineCounters::new();
+
+impl ProcessCommandLineCounters {
+    const fn new() -> Self {
+        Self {
+            attempted: AtomicU64::new(0),
+            captured: AtomicU64::new(0),
+            missed: AtomicU64::new(0),
+        }
+    }
+
+    pub fn record(&self, captured: bool) {
+        self.attempted.fetch_add(1, Ordering::Relaxed);
+        if captured {
+            self.captured.fetch_add(1, Ordering::Relaxed);
+        } else {
+            self.missed.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    pub fn snapshot(&self) -> Option<ProcessCommandLineSnapshot> {
+        let attempted = self.attempted.load(Ordering::Relaxed);
+        if attempted == 0 {
+            return None;
+        }
+        Some(ProcessCommandLineSnapshot {
+            attempted,
+            captured: self.captured.load(Ordering::Relaxed),
+            missed: self.missed.load(Ordering::Relaxed),
+        })
+    }
+}
+
+#[derive(Debug)]
+struct SensorEventCategoryCounters {
+    accepted: AtomicU64,
+    dropped: AtomicU64,
+}
+
+impl SensorEventCategoryCounters {
+    const fn new() -> Self {
+        Self {
+            accepted: AtomicU64::new(0),
+            dropped: AtomicU64::new(0),
+        }
+    }
+
+    fn record_accepted(&self) {
+        self.accepted.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn record_dropped(&self) {
+        self.dropped.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+static SENSOR_EVENT_CATEGORIES: [SensorEventCategoryCounters; 12] = [
+    SensorEventCategoryCounters::new(),
+    SensorEventCategoryCounters::new(),
+    SensorEventCategoryCounters::new(),
+    SensorEventCategoryCounters::new(),
+    SensorEventCategoryCounters::new(),
+    SensorEventCategoryCounters::new(),
+    SensorEventCategoryCounters::new(),
+    SensorEventCategoryCounters::new(),
+    SensorEventCategoryCounters::new(),
+    SensorEventCategoryCounters::new(),
+    SensorEventCategoryCounters::new(),
+    SensorEventCategoryCounters::new(),
+];
+
+fn sensor_event_category(category: EventCategory) -> (usize, &'static str) {
+    match category {
+        EventCategory::Process => (0, "process"),
+        EventCategory::Network => (1, "network"),
+        EventCategory::File => (2, "file"),
+        EventCategory::Registry => (3, "registry"),
+        EventCategory::Dns => (4, "dns"),
+        EventCategory::ImageLoad => (5, "image_load"),
+        EventCategory::Scripting => (6, "scripting"),
+        EventCategory::PowerShellModule => (7, "powershell_module"),
+        EventCategory::Wmi => (8, "wmi"),
+        EventCategory::Service => (9, "service"),
+        EventCategory::Task => (10, "task"),
+        EventCategory::Security => (11, "security"),
+    }
+}
+
+fn sensor_event_category_snapshots() -> Vec<SensorEventCategorySnapshot> {
+    [
+        EventCategory::Process,
+        EventCategory::Network,
+        EventCategory::File,
+        EventCategory::Registry,
+        EventCategory::Dns,
+        EventCategory::ImageLoad,
+        EventCategory::Scripting,
+        EventCategory::PowerShellModule,
+        EventCategory::Wmi,
+        EventCategory::Service,
+        EventCategory::Task,
+        EventCategory::Security,
+    ]
+    .into_iter()
+    .filter_map(|category| {
+        let (index, name) = sensor_event_category(category);
+        let counters = &SENSOR_EVENT_CATEGORIES[index];
+        let accepted = counters.accepted.load(Ordering::Relaxed);
+        let dropped = counters.dropped.load(Ordering::Relaxed);
+        (accepted > 0 || dropped > 0).then(|| SensorEventCategorySnapshot {
+            category: name.to_string(),
+            accepted,
+            dropped,
+        })
+    })
+    .collect()
+}
+
 /// Atomic accounting for one bounded channel.
 ///
 /// All counters are `Relaxed`: they are independent totals read for reporting,
@@ -432,11 +564,50 @@ pub fn try_send<T>(channel: ChannelId, tx: &Sender<T>, value: T) -> Result<(), T
     }
 }
 
+/// Send one sensor event while retaining accepted and dropped counts by category.
+#[allow(clippy::result_large_err)]
+pub fn try_send_sensor_event(
+    tx: &Sender<SensorEvent>,
+    value: SensorEvent,
+) -> Result<(), TrySendError<SensorEvent>> {
+    let (index, _) = sensor_event_category(value.category());
+    match try_send(ChannelId::SensorEvents, tx, value) {
+        Ok(()) => {
+            SENSOR_EVENT_CATEGORIES[index].record_accepted();
+            Ok(())
+        }
+        Err(err @ TrySendError::Full(_)) => {
+            SENSOR_EVENT_CATEGORIES[index].record_dropped();
+            Err(err)
+        }
+        Err(err @ TrySendError::Closed(_)) => Err(err),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
 
     use super::*;
+
+    #[test]
+    fn process_command_line_fidelity_counts_hits_and_misses() {
+        let counters = ProcessCommandLineCounters::new();
+        assert!(counters.snapshot().is_none());
+
+        counters.record(true);
+        counters.record(false);
+        counters.record(true);
+
+        assert_eq!(
+            counters.snapshot(),
+            Some(ProcessCommandLineSnapshot {
+                attempted: 3,
+                captured: 2,
+                missed: 1,
+            })
+        );
+    }
 
     #[test]
     fn an_attempted_empty_registry_rundown_is_still_visible() {

--- a/src/telemetry/snapshot.rs
+++ b/src/telemetry/snapshot.rs
@@ -108,6 +108,31 @@ pub struct RegistrySnapshot {
     pub snapshot_keys: usize,
 }
 
+/// Sensor queue traffic for one normalized event category.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SensorEventCategorySnapshot {
+    pub category: String,
+    pub accepted: u64,
+    pub dropped: u64,
+}
+
+/// Fidelity of the best-effort Windows process command-line back-fill.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProcessCommandLineSnapshot {
+    pub attempted: u64,
+    pub captured: u64,
+    pub missed: u64,
+}
+
+impl ProcessCommandLineSnapshot {
+    pub fn capture_rate_pct(&self) -> f64 {
+        if self.attempted == 0 {
+            return 100.0;
+        }
+        (self.captured as f64 / self.attempted as f64) * 100.0
+    }
+}
+
 impl RegistrySnapshot {
     /// Share of registry write events that reached the detectors with a path.
     ///
@@ -147,6 +172,12 @@ pub struct TelemetrySnapshot {
     /// How long that agent had been running.
     pub uptime_secs: u64,
     pub channels: Vec<ChannelSnapshot>,
+    /// Sensor ingress volume and loss split by event category.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub sensor_events_by_category: Vec<SensorEventCategorySnapshot>,
+    /// Final command-line availability for accepted Windows process starts.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub windows_process_command_line: Option<ProcessCommandLineSnapshot>,
     /// Registry key-path resolution. Absent on platforms without the ETW
     /// registry sensor, and on snapshots written before #341.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -165,6 +196,8 @@ impl TelemetrySnapshot {
                 .iter()
                 .map(|channel| channel.counters().snapshot())
                 .collect(),
+            sensor_events_by_category: super::sensor_event_category_snapshots(),
+            windows_process_command_line: super::WINDOWS_PROCESS_COMMAND_LINE.snapshot(),
             registry: super::REGISTRY.snapshot(),
         }
     }
@@ -331,6 +364,8 @@ mod tests {
             captured_at: "2026-08-24T00:00:00Z".to_string(),
             uptime_secs: 60,
             channels,
+            sensor_events_by_category: Vec::new(),
+            windows_process_command_line: None,
             registry: None,
         }
     }
@@ -378,6 +413,17 @@ mod tests {
 
         assert!(idle.is_idle());
         assert_eq!(idle.drop_rate_pct(), 0.0);
+    }
+
+    #[test]
+    fn process_command_line_capture_rate_uses_all_attempts() {
+        let fidelity = ProcessCommandLineSnapshot {
+            attempted: 4,
+            captured: 3,
+            missed: 1,
+        };
+
+        assert_eq!(fidelity.capture_rate_pct(), 75.0);
     }
 
     #[test]

--- a/tests/telemetry_backpressure.rs
+++ b/tests/telemetry_backpressure.rs
@@ -147,6 +147,8 @@ fn snapshot_with(channels: Vec<ChannelSnapshot>) -> TelemetrySnapshot {
         captured_at: "2026-08-24T09:30:00Z".to_string(),
         uptime_secs: 7200,
         channels,
+        sensor_events_by_category: Vec::new(),
+        windows_process_command_line: None,
         registry: None,
     }
 }


### PR DESCRIPTION
## Summary

- increase the Windows sensor event queue from 8,192 to 32,768 entries
- keep the process ETW session flushing under queue pressure so short-lived process command lines remain observable
- keep pausing the main ETW session flush when downstream queueing already controls latency
- move per-detection operational logging off the default info hot path
- report accepted and dropped sensor events by category
- report final Windows process command-line capture fidelity
- document the queue and flush behavior

This keeps the implementation intentionally simple: one larger bounded queue, session-specific flush behavior, and enough telemetry to prove whether fidelity is preserved.

## Checkpoint results

With current `rustinel-rules` main and the Windows Hunting pack:

- 25/25 Sigma atomic controls passed
- 3/3 YARA atomic controls passed
- all 28 gating controls passed
- 115,927 sensor events accepted with zero drops
- 58/58 process command lines captured in the atomic run
- 3/3 burst controls detected
- 143 ms median post-burst alert latency
- 0.103% median idle CPU
- 30.0 MiB median idle working set
- 3,038/3,044 command lines captured under immediate-exit process noise

The raw 2,633-rule upstream corpus also completed three runs with zero drops and 3/3 controls detected. Its median post-burst recovery was 2,110 ms, which confirms rule-set size remains the limiting factor after event loss is removed.

The optional EICAR atomic remains non-gating because it writes a non-executable file while the current IOC hash worker is triggered from process images.

## Type of change

- [x] `bug` - bug fix
- [ ] `refactor` - refactoring, no behaviour change
- [ ] `documentation` - docs only
- [ ] `ci` - CI and release changes
- [ ] `dependencies` - dependency update

## Test plan

- [x] Tested on Windows
- [x] Tested on Linux
- [x] Existing tests pass (`cargo test --locked`)
- [x] New tests added
- [x] `cargo clippy --all-targets --locked -- -D warnings`
- [x] Fresh Windows branch checkout: 503 passed, 0 failed, 7 privilege-dependent tests ignored
- [x] Windows optimized build passed
- [x] Maintained rules atomic suite and three burst repetitions passed

## Checklist

- [x] Labels added
- [x] Documentation updated