### PR TITLE
fix(logging): show detections by default in 1.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3174,7 +3174,7 @@ dependencies = [
 
 [[package]]
 name = "rustinel"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustinel"
-version = "1.5.0"
+version = "1.5.1"
 edition = "2021"
 authors = []
 description = "Open-source EDR for Windows, Linux, and macOS with Sigma, YARA, and IOC detection"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -437,6 +437,13 @@ TOML, so lists are JSON-style arrays.
     .\rustinel.exe run
     ```
 
+At the default info level, the console shows one summary for each emitted
+Sigma, YARA, or IOC alert, including severity, rule name, and available process,
+PID, and file context. Full event details remain in the ECS NDJSON alert file.
+When deduplication is enabled, the first occurrence appears immediately and
+suppressed repeats appear as an aggregate summary when the window is flushed.
+Detection summaries use the `engine` logging target at info level; `--log-level warn` or a custom filter can hide them without disabling JSON alert output.
+
 Interactive `run` also accepts `--log-level` and `--no-console` as one-off
 overrides. For repeatable deployments, prefer `config.toml` and `EDR__`
 variables. See the [CLI Reference](cli.md) for every flag.

--- a/docs/output.md
+++ b/docs/output.md
@@ -30,7 +30,7 @@ Field rendering varies by logger, but the message text is representative:
 9:00 PM INFO  rustinel: Rustinel (Linux eBPF)
 9:00 PM INFO  rustinel: Loading Sigma rules
 9:00:01 PM INFO  rustinel: YARA scanner initialized
-9:00:05 PM INFO  engine: Detection triggered engine=Sigma rule="Encoded PowerShell Command"
+9:00:05 PM INFO  engine: Detection triggered engine=Sigma severity=High rule="Encoded PowerShell Command" process="/tmp/test-process" pid=4242
 9:00:05 PM INFO  response: Active response would terminate process pid=4242 image="/tmp/test-process" dry_run=true
 ```
 

--- a/src/alerts/mod.rs
+++ b/src/alerts/mod.rs
@@ -11,7 +11,7 @@ use crate::models::ecs::EcsAlert;
 use crate::models::Alert;
 use std::io::Write;
 use std::sync::Arc;
-use tracing::error;
+use tracing::{error, info};
 use tracing_appender::non_blocking::NonBlocking;
 
 pub use dedup::Deduplicator;
@@ -48,7 +48,24 @@ impl AlertSink {
                 let mut writer = self.writer.clone();
                 if let Err(err) = writeln!(writer, "{}", line) {
                     error!(error = %err, "Failed to write ECS alert");
+                    return;
                 }
+                info!(
+                    target: "engine",
+                    engine = %ecs.edr_rule_engine,
+                    severity = %ecs.edr_rule_severity,
+                    rule = %ecs.rule_name,
+                    process = ecs.process_executable.as_deref(),
+                    pid = ecs.process_pid,
+                    file = ecs.file_path.as_deref(),
+                    repeats = ecs.event_count,
+                    "{}",
+                    if ecs.event_count.is_some() {
+                        "Detection repeats aggregated"
+                    } else {
+                        "Detection triggered"
+                    }
+                );
             }
             Err(err) => {
                 error!(error = %err, "Failed to serialize ECS alert");

--- a/src/engine/handler.rs
+++ b/src/engine/handler.rs
@@ -145,15 +145,6 @@ impl SensorEventHandler for NormalizedEventHandler {
                     self.normalizer
                         .enrich_process_context(&mut alert.event, event.pid.unwrap_or(0));
 
-                    debug!(
-                        target: TARGET_ENGINE,
-                        engine = ?alert.engine,
-                        rule = %alert.rule_name,
-                        severity = ?alert.severity,
-                        category = ?alert.event.category,
-                        "Detection triggered"
-                    );
-
                     detection.alert_sink.write_alert(&alert);
                     detection.response_engine.handle_alert(&alert);
                 }

--- a/src/runtime/ioc.rs
+++ b/src/runtime/ioc.rs
@@ -105,13 +105,6 @@ pub fn spawn_ioc_hash_worker(
 
             let matches = ioc_engine.match_hashes(&hashes);
             if !matches.is_empty() {
-                info!(
-                    target: "engine",
-                    pid = pid,
-                    file = %path,
-                    matches = matches.len(),
-                    "IOC hash match detected"
-                );
                 for ioc_match in matches {
                     let alert = ioc_engine
                         .build_alert_for_hash_match(&ioc_match, &path, pid, platform, provider);

--- a/src/runtime/logging.rs
+++ b/src/runtime/logging.rs
@@ -513,4 +513,94 @@ mod filter_tests {
         assert!(output.contains("detection event"));
         assert!(output.contains("actionable warning"));
     }
+
+    fn render_detection_summaries(level: &str, filter: Option<&str>) -> (String, String) {
+        use crate::alerts::{AlertSink, Deduplicator};
+        use crate::models::{Alert, AlertSeverity, DetectionEngine, NormalizedEvent};
+
+        let logging = logging(level, filter);
+        let console_filter = build_console_log_filter(&logging, &build_log_filter(&logging));
+        let output = Arc::new(Mutex::new(Vec::new()));
+        let writer_output = Arc::clone(&output);
+        let subscriber = tracing_subscriber::registry().with(
+            fmt::layer()
+                .compact()
+                .with_ansi(false)
+                .with_writer(move || SharedWriter(Arc::clone(&writer_output)))
+                .with_filter(console_filter),
+        );
+        let json_output = Arc::new(Mutex::new(Vec::new()));
+        let (writer, guard) =
+            tracing_appender::non_blocking(SharedWriter(Arc::clone(&json_output)));
+        let dedup = Arc::new(Deduplicator::new(60, 100));
+        let sink = AlertSink::new(writer).with_deduplicator(Arc::clone(&dedup));
+        let event: NormalizedEvent = serde_json::from_value(serde_json::json!({
+            "timestamp": "2026-09-06T08:54:30Z",
+            "platform": "windows",
+            "provider": "etw",
+            "category": "Process",
+            "event_id": 1,
+            "opcode": 1,
+            "fields": { "Image": "C:\\Windows\\System32\\whoami.exe", "ProcessId": "13504" }
+        }))
+        .unwrap();
+
+        tracing::subscriber::with_default(subscriber, || {
+            for engine in [
+                DetectionEngine::Sigma,
+                DetectionEngine::Yara,
+                DetectionEngine::Ioc,
+            ] {
+                let alert = Alert {
+                    severity: AlertSeverity::Low,
+                    rule_name: format!("{engine:?} test rule"),
+                    rule_description: None,
+                    rule_id: None,
+                    engine,
+                    event: event.clone(),
+                    match_details: None,
+                };
+                sink.write_alert(&alert);
+                sink.write_alert(&alert);
+                sink.write_alert(&alert);
+            }
+            dedup.flush_all(&sink);
+        });
+        drop(guard);
+        let console = String::from_utf8(output.lock().unwrap().clone()).unwrap();
+        let json = String::from_utf8(json_output.lock().unwrap().clone()).unwrap();
+        (console, json)
+    }
+
+    #[test]
+    fn default_console_shows_real_alerts_from_all_engines_and_deduplicates() {
+        let (console, json) = render_detection_summaries("info", None);
+        assert_eq!(console.matches("Detection triggered").count(), 3);
+        assert_eq!(console.matches("Detection repeats aggregated").count(), 3);
+        for engine in ["Sigma", "Yara", "Ioc"] {
+            assert!(console.contains(&format!("engine={engine}")), "{console}");
+            assert!(
+                console.contains(&format!("{engine} test rule")),
+                "{console}"
+            );
+        }
+        assert!(console.contains("severity=Low"), "{console}");
+        assert!(console.contains("whoami.exe"), "{console}");
+        assert!(console.contains("pid=13504"), "{console}");
+        assert_eq!(console.matches("repeats=2").count(), 3);
+        assert_eq!(json.lines().count(), 6);
+    }
+
+    #[test]
+    fn quiet_filters_hide_summaries_without_disabling_json_alerts() {
+        for (level, filter) in [("warn", None), ("info", Some("warn,engine=off"))] {
+            let (console, json) = render_detection_summaries(level, filter);
+            assert!(console.is_empty(), "{console}");
+            assert_eq!(json.lines().count(), 6);
+            for line in json.lines() {
+                let alert: serde_json::Value = serde_json::from_str(line).unwrap();
+                assert_eq!(alert["event.kind"], "alert");
+            }
+        }
+    }
 }

--- a/src/runtime/yara.rs
+++ b/src/runtime/yara.rs
@@ -256,15 +256,6 @@ pub fn spawn_yara_file_worker(
             match scan_result {
                 Ok(matches) => {
                     if !matches.is_empty() {
-                        let rule_names: Vec<String> =
-                            matches.iter().map(|rule| rule.rule.clone()).collect();
-                        warn!(
-                            pid = pid,
-                            file = %path,
-                            rules = ?rule_names,
-                            "YARA detection triggered"
-                        );
-
                         for rule_match in &matches {
                             let match_details = build_yara_match_details(match_debug, rule_match);
                             let alert = build_yara_alert(
@@ -397,15 +388,6 @@ pub fn spawn_yara_memory_worker(
                 };
 
                 if !matches.is_empty() {
-                    let rule_names: Vec<String> =
-                        matches.iter().map(|rule| rule.rule.clone()).collect();
-                    warn!(
-                        pid = job.expected_identity.pid,
-                        image = %job.expected_identity.image,
-                        rules = ?rule_names,
-                        "YARA memory detection triggered"
-                    );
-
                     for rule_match in &matches {
                         let details =
                             build_yara_memory_match_details(match_debug, rule_match, chunk);


### PR DESCRIPTION
## Summary

Running `whoami.exe` with the default info-level console produced a JSON alert but no visible detection message. Emit a concise info-level summary from the shared alert sink so Sigma, YARA file and memory scans, and IOC detections consistently show severity, rule name, and available process, PID, and file context.

Summaries follow alert deduplication: the first occurrence appears immediately and suppressed repeats appear as an aggregate when flushed. Remove redundant engine-specific messages, preserve quiet filters and JSON output, update the logging documentation, and bump the package and lockfile to 1.5.1.

## Type of change
- [x] `bug` - bug fix

## Test plan
- [x] 27 targeted tests passed on macOS after the version bump.
  - `cargo test --locked --lib runtime::logging::filter_tests`
  - `cargo test --locked --test alert_output --test dedup_integration --test pipeline_sigma --test capture_recording`
- [x] `cargo fmt --all --check`
- [x] `git diff --check`
- [x] New regression tests exercise the real alert sink through the default console filter for all three engines, repeat aggregation, and quiet filters that preserve JSON output.
- [ ] Native Windows validation of the updated binary
- [ ] Native Linux validation
- [ ] Full CI suite

## Checklist
- [x] Bug label added
- [x] Documentation updated
