### PR TITLE
perf(core): remove redundant IOC and Sigma allocations

### DIFF
--- a/src/engine/detect.rs
+++ b/src/engine/detect.rs
@@ -46,9 +46,7 @@ impl EventDetectors {
     /// matches in a deterministic order. The same event evaluated against the
     /// same detectors produces the same alerts in the same sequence.
     pub fn evaluate(&self, event: &NormalizedEvent) -> Vec<Alert> {
-        let mut alerts = Vec::new();
-
-        alerts.extend(self.sigma.evaluate_event(event));
+        let mut alerts = self.sigma.evaluate_event(event);
 
         for ioc_match in self.ioc.check_event(event) {
             alerts.push(self.ioc.build_alert_for_match(&ioc_match, event));

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -179,9 +179,9 @@ impl Engine {
 
             for alias in Self::concrete_logsource_aliases_for_event(event) {
                 let logsource = rsigma_parser::LogSource {
-                    product: alias.product.clone(),
-                    service: alias.service.clone(),
-                    category: alias.category.clone(),
+                    product: alias.product,
+                    service: alias.service,
+                    category: alias.category,
                     ..Default::default()
                 };
 

--- a/src/ioc/matchers.rs
+++ b/src/ioc/matchers.rs
@@ -6,22 +6,11 @@ use std::collections::HashSet;
 use std::net::IpAddr;
 
 fn normalize_domain(value: &str) -> Option<String> {
-    let mut host = value.trim().to_ascii_lowercase();
+    let host = value.trim().trim_end_matches('.');
     if host.is_empty() {
         return None;
     }
-    host = host.trim_end_matches('.').to_string();
-    if host.is_empty() {
-        return None;
-    }
-    Some(host)
-}
-
-fn extract_ips(value: &str) -> Vec<&str> {
-    value
-        .split(|c: char| c.is_whitespace() || c == ',' || c == ';')
-        .filter(|token| !token.is_empty())
-        .collect()
+    Some(host.to_ascii_lowercase())
 }
 
 impl IocEngine {
@@ -31,48 +20,32 @@ impl IocEngine {
         matches: &mut Vec<IocMatch>,
         seen: &mut HashSet<String>,
     ) {
-        let mut candidates = Vec::new();
+        let candidate = match &event.fields {
+            EventFields::DnsQuery(f) => f.query_name.as_deref(),
+            EventFields::NetworkConnection(f) => f.destination_hostname.as_deref(),
+            EventFields::WmiEvent(f) => f.destination_hostname.as_deref(),
+            _ => None,
+        };
+        let Some(host) = candidate.and_then(normalize_domain) else {
+            return;
+        };
 
-        match &event.fields {
-            EventFields::DnsQuery(f) => {
-                if let Some(v) = &f.query_name {
-                    candidates.push(v.as_str());
-                }
-            }
-            EventFields::NetworkConnection(f) => {
-                if let Some(v) = &f.destination_hostname {
-                    candidates.push(v.as_str());
-                }
-            }
-            EventFields::WmiEvent(f) => {
-                if let Some(v) = &f.destination_hostname {
-                    candidates.push(v.as_str());
-                }
-            }
-            _ => {}
+        if let Some(meta) = self.domain_iocs.exact.get(&host) {
+            push_match_unique(
+                matches,
+                seen,
+                build_match(IocKind::Domain, &host, &host, meta),
+            );
         }
 
-        for candidate in candidates {
-            let normalized = normalize_domain(candidate);
-            let Some(host) = normalized else { continue };
-
-            if let Some(meta) = self.domain_iocs.exact.get(&host) {
+        for (suffix, meta) in &self.domain_iocs.suffix {
+            if host == *suffix || host.ends_with(&format!(".{}", suffix)) {
+                let indicator = format!(".{}", suffix);
                 push_match_unique(
                     matches,
                     seen,
-                    build_match(IocKind::Domain, &host, &host, meta),
+                    build_match(IocKind::Domain, &indicator, &host, meta),
                 );
-            }
-
-            for (suffix, meta) in &self.domain_iocs.suffix {
-                if host == *suffix || host.ends_with(&format!(".{}", suffix)) {
-                    let indicator = format!(".{}", suffix);
-                    push_match_unique(
-                        matches,
-                        seen,
-                        build_match(IocKind::Domain, &indicator, &host, meta),
-                    );
-                }
             }
         }
     }
@@ -96,9 +69,10 @@ impl IocEngine {
             }
             EventFields::DnsQuery(f) => {
                 if let Some(v) = &f.query_results {
-                    for ip in extract_ips(v) {
-                        candidates.push(ip);
-                    }
+                    candidates.extend(
+                        v.split(|c: char| c.is_whitespace() || c == ',' || c == ';')
+                            .filter(|token| !token.is_empty()),
+                    );
                 }
             }
             _ => {}
@@ -140,41 +114,16 @@ impl IocEngine {
             return;
         };
 
-        let mut candidates = Vec::new();
+        let candidates = match &event.fields {
+            EventFields::ProcessCreation(f) => [f.image.as_deref(), f.target_image.as_deref()],
+            EventFields::FileEvent(f) => [f.target_filename.as_deref(), None],
+            EventFields::ImageLoad(f) => [f.image_loaded.as_deref(), None],
+            EventFields::PowerShellScript(f) => [f.path.as_deref(), None],
+            EventFields::ServiceCreation(f) => [f.service_file_name.as_deref(), None],
+            _ => [None, None],
+        };
 
-        match &event.fields {
-            EventFields::ProcessCreation(f) => {
-                if let Some(v) = &f.image {
-                    candidates.push(v.as_str());
-                }
-                if let Some(v) = &f.target_image {
-                    candidates.push(v.as_str());
-                }
-            }
-            EventFields::FileEvent(f) => {
-                if let Some(v) = &f.target_filename {
-                    candidates.push(v.as_str());
-                }
-            }
-            EventFields::ImageLoad(f) => {
-                if let Some(v) = &f.image_loaded {
-                    candidates.push(v.as_str());
-                }
-            }
-            EventFields::PowerShellScript(f) => {
-                if let Some(v) = &f.path {
-                    candidates.push(v.as_str());
-                }
-            }
-            EventFields::ServiceCreation(f) => {
-                if let Some(v) = &f.service_file_name {
-                    candidates.push(v.as_str());
-                }
-            }
-            _ => {}
-        }
-
-        for candidate in candidates {
+        for candidate in candidates.into_iter().flatten() {
             tracing::trace!(
                 target: "ioc",
                 candidate = %candidate,

--- a/tests/pipeline_ioc.rs
+++ b/tests/pipeline_ioc.rs
@@ -33,6 +33,30 @@ fn domain_ioc_matches_exact_and_suffix_dns_events() {
         .as_str()
         .expect("rule name")
         .starts_with("ioc:domain:"));
+
+    for (query, expected) in [
+        (Some("  EXAMPLE.TEST...\t"), 2),
+        (Some("example.test"), 2),
+        (Some("other.example.test"), 1),
+        (Some("notexample.test"), 0),
+        (Some("example.test.invalid"), 0),
+        (Some("..."), 0),
+        (Some(" \t"), 0),
+        (None, 0),
+    ] {
+        let mut variant = event.clone();
+        let rustinel::models::EventFields::DnsQuery(fields) = &mut variant.fields else {
+            panic!("expected DNS fields");
+        };
+        fields.query_name = query.map(str::to_owned);
+        let matches = engine.check_event(&variant);
+        assert_eq!(matches.len(), expected, "query: {query:?}");
+        if expected == 2 {
+            assert_eq!(matches[0].indicator, TEST_DOMAIN);
+            assert_eq!(matches[1].indicator, ".example.test");
+            assert!(matches.iter().all(|m| m.observed == TEST_DOMAIN));
+        }
+    }
 }
 
 #[test]
@@ -67,6 +91,31 @@ fn ip_ioc_matches_network_and_dns_response_ips() {
     let json = ecs_json(&alert);
     assert_ecs_field_eq(&json, "dns.question.name", TEST_DOMAIN);
     assert_ecs_field_present(&json, "related.ip");
+
+    let mut separated = dns.clone();
+    let rustinel::models::EventFields::DnsQuery(fields) = &mut separated.fields else {
+        panic!("expected DNS fields");
+    };
+    fields.query_results = Some(format!(
+        " ,;\t{TEST_DESTINATION_IP};invalid,\n{TEST_DESTINATION_IP}\u{2003}203.0.113.1;; "
+    ));
+    let separated_matches = engine.check_event(&separated);
+    let match_identity = |m: &rustinel::ioc::IocMatch| {
+        (
+            m.kind,
+            m.indicator.clone(),
+            m.observed.clone(),
+            m.source.clone(),
+            m.line,
+        )
+    };
+    assert_eq!(
+        separated_matches
+            .iter()
+            .map(match_identity)
+            .collect::<Vec<_>>(),
+        matches.iter().map(match_identity).collect::<Vec<_>>()
+    );
 }
 
 #[test]


### PR DESCRIPTION
IOC matching creates temporary candidate collections and copies normalized domains. Detector evaluation also clones owned logsource strings and copies Sigma alerts into another vector.

Use borrowed IOC candidates, trim domains before ASCII case folding, move owned logsource fields, and append IOC alerts to Sigma's returned vector. Matching order, event values, output contracts, configuration and sensor behavior remain unchanged.

Two independent code commits remove 53 net production lines (38 added, 91 removed). Two existing IOC tests gain 49 lines covering normalization, separators, duplicate IPs and match order. The private `extract_ips` wrapper is removed; no new production abstraction.

Validation:

- Local baseline and final all-target suites: 428 passed, 8 ignored.
- IOC boundary assertions passed before and after the implementation change.
- Formatting and all-target Clippy passed after each code change.
- Native tests and Clippy on Linux, Windows and macOS, live Linux/Windows atomics, and pinned SigmaHQ compatibility passed on the identical code before documentation-only commits were removed. Checks rerun on the rewritten branch.

No entitled live macOS sensor run was performed and no throughput percentage is claimed.
