### PR TITLE
refactor(runtime): share configuration and logging startup

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -166,6 +166,10 @@ command handling when service dispatch does not start.
 
 ## Shared Pipeline
 
+`src/runtime/startup.rs` loads configuration and CLI overrides, initializes
+logging and alert deduplication, and starts telemetry reporting. Logging guards
+remain in each platform runtime until its final shutdown messages are written.
+
 `src/runtime/pipeline.rs` builds shared caches, detectors, reload workers, YARA
 and IOC workers, normalization, and the event router for all three platforms.
 Platform runtimes retain privilege checks, Windows process snapshotting, sensor

--- a/src/runtime/linux.rs
+++ b/src/runtime/linux.rs
@@ -1,10 +1,8 @@
-use crate::alerts::dedup::{spawn_flush_worker, Deduplicator};
-use crate::config;
 use crate::response::ResponseEngine;
 use crate::runtime::capture::{CaptureContext, CaptureOptions, CaptureSession};
-use crate::runtime::logging::{init_logging, log_startup_banner, TARGET_CONSOLE};
+use crate::runtime::logging::TARGET_CONSOLE;
 use crate::runtime::pipeline::{LivePipeline, SharedState};
-use crate::runtime::telemetry::TelemetryReporter;
+use crate::runtime::startup::{load_config, RuntimeLogging};
 use crate::sensor::linux::EbpfSensor;
 use crate::sensor::{Platform, Sensor, SensorEvent};
 use arc_swap::ArcSwap;
@@ -52,47 +50,14 @@ async fn run_linux_edr(
     log_level_override: Option<String>,
     config_path: Option<std::path::PathBuf>,
 ) -> anyhow::Result<()> {
-    // 1. Configuration
-    let resolved_config_path = config::AppConfig::resolve_config_path(config_path.clone());
-    let mut cfg = match config::AppConfig::from_config_path(config_path) {
-        Ok(cfg) => cfg,
-        Err(err) => {
-            eprintln!("Failed to load configuration: {}", err);
-            eprintln!("Hint: run rustinel doctor --config <path> to inspect configuration and runtime prerequisites.");
-            return Err(anyhow::anyhow!("configuration error: {}", err));
-        }
-    };
-    if let Some(console_output) = console_output_override {
-        cfg.logging.console_output = console_output;
-    }
-    if let Some(level) = log_level_override {
-        if !level.trim().is_empty() {
-            cfg.logging.level = level;
-        }
-    }
-
-    // 2. Logging
-    let (app_guard, alert_guard, mut alert_sink) = init_logging(&cfg);
-    let _guards = (app_guard, alert_guard);
-
-    // 2a. Alert deduplication
-    let dedup_worker_handle = if cfg.dedup.enabled {
-        let dedup = Arc::new(Deduplicator::new(
-            cfg.dedup.window_secs,
-            cfg.dedup.max_entries,
-        ));
-        let tick = std::time::Duration::from_secs(cfg.dedup.window_secs.max(1));
-        let handle = spawn_flush_worker(Arc::clone(&dedup), alert_sink.clone(), tick);
-        alert_sink = alert_sink.with_deduplicator(dedup);
-        Some(handle)
-    } else {
-        None
-    };
-
-    log_startup_banner("Linux eBPF");
-
-    // 2b. Pipeline drop counters, published for `rustinel doctor`
-    let telemetry_reporter = TelemetryReporter::start(&cfg);
+    let (cfg, resolved_config_path) =
+        load_config(console_output_override, log_level_override, config_path)?;
+    let RuntimeLogging {
+        alert_sink,
+        dedup_worker_handle,
+        telemetry_reporter,
+        _guards,
+    } = RuntimeLogging::start(&cfg, "Linux eBPF");
 
     // 3. Shared state
     let state = SharedState::new(&cfg);

--- a/src/runtime/macos.rs
+++ b/src/runtime/macos.rs
@@ -1,10 +1,8 @@
-use crate::alerts::dedup::{spawn_flush_worker, Deduplicator};
-use crate::config;
 use crate::response::ResponseEngine;
 use crate::runtime::capture::{CaptureContext, CaptureOptions, CaptureSession};
-use crate::runtime::logging::{init_logging, log_startup_banner, TARGET_CONSOLE};
+use crate::runtime::logging::TARGET_CONSOLE;
 use crate::runtime::pipeline::{LivePipeline, SharedState};
-use crate::runtime::telemetry::TelemetryReporter;
+use crate::runtime::startup::{load_config, RuntimeLogging};
 use crate::sensor::macos::{BpfSensor, EsfSensor};
 use crate::sensor::{Platform, Sensor, SensorEvent};
 use arc_swap::ArcSwap;
@@ -69,46 +67,14 @@ async fn run_macos_edr(
     log_level_override: Option<String>,
     config_path: Option<std::path::PathBuf>,
 ) -> anyhow::Result<()> {
-    // 1. Configuration
-    let resolved_config_path = config::AppConfig::resolve_config_path(config_path.clone());
-    let mut cfg = match config::AppConfig::from_config_path(config_path) {
-        Ok(cfg) => cfg,
-        Err(err) => {
-            eprintln!("Failed to load configuration: {}", err);
-            eprintln!("Hint: run rustinel doctor --config <path> to inspect configuration and runtime prerequisites.");
-            return Err(anyhow::anyhow!("configuration error: {}", err));
-        }
-    };
-    if let Some(console_output) = console_output_override {
-        cfg.logging.console_output = console_output;
-    }
-    if let Some(level) = log_level_override {
-        if !level.trim().is_empty() {
-            cfg.logging.level = level;
-        }
-    }
-
-    // 2. Logging
-    let (app_guard, alert_guard, mut alert_sink) = init_logging(&cfg);
-    let _guards = (app_guard, alert_guard);
-
-    let dedup_worker_handle = if cfg.dedup.enabled {
-        let dedup = Arc::new(Deduplicator::new(
-            cfg.dedup.window_secs,
-            cfg.dedup.max_entries,
-        ));
-        let tick = std::time::Duration::from_secs(cfg.dedup.window_secs.max(1));
-        let handle = spawn_flush_worker(Arc::clone(&dedup), alert_sink.clone(), tick);
-        alert_sink = alert_sink.with_deduplicator(dedup);
-        Some(handle)
-    } else {
-        None
-    };
-
-    log_startup_banner("macOS ESF");
-
-    // Pipeline drop counters, published for `rustinel doctor`
-    let telemetry_reporter = TelemetryReporter::start(&cfg);
+    let (cfg, resolved_config_path) =
+        load_config(console_output_override, log_level_override, config_path)?;
+    let RuntimeLogging {
+        alert_sink,
+        dedup_worker_handle,
+        telemetry_reporter,
+        _guards,
+    } = RuntimeLogging::start(&cfg, "macOS ESF");
 
     // 3. Shared state
     let state = SharedState::new(&cfg);

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -10,6 +10,8 @@ mod orchestration;
 mod pipeline;
 #[cfg(any(windows, target_os = "linux", target_os = "macos"))]
 mod shutdown;
+#[cfg(any(windows, target_os = "linux", target_os = "macos"))]
+mod startup;
 pub mod telemetry;
 #[cfg(windows)]
 mod windows;

--- a/src/runtime/startup.rs
+++ b/src/runtime/startup.rs
@@ -1,0 +1,85 @@
+//! Shared configuration overrides, logging, and startup reporting.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use tokio::task::JoinHandle;
+use tracing_appender::non_blocking::WorkerGuard;
+
+use crate::alerts::dedup::{spawn_flush_worker, Deduplicator};
+use crate::alerts::AlertSink;
+use crate::config;
+use crate::runtime::logging::{init_logging, log_startup_banner};
+use crate::runtime::telemetry::TelemetryReporter;
+
+pub(super) fn load_config(
+    console_output_override: Option<bool>,
+    log_level_override: Option<String>,
+    config_path: Option<PathBuf>,
+) -> anyhow::Result<(config::AppConfig, Option<PathBuf>)> {
+    let resolved_config_path = config::AppConfig::resolve_config_path(config_path.clone());
+    let mut cfg = match config::AppConfig::from_config_path(config_path) {
+        Ok(cfg) => cfg,
+        Err(err) => {
+            eprintln!("Failed to load configuration: {}", err);
+            eprintln!("Hint: run rustinel doctor --config <path> to inspect configuration and runtime prerequisites.");
+            let context = if cfg!(windows) {
+                "Failed to load configuration"
+            } else {
+                "configuration error"
+            };
+            return Err(anyhow::anyhow!("{}: {}", context, err));
+        }
+    };
+    if let Some(console_output) = console_output_override {
+        cfg.logging.console_output = console_output;
+    }
+    if let Some(level) = log_level_override {
+        if !level.trim().is_empty() {
+            cfg.logging.level = level;
+        }
+    }
+
+    Ok((cfg, resolved_config_path))
+}
+
+pub(super) struct RuntimeLogging {
+    pub alert_sink: AlertSink,
+    pub dedup_worker_handle: Option<JoinHandle<()>>,
+    pub telemetry_reporter: Option<TelemetryReporter>,
+    // Kept in the platform runtime until its final shutdown messages are written.
+    pub _guards: (WorkerGuard, WorkerGuard),
+}
+
+impl RuntimeLogging {
+    pub fn start(cfg: &config::AppConfig, runtime_label: &str) -> Self {
+        let (app_guard, alert_guard, mut alert_sink) = init_logging(cfg);
+        let _guards = (app_guard, alert_guard);
+
+        // 2a. Alert deduplication
+        let dedup_worker_handle = if cfg.dedup.enabled {
+            let dedup = Arc::new(Deduplicator::new(
+                cfg.dedup.window_secs,
+                cfg.dedup.max_entries,
+            ));
+            let tick = std::time::Duration::from_secs(cfg.dedup.window_secs.max(1));
+            let handle = spawn_flush_worker(Arc::clone(&dedup), alert_sink.clone(), tick);
+            alert_sink = alert_sink.with_deduplicator(dedup);
+            Some(handle)
+        } else {
+            None
+        };
+
+        log_startup_banner(runtime_label);
+
+        // 2b. Pipeline drop counters, published for `rustinel doctor`
+        let telemetry_reporter = TelemetryReporter::start(cfg);
+
+        Self {
+            alert_sink,
+            dedup_worker_handle,
+            telemetry_reporter,
+            _guards,
+        }
+    }
+}

--- a/src/runtime/windows.rs
+++ b/src/runtime/windows.rs
@@ -1,10 +1,8 @@
-use crate::alerts::dedup::{spawn_flush_worker, Deduplicator};
-use crate::config;
 use crate::response::ResponseEngine;
 use crate::runtime::capture::{CaptureContext, CaptureOptions, CaptureSession};
-use crate::runtime::logging::{init_logging, log_startup_banner, TARGET_CONSOLE};
+use crate::runtime::logging::TARGET_CONSOLE;
 use crate::runtime::pipeline::{LivePipeline, SharedState};
-use crate::runtime::telemetry::TelemetryReporter;
+use crate::runtime::startup::{load_config, RuntimeLogging};
 use crate::sensor::windows::EtwSensor;
 use crate::sensor::{Platform, Sensor, SensorEvent};
 
@@ -270,47 +268,14 @@ async fn run_edr(
     log_level_override: Option<String>,
     config_path: Option<std::path::PathBuf>,
 ) -> anyhow::Result<()> {
-    // 1. Load Configuration
-    let resolved_config_path = config::AppConfig::resolve_config_path(config_path.clone());
-    let mut cfg = match config::AppConfig::from_config_path(config_path) {
-        Ok(cfg) => cfg,
-        Err(err) => {
-            eprintln!("Failed to load configuration: {}", err);
-            eprintln!("Hint: run rustinel doctor --config <path> to inspect configuration and runtime prerequisites.");
-            return Err(anyhow::anyhow!("Failed to load configuration: {}", err));
-        }
-    };
-    if let Some(console_output) = console_output_override {
-        cfg.logging.console_output = console_output;
-    }
-    if let Some(level) = log_level_override {
-        if !level.trim().is_empty() {
-            cfg.logging.level = level;
-        }
-    }
-
-    // 2. Initialize Logging (CRITICAL: Store guards to keep file writing alive)
-    let (app_guard, alert_guard, mut alert_sink) = init_logging(&cfg);
-    let _guards = (app_guard, alert_guard);
-
-    // 2a. Alert deduplication
-    let dedup_worker_handle = if cfg.dedup.enabled {
-        let dedup = Arc::new(Deduplicator::new(
-            cfg.dedup.window_secs,
-            cfg.dedup.max_entries,
-        ));
-        let tick = std::time::Duration::from_secs(cfg.dedup.window_secs.max(1));
-        let handle = spawn_flush_worker(Arc::clone(&dedup), alert_sink.clone(), tick);
-        alert_sink = alert_sink.with_deduplicator(dedup);
-        Some(handle)
-    } else {
-        None
-    };
-
-    log_startup_banner("Windows ETW");
-
-    // Pipeline drop counters, published for `rustinel doctor`
-    let telemetry_reporter = TelemetryReporter::start(&cfg);
+    let (cfg, resolved_config_path) =
+        load_config(console_output_override, log_level_override, config_path)?;
+    let RuntimeLogging {
+        alert_sink,
+        dedup_worker_handle,
+        telemetry_reporter,
+        _guards,
+    } = RuntimeLogging::start(&cfg, "Windows ETW");
 
     // 2.1 Initialize Active Response Engine (optional)
     let response_config = Arc::new(ArcSwap::from(Arc::new(cfg.response.clone())));


### PR DESCRIPTION
Live runtimes duplicated configuration loading, CLI overrides, logging guards, alert deduplication, startup banners, and telemetry setup. Move those shared startup steps into `runtime/startup.rs`.

Keep the platform-specific configuration error context and startup ordering. The logging guards remain owned by the platform runtime through its final shutdown messages. Windows privilege checks and process snapshotting stay explicit in the Windows runtime.

Part of #361. Rebased onto main after #387, #388, #389, and #391 merged.

Validation:
- Full macOS tests.
- `cargo clippy --locked --all-targets -- -D clippy::all`
- `cargo fmt --all -- --check`

The native CI matrix runs against the rebased branch targeting main.
