### PR TITLE
docs(readme): clarify cross-platform detection positioning and onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,54 +5,56 @@
 <h1 align="center">Rustinel</h1>
 
 <p align="center">
-  <b>Open-source endpoint detection for Windows, Linux, and macOS.</b><br>
-  Sigma, YARA, and IOC detections on native telemetry. No cloud, no account, nothing phoning home.<br>
-  Capture endpoint behavior once, then replay it against your rules anywhere. Written in Rust.
+  <b>Open-source endpoint detection. Three platforms. Your rules.</b><br>
+  Run Sigma, YARA, and IOC detections on native Windows, Linux, and macOS telemetry.<br>
+  Written in Rust, with local alerts and no cloud account required.
 </p>
 
 <p align="center">
-  <a href="https://github.com/Karib0u/rustinel/actions/workflows/ci.yml"><img src="https://github.com/Karib0u/rustinel/actions/workflows/ci.yml/badge.svg?style=flat-square" alt="CI"></a>
+  <a href="https://github.com/Karib0u/rustinel/actions/workflows/ci.yml"><img src="https://github.com/Karib0u/rustinel/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://github.com/Karib0u/rustinel/releases/latest"><img src="https://img.shields.io/github/v/release/Karib0u/rustinel?style=flat-square&color=ff8a3d" alt="Latest release"></a>
   <a href="https://github.com/Karib0u/rustinel/releases"><img src="https://img.shields.io/github/downloads/Karib0u/rustinel/total?style=flat-square&color=ff8a3d" alt="Downloads"></a>
-  <a href="https://github.com/Karib0u/rustinel/stargazers"><img src="https://img.shields.io/github/stars/Karib0u/rustinel?style=flat-square&color=ff8a3d" alt="Stars"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-ff8a3d?style=flat-square" alt="License"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-ff8a3d?style=flat-square" alt="Apache 2.0 license"></a>
 </p>
 
 <p align="center">
-  <a href="https://rustinel.io/">Website</a> |
-  <a href="https://docs.rustinel.io/">Docs</a> |
+  Bring your detection content, monitor your endpoints, and send alerts to the tools you already use.
+</p>
+
+<p align="center">
   <a href="https://github.com/Karib0u/rustinel/releases/latest">Download</a> |
-  <a href="https://docs.rustinel.io/coverage/">Sigma coverage</a> |
-  <a href="docs/siem-demos.md">SIEM demos</a>
+  <a href="https://docs.rustinel.io/">Documentation</a> |
+  <a href="https://github.com/Karib0u/rustinel-rules">Detection packs</a> |
+  <a href="https://rustinel.io/">Website</a>
 </p>
 
 <p align="center">
   <img src="docs/images/demo.gif" alt="Rustinel demo" width="860">
 </p>
 
----
+## Why Rustinel?
 
-## Quick Start
+Endpoint detection should work with the platforms you run and the rules you
+already understand.
 
-### 1. Install
+Rustinel brings native telemetry, established detection formats, and a common
+alert format into one open-source engine.
 
-**Windows** - from PowerShell:
+- **Use Sigma and YARA rules.** Detect behavior with Sigma, scan files and process memory with YARA, and match hash, IP, domain, and path indicators.
+- **Run across Windows, Linux, and macOS.** Use one engine with a shared configuration model and normalized events. Sensors and detection coverage vary by platform.
+- **Keep control of your data.** The live agent makes no outbound network connections. Alerts are local files you can inspect or forward yourself.
+- **Connect your existing tools.** ECS 9.4.0 NDJSON output works with Elastic, Splunk, and other log pipelines.
+- **Test detections against recorded behavior.** Capture telemetry once and replay it as your rules change, without repeating the activity.
+- **Inspect and extend the engine.** Written in Rust and licensed under Apache 2.0.
 
-```powershell
-irm https://rustinel.io/install.ps1 | iex
-```
+## Get your first alert
 
-The Windows release binary requires the x64 Microsoft Visual C++ Redistributable.
-See [Getting Started](https://docs.rustinel.io/getting-started/#windows) if the
-process exits before printing output.
+Release archives include a binary, default configuration, and demo rules so you
+can verify detection before deploying a service.
 
-**Linux:**
+### Linux
 
-```bash
-curl -fsSL https://rustinel.io/install.sh | sh -s -- --run
-```
-
-**macOS** (experimental):
+Requires Linux 5.8+ with BTF support.
 
 ```bash
 curl -fsSL https://rustinel.io/install.sh | sh
@@ -60,214 +62,192 @@ cd rustinel
 sudo ./rustinel run
 ```
 
-macOS requires a one-time Full Disk Access approval before Endpoint Security can
-start. Follow the [Getting Started](https://docs.rustinel.io/getting-started/)
-macOS notes before using it beyond a first test.
+### Windows
 
-Prefer to inspect first? Download the [install script](scripts/install/install.sh)
-or a package from the [latest release](https://github.com/Karib0u/rustinel/releases/latest).
-Installers only download published release binaries.
-
-### 2. Deploy
-
-`setup` writes the managed configuration, installs the Essential rules pack,
-registers the platform's native service, starts it, and runs health checks.
+Run in an elevated PowerShell:
 
 ```powershell
-rustinel setup --yes
-rustinel doctor
+irm https://rustinel.io/install.ps1 | iex
+Set-Location rustinel
+.\rustinel.exe run
 ```
+
+Requires the x64 Microsoft Visual C++ Redistributable. See
+[Windows prerequisites](https://docs.rustinel.io/getting-started/#windows).
+
+### macOS
+
+macOS support is experimental. Complete the
+[signing and Full Disk Access setup](https://docs.rustinel.io/getting-started/)
+before starting the sensor.
 
 ```bash
-sudo rustinel setup --yes
-rustinel doctor
+curl -fsSL https://rustinel.io/install.sh | sh
+cd rustinel
+sudo ./rustinel run
 ```
 
-Use `--pack advanced` for the larger pack, or `--no-start` to register the
-service without starting it.
+### Trigger the demo rule
 
-### 3. See a first alert
-
-With the agent running, trigger the bundled demo rule:
+While Rustinel is running, open another terminal and run:
 
 ```bash
 whoami
 ```
 
-Alerts are ECS NDJSON, one object per line, written to `alerts.json.<date>`:
+The bundled demo rule detects the process. Find the alert in
+`logs/alerts.json.<date>` inside the extracted release directory.
 
-| Platform | Managed install | Archive `./rustinel run` |
-| --- | --- | --- |
-| Windows | `C:\ProgramData\Rustinel\logs\` | `logs\` |
-| Linux | `/var/log/rustinel/` | `logs/` |
-| macOS | `/Library/Logs/Rustinel/` | `logs/` |
+The demo rules verify that the pipeline works. For broader coverage, install a
+detection pack or add your own rules.
 
----
+Prefer a manual installation? Browse the
+[release archives](https://github.com/Karib0u/rustinel/releases/latest) or inspect
+the [install scripts](scripts/install).
 
-## Why Rustinel
+## Deploy for ongoing monitoring
 
-A transparent endpoint detection engine you can read, run, test, and extend.
+Stop the foreground agent with Ctrl-C, then run setup from the extracted release
+directory.
 
-- **Native telemetry:** ETW and Windows Event Log on Windows, eBPF on Linux, Endpoint Security and `/dev/bpf` on macOS. One normalized event model across all three.
-- **Detection formats:** Sigma for behavior, YARA for files and process memory, IOC matching for hashes, IPs, domains, and path regexes.
-- **Rule reuse:** bring existing Sigma and YARA rules instead of rewriting them into a proprietary format. **74% of the SigmaHQ Windows corpus can fire today** - measured against a pinned corpus commit, not estimated. See [Sigma coverage](https://docs.rustinel.io/coverage/).
-- **Offline rule development:** `capture` a behavior once, then `replay` it against your rules as often as you like. No sensors, no privileges, no re-detonation.
-- **Local by design:** the running agent makes no network connections. Alerts are files on disk - ship them with your own pipeline, or just read them where they land. Rules packs are the only exception, downloaded when you explicitly run `setup` or `rules install`.
-- **SIEM output:** ECS 9.4.0 NDJSON alerts for Elastic, Splunk, and other log pipelines.
-- **Operations:** hot reload for rules and IOCs, versioned rules packs, optional active response (process termination, off by default), and native service management via SCM, systemd, and launchd.
-
----
-
-## Record once, replay anywhere
-
-Detonating a sample to test one rule change is slow, and you cannot detonate on
-the box where you write rules. `capture` records normalized telemetry to a file
-without evaluating anything; `replay` runs that file through the same detector
-code the live pipeline uses.
+**Linux and macOS:**
 
 ```bash
-sudo rustinel capture --output run-42.ndjson   # start, run the sample, Ctrl-C
-rustinel replay run-42.ndjson                  # iterate on rules, no sensors needed
+sudo ./rustinel setup --yes
+./rustinel doctor
 ```
 
-A recording made on Windows replays on Linux or macOS, unprivileged, as often as
-the rules change. Replay loads detectors once with hot reload and deduplication
-off, so two replays of one recording against one configuration produce identical
-output - which makes recordings usable as regression fixtures in CI.
+**Windows, in an elevated PowerShell:**
 
-YARA and hash IOC checks are skipped and reported as skipped: a recording holds
-events, not files. Active response is never invoked. Recordings contain full
-command lines, paths, and user names, so handle them as sensitive artifacts.
+```powershell
+.\rustinel.exe setup --yes
+.\rustinel.exe doctor
+```
 
-See the [CLI reference](https://docs.rustinel.io/cli/#replay) for details.
+Setup writes the managed configuration, installs the Essential rules pack,
+registers the native service, starts it, and checks its health.
 
----
+Use `--pack advanced` for the larger pack or `--no-start` to register the service
+without starting it.
+
+| Platform | Service manager | Managed alert directory |
+| --- | --- | --- |
+| Windows | SCM | `C:\ProgramData\Rustinel\logs\` |
+| Linux | systemd | `/var/log/rustinel/` |
+| macOS | launchd | `/Library/Logs/Rustinel/` |
+
+Rules and IOCs support hot reload. Optional process termination is available and
+disabled by default.
+
+[Configuration](https://docs.rustinel.io/configuration/) |
+[Operations](https://docs.rustinel.io/operations/) |
+[SIEM examples](docs/siem-demos.md)
+
+## Your rules, with documented coverage
+
+Use your own detection content or start with
+**[rustinel-rules](https://github.com/Karib0u/rustinel-rules)**, the official
+versioned Sigma, YARA, and IOC packs.
+
+Packs are downloaded, SHA-256 verified, validated, and activated atomically. A
+failed download leaves the current rules in place.
+
+Rule compatibility depends on the telemetry and fields available on each
+platform. A Windows rule does not automatically become a Linux detection.
+
+We publish [Sigma coverage measurements](https://docs.rustinel.io/coverage/)
+against a pinned SigmaHQ corpus, including missing collectors and unavailable
+fields. These measure whether rules have the data needed to fire, not whether
+they will detect every attack.
+
+[Rule authoring](https://docs.rustinel.io/detection/) |
+[Pack catalog](https://github.com/Karib0u/rustinel-rules) |
+[Coverage and gaps](https://docs.rustinel.io/coverage/)
+
+## Capture once. Replay as your rules improve.
+
+Record endpoint activity, then evaluate the same events against new rules without
+repeating the activity or running sensors on your development machine.
+
+From the release directory on Linux or macOS:
+
+```bash
+# Start recording, perform the activity, then press Ctrl-C.
+sudo ./rustinel capture --output session.ndjson
+
+# Evaluate the recording without elevated privileges.
+./rustinel replay session.ndjson
+
+# Compare another configuration.
+./rustinel replay session.ndjson --config candidate.toml
+
+# Export results for automated comparison.
+./rustinel replay session.ndjson --output results.ndjson
+```
+
+On Windows, use `.\rustinel.exe` and an elevated PowerShell for capture.
+
+A Windows recording can replay on Linux or macOS. Replay uses the recorded
+platform for Sigma routing and produces reproducible results for the same
+recording and configuration.
+
+Keep the recording and its `.manifest.json` sidecar together. Recordings contain
+sensitive endpoint data, including command lines, paths, network destinations,
+and user names.
+
+Replay evaluates Sigma and IP, domain, and path IOC checks. YARA and hash checks
+are skipped because recordings contain events rather than file contents. Active
+response never runs during replay.
+
+[Capture and replay reference](https://docs.rustinel.io/cli/)
 
 ## Platform support
 
-| Platform | Sensor | Telemetry | Status |
+| Platform | Sensors | Telemetry | Status |
 | --- | --- | --- | --- |
-| Windows 10/11, Server 2016+ | ETW + Windows Event Log | Process, image load, network, file, registry, DNS, PowerShell, WMI, service, task, Security channel (6 audited event IDs) | Stable |
-| Linux 5.8+ (BTF) | eBPF | Process, network, file, DNS | Stable |
+| Windows 10/11, Server 2016+ | ETW + Windows Event Log | Process, image load, network, file, registry, DNS, PowerShell, WMI, service, task, selected Security events | Stable |
+| Linux 5.8+ with BTF | eBPF | Process, network, file, DNS | Stable |
 | macOS 11+ | Endpoint Security + `/dev/bpf` | Process, file, network, DNS | Experimental |
 
-Windows coverage is the broadest today. Linux and macOS focus on process,
-network, file, and DNS telemetry. macOS remains experimental. Current gaps are
-listed in [Limitations](https://docs.rustinel.io/limitations/).
+Windows has the broadest coverage today. See
+[requirements](https://docs.rustinel.io/getting-started/) and
+[limitations](https://docs.rustinel.io/limitations/) for platform-specific details.
 
----
+## Local operation, explicit downloads
 
-## How detection works
+The live agent collects and evaluates telemetry locally. It does not send
+telemetry home or require a vendor account.
 
-```text
-   ETW + Event Log         eBPF             Endpoint Security
-      (Windows)           (Linux)          + /dev/bpf (macOS)
-          └──────────────────┴──────────────────────┘
-                             │
-                  Normalized event model
-                             │
-          ┌──────────────────┬──────────────────────┐
-        Sigma              YARA                    IOC
-      behavior           files and            hashes, IPs,
-        rules             memory             domains, paths
-          └──────────────────┴──────────────────────┘
-                             │
-                     ECS NDJSON alerts
-                             │
-                 Optional active response
-```
+Installers download published releases. `setup`, `rules list`, and `rules install`
+fetch the rules catalog; setup and rule installation also download packs.
 
-The same event model feeds the offline loop:
+Alerts remain on the endpoint unless you forward them through your own pipeline.
 
-```text
-   Normalized event model ─── capture ──► recording (NDJSON + manifest)
-              ▲                                         │
-              └──────────────── replay ─────────────────┘
-```
+## Know the boundaries
 
-See the [detection docs](https://docs.rustinel.io/detection/) for rule authoring, YARA memory scanning, and IOC formats.
+Rustinel supports endpoint monitoring, detection engineering, security labs, and
+SIEM pipeline validation.
 
----
+It is not a drop-in replacement for a mature commercial EDR. It does not provide
+kernel-level self-protection, pre-execution blocking, anti-tamper guarantees, or
+managed response. A sufficiently privileged attacker may interfere with
+user-mode telemetry.
 
-## Detection packs
+Read the [current limitations](https://docs.rustinel.io/limitations/) when
+evaluating it for your environment.
 
-The bundled rules only prove that the pipeline works. For real coverage, load
-curated content from **[rustinel-rules](https://github.com/Karib0u/rustinel-rules)**,
-the official versioned detection repository.
+## Contribute
 
-```text
-rustinel        ->  the engine that collects telemetry and evaluates rules
-rustinel-rules  ->  the Sigma, YARA, and IOC packs it loads
-```
+Help improve platform coverage, test detections, report bugs, or make setup
+easier.
 
-`rustinel setup` already installed the Essential pack. To see what else is
-available for this platform and switch:
+If you use Rustinel, tell us what you monitor, which rules matter to you, and
+where you get stuck. Real deployment feedback helps guide the project.
 
-```bash
-rustinel rules list
-sudo rustinel rules install linux-essential
-```
-
-Packs are downloaded, SHA-256 verified, validated, and activated atomically, so
-a failed download leaves the current rules in place. Browse the
-[pack catalog](https://github.com/Karib0u/rustinel-rules) for what ships today.
-
----
-
-## Who it's for
-
-**Endpoint monitoring you control.** Workstations and servers where you want
-real visibility without a cloud console, a vendor account, or an agent that
-reports home. Install it, point it at a rules pack, and everything it observes
-stays on the machine.
-
-**Detection engineering.** Rule development and testing, blue-team labs,
-cross-platform detection research, and SIEM pipeline validation - with `capture`
-and `replay` for iterating on rules without re-running samples.
-
-**What it is not.** A drop-in replacement for a mature commercial EDR. Rustinel
-does not provide kernel-level self-protection, pre-execution blocking, anti-tamper
-guarantees, or managed response. A sufficiently privileged attacker may interfere
-with user-mode telemetry.
-
-That trade is deliberate: Rustinel uses telemetry the operating system already
-exposes rather than shipping a kernel driver. That costs visibility and
-enforcement points, and keeps the agent transparent, portable, and inspectable.
-
----
-
-## Build from source
-
-```bash
-cargo build --release
-sudo ./target/release/rustinel run
-```
-
-macOS requires the app-like signed bundle described in [Getting Started](https://docs.rustinel.io/getting-started/).
-
----
-
-## Documentation
-
-[Website](https://rustinel.io/) |
-[Docs home](https://docs.rustinel.io/) |
-[Getting Started](https://docs.rustinel.io/getting-started/) |
-[Configuration](https://docs.rustinel.io/configuration/) |
-[Detection](https://docs.rustinel.io/detection/) |
-[CLI reference](https://docs.rustinel.io/cli/) |
-[Sigma coverage](https://docs.rustinel.io/coverage/) |
-[Architecture](https://docs.rustinel.io/architecture/) |
-[Operations](https://docs.rustinel.io/operations/) |
-[Troubleshooting](https://docs.rustinel.io/troubleshooting/) |
-[FAQ](https://docs.rustinel.io/faq/) |
-[Detection rules](https://github.com/Karib0u/rustinel-rules) |
+[Contributing](CONTRIBUTING.md) |
+[Issues](https://github.com/Karib0u/rustinel/issues) |
+[Development guide](https://docs.rustinel.io/development/) |
 [Roadmap](https://github.com/Karib0u/rustinel/milestones)
-
----
-
-## Contributing
-
-Testing, feedback, and detection ideas are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 
 <p align="center">
   <b>Open-source endpoint detection for Windows, Linux, and macOS.</b><br>
-  Native telemetry to Sigma, YARA, IOC detection, and SIEM-ready alerts. Written in Rust.
+  Sigma, YARA, and IOC detections on native telemetry. No cloud, no account, nothing phoning home.<br>
+  Capture endpoint behavior once, then replay it against your rules anywhere. Written in Rust.
 </p>
 
 <p align="center">
@@ -21,6 +22,7 @@
   <a href="https://rustinel.io/">Website</a> |
   <a href="https://docs.rustinel.io/">Docs</a> |
   <a href="https://github.com/Karib0u/rustinel/releases/latest">Download</a> |
+  <a href="https://docs.rustinel.io/coverage/">Sigma coverage</a> |
   <a href="docs/siem-demos.md">SIEM demos</a>
 </p>
 
@@ -32,55 +34,59 @@
 
 ## Quick Start
 
-Rustinel ships release archives with a binary, default config, demo rules, and a
-`logs/` directory.
+### 1. Install
 
-**Windows** - test from PowerShell:
+**Windows** - from PowerShell:
 
 ```powershell
 irm https://rustinel.io/install.ps1 | iex
-```
-
-Then deploy from an elevated PowerShell and diagnose the managed installation:
-
-```powershell
-rustinel setup --yes
-rustinel doctor
 ```
 
 The Windows release binary requires the x64 Microsoft Visual C++ Redistributable.
 See [Getting Started](https://docs.rustinel.io/getting-started/#windows) if the
 process exits before printing output.
 
-**Linux** - test, deploy, and diagnose:
+**Linux:**
 
 ```bash
 curl -fsSL https://rustinel.io/install.sh | sh -s -- --run
-sudo rustinel setup --yes
-rustinel doctor
 ```
 
-**macOS** (experimental)
+**macOS** (experimental):
 
 ```bash
 curl -fsSL https://rustinel.io/install.sh | sh
 cd rustinel
+sudo ./rustinel run
 ```
 
 macOS requires a one-time Full Disk Access approval before Endpoint Security can
 start. Follow the [Getting Started](https://docs.rustinel.io/getting-started/)
 macOS notes before using it beyond a first test.
 
-```bash
-sudo ./rustinel run
+Prefer to inspect first? Download the [install script](scripts/install/install.sh)
+or a package from the [latest release](https://github.com/Karib0u/rustinel/releases/latest).
+Installers only download published release binaries.
+
+### 2. Deploy
+
+`setup` writes the managed configuration, installs the Essential rules pack,
+registers the platform's native service, starts it, and runs health checks.
+
+```powershell
+rustinel setup --yes
+rustinel doctor
 ```
 
-After Full Disk Access is granted, deploy and diagnose the managed installation:
-
 ```bash
-sudo ./rustinel setup --yes
-./rustinel doctor
+sudo rustinel setup --yes
+rustinel doctor
 ```
+
+Use `--pack advanced` for the larger pack, or `--no-start` to register the
+service without starting it.
+
+### 3. See a first alert
 
 With the agent running, trigger the bundled demo rule:
 
@@ -88,11 +94,13 @@ With the agent running, trigger the bundled demo rule:
 whoami
 ```
 
-Alerts are written to `logs/alerts.json.<date>` as ECS NDJSON.
+Alerts are ECS NDJSON, one object per line, written to `alerts.json.<date>`:
 
-Prefer to inspect first? Download the [install script](scripts/install/install.sh)
-or a package from the [latest release](https://github.com/Karib0u/rustinel/releases/latest).
-Installers only download published release binaries.
+| Platform | Managed install | Archive `./rustinel run` |
+| --- | --- | --- |
+| Windows | `C:\ProgramData\Rustinel\logs\` | `logs\` |
+| Linux | `/var/log/rustinel/` | `logs/` |
+| macOS | `/Library/Logs/Rustinel/` | `logs/` |
 
 ---
 
@@ -100,11 +108,38 @@ Installers only download published release binaries.
 
 A transparent endpoint detection engine you can read, run, test, and extend.
 
-- **Native telemetry:** ETW and Windows Event Log on Windows, eBPF on Linux, Endpoint Security and `/dev/bpf` on macOS.
-- **Detection formats:** Sigma for behavior, YARA for files and memory, IOC matching for hashes, IPs, domains, and path regexes.
-- **Rule reuse:** bring existing Sigma and YARA rules instead of rewriting them into a proprietary format.
+- **Native telemetry:** ETW and Windows Event Log on Windows, eBPF on Linux, Endpoint Security and `/dev/bpf` on macOS. One normalized event model across all three.
+- **Detection formats:** Sigma for behavior, YARA for files and process memory, IOC matching for hashes, IPs, domains, and path regexes.
+- **Rule reuse:** bring existing Sigma and YARA rules instead of rewriting them into a proprietary format. **74% of the SigmaHQ Windows corpus can fire today** - measured against a pinned corpus commit, not estimated. See [Sigma coverage](https://docs.rustinel.io/coverage/).
+- **Offline rule development:** `capture` a behavior once, then `replay` it against your rules as often as you like. No sensors, no privileges, no re-detonation.
+- **Local by design:** the running agent makes no network connections. Alerts are files on disk - ship them with your own pipeline, or just read them where they land. Rules packs are the only exception, downloaded when you explicitly run `setup` or `rules install`.
 - **SIEM output:** ECS 9.4.0 NDJSON alerts for Elastic, Splunk, and other log pipelines.
-- **Operations:** hot reload for rules and IOCs, optional active response (off by default) on all three platforms, and native service management via SCM, systemd, and launchd.
+- **Operations:** hot reload for rules and IOCs, versioned rules packs, optional active response (process termination, off by default), and native service management via SCM, systemd, and launchd.
+
+---
+
+## Record once, replay anywhere
+
+Detonating a sample to test one rule change is slow, and you cannot detonate on
+the box where you write rules. `capture` records normalized telemetry to a file
+without evaluating anything; `replay` runs that file through the same detector
+code the live pipeline uses.
+
+```bash
+sudo rustinel capture --output run-42.ndjson   # start, run the sample, Ctrl-C
+rustinel replay run-42.ndjson                  # iterate on rules, no sensors needed
+```
+
+A recording made on Windows replays on Linux or macOS, unprivileged, as often as
+the rules change. Replay loads detectors once with hot reload and deduplication
+off, so two replays of one recording against one configuration produce identical
+output - which makes recordings usable as regression fixtures in CI.
+
+YARA and hash IOC checks are skipped and reported as skipped: a recording holds
+events, not files. Active response is never invoked. Recordings contain full
+command lines, paths, and user names, so handle them as sensitive artifacts.
+
+See the [CLI reference](https://docs.rustinel.io/cli/#replay) for details.
 
 ---
 
@@ -112,7 +147,7 @@ A transparent endpoint detection engine you can read, run, test, and extend.
 
 | Platform | Sensor | Telemetry | Status |
 | --- | --- | --- | --- |
-| Windows 10/11, Server 2016+ | ETW + Windows Event Log | Process, image load, network, file, registry, DNS, PowerShell, WMI, service, task | Stable |
+| Windows 10/11, Server 2016+ | ETW + Windows Event Log | Process, image load, network, file, registry, DNS, PowerShell, WMI, service, task, Security channel (6 audited event IDs) | Stable |
 | Linux 5.8+ (BTF) | eBPF | Process, network, file, DNS | Stable |
 | macOS 11+ | Endpoint Security + `/dev/bpf` | Process, file, network, DNS | Experimental |
 
@@ -125,19 +160,29 @@ listed in [Limitations](https://docs.rustinel.io/limitations/).
 ## How detection works
 
 ```text
-  ETW (Windows) | eBPF (Linux) | ESF + /dev/bpf (macOS)
-                        │
-              Normalized event model
-                        │
-        ┌───────────────┼───────────────┐
-      Sigma            YARA             IOC
-    behavior        files +         hashes, IPs,
-      rules          memory         domains, paths
-        └───────────────┼───────────────┘
-                        │
-                ECS NDJSON alerts
-                        │
-              Optional active response
+   ETW + Event Log         eBPF             Endpoint Security
+      (Windows)           (Linux)          + /dev/bpf (macOS)
+          └──────────────────┴──────────────────────┘
+                             │
+                  Normalized event model
+                             │
+          ┌──────────────────┬──────────────────────┐
+        Sigma              YARA                    IOC
+      behavior           files and            hashes, IPs,
+        rules             memory             domains, paths
+          └──────────────────┴──────────────────────┘
+                             │
+                     ECS NDJSON alerts
+                             │
+                 Optional active response
+```
+
+The same event model feeds the offline loop:
+
+```text
+   Normalized event model ─── capture ──► recording (NDJSON + manifest)
+              ▲                                         │
+              └──────────────── replay ─────────────────┘
 ```
 
 See the [detection docs](https://docs.rustinel.io/detection/) for rule authoring, YARA memory scanning, and IOC formats.
@@ -155,18 +200,39 @@ rustinel        ->  the engine that collects telemetry and evaluates rules
 rustinel-rules  ->  the Sigma, YARA, and IOC packs it loads
 ```
 
-Each pack materializes into folders you point `config.toml` straight at. Browse the [pack catalog](https://github.com/Karib0u/rustinel-rules) to get started.
+`rustinel setup` already installed the Essential pack. To see what else is
+available for this platform and switch:
+
+```bash
+rustinel rules list
+sudo rustinel rules install linux-essential
+```
+
+Packs are downloaded, SHA-256 verified, validated, and activated atomically, so
+a failed download leaves the current rules in place. Browse the
+[pack catalog](https://github.com/Karib0u/rustinel-rules) for what ships today.
 
 ---
 
-## Good for / not for
+## Who it's for
 
-**Use it for** detection engineering, rule development and testing, blue-team labs, cross-platform detection research, and SIEM pipeline validation.
+**Endpoint monitoring you control.** Workstations and servers where you want
+real visibility without a cloud console, a vendor account, or an agent that
+reports home. Install it, point it at a rules pack, and everything it observes
+stays on the machine.
 
-**It is not** a drop-in replacement for a mature commercial EDR. Rustinel does
-not provide kernel-level self-protection, pre-execution blocking, anti-tamper
+**Detection engineering.** Rule development and testing, blue-team labs,
+cross-platform detection research, and SIEM pipeline validation - with `capture`
+and `replay` for iterating on rules without re-running samples.
+
+**What it is not.** A drop-in replacement for a mature commercial EDR. Rustinel
+does not provide kernel-level self-protection, pre-execution blocking, anti-tamper
 guarantees, or managed response. A sufficiently privileged attacker may interfere
 with user-mode telemetry.
+
+That trade is deliberate: Rustinel uses telemetry the operating system already
+exposes rather than shipping a kernel driver. That costs visibility and
+enforcement points, and keeps the agent transparent, portable, and inspectable.
 
 ---
 
@@ -188,6 +254,8 @@ macOS requires the app-like signed bundle described in [Getting Started](https:/
 [Getting Started](https://docs.rustinel.io/getting-started/) |
 [Configuration](https://docs.rustinel.io/configuration/) |
 [Detection](https://docs.rustinel.io/detection/) |
+[CLI reference](https://docs.rustinel.io/cli/) |
+[Sigma coverage](https://docs.rustinel.io/coverage/) |
 [Architecture](https://docs.rustinel.io/architecture/) |
 [Operations](https://docs.rustinel.io/operations/) |
 [Troubleshooting](https://docs.rustinel.io/troubleshooting/) |


### PR DESCRIPTION
## Summary

The README previously led with a feature list and mixed portable evaluation with managed deployment. It now leads with Rustinel's core proposition: open-source endpoint detection across Windows, Linux, and macOS using Sigma, YARA, and IOC rules, written in Rust with local alerts and no cloud account required.

- Guide readers from installation and a bundled demo alert to persistent monitoring, detection packs, and capture/replay.
- Retain the centered logo, demo, and CI, release, download, and license badges.
- Use platform-specific commands that invoke the extracted binary, and document managed alert locations.
- Explain coverage without equating rule compatibility with detection efficacy, and retain platform and product limitations.
- Clarify that rules catalog access includes `rules list`, alongside `setup` and `rules install`.
- Invite users to share deployment needs and onboarding friction.

## Validation

- Checked documented commands and paths against the installers, CLI, configuration, and replay documentation.
- `git diff --check` passed.
- Checked Markdown fence balance and all seven relative links and asset references.
- Documentation-only change; no runtime tests run for this revision.
