### PR TITLE
fix(engine): stop advertising file_change as collected on Linux and macOS

### DIFF
--- a/docs/detection.md
+++ b/docs/detection.md
@@ -163,7 +163,9 @@ Two things rule authors need to know:
   Windows, `CreationUtcTime` and `PreviousCreationUtcTime` stay empty because
   the provider reports which information class was set but never the values, so a
   `file_change` rule keyed on those fields cannot fire, one keyed on
-  `TargetFilename` and `Image` can.
+  `TargetFilename` and `Image` can. On Linux and macOS no sensor emits the
+  action at all, so `file_change` rules load there but are reported as having
+  no backing collector.
 - **File events whose path cannot be resolved are dropped, not emitted bare.**
   On both Windows and Linux the kernel names the target by handle or descriptor
   rather than by path, and the path has to be reconstructed. When that fails the

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -20,7 +20,6 @@ full rather than hide them.
 | Security channel events depend on audit policy Rustinel does not set | Windows |
 | Image paths are truncated, and truncation is unmarked on process events | Linux |
 | `Protocol` is reported as `tcp` on every connection, including UDP | Linux |
-| `file_change` is advertised as collected but no sensor emits it | Linux, macOS |
 
 ## Windows (ETW and Event Log)
 
@@ -230,13 +229,13 @@ would succeed.
   [Sigma Coverage](coverage.md) for the measured share of SigmaHQ that can fire
   per platform; per-rule diagnostics are tracked by
   [#184](https://github.com/Karib0u/rustinel/issues/184).
-- **`file_change` is advertised as collected on Linux and macOS but is not
-  (silent risk).** The category is listed among the active logsources on both
-  platforms, so its rules are reported as backed by a live collector. Neither
-  sensor emits the metadata-change action that `file_change` denotes, so those
-  rules can never fire. This is worse than the general case above: the rule is
-  not merely inert, it is counted as covered
-  ([#293](https://github.com/Karib0u/rustinel/issues/293)).
+- **`file_change` has no collector on Linux or macOS.** Neither the eBPF nor
+  the ESF sensor emits the metadata-change action that `file_change` denotes
+  (Sysmon Event ID 2), so its rules cannot fire on those platforms. They still
+  load, and are reported as having no backing collector rather than counted as
+  covered ([#293](https://github.com/Karib0u/rustinel/issues/293)); the
+  telemetry itself is tracked by
+  [#146](https://github.com/Karib0u/rustinel/issues/146).
 - **Correlation state resets on Sigma reload.** A reload creates a fresh
   correlation engine, so events in an open window are forgotten. Correlation
   windows also rely on events arriving to trigger cleanup; there is no separate

--- a/src/engine/logsource.rs
+++ b/src/engine/logsource.rs
@@ -248,7 +248,6 @@ impl Engine {
                 LogSourceKey::from_parts(Some("linux"), Some("sysmon"), Some("file_event")),
                 LogSourceKey::from_parts(Some("linux"), Some("sysmon"), Some("file_create")),
                 LogSourceKey::from_parts(Some("linux"), Some("sysmon"), Some("file_delete")),
-                LogSourceKey::from_parts(Some("linux"), Some("sysmon"), Some("file_change")),
                 LogSourceKey::from_parts(Some("linux"), Some("sysmon"), Some("file_rename")),
                 LogSourceKey::from_parts(Some("linux"), Some("sysmon"), Some("dns_query")),
             ],
@@ -260,7 +259,6 @@ impl Engine {
                 LogSourceKey::from_parts(Some("macos"), Some("sysmon"), Some("file_event")),
                 LogSourceKey::from_parts(Some("macos"), Some("sysmon"), Some("file_create")),
                 LogSourceKey::from_parts(Some("macos"), Some("sysmon"), Some("file_delete")),
-                LogSourceKey::from_parts(Some("macos"), Some("sysmon"), Some("file_change")),
                 LogSourceKey::from_parts(Some("macos"), Some("sysmon"), Some("file_rename")),
                 LogSourceKey::from_parts(Some("macos"), Some("sysmon"), Some("dns_query")),
             ],
@@ -343,16 +341,28 @@ impl Engine {
         let service = logsource.service.as_deref();
 
         match self.platform {
-            // macOS shares the Linux collector model: only the generic DNS
-            // network logsource is known-but-inactive.
+            // macOS shares the Linux collector model.
             Platform::Linux | Platform::MacOS => {
-                matches!(service, Some("dns"))
-                    && matches!(category, None | Some("network"))
-                    && logsource
-                        .product
-                        .as_deref()
-                        .map(|product| product == platform_product(self.platform))
-                        .unwrap_or(true)
+                let product_matches = logsource
+                    .product
+                    .as_deref()
+                    .map(|product| product == platform_product(self.platform))
+                    .unwrap_or(true);
+
+                // The generic DNS network logsource.
+                let dns_network =
+                    matches!(service, Some("dns")) && matches!(category, None | Some("network"));
+
+                // `file_change` is Sysmon Event ID 2 — the file's timestamps
+                // were changed — which neither the eBPF nor the ESF sensor
+                // emits: both stop at Create, Modify, Delete and Rename. The
+                // category is a real one and its rules load, but nothing can
+                // produce a matching event, so it is reported as unbacked
+                // rather than counted as covered (issue #293).
+                let file_change = matches!(category, Some("file_change"))
+                    && matches!(service, None | Some("sysmon"));
+
+                product_matches && (dns_network || file_change)
             }
             Platform::Windows => {
                 let service_known = service

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -260,6 +260,10 @@ mod tests {
         Engine::new_for_platform(Platform::Linux)
     }
 
+    fn macos_engine() -> Engine {
+        Engine::new_for_platform(Platform::MacOS)
+    }
+
     fn logsource(
         product: Option<&str>,
         service: Option<&str>,
@@ -354,6 +358,81 @@ mod tests {
 
         assert_eq!(classification.status, LogSourceStatus::Supported);
         assert_eq!(classification.collector_active, Some(true));
+    }
+
+    #[test]
+    fn file_change_has_no_backing_collector_off_windows() {
+        // Sysmon Event ID 2 is a metadata change; neither the eBPF nor the ESF
+        // sensor emits it, so its rules load but are reported as unbacked
+        // rather than counted as covered (issue #293).
+        let source = logsource(None, Some("sysmon"), Some("file_change"));
+
+        for engine in [linux_engine(), macos_engine()] {
+            let classification = engine.classify_logsource(&source);
+            assert_eq!(classification.status, LogSourceStatus::Supported);
+            assert_eq!(classification.collector_active, Some(false));
+        }
+
+        let windows = windows_engine().classify_logsource(&source);
+        assert_eq!(windows.status, LogSourceStatus::Supported);
+        assert_eq!(windows.collector_active, Some(true));
+    }
+
+    #[test]
+    fn platform_qualified_file_change_has_no_backing_collector_off_windows() {
+        for (engine, product) in [(linux_engine(), "linux"), (macos_engine(), "macos")] {
+            let classification = engine.classify_logsource(&logsource(
+                Some(product),
+                Some("sysmon"),
+                Some("file_change"),
+            ));
+
+            assert_eq!(classification.status, LogSourceStatus::Supported);
+            assert_eq!(classification.collector_active, Some(false));
+        }
+    }
+
+    #[test]
+    fn sibling_file_categories_stay_active_off_windows() {
+        // Only `file_change` loses its collector: the rest of the file family
+        // is still emitted by both sensors.
+        for (engine, product) in [(linux_engine(), "linux"), (macos_engine(), "macos")] {
+            for category in ["file_event", "file_create", "file_delete", "file_rename"] {
+                let classification = engine.classify_logsource(&logsource(
+                    Some(product),
+                    Some("sysmon"),
+                    Some(category),
+                ));
+
+                assert_eq!(
+                    classification.collector_active,
+                    Some(true),
+                    "{product}/{category} should stay backed by a collector"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn linux_file_change_rule_is_counted_as_inactive() {
+        let engine = engine_with_rule(
+            Platform::Linux,
+            r#"title: Linux Timestomp
+logsource:
+  product: linux
+  service: sysmon
+  category: file_change
+detection:
+  selection:
+    TargetFilename|endswith: ".sh"
+  condition: selection
+level: medium
+"#,
+        );
+
+        let stats = engine.stats();
+        assert_eq!(stats.total_rules, 1, "the rule still loads");
+        assert_eq!(stats.inactive_collector_rules, 1);
     }
 
     #[test]


### PR DESCRIPTION
Closes #293.

## Problem

`Engine::active_logsource_tuples()` listed `linux/sysmon/file_change` and
`macos/sysmon/file_change` among the active logsources, so rules in that
category were reported as backed by a live collector.

`file_change` is Sysmon Event ID 2 — the file's timestamps or attributes were
set — reached through `SensorAction::Set`. Neither sensor emits it: the eBPF
converters stop at Create, Modify, Delete and Rename, and macOS ESF emits the
same set. `docs/detection.md` already recorded `file_change` as `No` for both
platforms, so the tuple list and the documentation disagreed.

This is worse than the general inert-rule case: the rule is not merely inert,
it is counted as covered.

## Change

- Remove both tuples from `active_logsource_tuples()`.
- Make `file_change` *known but inactive* on Linux and macOS in
  `is_known_but_inactive_logsource()`, rather than letting it fall through to
  `Unknown`. The category is real and its rules still load and evaluate — they
  are counted in `inactive_collector_rules` and reported as having no backing
  collector, instead of being silently skipped as an unrecognized logsource.
- Windows is unchanged: ETW `FILE_BASIC_INFORMATION` still emits `Set`.

Docs updated: the limitation is no longer a silent risk, so it drops out of
the "Start with these" table in `docs/limitations.md` and is rewritten as a
plain collector gap pointing at #146; `docs/detection.md` notes that
`file_change` rules load on Linux/macOS without a collector.

## Tests

Four new tests in `src/engine`:

- `file_change_has_no_backing_collector_off_windows` — Linux and macOS report
  `Supported` with `collector_active: Some(false)`; Windows stays `Some(true)`.
- `platform_qualified_file_change_has_no_backing_collector_off_windows` — same
  with an explicit `product:`.
- `sibling_file_categories_stay_active_off_windows` — `file_event`,
  `file_create`, `file_delete`, `file_rename` keep their collectors.
- `linux_file_change_rule_is_counted_as_inactive` — a real rule loaded through
  the loader lands in `inactive_collector_rules`, and still loads.

`cargo test` (30 binaries), `cargo clippy --all-targets` and `cargo fmt --check`
are clean on macOS.