### PR TITLE
refactor(runtime): centralize worker drain and final flush ordering

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -165,7 +165,10 @@ command handling when service dispatch does not start.
 and IOC workers, normalization, and the event router for all three platforms.
 Platform runtimes retain privilege checks, Windows process snapshotting, sensor
 startup, event-channel capacity, and Windows PE enrichment. Detector startup logs
-use the same messages across platforms.
+use the same messages across platforms. After sensors stop, `runtime/shutdown.rs`
+drains sensor events, YARA file/memory scans, and IOC hashes, then stops reload
+polling, closes reload requests, and drains the reload and response workers.
+Deduplication flushes and the final telemetry snapshot follow worker completion.
 
 Once a platform sensor emits a raw `SensorEvent`, the rest of the runtime is shared:
 

--- a/src/runtime/linux.rs
+++ b/src/runtime/linux.rs
@@ -101,15 +101,7 @@ async fn run_linux_edr(
     let response_config = Arc::new(ArcSwap::from(Arc::new(cfg.response.clone())));
     let (response_engine, response_worker_handle) = ResponseEngine::new(response_config.clone());
 
-    let LivePipeline {
-        router,
-        yara_worker_handle,
-        yara_memory_worker_handle,
-        mut ioc_hash_worker_handle,
-        mut reload_poller,
-        mut reload_worker_handle,
-        mut reload_tx,
-    } = LivePipeline::new(
+    let pipeline = LivePipeline::new(
         &cfg,
         resolved_config_path,
         Platform::Linux,
@@ -128,7 +120,7 @@ async fn run_linux_edr(
     );
 
     let (sensor_tx, mut sensor_rx) = mpsc::channel::<SensorEvent>(8192);
-    let router_for_worker = Arc::clone(&router);
+    let router_for_worker = Arc::clone(&pipeline.router);
     let sensor_worker_handle = tokio::task::spawn_blocking(move || {
         while let Some(event) = sensor_rx.blocking_recv() {
             router_for_worker.route_event(&event);
@@ -148,40 +140,16 @@ async fn run_linux_edr(
     }
     sensor.shutdown();
 
-    // Drain workers
-    drop(router);
     drop(response_engine);
-    let _ = sensor_worker_handle.await;
-    if let Some(h) = yara_worker_handle {
-        let _ = h.await;
-    }
-    if let Some(h) = yara_memory_worker_handle {
-        let _ = h.await;
-    }
-    if let Some(h) = ioc_hash_worker_handle.take() {
-        let _ = h.await;
-    }
-    if let Some(poller) = reload_poller.take() {
-        poller.shutdown().await;
-    }
-    drop(reload_tx.take());
-    if let Some(h) = reload_worker_handle.take() {
-        let _ = h.await;
-    }
-    let _ = response_worker_handle.await;
-
-    if let Some(handle) = dedup_worker_handle {
-        handle.abort();
-        let _ = handle.await;
-    }
-    if let Some(dedup) = alert_sink.dedup() {
-        dedup.flush_all(&alert_sink);
-        dedup.log_metrics();
-    }
-
-    if let Some(reporter) = telemetry_reporter {
-        reporter.finish().await;
-    }
+    pipeline
+        .shutdown(
+            sensor_worker_handle,
+            response_worker_handle,
+            dedup_worker_handle,
+            &alert_sink,
+            telemetry_reporter,
+        )
+        .await;
 
     info!(target: TARGET_CONSOLE, "Shutdown complete");
     Ok(())

--- a/src/runtime/macos.rs
+++ b/src/runtime/macos.rs
@@ -117,15 +117,7 @@ async fn run_macos_edr(
     let response_config = Arc::new(ArcSwap::from(Arc::new(cfg.response.clone())));
     let (response_engine, response_worker_handle) = ResponseEngine::new(response_config.clone());
 
-    let LivePipeline {
-        router,
-        yara_worker_handle,
-        yara_memory_worker_handle,
-        mut ioc_hash_worker_handle,
-        mut reload_poller,
-        mut reload_worker_handle,
-        mut reload_tx,
-    } = LivePipeline::new(
+    let pipeline = LivePipeline::new(
         &cfg,
         resolved_config_path,
         Platform::MacOS,
@@ -145,7 +137,7 @@ async fn run_macos_edr(
     );
 
     let (sensor_tx, mut sensor_rx) = mpsc::channel::<SensorEvent>(8192);
-    let router_for_worker = Arc::clone(&router);
+    let router_for_worker = Arc::clone(&pipeline.router);
     let sensor_worker_handle = tokio::task::spawn_blocking(move || {
         while let Some(event) = sensor_rx.blocking_recv() {
             router_for_worker.route_event(&event);
@@ -176,40 +168,16 @@ async fn run_macos_edr(
     esf_sensor.shutdown();
     bpf_sensor.shutdown();
 
-    // Drain workers
-    drop(router);
     drop(response_engine);
-    let _ = sensor_worker_handle.await;
-    if let Some(h) = yara_worker_handle {
-        let _ = h.await;
-    }
-    if let Some(h) = yara_memory_worker_handle {
-        let _ = h.await;
-    }
-    if let Some(h) = ioc_hash_worker_handle.take() {
-        let _ = h.await;
-    }
-    if let Some(poller) = reload_poller.take() {
-        poller.shutdown().await;
-    }
-    drop(reload_tx.take());
-    if let Some(h) = reload_worker_handle.take() {
-        let _ = h.await;
-    }
-    let _ = response_worker_handle.await;
-
-    if let Some(handle) = dedup_worker_handle {
-        handle.abort();
-        let _ = handle.await;
-    }
-    if let Some(dedup) = alert_sink.dedup() {
-        dedup.flush_all(&alert_sink);
-        dedup.log_metrics();
-    }
-
-    if let Some(reporter) = telemetry_reporter {
-        reporter.finish().await;
-    }
+    pipeline
+        .shutdown(
+            sensor_worker_handle,
+            response_worker_handle,
+            dedup_worker_handle,
+            &alert_sink,
+            telemetry_reporter,
+        )
+        .await;
 
     info!(target: TARGET_CONSOLE, "Shutdown complete");
     Ok(())

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -8,6 +8,8 @@ mod macos;
 mod orchestration;
 #[cfg(any(windows, target_os = "linux", target_os = "macos"))]
 mod pipeline;
+#[cfg(any(windows, target_os = "linux", target_os = "macos"))]
+mod shutdown;
 pub mod telemetry;
 #[cfg(windows)]
 mod windows;

--- a/src/runtime/pipeline.rs
+++ b/src/runtime/pipeline.rs
@@ -329,28 +329,19 @@ mod tests {
             assert_eq!(pipeline.reload_poller.is_some(), enabled);
             assert_eq!(pipeline.reload_worker_handle.is_some(), enabled);
             assert_eq!(pipeline.reload_tx.is_some(), enabled);
-            drop(pipeline.router);
             drop(response);
-            tokio::time::timeout(std::time::Duration::from_secs(5), async {
-                for handle in [
-                    pipeline.yara_worker_handle,
-                    pipeline.yara_memory_worker_handle,
-                    pipeline.ioc_hash_worker_handle,
-                ]
-                .into_iter()
-                .flatten()
-                {
-                    handle.await.unwrap();
-                }
-                if let Some(poller) = pipeline.reload_poller {
-                    poller.shutdown().await;
-                }
-                drop(pipeline.reload_tx);
-                if let Some(handle) = pipeline.reload_worker_handle {
-                    handle.await.unwrap();
-                }
-                response_worker.await.unwrap();
-            })
+            let sensor_worker = tokio::spawn(async {});
+            let (writer, _shutdown_guard) = tracing_appender::non_blocking(std::io::sink());
+            tokio::time::timeout(
+                std::time::Duration::from_secs(5),
+                pipeline.shutdown(
+                    sensor_worker,
+                    response_worker,
+                    None,
+                    &AlertSink::new(writer),
+                    None,
+                ),
+            )
             .await
             .expect("pipeline must release all worker senders");
         }

--- a/src/runtime/shutdown.rs
+++ b/src/runtime/shutdown.rs
@@ -10,6 +10,7 @@ use crate::runtime::telemetry::TelemetryReporter;
 impl LivePipeline {
     /// The caller must stop sensors and drop its response-engine sender first.
     /// The sensor worker retains the router until its queued events are drained.
+    /// No other router clones may outlive that worker, since they own job senders.
     pub async fn shutdown(
         self,
         sensor_worker: JoinHandle<()>,

--- a/src/runtime/shutdown.rs
+++ b/src/runtime/shutdown.rs
@@ -1,0 +1,137 @@
+//! Drain live detection workers after the platform sensors have stopped.
+
+use tokio::task::JoinHandle;
+use tracing::{error, info};
+
+use crate::alerts::AlertSink;
+use crate::runtime::pipeline::LivePipeline;
+use crate::runtime::telemetry::TelemetryReporter;
+
+impl LivePipeline {
+    /// The caller must stop sensors and drop its response-engine sender first.
+    /// The sensor worker retains the router until its queued events are drained.
+    pub async fn shutdown(
+        self,
+        sensor_worker: JoinHandle<()>,
+        response_worker: JoinHandle<()>,
+        dedup_worker: Option<JoinHandle<()>>,
+        alert_sink: &AlertSink,
+        telemetry_reporter: Option<TelemetryReporter>,
+    ) {
+        drop(self.router);
+        join_worker("sensor event", sensor_worker).await;
+        for (name, handle) in [
+            ("YARA file", self.yara_worker_handle),
+            ("YARA memory", self.yara_memory_worker_handle),
+            ("IOC hash", self.ioc_hash_worker_handle),
+        ] {
+            if let Some(handle) = handle {
+                join_worker(name, handle).await;
+            }
+        }
+        if let Some(poller) = self.reload_poller {
+            poller.shutdown().await;
+        }
+        drop(self.reload_tx);
+        if let Some(handle) = self.reload_worker_handle {
+            join_worker("hot-reload", handle).await;
+        }
+        join_worker("response", response_worker).await;
+
+        // The response worker can still emit alerts, so flush only after it exits.
+        if let Some(handle) = dedup_worker {
+            handle.abort();
+            let _ = handle.await;
+        }
+        if let Some(dedup) = alert_sink.dedup() {
+            dedup.flush_all(alert_sink);
+            dedup.log_metrics();
+        }
+        if let Some(reporter) = telemetry_reporter {
+            reporter.finish().await;
+        }
+    }
+}
+
+async fn join_worker(name: &str, handle: JoinHandle<()>) {
+    match handle.await {
+        Ok(()) => info!(worker = name, "Worker finished"),
+        Err(error) => error!(worker = name, %error, "Failed to join worker"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use tokio::sync::mpsc;
+
+    struct Stopped(Arc<AtomicBool>);
+
+    impl Drop for Stopped {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::SeqCst);
+        }
+    }
+
+    #[tokio::test]
+    async fn queued_sensor_work_reaches_response_before_final_flush() {
+        let (jobs, mut job_rx) = mpsc::channel(1);
+        let (responses, mut response_rx) = mpsc::channel(1);
+        let router = Arc::new(crate::sensor::SensorEventRouter::new());
+        let worker_router = router.clone();
+        let sensor = tokio::spawn(async move {
+            tokio::task::yield_now().await;
+            jobs.send(1).await.unwrap();
+            drop(worker_router);
+        });
+        let yara = tokio::spawn(async move {
+            while let Some(job) = job_rx.recv().await {
+                responses.send(job).await.unwrap();
+            }
+        });
+        let completed = Arc::new(AtomicUsize::new(0));
+        let dedup_stopped = Arc::new(AtomicBool::new(false));
+        let completion_count = completed.clone();
+        let stopped = dedup_stopped.clone();
+        let response = tokio::spawn(async move {
+            while let Some(job) = response_rx.recv().await {
+                assert!(!stopped.load(Ordering::SeqCst));
+                completion_count.fetch_add(job, Ordering::SeqCst);
+            }
+        });
+        let marker = Stopped(dedup_stopped.clone());
+        let dedup = tokio::spawn(async move {
+            let _marker = marker;
+            std::future::pending::<()>().await;
+        });
+        let (reload_tx, mut reload_rx) = mpsc::unbounded_channel();
+        reload_tx.send(crate::reload::ReloadTarget::Sigma).unwrap();
+        let reload = tokio::spawn(async move {
+            assert_eq!(
+                reload_rx.recv().await,
+                Some(crate::reload::ReloadTarget::Sigma)
+            );
+            assert_eq!(reload_rx.recv().await, None);
+        });
+        let pipeline = LivePipeline {
+            router,
+            yara_worker_handle: Some(yara),
+            yara_memory_worker_handle: None,
+            ioc_hash_worker_handle: None,
+            reload_poller: None,
+            reload_worker_handle: Some(reload),
+            reload_tx: Some(reload_tx),
+        };
+        let (writer, _guard) = tracing_appender::non_blocking(std::io::sink());
+        tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            pipeline.shutdown(sensor, response, Some(dedup), &AlertSink::new(writer), None),
+        )
+        .await
+        .expect("queued work must drain without retaining senders");
+        assert_eq!(completed.load(Ordering::SeqCst), 1);
+        assert!(dedup_stopped.load(Ordering::SeqCst));
+    }
+}

--- a/src/runtime/windows.rs
+++ b/src/runtime/windows.rs
@@ -362,15 +362,7 @@ async fn run_edr(
         cfg.windows.etw_process_flush_interval_ms,
     ));
 
-    let LivePipeline {
-        router,
-        yara_worker_handle,
-        yara_memory_worker_handle,
-        mut ioc_hash_worker_handle,
-        mut reload_poller,
-        mut reload_worker_handle,
-        mut reload_tx,
-    } = LivePipeline::new(
+    let pipeline = LivePipeline::new(
         &cfg,
         resolved_config_path,
         Platform::Windows,
@@ -394,7 +386,7 @@ async fn run_edr(
 
     // Start shared sensor event pipeline
     let (sensor_tx, mut sensor_rx) = mpsc::channel::<SensorEvent>(SENSOR_EVENT_CHANNEL_CAPACITY);
-    let router_clone = Arc::clone(&router);
+    let router_clone = Arc::clone(&pipeline.router);
     let sensor_worker_handle = tokio::task::spawn_blocking(move || {
         info!(target: "sensor", "Sensor event worker thread started");
         while let Some(mut event) = sensor_rx.blocking_recv() {
@@ -461,70 +453,16 @@ async fn run_edr(
         }
     }
 
-    // Common teardown (not reached if exit(1) above)
-    match sensor_worker_handle.await {
-        Ok(_) => info!("Sensor event worker thread finished"),
-        Err(e) => error!("Failed to join sensor event worker thread: {}", e),
-    }
-
-    drop(router);
     drop(response_engine);
-    if let Some(handle) = yara_worker_handle {
-        info!("Signaling YARA worker to shut down...");
-        match handle.await {
-            Ok(_) => info!("YARA worker thread finished"),
-            Err(e) => error!("Failed to join YARA worker thread: {}", e),
-        }
-    }
-
-    if let Some(handle) = yara_memory_worker_handle {
-        match handle.await {
-            Ok(_) => info!("YARA memory worker thread finished"),
-            Err(e) => error!("Failed to join YARA memory worker thread: {}", e),
-        }
-    }
-
-    if let Some(handle) = ioc_hash_worker_handle.take() {
-        info!("Signaling IOC hash worker to shut down...");
-        match handle.await {
-            Ok(_) => info!("IOC hash worker thread finished"),
-            Err(e) => error!("Failed to join IOC hash worker thread: {}", e),
-        }
-    }
-
-    if let Some(poller) = reload_poller.take() {
-        info!("Signaling hot-reload poller to shut down...");
-        poller.shutdown().await;
-        info!("Hot-reload poller thread finished");
-    }
-    drop(reload_tx.take());
-    if let Some(handle) = reload_worker_handle.take() {
-        info!("Signaling hot-reload worker to shut down...");
-        match handle.await {
-            Ok(_) => info!("Hot-reload worker thread finished"),
-            Err(e) => error!("Failed to join hot-reload worker thread: {}", e),
-        }
-    }
-
-    info!("Signaling response worker to shut down...");
-    match response_worker_handle.await {
-        Ok(_) => info!("Response worker thread finished"),
-        Err(e) => error!("Failed to join response worker thread: {}", e),
-    }
-
-    // Flush any pending dedup rollups before the alert file is closed.
-    if let Some(handle) = dedup_worker_handle {
-        handle.abort();
-        let _ = handle.await;
-    }
-    if let Some(dedup) = alert_sink.dedup() {
-        dedup.flush_all(&alert_sink);
-        dedup.log_metrics();
-    }
-
-    if let Some(reporter) = telemetry_reporter {
-        reporter.finish().await;
-    }
+    pipeline
+        .shutdown(
+            sensor_worker_handle,
+            response_worker_handle,
+            dedup_worker_handle,
+            &alert_sink,
+            telemetry_reporter,
+        )
+        .await;
 
     info!("");
     info!(target: TARGET_CONSOLE, "Shutdown complete");


### PR DESCRIPTION
The platform runtimes duplicated the same worker drain sequence. Centralize it in `runtime/shutdown.rs`, consuming the live pipeline after platform sensors stop and the caller drops its response sender.

Drain sensor events first, then YARA file/memory and IOC hash work. Stop the reload poller before closing reload requests, then join reload and response workers. Abort the periodic dedup flush worker and flush pending alerts only after response completion, followed by the final telemetry snapshot. Join failures are logged consistently on all platforms.

Part of #361. Builds on the merged pipeline construction PR #386 and now targets main.

Validation:
- Full macOS tests, Clippy with `-D clippy::all`, and formatting pass.
- Added a queued-work regression test proving sensor work reaches response before dedup is stopped, and reload requests drain before channel closure.
- The pipeline construction test exercises shutdown with optional workers enabled and disabled.
- Native Linux and Windows checks run in CI.
