### PR TITLE
chore(release): prepare 1.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3174,7 +3174,7 @@ dependencies = [
 
 [[package]]
 name = "rustinel"
-version = "1.5.0-rc.1"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustinel"
-version = "1.5.0-rc.1"
+version = "1.5.0"
 edition = "2021"
 authors = []
 description = "Open-source EDR for Windows, Linux, and macOS with Sigma, YARA, and IOC detection"


### PR DESCRIPTION
## Summary

- bump the package version from `1.5.0-rc.1` to `1.5.0`
- update the lockfile package version
- prepare the final 1.5.0 release after the release candidate

## Release notes draft

# Rustinel 1.5.0: correlated detection, stronger fidelity

Rustinel 1.5 makes Sigma detection more capable and the live sensor pipeline more resilient. RSigma is now the single Sigma engine, with correlation and filter rule evaluation built into the same path used by live monitoring and replay. Windows burst handling, rule reload behavior, and hot-path allocation costs have also been tightened.

### Sigma detection

- Sigma correlation and filter documents are now evaluated, including event-count and temporal correlations.
- Detection rules are compiled into one shared engine, improving evaluation performance on large rulesets.
- A pinned SigmaHQ compatibility gate now checks the supported corpus continuously.

### Reliability and performance

- Windows event buffering and flush behavior preserve detection fidelity under burst load and report accepted and dropped events by category.
- Rule hot reload ignores access-only filesystem notifications, preventing self-sustaining CPU loops on large rule trees.
- PE metadata enrichment runs outside the ETW callback, the PE cache is bounded, and IOC and Sigma matching avoid several redundant allocations.
- Runtime, reload, test, and allowlist internals have been simplified without changing their external behavior.

### Upgrading from 1.4.x

Existing configuration files continue to load. The former `scanner.sigma_engine` setting is ignored, while scripts using the removed `--sigma-engine` command-line flag must remove it. The `rsigma-engine` Cargo feature has also been removed.

## Verification

- `git diff --check`
- `cargo metadata --locked --no-deps --format-version 1`
- `cargo check --locked`

## Checklist

- [x] All pull requests since `v1.4.1` have a release-note category label
- [x] Release notes draft prepared
- [x] `maintenance` label added to this pull request
