### PR TITLE
refactor(allowlist): centralize path matching with explicit compatibility policies

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -193,6 +193,22 @@ If hot reload is enabled:
 - Successful rebuilds are swapped in atomically
 - Failed rebuilds keep the previous live detector instances
 
+## Path Allowlists
+
+`src/utils/path_allowlist.rs` owns path-prefix normalization and matching. Its
+explicit policies preserve the configuration behavior used by each caller:
+
+| Policy | Windows | Linux/macOS | Prefix boundary | Empty entries |
+| --- | --- | --- | --- | --- |
+| YARA scanner | ASCII case folded, slash converted to backslash | Case preserved, native separators | Directory separator appended | Ignored |
+| IOC hashing | ASCII case folded, slash converted to backslash | Case preserved, native separators | Raw prefix | Match every path |
+| Active response | ASCII case folded, slash converted to backslash | ASCII case folded, native separators | Directory separator appended | Ignored |
+
+All policies trim surrounding whitespace without resolving paths or symlinks.
+`tests/path_allowlist.rs` checks these contracts through all three public callers.
+Changing these policies requires a separate behavior change, particularly for
+IOC raw prefixes and case-insensitive response exclusions on Unix.
+
 ## Normalization and Enrichment
 
 The normalizer keeps one event model across all three platforms and adds context where available:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -192,7 +192,9 @@ What reloads and what does not:
 
 `response.allowlist_paths`, `ioc.hash_allowlist_paths`, and
 `scanner.yara_allowlist_paths` each inherit this list while they are empty, and
-override it entirely once set.
+override it entirely once set. Matching follows the existing
+[module-specific path policies](architecture.md#path-allowlists), including IOC
+raw prefixes and case-insensitive response exclusions on Unix.
 
 #### Default trusted paths
 

--- a/src/ioc/hash.rs
+++ b/src/ioc/hash.rs
@@ -13,20 +13,6 @@ use crate::utils::file_identity::{self, FileIdentity};
 const HASH_CACHE_MAX_ENTRIES: usize = 10_000;
 const HASH_CACHE_TTL_SECS: u64 = 6 * 60 * 60;
 
-/// Normalize a file path for allowlist prefix matching.
-/// Windows: convert to backslashes and lowercase (case-insensitive FS).
-/// Linux:   keep as-is (case-sensitive FS, native forward-slash paths).
-pub(crate) fn normalize_allowlist_path(path: &str) -> String {
-    #[cfg(windows)]
-    {
-        path.trim().replace('/', "\\").to_ascii_lowercase()
-    }
-    #[cfg(not(windows))]
-    {
-        path.trim().to_string()
-    }
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct HashRequirements {
     pub md5: bool,

--- a/src/ioc/mod.rs
+++ b/src/ioc/mod.rs
@@ -20,8 +20,8 @@ use crate::sensor::Platform;
 use std::collections::HashSet;
 use tracing::info;
 
+use crate::utils::path_allowlist::PathAllowlistPolicy;
 use alert::{build_match, ioc_rule_description, ioc_rule_name};
-use hash::normalize_allowlist_path;
 use load::{load_domains, load_hashes, load_ips, load_path_regexes, parse_severity};
 use types::{DomainIocs, HashIocs, IpIocs, PathIocs};
 
@@ -62,11 +62,8 @@ impl IocEngine {
         let path_iocs = load_path_regexes(&cfg.paths_regex_path);
 
         let max_file_size_bytes = cfg.max_file_size_mb * 1024 * 1024;
-        let hash_allowlist_paths: Vec<String> = cfg
-            .hash_allowlist_paths
-            .iter()
-            .map(|p| normalize_allowlist_path(p))
-            .collect();
+        let hash_allowlist_paths =
+            PathAllowlistPolicy::IocPrefix.normalize_prefixes(&cfg.hash_allowlist_paths);
 
         if !hash_allowlist_paths.is_empty() {
             info!(
@@ -136,10 +133,7 @@ impl IocEngine {
     }
 
     pub fn is_hash_allowlisted(&self, path: &str) -> bool {
-        let normalized = normalize_allowlist_path(path);
-        self.hash_allowlist_paths
-            .iter()
-            .any(|prefix| normalized.starts_with(prefix.as_str()))
+        PathAllowlistPolicy::IocPrefix.is_match(path, &self.hash_allowlist_paths)
     }
 
     pub fn check_event(&self, event: &NormalizedEvent) -> Vec<IocMatch> {

--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -540,22 +540,7 @@ fn parse_pid(value: Option<&str>) -> Option<u32> {
 }
 
 fn normalize_allowlist_paths(values: &[String]) -> Vec<String> {
-    #[cfg(any(target_os = "linux", target_os = "macos"))]
-    const SEP: char = '/';
-    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
-    const SEP: char = '\\';
-
-    values
-        .iter()
-        .filter(|v| !v.trim().is_empty())
-        .map(|value| {
-            let mut normalized = normalize_path_for_comparison(value);
-            if !normalized.ends_with(SEP) {
-                normalized.push(SEP);
-            }
-            normalized
-        })
-        .collect()
+    crate::utils::path_allowlist::PathAllowlistPolicy::ResponseDirectory.normalize_prefixes(values)
 }
 
 fn normalize_allowlist_images(values: &[String]) -> Vec<String> {
@@ -578,10 +563,7 @@ fn image_basename(path: &str) -> &str {
 fn is_allowlisted(image: &str, allowlist_images: &[String], allowlist_paths: &[String]) -> bool {
     let normalized = normalize_path_for_comparison(image);
 
-    if allowlist_paths
-        .iter()
-        .any(|prefix| normalized.starts_with(prefix))
-    {
+    if crate::utils::path_allowlist::matches_normalized(&normalized, allowlist_paths) {
         return true;
     }
 

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -31,45 +31,14 @@ fn normalize_yara_path(path: &str) -> String {
     path.to_string()
 }
 
-/// Normalize a path for allowlist prefix matching.
-/// Windows: backslash separator, lowercase (case-insensitive FS).
-/// Linux:   forward slash separator, case preserved (case-sensitive FS).
-fn normalize_path_for_allowlist(path: &str) -> String {
-    #[cfg(windows)]
-    {
-        path.trim().replace('/', "\\").to_ascii_lowercase()
-    }
-    #[cfg(not(windows))]
-    {
-        path.trim().to_string()
-    }
-}
-
-const PATH_SEPARATOR: char = if cfg!(windows) { '\\' } else { '/' };
-
+/// Normalize directory prefixes using the scanner's native path policy.
 pub fn normalize_allowlist_paths(values: &[String]) -> Vec<String> {
-    values
-        .iter()
-        .filter(|v| !v.trim().is_empty())
-        .map(|value| {
-            let mut normalized = normalize_path_for_allowlist(value);
-            if !normalized.ends_with(PATH_SEPARATOR) {
-                normalized.push(PATH_SEPARATOR);
-            }
-            normalized
-        })
-        .collect()
+    crate::utils::path_allowlist::PathAllowlistPolicy::ScannerDirectory.normalize_prefixes(values)
 }
 
 pub fn is_path_allowlisted(path: &str, allowlist_paths: &[String]) -> bool {
-    if allowlist_paths.is_empty() {
-        return false;
-    }
-
-    let normalized = normalize_path_for_allowlist(path);
-    allowlist_paths
-        .iter()
-        .any(|prefix| normalized.starts_with(prefix.as_str()))
+    crate::utils::path_allowlist::PathAllowlistPolicy::ScannerDirectory
+        .is_match(path, allowlist_paths)
 }
 
 /// Default per-scan timeout applied to file and memory scans.

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -6,6 +6,7 @@ pub(crate) mod file_identity;
 pub mod fs;
 pub mod log_rate_limiter;
 pub mod path;
+pub(crate) mod path_allowlist;
 #[cfg(windows)]
 pub mod pe;
 pub mod process;

--- a/src/utils/path_allowlist.rs
+++ b/src/utils/path_allowlist.rs
@@ -1,0 +1,63 @@
+//! Path-prefix matching policies used by detection and active response.
+//!
+//! Keep the existing policies explicit: YARA and response use directory
+//! boundaries, while IOC configuration accepts raw prefixes (including empty
+//! prefixes). Response comparisons fold ASCII case on Unix too. Unifying these
+//! policies would change which files are scanned or which responses are allowed.
+
+use super::normalize_path_for_comparison;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PathAllowlistPolicy {
+    ScannerDirectory,
+    IocPrefix,
+    ResponseDirectory,
+}
+
+impl PathAllowlistPolicy {
+    pub fn normalize_path(self, path: &str) -> String {
+        if self == Self::ResponseDirectory {
+            return normalize_path_for_comparison(path);
+        }
+        #[cfg(windows)]
+        {
+            path.trim().replace('/', "\\").to_ascii_lowercase()
+        }
+        #[cfg(not(windows))]
+        {
+            path.trim().to_string()
+        }
+    }
+
+    pub fn normalize_prefixes(self, values: &[String]) -> Vec<String> {
+        let separator = match self {
+            Self::ResponseDirectory if !cfg!(any(target_os = "linux", target_os = "macos")) => '\\',
+            _ if cfg!(windows) => '\\',
+            _ => '/',
+        };
+        values
+            .iter()
+            .filter(|value| self == Self::IocPrefix || !value.trim().is_empty())
+            .map(|value| {
+                let mut normalized = self.normalize_path(value);
+                if self != Self::IocPrefix && !normalized.ends_with(separator) {
+                    normalized.push(separator);
+                }
+                normalized
+            })
+            .collect()
+    }
+
+    pub fn is_match(self, path: &str, normalized_prefixes: &[String]) -> bool {
+        if normalized_prefixes.is_empty() {
+            return false;
+        }
+        matches_normalized(&self.normalize_path(path), normalized_prefixes)
+    }
+}
+
+pub(crate) fn matches_normalized(path: &str, normalized_prefixes: &[String]) -> bool {
+    normalized_prefixes
+        .iter()
+        .any(|prefix| path.starts_with(prefix))
+}

--- a/tests/path_allowlist.rs
+++ b/tests/path_allowlist.rs
@@ -1,0 +1,106 @@
+//! Cross-module contracts for existing path allowlist behavior.
+
+mod common;
+
+use std::sync::Arc;
+
+use rustinel::{
+    config::AppConfig,
+    ioc::IocEngine,
+    models::{Alert, AlertSeverity, DetectionEngine, EventFields},
+    response::{ResponseDecision, ResponseEngine},
+    scanner::{is_path_allowlisted, normalize_allowlist_paths},
+    sensor::Platform,
+};
+
+async fn check(prefix: &str, path: &str, expected: [bool; 3]) {
+    let fixture = common::IocFixture::new();
+    let mut ioc_cfg = fixture.config();
+    ioc_cfg.hash_allowlist_paths = vec![prefix.into()];
+    let ioc = IocEngine::load(&ioc_cfg);
+    let yara_paths = normalize_allowlist_paths(&[prefix.into()]);
+
+    let mut response_cfg = AppConfig::default().response;
+    response_cfg.enabled = true;
+    response_cfg.prevention_enabled = false;
+    response_cfg.min_severity = "low".into();
+    response_cfg.allowlist_images.clear();
+    response_cfg.allowlist_paths = vec![prefix.into()];
+    let (response, worker) =
+        ResponseEngine::new(Arc::new(arc_swap::ArcSwap::from_pointee(response_cfg)));
+    let mut event = common::TestNormalizer::new(false)
+        .normalizer
+        .normalize(&common::process_start_event(Platform::Linux))
+        .unwrap();
+    let EventFields::ProcessCreation(fields) = &mut event.fields else {
+        panic!("process fixture");
+    };
+    fields.image = Some(path.into());
+    fields.process_id = Some(u32::MAX.to_string());
+    let decision = response.decision_for_alert(&Alert {
+        severity: AlertSeverity::Critical,
+        rule_name: "allowlist contract".into(),
+        rule_description: None,
+        rule_id: None,
+        engine: DetectionEngine::Sigma,
+        event,
+        match_details: None,
+    });
+    assert!(matches!(
+        decision,
+        ResponseDecision::Allowlisted { .. } | ResponseDecision::DryRun { .. }
+    ));
+    assert_eq!(
+        [
+            is_path_allowlisted(path, &yara_paths),
+            ioc.is_hash_allowlisted(path),
+            matches!(decision, ResponseDecision::Allowlisted { .. }),
+        ],
+        expected,
+        "YARA, IOC, response: prefix {prefix:?}, path {path:?}",
+    );
+    drop(response);
+    worker.await.unwrap();
+}
+
+#[tokio::test]
+async fn directory_boundaries_and_raw_ioc_prefixes_remain_distinct() {
+    let root = if cfg!(windows) {
+        "C:\\trusted"
+    } else {
+        "/trusted"
+    };
+    let sep = if cfg!(windows) { '\\' } else { '/' };
+    check(root, &format!("{root}{sep}app"), [true, true, true]).await;
+    check(root, &format!("{root}-other{sep}app"), [false, true, false]).await;
+    check(root, root, [false, true, false]).await;
+    check(
+        &format!(" {root}{sep} "),
+        &format!(" {root}{sep}app "),
+        [true, true, true],
+    )
+    .await;
+    check(
+        &format!("{root}{sep}"),
+        &format!("{root}-other{sep}app"),
+        [false, false, false],
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn empty_prefixes_preserve_the_existing_ioc_match_all_behavior() {
+    check("   ", "/any/path", [false, true, false]).await;
+}
+
+#[tokio::test]
+async fn case_and_separator_contracts_are_platform_specific() {
+    if cfg!(windows) {
+        check("C:/TRUSTED", "c:\\trusted\\app.exe", [true, true, true]).await;
+        check("c:\\trusted", "C:/TRUSTED/app.exe", [true, true, true]).await;
+    } else {
+        check("/Trusted", "/trusted/app", [false, false, true]).await;
+        check("/Trusted", "/Trusted/app", [true, true, true]).await;
+        check("/trusted", "/trusted\\app", [false, true, false]).await;
+    }
+}


### PR DESCRIPTION
YARA, IOC hashing, and active response duplicated path-prefix normalization and matching. Centralize those operations in `utils/path_allowlist.rs` with explicit scanner-directory, IOC-prefix, and response-directory policies.

This preserves current behavior: Windows comparisons fold ASCII case and separators; YARA/IOC preserve Unix case while response folds it; YARA/response append a directory separator and ignore blank entries, while IOC retains raw prefixes and blank-prefix matching. Standardizing those differences would change scanning and response exclusions, so that remains a separate behavior decision.

Document the policies and add cross-module tests through all three public callers. The contract tests passed against the original callers before migration and pass against the shared implementation afterward.

Part of #361. Independent of the runtime and ETW refactors. Public scanner helpers and configuration formats stay compatible.

Validation:
- `cargo test --locked --test path_allowlist` before replacing callers.
- Full macOS test suite after replacing callers.
- `cargo clippy --locked --all-targets -- -D clippy::all`
- `cargo fmt --all -- --check`
- Native Linux and Windows validation runs in CI.
