### PR TITLE
chore: prepare release 1.5.0-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3174,7 +3174,7 @@ dependencies = [
 
 [[package]]
 name = "rustinel"
-version = "1.4.1"
+version = "1.5.0-rc.1"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustinel"
-version = "1.4.1"
+version = "1.5.0-rc.1"
 edition = "2021"
 authors = []
 description = "Open-source EDR for Windows, Linux, and macOS with Sigma, YARA, and IOC detection"


### PR DESCRIPTION
## Summary

- bump the package version to `1.5.0-rc.1`
- update the lockfile package version

## Verification

- `cargo check --locked`
- `cargo metadata --locked --no-deps --format-version 1`