### PR TITLE
fix(linux-ebpf): report the real transport on connect events

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -19,7 +19,6 @@ full rather than hide them.
 | Writes through handles or keys opened before startup are invisible | Windows |
 | Security channel events depend on audit policy Rustinel does not set | Windows |
 | Image paths are truncated, and truncation is unmarked on process events | Linux |
-| `Protocol` is reported as `tcp` on every connection, including UDP | Linux |
 | `file_change` is advertised as collected but no sensor emits it | Linux, macOS |
 
 ## Windows (ETW and Event Log)
@@ -184,11 +183,17 @@ The Linux sensor covers process, network, file, and DNS.
   absent rather than misreported. Because capture is at syscall entry, failed
   connections are reported as connections, and `SourceIp`/`SourcePort` are not
   yet assigned ([#299](https://github.com/Karib0u/rustinel/issues/299),
-  [#301](https://github.com/Karib0u/rustinel/issues/301)). `Protocol` is reported
-  as `tcp` on every event even though the hook also captures UDP connects, so
-  a rule selecting `Protocol: 'udp'` never matches and one selecting `'tcp'`
-  matches UDP traffic ([#300](https://github.com/Karib0u/rustinel/issues/300)). Only
-  AF_INET and AF_INET6.
+  [#301](https://github.com/Karib0u/rustinel/issues/301)). Only AF_INET and
+  AF_INET6.
+- **`Protocol` is absent for sockets created before the sensor started.** The
+  transport comes from the type the socket was created with, so `socket(2)` is
+  watched and the type indexed by descriptor. A descriptor the sensor never
+  watched being created — opened before startup, inherited across `fork`, or
+  received over `SCM_RIGHTS` — reports no `Protocol` at all, and a rule
+  selecting either value does not match it. That is deliberate: the field used
+  to be a fixed `tcp`, which matched UDP traffic and never matched
+  `Protocol: 'udp'`. Socket types other than `SOCK_STREAM` and `SOCK_DGRAM`
+  (a raw or SCTP socket) are also left absent rather than named.
 - **No library-load, module-load, or ptrace events.** Sigma rules in those
   categories never match.
 - **Kernel requirements.** Linux 5.8+ with BTF and `CAP_BPF` + `CAP_PERFMON` +

--- a/ebpf/src/events.rs
+++ b/ebpf/src/events.rs
@@ -50,6 +50,16 @@ pub struct ProcessEvent {
     pub args: [u8; ARGV_CAPACITY],
 }
 
+/// The sensor did not watch this socket being created, so its type is not
+/// known. Userspace reports no `Protocol` rather than guessing one.
+pub const SOCK_TYPE_UNKNOWN: u8 = 0;
+
+/// `SOCK_STREAM` — TCP for AF_INET and AF_INET6.
+pub const SOCK_STREAM: u8 = 1;
+
+/// `SOCK_DGRAM` — UDP for AF_INET and AF_INET6.
+pub const SOCK_DGRAM: u8 = 2;
+
 /// Outbound connection event. Emitted by `handle_connect` on
 /// `syscalls/sys_enter_connect`.
 #[repr(C)]
@@ -68,7 +78,11 @@ pub struct NetworkEvent {
     pub sport: u16,
     /// Address family: 2 = AF_INET, 10 = AF_INET6.
     pub af: u16,
-    pub _pad1: u16,
+    /// Socket type the descriptor was created with, masked to
+    /// `SOCK_TYPE_MASK`: [`SOCK_STREAM`], [`SOCK_DGRAM`], another `SOCK_*`
+    /// value, or [`SOCK_TYPE_UNKNOWN`] when the creation was not observed.
+    pub sock_type: u8,
+    pub _pad1: u8,
     /// Destination address. For AF_INET: first 4 bytes hold the IPv4 address
     /// (network byte order); remaining bytes are zero. For AF_INET6: all 16
     /// bytes hold the address.

--- a/ebpf/src/file.rs
+++ b/ebpf/src/file.rs
@@ -79,6 +79,7 @@ use crate::events::{
     FileEvent, FileIndexEvent, FILE_FLAG_AUX_PATH_TRUNCATED, FILE_FLAG_PATH_TRUNCATED,
     FILE_PATH_LEN,
 };
+use crate::network::forget_socket_type;
 
 /// O_CREAT flag — create file if it does not exist.
 const O_CREAT: u64 = 0x40;
@@ -285,11 +286,24 @@ unsafe fn current_dir_token(pid: u32, fd: i32) -> u64 {
     }
 }
 
+/// Invalidate every per-descriptor index entry `fd` owns before the number can
+/// be recycled.
+///
+/// The directory index and the socket-type index are keyed the same way and
+/// invalidated at the same moments, so they share this one program rather than
+/// each attaching to `sys_enter_close`, which is among the hottest tracepoints
+/// on the machine.
+#[inline(always)]
+unsafe fn invalidate_fd(pid: u32, fd: i32) {
+    invalidate_dir_token(pid, fd);
+    forget_socket_type(pid, fd);
+}
+
 #[inline(always)]
 unsafe fn try_invalidate_close(ctx: &TracePointContext) -> Result<u32, i64> {
     let fd = ctx.read_at::<i64>(16)? as i32;
     let pid = (bpf_get_current_pid_tgid() >> 32) as u32;
-    invalidate_dir_token(pid, fd);
+    invalidate_fd(pid, fd);
     Ok(0)
 }
 
@@ -316,7 +330,8 @@ unsafe fn try_invalidate_dup_target(ctx: &TracePointContext) -> Result<u32, i64>
         return Ok(0);
     }
     let pid = (bpf_get_current_pid_tgid() >> 32) as u32;
-    invalidate_dir_token(pid, new_fd);
+    // `dup2`/`dup3` close whatever `new_fd` held without a `close` syscall.
+    invalidate_fd(pid, new_fd);
     Ok(0)
 }
 

--- a/ebpf/src/main.rs
+++ b/ebpf/src/main.rs
@@ -11,6 +11,8 @@
 //! | `handle_execve`       | `syscalls/sys_enter_execve` | capture argv    |
 //! | `handle_execveat`     | `syscalls/sys_enter_execveat`| capture argv   |
 //! | `handle_connect`      | `syscalls/sys_enter_connect`| Event 3         |
+//! | `handle_socket`       | `syscalls/sys_enter_socket` | capture type    |
+//! | `handle_socket_exit`  | `syscalls/sys_exit_socket`  | index fd type   |
 //! | `handle_openat`       | `syscalls/sys_enter_openat` | queue Event 11  |
 //! | `handle_vfs_create`   | `kprobe/vfs_create`         | confirm create  |
 //! | `handle_openat_exit`  | `syscalls/sys_exit_openat`  | emit Event 11   |

--- a/ebpf/src/network.rs
+++ b/ebpf/src/network.rs
@@ -1,10 +1,27 @@
-//! Network connection eBPF program.
+//! Network connection eBPF programs.
 //!
-//! Attaches to `syscalls/sys_enter_connect`. Fires when a process calls
-//! `connect(2)`, covering both TCP and UDP outbound connections. Reading the
-//! sockaddr at the syscall entry point gives us the destination before the
-//! kernel acts on it, while still running in full task context so
+//! `handle_connect` attaches to `syscalls/sys_enter_connect`. It fires when a
+//! process calls `connect(2)`, covering both TCP and UDP outbound connections.
+//! Reading the sockaddr at the syscall entry point gives us the destination
+//! before the kernel acts on it, while still running in full task context so
 //! `bpf_get_current_pid_tgid()` is valid.
+//!
+//! `connect(2)` itself never says which transport it speaks — that was decided
+//! when the socket was created. So `socket(2)` is watched as well and the type
+//! it returns is indexed by `(pid, fd)` for the connect hook to read back. The
+//! type argument is only known at syscall entry and the descriptor only at
+//! syscall exit, so the two are joined through a per-thread slot.
+//!
+//! A descriptor the sensor never watched being created reports
+//! [`SOCK_TYPE_UNKNOWN`], and userspace leaves `Protocol` absent rather than
+//! guessing. That covers sockets opened before the agent started, inherited
+//! across `fork` (the key is per-process), or received over `SCM_RIGHTS`.
+//!
+//! Descriptor numbers are recycled, so an index entry is dropped as soon as its
+//! descriptor can name a different socket: on `close`, and on the `dup2`/`dup3`
+//! target that is closed implicitly. Those tracepoints already carry a program
+//! for the directory index, which calls [`forget_socket_type`] rather than pay
+//! a second tracepoint dispatch on paths as hot as `close`.
 //!
 //! sys_enter_connect tracepoint format (x86_64, 64-bit ABI):
 //!   offset  0: common_type         (u16)
@@ -16,20 +33,32 @@
 //!   offset 16: fd                  (i64)
 //!   offset 24: uservaddr           (u64 — pointer to user-space sockaddr)
 //!   offset 32: addrlen             (i32)
+//!
+//! sys_enter_socket tracepoint format (same header):
+//!   offset 16: family              (i64)
+//!   offset 24: type                (i64 — socket type OR'd with SOCK_* flags)
+//!   offset 32: protocol            (i64)
+//!
+//! sys_exit_socket tracepoint format (same header):
+//!   offset 16: ret                 (i64 — the new descriptor, or -errno)
 
 use aya_ebpf::{
     helpers::{bpf_get_current_pid_tgid, bpf_get_current_uid_gid, bpf_probe_read_user},
     macros::{map, tracepoint},
-    maps::RingBuf,
+    maps::{HashMap, LruHashMap, RingBuf},
     programs::TracePointContext,
 };
 
-use crate::events::NetworkEvent;
+use crate::events::{NetworkEvent, SOCK_TYPE_UNKNOWN};
 
 /// AF_INET (IPv4).
 const AF_INET: u16 = 2;
 /// AF_INET6 (IPv6).
 const AF_INET6: u16 = 10;
+
+/// Bits of the `socket(2)` type argument that name the type. The rest carry
+/// `SOCK_NONBLOCK` and `SOCK_CLOEXEC`, which say nothing about the transport.
+const SOCK_TYPE_MASK: i64 = 0xf;
 
 /// IPv4 socket address as laid out by the C ABI.
 #[repr(C)]
@@ -56,10 +85,99 @@ struct SockAddrIn6 {
 #[map]
 pub static NETWORK_RING: RingBuf = RingBuf::with_byte_size(256 * 1024, 0);
 
+/// Socket type of the `socket(2)` call a thread is currently inside, keyed by
+/// TID. A thread is inside at most one syscall at a time, so one slot per
+/// thread is enough to carry the type from entry to exit.
+#[map]
+static SOCKET_PENDING: HashMap<u32, u8> = HashMap::with_max_entries(16_384, 0);
+
+/// Socket type of every IP socket the sensor watched being created, keyed by
+/// `(pid, fd)`.
+///
+/// LRU rather than plain hash: entries are dropped when their descriptor is
+/// closed, but a process killed with sockets open leaves its entries behind,
+/// and eviction bounds that. An evicted entry costs a `Protocol` value, never
+/// a wrong one.
+#[map]
+static SOCKET_TYPES: LruHashMap<u64, u8> = LruHashMap::with_max_entries(16_384, 0);
+
 /// Tracepoint handler for `syscalls/sys_enter_connect`.
 #[tracepoint]
 pub fn handle_connect(ctx: TracePointContext) -> u32 {
     unsafe { try_handle_connect(&ctx) }.unwrap_or(1)
+}
+
+/// Tracepoint handler for `syscalls/sys_enter_socket`, where the socket type
+/// is still visible.
+#[tracepoint]
+pub fn handle_socket(ctx: TracePointContext) -> u32 {
+    unsafe { try_handle_socket(&ctx) }.unwrap_or(1)
+}
+
+/// Tracepoint handler for `syscalls/sys_exit_socket`, where the descriptor the
+/// pending type belongs to is finally known.
+#[tracepoint]
+pub fn handle_socket_exit(ctx: TracePointContext) -> u32 {
+    unsafe { try_handle_socket_exit(&ctx) }.unwrap_or(1)
+}
+
+#[inline(always)]
+fn socket_key(pid: u32, fd: i32) -> u64 {
+    ((pid as u64) << 32) | (fd as u32 as u64)
+}
+
+/// Drop the indexed socket type for `(pid, fd)`.
+///
+/// Called from the descriptor-lifetime hooks in [`crate::file`] — see this
+/// module's documentation for why they are shared.
+///
+/// # Safety
+///
+/// Must be called from a BPF program context.
+#[inline(always)]
+pub unsafe fn forget_socket_type(pid: u32, fd: i32) {
+    if fd < 0 {
+        return;
+    }
+    let _ = SOCKET_TYPES.remove(&socket_key(pid, fd));
+}
+
+#[inline(always)]
+unsafe fn try_handle_socket(ctx: &TracePointContext) -> Result<u32, i64> {
+    let tid = bpf_get_current_pid_tgid() as u32;
+
+    // Only IP sockets can reach the connect hook's address-family filter;
+    // indexing AF_UNIX and AF_NETLINK would evict entries that can be used.
+    let family = ctx.read_at::<i64>(16)?;
+    if family != AF_INET as i64 && family != AF_INET6 as i64 {
+        // Anything still pending belongs to a thread that was killed inside an
+        // earlier `socket()`; drop it so this call's exit cannot claim it.
+        let _ = SOCKET_PENDING.remove(&tid);
+        return Ok(0);
+    }
+
+    let sock_type = (ctx.read_at::<i64>(24)? & SOCK_TYPE_MASK) as u8;
+    let _ = SOCKET_PENDING.insert(&tid, &sock_type, 0);
+    Ok(0)
+}
+
+#[inline(always)]
+unsafe fn try_handle_socket_exit(ctx: &TracePointContext) -> Result<u32, i64> {
+    let tid = bpf_get_current_pid_tgid() as u32;
+    let Some(sock_type) = SOCKET_PENDING.get(&tid).copied() else {
+        return Ok(0);
+    };
+    let _ = SOCKET_PENDING.remove(&tid);
+
+    // A failed socket(2) returns -errno and owns no descriptor.
+    let ret = ctx.read_at::<i64>(16)?;
+    if ret < 0 {
+        return Ok(0);
+    }
+
+    let pid = (bpf_get_current_pid_tgid() >> 32) as u32;
+    let _ = SOCKET_TYPES.insert(&socket_key(pid, ret as i32), &sock_type, 0);
+    Ok(0)
 }
 
 #[inline(always)]
@@ -102,6 +220,11 @@ unsafe fn try_handle_connect(ctx: &TracePointContext) -> Result<u32, i64> {
         return Ok(0);
     }
 
+    let sock_type = match SOCKET_TYPES.get(&socket_key(pid, fd)) {
+        Some(value) => *value,
+        None => SOCK_TYPE_UNKNOWN,
+    };
+
     if let Some(mut entry) = NETWORK_RING.reserve::<NetworkEvent>(0) {
         entry.write(NetworkEvent {
             pid,
@@ -111,6 +234,7 @@ unsafe fn try_handle_connect(ctx: &TracePointContext) -> Result<u32, i64> {
             dport,
             sport,
             af: family,
+            sock_type,
             _pad1: 0,
             daddr,
             saddr: [0u8; 16],

--- a/src/sensor/linux/ebpf.rs
+++ b/src/sensor/linux/ebpf.rs
@@ -119,6 +119,15 @@ impl Sensor for EbpfSensor {
             "sys_enter_execveat",
         )?;
         attach_tracepoint(&mut bpf, "handle_connect", "syscalls", "sys_enter_connect")?;
+        // `connect()` does not name its transport; the socket type is only
+        // visible while `socket()` runs, and its descriptor only on return.
+        attach_tracepoint(&mut bpf, "handle_socket", "syscalls", "sys_enter_socket")?;
+        attach_tracepoint(
+            &mut bpf,
+            "handle_socket_exit",
+            "syscalls",
+            "sys_exit_socket",
+        )?;
         attach_tracepoint(&mut bpf, "handle_openat", "syscalls", "sys_enter_openat")?;
         attach_kprobe(&mut bpf, "handle_vfs_create", "vfs_create")?;
         attach_tracepoint(
@@ -597,7 +606,13 @@ fn build_network_event(ev: &NetworkEvent) -> Option<SensorEvent> {
             image: None,
             user: Some(user),
             destination_hostname: None,
-            protocol: socket_metadata.and_then(|value| value.protocol),
+            // The kernel-side socket type is authoritative: it is recorded when
+            // the socket is created, while `/proc/net` is read after the event
+            // is drained and answers for whatever the descriptor points at then.
+            protocol: ev
+                .transport()
+                .map(str::to_string)
+                .or_else(|| socket_metadata.and_then(|value| value.protocol)),
             // The probe hooks `connect()` only, so every captured connection
             // is one this host opened. `accept()` is not hooked, so no inbound
             // connection can reach here and be mislabelled.
@@ -1124,6 +1139,7 @@ mod tests {
             dport: 443,
             sport: 0,
             af: 2,
+            sock_type: 0,
             _pad1: 0,
             daddr,
             saddr: [0u8; 16],
@@ -1141,6 +1157,41 @@ mod tests {
     }
 
     #[test]
+    fn build_network_event_reports_the_kernel_socket_type() {
+        let mut daddr = [0u8; 16];
+        daddr[..4].copy_from_slice(&[198, 51, 100, 10]);
+
+        let mut raw = NetworkEvent {
+            pid: 77,
+            uid: 1000,
+            // A closed descriptor, so `/proc/net` cannot supply a protocol and
+            // only the kernel-side socket type can answer.
+            fd: -1,
+            _pad0: 0,
+            dport: 53,
+            sport: 0,
+            af: 2,
+            sock_type: 2, // SOCK_DGRAM
+            _pad1: 0,
+            daddr,
+            saddr: [0u8; 16],
+        };
+
+        let event = build_network_event(&raw).expect("udp connect should build");
+        match event.payload {
+            SensorPayload::Network(fields) => assert_eq!(fields.protocol.as_deref(), Some("udp")),
+            other => panic!("unexpected payload: {:?}", other),
+        }
+
+        raw.sock_type = 1; // SOCK_STREAM
+        let event = build_network_event(&raw).expect("tcp connect should build");
+        match event.payload {
+            SensorPayload::Network(fields) => assert_eq!(fields.protocol.as_deref(), Some("tcp")),
+            other => panic!("unexpected payload: {:?}", other),
+        }
+    }
+
+    #[test]
     fn build_network_event_supports_ipv6() {
         let raw = NetworkEvent {
             pid: 88,
@@ -1150,6 +1201,7 @@ mod tests {
             dport: 8443,
             sport: 5353,
             af: 10,
+            sock_type: 0,
             _pad1: 0,
             daddr: Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0x10).octets(),
             saddr: Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 0x20).octets(),
@@ -1177,6 +1229,7 @@ mod tests {
             dport: 443,
             sport: 0,
             af: 2,
+            sock_type: 0,
             _pad1: 0,
             daddr: [0u8; 16],
             saddr: [0u8; 16],

--- a/src/sensor/linux/events.rs
+++ b/src/sensor/linux/events.rs
@@ -62,6 +62,16 @@ impl ProcessEvent {
     }
 }
 
+/// The kernel did not watch this socket being created, so its type is not
+/// known. Mirrors `SOCK_TYPE_UNKNOWN` in `ebpf/src/events.rs`.
+pub const SOCK_TYPE_UNKNOWN: u8 = 0;
+
+/// `SOCK_STREAM` — TCP for AF_INET and AF_INET6.
+pub const SOCK_STREAM: u8 = 1;
+
+/// `SOCK_DGRAM` — UDP for AF_INET and AF_INET6.
+pub const SOCK_DGRAM: u8 = 2;
+
 /// Outbound connection event. Produced by `handle_connect`
 /// (`syscalls/sys_enter_connect`).
 #[repr(C)]
@@ -78,9 +88,29 @@ pub struct NetworkEvent {
     pub sport: u16,
     /// Address family: 2 = IPv4, 10 = IPv6.
     pub af: u16,
-    pub _pad1: u16,
+    /// Socket type the descriptor was created with: [`SOCK_STREAM`],
+    /// [`SOCK_DGRAM`], another `SOCK_*` value, or [`SOCK_TYPE_UNKNOWN`].
+    pub sock_type: u8,
+    pub _pad1: u8,
     pub daddr: [u8; 16],
     pub saddr: [u8; 16],
+}
+
+impl NetworkEvent {
+    /// Transport name for the Sigma `Protocol` field and ECS
+    /// `network.transport`.
+    ///
+    /// `None` when the socket type was not captured, or names a transport
+    /// this maps no name for. `connect(2)` carries no protocol of its own, so
+    /// the alternative to an absent value is a guess: before the socket type
+    /// was tracked every event was labelled `tcp`, including UDP connects.
+    pub fn transport(&self) -> Option<&'static str> {
+        match self.sock_type {
+            SOCK_STREAM => Some("tcp"),
+            SOCK_DGRAM => Some("udp"),
+            _ => None,
+        }
+    }
 }
 
 /// Bytes captured for one file path, including the NUL terminator.
@@ -178,7 +208,8 @@ const _: () = assert!(
     "ProcessEvent argv fields moved — update ebpf/src/events.rs to match"
 );
 const _: () = assert!(
-    core::mem::size_of::<NetworkEvent>() == 56,
+    core::mem::size_of::<NetworkEvent>() == 56
+        && core::mem::offset_of!(NetworkEvent, sock_type) == 22,
     "NetworkEvent layout changed — update ebpf/src/events.rs to match"
 );
 const _: () = assert!(
@@ -295,7 +326,7 @@ pub mod mapping {
                 image: None,
                 user: Some(event.uid.to_string()),
                 destination_hostname: None,
-                protocol: Some("tcp".to_string()),
+                protocol: event.transport().map(str::to_string),
                 // The probe hooks `connect()` only, so every captured
                 // connection is one this host opened.
                 initiated: Some(true),
@@ -430,6 +461,34 @@ mod tests {
             decoded.kernel_command_line().as_deref(),
             Some("/bin/true --quiet")
         );
+    }
+
+    #[test]
+    fn transport_names_only_the_socket_types_it_knows() {
+        let mut event = NetworkEvent {
+            pid: 42,
+            uid: 1000,
+            fd: 3,
+            _pad0: 0,
+            dport: 53,
+            sport: 0,
+            af: 2,
+            sock_type: SOCK_DGRAM,
+            _pad1: 0,
+            daddr: [0u8; 16],
+            saddr: [0u8; 16],
+        };
+        assert_eq!(event.transport(), Some("udp"));
+
+        event.sock_type = SOCK_STREAM;
+        assert_eq!(event.transport(), Some("tcp"));
+
+        // A socket the sensor never saw created, and a type with no name here,
+        // are both absent rather than guessed as `tcp`.
+        event.sock_type = SOCK_TYPE_UNKNOWN;
+        assert_eq!(event.transport(), None);
+        event.sock_type = 3; // SOCK_RAW
+        assert_eq!(event.transport(), None);
     }
 
     #[test]

--- a/tests/platform_mapping.rs
+++ b/tests/platform_mapping.rs
@@ -72,6 +72,7 @@ fn linux_ebpf_raw_events_map_to_sensor_events() {
         dport: 443,
         sport: 51324,
         af: 2,
+        sock_type: 2,
         _pad1: 0,
         daddr: [0; 16],
         saddr: [0; 16],
@@ -83,6 +84,9 @@ fn linux_ebpf_raw_events_map_to_sensor_events() {
         SensorPayload::Network(fields) => {
             assert_eq!(fields.destination_ip.as_deref(), Some("198.51.100.10"));
             assert_eq!(fields.source_port.as_deref(), Some("51324"));
+            // The hook covers UDP connects too, so the transport comes from
+            // the socket type rather than a fixed `tcp`.
+            assert_eq!(fields.protocol.as_deref(), Some("udp"));
             // The probe hooks `connect()` only, so a captured connection is
             // outbound by construction.
             assert_eq!(fields.initiated, Some(true));


### PR DESCRIPTION
Closes #300.

## Problem

`connect(2)` never names its transport — that was decided when the socket was created — so the Linux sensor labelled every connection `tcp`, even though the hook captures UDP connects too. A rule selecting `Protocol: 'udp'` could never match, and one selecting `'tcp'` matched UDP traffic.

Two paths were affected differently. `mapping::network_event_to_sensor` (the userspace mirror exercised by the cross-platform mapping test) hard-coded `Some("tcp")`. The drain path in `build_network_event` did better — it read the protocol back from `/proc/net/{tcp,tcp6,udp,udp6}` — but that scan runs after the event is drained, answers for whatever the descriptor points at *then*, and costs a full read of `/proc/net/tcp` per connect.

## Fix

The issue's preferred option: read the socket type in the eBPF program.

- `handle_socket` / `handle_socket_exit` watch `socket(2)` and index the socket type by `(pid, fd)`. The type argument is only visible at syscall entry and the descriptor only on return, so the two are joined through a per-thread slot. Only AF_INET and AF_INET6 are indexed — nothing else reaches the connect hook's family filter.
- `handle_connect` reads the type back and puts it in `NetworkEvent::sock_type`.
- Index entries are dropped as soon as their descriptor can name a different socket: on `close`, and on the `dup2`/`dup3` target that is closed implicitly. Those tracepoints already carry the directory-index program, which now invalidates both indexes rather than pay a second tracepoint dispatch on a path as hot as `close`.
- Userspace maps `SOCK_STREAM` → `tcp` and `SOCK_DGRAM` → `udp`. Anything else — a descriptor the sensor never watched being created (opened before startup, inherited across `fork`, received over `SCM_RIGHTS`), or a raw/SCTP socket — reports nothing, so `Protocol` is **absent rather than guessed**. The drain path keeps the `/proc/net` lookup as a fallback, since it is already being read for `SourceIp`/`SourcePort`.

`NetworkEvent` gains `sock_type` in the low half of the old `_pad1`, so the wire layout stays 56 bytes; the size assertion now pins the field's offset too.

## Verification

Built and **live-loaded** on lab-ubuntu (kernel 7.0) — not just compiled, since the BPF verifier only runs at load time. `rustinel capture` recorded:

| connect | `Protocol` |
| --- | --- |
| IPv4 `SOCK_STREAM` | `tcp` |
| IPv4 `SOCK_DGRAM` | `udp` |
| IPv6 `SOCK_STREAM` | `tcp` |
| IPv6 `SOCK_DGRAM` | `udp` |
| UDP socket `dup2`'d over a closed TCP descriptor number, then connected | *absent* (stale entry invalidated — previously would have said `tcp`) |
| socket created before the agent started | `udp` / `tcp` via the `/proc/net` fallback |

`cargo test --release`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo fmt --check` all pass on that box, plus `cargo fmt --check` for `ebpf/`.

## Docs

`docs/limitations.md` drops the "reported as `tcp` on every connection" entry and gains one for the remaining gap: `Protocol` is absent for sockets whose creation the sensor did not observe.