### PR TITLE
refactor(runtime): share Linux and macOS command dispatch

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -151,6 +151,14 @@ if it cannot start. Requirements for the macOS sensor are root, the
 `com.apple.developer.endpoint-security.client` entitlement (or SIP/AMFI relaxed
 for local testing), and access to the bpf device nodes.
 
+## Command Dispatch
+
+`src/runtime/orchestration.rs` handles portable replay commands before platform
+dispatch. Linux and macOS share one command dispatcher, with foreground runs and
+capture delegated to their platform runtime modules. Windows keeps its separate
+dispatcher: replay and doctor run before service dispatch, followed by console
+command handling when service dispatch does not start.
+
 ## Shared Pipeline
 
 Once a platform sensor emits a raw `SensorEvent`, the rest of the runtime is shared:

--- a/src/runtime/orchestration.rs
+++ b/src/runtime/orchestration.rs
@@ -2,6 +2,10 @@ use crate::cli::{Cli, Commands};
 use crate::replay::ReplayOptions;
 #[cfg(any(windows, target_os = "linux", target_os = "macos"))]
 use crate::runtime::capture::CaptureOptions;
+#[cfg(target_os = "linux")]
+use crate::runtime::linux as platform_runtime;
+#[cfg(target_os = "macos")]
+use crate::runtime::macos as platform_runtime;
 
 /// Commands that need neither sensors nor a platform runtime, handled before
 /// any platform dispatch so they behave identically everywhere.
@@ -75,7 +79,7 @@ pub fn run() -> anyhow::Result<()> {
     }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 pub fn run() -> anyhow::Result<()> {
     let cli = Cli::parse_args();
 
@@ -105,55 +109,14 @@ pub fn run() -> anyhow::Result<()> {
             catalog_url,
         }),
         Some(Commands::Run { no_console, .. }) => {
-            crate::runtime::linux::run(!no_console, cli.log_level, cli.config)
+            platform_runtime::run(!no_console, cli.log_level, cli.config)
         }
-        Some(Commands::Capture { output }) => crate::runtime::linux::run_capture(CaptureOptions {
+        Some(Commands::Capture { output }) => platform_runtime::run_capture(CaptureOptions {
             output,
             log_level: cli.log_level,
             config_path: cli.config,
         }),
-        None => crate::runtime::linux::run(true, cli.log_level, cli.config),
-    }
-}
-
-#[cfg(target_os = "macos")]
-pub fn run() -> anyhow::Result<()> {
-    let cli = Cli::parse_args();
-
-    if let Some(result) = run_portable_command(&cli) {
-        return result;
-    }
-
-    match cli.command {
-        Some(Commands::Replay { .. }) => unreachable!("replay is handled before platform dispatch"),
-        Some(Commands::Service { action }) => crate::platform::handle_service_command(action),
-        Some(Commands::Doctor { json }) => {
-            let code = crate::doctor::run_cli(cli.config, json)?;
-            std::process::exit(code);
-        }
-        Some(Commands::Rules { action }) => crate::rules::run_cli(action, cli.config),
-        Some(Commands::Setup {
-            pack,
-            yes,
-            no_start,
-            force,
-            catalog_url,
-        }) => crate::setup::run_cli(crate::setup::SetupOptions {
-            pack,
-            yes,
-            no_start,
-            force,
-            catalog_url,
-        }),
-        Some(Commands::Run { no_console, .. }) => {
-            crate::runtime::macos::run(!no_console, cli.log_level, cli.config)
-        }
-        Some(Commands::Capture { output }) => crate::runtime::macos::run_capture(CaptureOptions {
-            output,
-            log_level: cli.log_level,
-            config_path: cli.config,
-        }),
-        None => crate::runtime::macos::run(true, cli.log_level, cli.config),
+        None => platform_runtime::run(true, cli.log_level, cli.config),
     }
 }
 


### PR DESCRIPTION
Linux and macOS had identical command dispatchers apart from the runtime module used for foreground runs and capture. Share that dispatcher and select the platform runtime with conditional imports, so command handling only needs to be maintained once.

Replay still runs before platform dispatch. Command arguments, doctor exit handling, and default console behavior are preserved. Windows service dispatch and platform sensor lifecycles are unchanged. Document the dispatch boundary in the architecture guide.

Part of #361: completes Linux/macOS command-dispatch consolidation. Shared pipeline construction and shutdown ordering remain separate follow-ups.

Validation on macOS:
- `cargo test --locked`
- `cargo clippy --locked --all-targets -- -D clippy::all`
- `cargo fmt --all -- --check`
- Confirmed the original Unix dispatchers were identical after substituting the platform name, and the Windows dispatcher is unchanged.

Linux and Windows validation runs in the repository CI matrix.
