### PR TITLE
perf(windows-etw): move PE enrichment out of callback

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -297,8 +297,9 @@ command-line capture stayed at 100%. A process that exits before
 the back-fill can still have no `CommandLine` even at 5 ms; the race is
 structural, and only its width is under Rustinel's control. Rustinel narrows it
 on the decode side too: the back-fill runs as soon as the PID is parsed, ahead
-of PE version-resource parsing and every path conversion, so no avoidable work
-sits between the event arriving and the live-process read.
+of every path conversion, so no avoidable work sits between the event arriving
+and the live-process read. PE version-resource parsing runs later in the sensor
+worker, after the bounded channel, so its file I/O cannot stall the ETW callback.
 
 The buffers are non-paged pool: 18 MB is committed for the life of the agent
 across both sessions and grows to at most 48 MB under load. Read the live values

--- a/src/runtime/capture.rs
+++ b/src/runtime/capture.rs
@@ -153,6 +153,12 @@ impl CaptureSession {
         let router = Arc::clone(&self.router);
         let worker = tokio::task::spawn_blocking(move || {
             while let Some(event) = rx.blocking_recv() {
+                #[cfg(windows)]
+                let event = {
+                    let mut event = event;
+                    crate::sensor::windows::enrich_event(&mut event);
+                    event
+                };
                 router.route_event(&event);
             }
         });

--- a/src/runtime/windows.rs
+++ b/src/runtime/windows.rs
@@ -647,7 +647,10 @@ async fn run_edr(
     let router_clone = Arc::clone(&router);
     let sensor_worker_handle = tokio::task::spawn_blocking(move || {
         info!(target: "sensor", "Sensor event worker thread started");
-        while let Some(event) = sensor_rx.blocking_recv() {
+        while let Some(mut event) = sensor_rx.blocking_recv() {
+            // PE parsing opens and maps the image, so it must happen after the
+            // bounded channel rather than in the ETW callback.
+            crate::sensor::windows::enrich_event(&mut event);
             router_clone.route_event(&event);
         }
         info!(target: "sensor", "Sensor event worker thread shutting down");

--- a/src/sensor/windows/enrichment.rs
+++ b/src/sensor/windows/enrichment.rs
@@ -1,0 +1,149 @@
+//! Post-callback enrichment for Windows sensor events.
+//!
+//! ETW callbacks only decode data already carried by an event. Work that can
+//! block, including opening and mapping PE images, belongs here after the
+//! bounded sensor channel has accepted the event.
+
+use crate::sensor::{SensorAction, SensorEvent, SensorPayload};
+use crate::utils::{parse_metadata, pe};
+
+/// Add PE version-resource fields to process-start and image-load events.
+pub(crate) fn enrich_event(event: &mut SensorEvent) {
+    match &mut event.payload {
+        SensorPayload::Process(fields) if event.action == SensorAction::Start => {
+            let metadata = fields.image.as_deref().and_then(parse_metadata);
+            (
+                fields.original_file_name,
+                fields.product,
+                fields.description,
+                fields.company,
+                fields.file_version,
+            ) = pe::version_fields(metadata);
+        }
+        SensorPayload::ImageLoad(fields) => {
+            let metadata = fields.image_loaded.as_deref().and_then(parse_metadata);
+            (
+                fields.original_file_name,
+                fields.product,
+                fields.description,
+                fields.company,
+                fields.file_version,
+            ) = pe::version_fields(metadata);
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::UNIX_EPOCH;
+
+    use crate::models::{ImageLoadFields, ProcessCreationFields};
+    use crate::sensor::{Platform, SensorNormalization};
+
+    use super::*;
+
+    fn event(action: SensorAction, payload: SensorPayload) -> SensorEvent {
+        SensorEvent {
+            platform: Platform::Windows,
+            provider: "etw",
+            action,
+            normalization: SensorNormalization {
+                event_id: 1,
+                action_code: 1,
+            },
+            pid: Some(42),
+            timestamp: UNIX_EPOCH,
+            process_start_key: None,
+            payload,
+        }
+    }
+
+    fn process_fields(image: &str) -> ProcessCreationFields {
+        ProcessCreationFields {
+            image: Some(image.to_string()),
+            original_file_name: None,
+            product: None,
+            description: None,
+            company: None,
+            file_version: None,
+            target_image: None,
+            command_line: None,
+            process_id: Some("42".to_string()),
+            process_start_time: None,
+            parent_process_id: None,
+            parent_image: None,
+            parent_command_line: None,
+            current_directory: None,
+            integrity_level: None,
+            user: None,
+        }
+    }
+
+    fn image_load_fields(image: &str) -> ImageLoadFields {
+        ImageLoadFields {
+            image_loaded: Some(image.to_string()),
+            process_id: Some("42".to_string()),
+            image: None,
+            original_file_name: None,
+            product: None,
+            description: None,
+            company: None,
+            file_version: None,
+            signed: None,
+            signature: None,
+            user: None,
+        }
+    }
+
+    #[test]
+    fn process_start_is_enriched_after_decode() {
+        let mut event = event(
+            SensorAction::Start,
+            SensorPayload::Process(process_fields(r"C:\Windows\System32\cmd.exe")),
+        );
+
+        enrich_event(&mut event);
+
+        let SensorPayload::Process(fields) = event.payload else {
+            panic!("expected process payload");
+        };
+        assert!(fields.original_file_name.is_some());
+        assert!(fields.product.is_some());
+        assert!(fields.description.is_some());
+    }
+
+    #[test]
+    fn image_load_is_enriched_after_decode() {
+        let mut event = event(
+            SensorAction::Load,
+            SensorPayload::ImageLoad(image_load_fields(r"C:\Windows\System32\cmd.exe")),
+        );
+
+        enrich_event(&mut event);
+
+        let SensorPayload::ImageLoad(fields) = event.payload else {
+            panic!("expected image-load payload");
+        };
+        assert!(fields.original_file_name.is_some());
+        assert!(fields.product.is_some());
+        assert!(fields.description.is_some());
+    }
+
+    #[test]
+    fn process_stop_does_not_read_the_image() {
+        let mut event = event(
+            SensorAction::Stop,
+            SensorPayload::Process(process_fields(r"C:\Windows\System32\cmd.exe")),
+        );
+
+        enrich_event(&mut event);
+
+        let SensorPayload::Process(fields) = event.payload else {
+            panic!("expected process payload");
+        };
+        assert!(fields.original_file_name.is_none());
+        assert!(fields.product.is_none());
+        assert!(fields.description.is_none());
+    }
+}

--- a/src/sensor/windows/etw.rs
+++ b/src/sensor/windows/etw.rs
@@ -26,8 +26,7 @@ use crate::sensor::{
     Platform, ProcessStartKey, Sensor, SensorAction, SensorEvent, SensorNormalization,
     SensorPayload,
 };
-use crate::utils::pe;
-use crate::utils::{convert_nt_to_dos, parse_metadata, query_process_command_line};
+use crate::utils::{convert_nt_to_dos, query_process_command_line};
 
 use super::event_log::EventLogSubscriptions;
 use super::file_paths::FilePathCache;
@@ -1529,12 +1528,9 @@ fn decode_process(
     let mappings = field_maps::process_creation_mappings();
 
     // The PID and the command line come first, and nothing is allowed between
-    // them and the back-fill below. Everything else this function does is
-    // reading a property out of a buffer that is already in memory; the
-    // back-fill is the one step racing a live process, and `parse_metadata`
-    // in particular opens and maps the image off disk. Decoding in field order
-    // put that read, and every path conversion, ahead of the race for no
-    // reason. See `PROCESS_TRACE_SESSION_NAME`.
+    // them and the back-fill below. Everything else this function does reads
+    // data already carried by the event. PE metadata is added by the consumer
+    // after the bounded channel. See `PROCESS_TRACE_SESSION_NAME`.
     let process_id = try_get_uint(parser, mappings.get_etw_field("ProcessId")?)
         .or_else(|| Some(record.process_id().to_string()));
     let pid = process_id
@@ -1572,22 +1568,13 @@ fn decode_process(
     let parent_image = raw_parent_image.map(|path| convert_nt_to_dos(&path));
     let current_directory = raw_current_directory.map(|path| convert_nt_to_dos(&path));
 
-    // Version resources are only worth reading on a start: on a stop the image
-    // is often already gone, and the fields describe the binary, not the exit.
-    let pe_metadata = match image.as_deref() {
-        Some(path) if action == SensorAction::Start => parse_metadata(path),
-        _ => None,
-    };
-    let (original_file_name, product, description, company, file_version) =
-        pe::version_fields(pe_metadata);
-
     let fields = ProcessCreationFields {
         image: image.clone(),
-        original_file_name,
-        product,
-        description,
-        company,
-        file_version,
+        original_file_name: None,
+        product: None,
+        description: None,
+        company: None,
+        file_version: None,
         // Process creation describes one image and has no target process.
         target_image: None,
         command_line,
@@ -2005,20 +1992,16 @@ fn decode_image_load(parser: &Parser, record: &EventRecord) -> Option<DecodedEtw
     let image_loaded = try_get_string(parser, mappings.get_etw_field("ImageLoaded")?)
         .map(|path| convert_nt_to_dos(&path));
 
-    let pe_metadata = image_loaded.as_deref().and_then(parse_metadata);
-    let (original_file_name, product, description, company, file_version) =
-        pe::version_fields(pe_metadata);
-
     let fields = ImageLoadFields {
         image_loaded,
         process_id: try_get_uint(parser, mappings.get_etw_field("ProcessId")?),
         image: try_get_string(parser, mappings.get_etw_field("Image")?)
             .map(|path| convert_nt_to_dos(&path)),
-        original_file_name,
-        product,
-        description,
-        company,
-        file_version,
+        original_file_name: None,
+        product: None,
+        description: None,
+        company: None,
+        file_version: None,
         signed: try_get_string(parser, mappings.get_etw_field("Signed")?),
         signature: try_get_string(parser, mappings.get_etw_field("Signature")?),
         user: try_get_string(parser, mappings.get_etw_field("User")?),

--- a/src/sensor/windows/mod.rs
+++ b/src/sensor/windows/mod.rs
@@ -1,3 +1,4 @@
+mod enrichment;
 pub mod etw;
 mod event_log;
 mod field_maps;
@@ -9,4 +10,5 @@ mod registry_paths;
 mod registry_rundown;
 mod registry_value_data;
 
+pub(crate) use enrichment::enrich_event;
 pub use etw::EtwSensor;


### PR DESCRIPTION
## Summary

- decode process and image-load records without opening PE files in the ETW callback
- enrich PE version-resource fields in the sensor worker after the bounded channel
- keep `OriginalFileName`, `Product`, `Description`, `Company`, and `FileVersion` behavior for process-start and image-load events
- document the post-queue enrichment boundary

Closes #298

## Validation

- `cargo fmt --all -- --check`
- `cargo test --locked` on macOS: 335 unit tests passed, all integration and doc tests passed
- `cargo clippy --locked --all-targets -- -D clippy::all` on macOS
- `cargo test --locked` on Windows 11: 396 unit tests passed, all enabled integration and doc tests passed
- `cargo clippy --locked --all-targets -- -D clippy::all` on Windows 11

## Windows stress test

Ran a release build against 4,000 distinct copies of `cmd.exe` so every process image forced a PE metadata cache miss:

- process launches: 4,000 / 4,000
- process starts captured: 4,000 / 4,000
- starts with `OriginalFileName`, `Product`, and `Description`: 4,000 / 4,000
- ETW kernel events lost: 0
- sensor queue drop warnings: 0
