### PR TITLE
fix(ci): consume validated Windows Run key atomic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ env:
   CARGO_TERM_COLOR: always
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   # Update this commit deliberately when the rules repository's atomic suite changes.
-  RUSTINEL_RULES_REF: 724b584089cd4f09f0fbaf9e33f95b88eaa20226
+  RUSTINEL_RULES_REF: c1d78b4dec00eef42b5ccb741da6f7e7521dd854
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ env:
   CARGO_TERM_COLOR: always
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   # Update this commit deliberately when the rules repository's atomic suite changes.
-  RUSTINEL_RULES_REF: 724b584089cd4f09f0fbaf9e33f95b88eaa20226
+  RUSTINEL_RULES_REF: c1d78b4dec00eef42b5ccb741da6f7e7521dd854
 
 permissions:
   contents: read


### PR DESCRIPTION
Both atomic workflows still pin rustinel-rules at `724b584`, so release 1.5.0 never consumed the Run key fixture fix already merged in Karib0u/rustinel-rules#53. Update both pins to `c1d78b4dec00eef42b5ccb741da6f7e7521dd854`.

The old script assumes the HKCU Run key exists, suppresses write errors, and exits 0 even when no write occurred. The new script creates a missing key, verifies its write, surfaces errors, and cleans up in finally. Its matcher requires the actual test value path as well as the rule name.

Evidence:
- Release run https://github.com/Karib0u/rustinel/actions/runs/33981999927 failed this atomic in both attempts. Neither artifact contains a Run key alert; sensor-channel drops were zero. Other registry atomics passed.
- Source-built CI https://github.com/Karib0u/rustinel/actions/runs/33981983808 passed at the same engine SHA, with an alert for the actual test value. Both jobs used runner image `windows-2025-vs2026` version `20260824.214.3`.
- On the Windows 11 lab, using the exact release artifact and unchanged pinned Sigma rule, the old script returned 0 with no output in all cases: absent Run key produced 0/5 alerts; existing key produced 5/5 alerts.
- The already-merged script produced the expected registry-set alert in 10/10 absent-key cases and 10/10 existing-key cases. A process-local HKCU drive rooted in an isolated test subtree provided each fixture; production startup values were untouched and the subtree was removed afterward.
- Six matcher regression tests passed. Strict coverage reported zero missing or unknown entries. All 81 artifacts validated without warnings and all seven packs built.

The historical artifacts do not record whether the Run key existed. They also report some unresolved registry events, so this does not establish the cause of every past miss or claim to eliminate every ETW resolution issue. It does reproduce a deterministic fixture failure and consume the existing fix without changing the engine or weakening the detection rule.

The full Windows atomic suite passed on the lab against the unchanged release binary: 28/29 fired, exit 0. The only miss was the existing allowed EICAR test. The Run key check passed with the new exact-value matcher.
