### PR TITLE
fix(linux-ebpf): stop reporting source fields the sensor never measured

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -183,8 +183,11 @@ The Linux sensor covers process, network, file, and DNS.
   `Initiated: 'false'` has nothing to match on Linux — inbound connections are
   absent rather than misreported. Because capture is at syscall entry, failed
   connections are reported as connections, and `SourceIp`/`SourcePort` are not
-  yet assigned ([#299](https://github.com/Karib0u/rustinel/issues/299),
-  [#301](https://github.com/Karib0u/rustinel/issues/301)). `Protocol` is reported
+  yet assigned — they are **reported as absent**, never as `0.0.0.0`/`0`. A
+  `/proc/net` lookup fills them in when it provably describes the same
+  connection, which under happy-eyeballs it usually does not, so most Linux
+  network events carry no source address or port until the two-phase connect
+  capture lands ([#301](https://github.com/Karib0u/rustinel/issues/301)). `Protocol` is reported
   as `tcp` on every event even though the hook also captures UDP connects, so
   a rule selecting `Protocol: 'udp'` never matches and one selecting `'tcp'`
   matches UDP traffic ([#300](https://github.com/Karib0u/rustinel/issues/300)). Only

--- a/src/models/ecs/mod.rs
+++ b/src/models/ecs/mod.rs
@@ -698,6 +698,31 @@ mod tests {
     }
 
     #[test]
+    fn an_absent_source_ip_leaves_related_ip_to_the_destination() {
+        // `related.ip` is a correlation field. A sensor that cannot see the
+        // local address reports none, and nothing may be invented in its
+        // place — a fabricated entry there is indistinguishable from a host
+        // that really used that address.
+        let mut alert = network_alert(Some(true));
+        if let EventFields::NetworkConnection(fields) = &mut alert.event.fields {
+            fields.source_ip = None;
+            fields.source_port = None;
+        }
+
+        let ecs = EcsAlert::from(&alert);
+        assert!(ecs.source_ip.is_none());
+        assert!(ecs.source_port.is_none());
+        assert_eq!(
+            ecs.related_ip,
+            Some(vec!["198.51.100.10".to_string()]),
+            "related.ip should carry the destination alone"
+        );
+        // The type still describes the connection, derived from the address
+        // the sensor actually observed.
+        assert_eq!(ecs.network_type, Some("ipv4".to_string()));
+    }
+
+    #[test]
     fn test_ecs_dns_mapping() {
         let alert = Alert {
             severity: AlertSeverity::Low,

--- a/src/sensor/linux/ebpf.rs
+++ b/src/sensor/linux/ebpf.rs
@@ -11,7 +11,7 @@
 //!
 //! Requirements: Linux 5.8+ with BTF, `CAP_BPF` (or `CAP_SYS_ADMIN`).
 
-use std::net::{Ipv4Addr, Ipv6Addr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::SystemTime;
@@ -31,7 +31,9 @@ use crate::sensor::{
     Platform, ProcessStartKey, Sensor, SensorAction, SensorEvent, SensorNormalization,
     SensorPayload,
 };
-use crate::utils::{lookup_username_by_uid, query_process_details, query_socket_metadata};
+use crate::utils::{
+    lookup_username_by_uid, query_process_details, query_socket_metadata, SocketMetadata,
+};
 
 use super::events::{
     bytes_to_string, parse_event, DnsEvent, FileEvent, FileEventHeader, FileIndexEvent,
@@ -561,19 +563,34 @@ fn build_network_event(ev: &NetworkEvent) -> Option<SensorEvent> {
         _ => return None,
     };
 
-    let socket_metadata = query_socket_metadata(ev.pid, ev.fd);
+    // `/proc` is read after the fact, so it may describe a different socket
+    // than the one this event captured; see `socket_matches_connection`.
+    let socket_metadata = query_socket_metadata(ev.pid, ev.fd)
+        .filter(|value| socket_matches_connection(value, &destination_ip, ev.dport));
     let user = resolved_linux_user(ev.uid);
     let source_ip = source_ip.or_else(|| {
         socket_metadata
             .as_ref()
             .and_then(|value| filter_unspecified_ip(value.source_ip.clone()))
+            // A v4-mapped local address belongs to an IPv4 connection; keeping
+            // the `::ffff:` form would make `network.type` disagree with the
+            // destination it is paired with.
+            .map(|value| match value.parse::<IpAddr>() {
+                Ok(address) => unmap_ipv4(address).to_string(),
+                Err(_) => value,
+            })
     });
     let source_port = if ev.sport > 0 {
         Some(ev.sport.to_string())
     } else {
+        // An unbound socket can still be listed with a local port of 0. That
+        // is a placeholder, not a measurement, so it is dropped like the
+        // unspecified source address above.
         socket_metadata
             .as_ref()
-            .and_then(|value| value.source_port.map(|port| port.to_string()))
+            .and_then(|value| value.source_port)
+            .filter(|port| *port > 0)
+            .map(|port| port.to_string())
     };
 
     Some(SensorEvent {
@@ -743,6 +760,52 @@ fn unix_epoch_nanos(timestamp: SystemTime) -> u64 {
         .duration_since(SystemTime::UNIX_EPOCH)
         .map(|duration| duration.as_nanos() as u64)
         .unwrap_or(0)
+}
+
+/// Does this `/proc/net` entry describe the connection the probe reported?
+///
+/// The metadata is resolved from `/proc/<pid>/fd/<fd>` well after the
+/// `connect()` entry that produced the event. A process that closes and reuses
+/// the descriptor in between — what happy-eyeballs does on every dual-stack
+/// name — hands back a different socket, whose local address and protocol
+/// would then be attributed to this connection. That is the same failure as
+/// reporting an unassigned address: a value nothing downstream can tell apart
+/// from a measured one. Accept the entry only when its remote end is the one
+/// the probe saw.
+fn socket_matches_connection(
+    metadata: &SocketMetadata,
+    destination_ip: &str,
+    destination_port: u16,
+) -> bool {
+    let ip_matches = metadata
+        .destination_ip
+        .as_deref()
+        .is_none_or(|value| same_ip(value, destination_ip));
+    let port_matches = metadata
+        .destination_port
+        .is_none_or(|value| value == destination_port);
+    ip_matches && port_matches
+}
+
+/// Compare two addresses, treating an IPv4-mapped form as its IPv4 address.
+///
+/// A dual-stack socket reaching an IPv4 peer is listed in `/proc/net/tcp6` as
+/// `::ffff:a.b.c.d`, while the probe read `a.b.c.d` out of the `sockaddr`.
+/// They are the same peer.
+fn same_ip(left: &str, right: &str) -> bool {
+    match (left.parse::<IpAddr>(), right.parse::<IpAddr>()) {
+        (Ok(left), Ok(right)) => unmap_ipv4(left) == unmap_ipv4(right),
+        _ => left == right,
+    }
+}
+
+fn unmap_ipv4(ip: IpAddr) -> IpAddr {
+    match ip {
+        IpAddr::V6(address) => address
+            .to_ipv4_mapped()
+            .map_or(IpAddr::V6(address), IpAddr::V4),
+        address => address,
+    }
 }
 
 fn filter_unspecified_ip(value: Option<String>) -> Option<String> {
@@ -1134,6 +1197,7 @@ mod tests {
             SensorPayload::Network(fields) => {
                 assert_eq!(fields.destination_ip.as_deref(), Some("198.51.100.10"));
                 assert!(fields.source_ip.is_none());
+                assert!(fields.source_port.is_none());
                 assert!(fields.protocol.is_none());
             }
             other => panic!("unexpected payload: {:?}", other),
@@ -1165,6 +1229,39 @@ mod tests {
             }
             other => panic!("unexpected payload: {:?}", other),
         }
+    }
+
+    #[test]
+    fn socket_metadata_from_a_reused_descriptor_is_rejected() {
+        // Happy-eyeballs closes the losing socket and the descriptor comes
+        // back for the next attempt, so a late `/proc` read can describe a
+        // connection to a different peer entirely.
+        let reused = SocketMetadata {
+            source_ip: Some("2001:db8::20".to_string()),
+            source_port: Some(41406),
+            destination_ip: Some("2606:4700:10::6814:179a".to_string()),
+            destination_port: Some(443),
+            protocol: Some("tcp".to_string()),
+        };
+        assert!(!socket_matches_connection(&reused, "198.51.100.10", 443));
+
+        let same_peer = SocketMetadata {
+            destination_ip: Some("198.51.100.10".to_string()),
+            ..reused.clone()
+        };
+        assert!(socket_matches_connection(&same_peer, "198.51.100.10", 443));
+
+        // The same host on another port is another connection.
+        assert!(!socket_matches_connection(&same_peer, "198.51.100.10", 80));
+
+        // A dual-stack socket lists an IPv4 peer in v4-mapped form. It is the
+        // same connection, and rejecting it would throw away good data.
+        let dual_stack = SocketMetadata {
+            source_ip: Some("::ffff:192.168.1.27".to_string()),
+            destination_ip: Some("::ffff:198.51.100.10".to_string()),
+            ..reused
+        };
+        assert!(socket_matches_connection(&dual_stack, "198.51.100.10", 443));
     }
 
     #[test]

--- a/src/sensor/linux/events.rs
+++ b/src/sensor/linux/events.rs
@@ -74,12 +74,15 @@ pub struct NetworkEvent {
     pub _pad0: u32,
     /// Destination port in host byte order.
     pub dport: u16,
-    /// Source port (may be 0).
+    /// Source port. Zero until the kernel binds the socket, which has not
+    /// happened yet at `connect()` entry.
     pub sport: u16,
     /// Address family: 2 = IPv4, 10 = IPv6.
     pub af: u16,
     pub _pad1: u16,
     pub daddr: [u8; 16],
+    /// Source address. Unspecified (all zero) until the socket is bound; see
+    /// [`sport`](Self::sport).
     pub saddr: [u8; 16],
 }
 
@@ -216,7 +219,7 @@ pub fn bytes_to_string(buf: &[u8]) -> String {
 #[cfg(target_os = "linux")]
 #[allow(dead_code)]
 pub mod mapping {
-    use std::net::{Ipv4Addr, Ipv6Addr};
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
     use std::time::SystemTime;
 
     use crate::models::{
@@ -288,9 +291,13 @@ pub mod mapping {
             process_start_key: None,
             payload: SensorPayload::Network(NetworkConnectionFields {
                 destination_ip: Some(ip_to_string(event.af, &event.daddr)),
-                source_ip: Some(ip_to_string(event.af, &event.saddr)),
+                // The probe fires at `connect()` entry, before the kernel
+                // binds the socket, so both source fields arrive zeroed.
+                // Stringifying them would publish `0.0.0.0`/`0` as if they
+                // had been measured; absent is the honest answer.
+                source_ip: source_ip_to_string(event.af, &event.saddr),
                 destination_port: Some(event.dport.to_string()),
-                source_port: Some(event.sport.to_string()),
+                source_port: (event.sport > 0).then(|| event.sport.to_string()),
                 process_id: Some(event.pid.to_string()),
                 image: None,
                 user: Some(event.uid.to_string()),
@@ -383,6 +390,20 @@ pub mod mapping {
             10 => Ipv6Addr::from(*bytes).to_string(),
             _ => Ipv4Addr::new(bytes[0], bytes[1], bytes[2], bytes[3]).to_string(),
         }
+    }
+
+    /// Source address, or `None` when the kernel has not assigned one.
+    ///
+    /// An unspecified address (`0.0.0.0` / `::`) is the placeholder the socket
+    /// carries before it is bound, never a real local address for an outbound
+    /// connection. Emitting it would be indistinguishable downstream from a
+    /// measured value.
+    fn source_ip_to_string(af: u16, bytes: &[u8; 16]) -> Option<String> {
+        let ip = match af {
+            10 => IpAddr::V6(Ipv6Addr::from(*bytes)),
+            _ => IpAddr::V4(Ipv4Addr::new(bytes[0], bytes[1], bytes[2], bytes[3])),
+        };
+        (!ip.is_unspecified()).then(|| ip.to_string())
     }
 }
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -30,7 +30,7 @@ pub use process::{
     validate_process_identity, ProcessIdentity,
 };
 #[cfg(target_os = "linux")]
-pub use socket::query_socket_metadata;
+pub use socket::{query_socket_metadata, SocketMetadata};
 pub use time::now_timestamp_string;
 #[cfg(windows)]
 pub use user::lookup_account_sid;

--- a/tests/platform_mapping.rs
+++ b/tests/platform_mapping.rs
@@ -82,11 +82,35 @@ fn linux_ebpf_raw_events_map_to_sensor_events() {
     match mapped.payload {
         SensorPayload::Network(fields) => {
             assert_eq!(fields.destination_ip.as_deref(), Some("198.51.100.10"));
+            assert_eq!(fields.source_ip.as_deref(), Some("10.0.0.5"));
             assert_eq!(fields.source_port.as_deref(), Some("51324"));
             // The probe hooks `connect()` only, so a captured connection is
             // outbound by construction.
             assert_eq!(fields.initiated, Some(true));
         }
+        _ => panic!("expected network payload"),
+    }
+
+    // What the probe actually delivers today: `connect()` entry runs before
+    // the socket is bound, so the source address and port arrive zeroed. They
+    // must be reported as absent, not as `0.0.0.0` and `0`.
+    network.sport = 0;
+    network.saddr = [0; 16];
+    let mapped = mapping::network_event_to_sensor(&network);
+    match mapped.payload {
+        SensorPayload::Network(fields) => {
+            assert_eq!(fields.destination_ip.as_deref(), Some("198.51.100.10"));
+            assert!(fields.source_ip.is_none());
+            assert!(fields.source_port.is_none());
+        }
+        _ => panic!("expected network payload"),
+    }
+
+    // Same for IPv6, where the unassigned address is `::`.
+    network.af = 10;
+    let mapped = mapping::network_event_to_sensor(&network);
+    match mapped.payload {
+        SensorPayload::Network(fields) => assert!(fields.source_ip.is_none()),
         _ => panic!("expected network payload"),
     }
 


### PR DESCRIPTION
Closes #299.

## The reported bug

`ebpf/src/network.rs` captures at `sys_enter_connect`, before the kernel binds the socket, so `saddr` and `sport` arrive zeroed. `mapping::network_event_to_sensor` stringified both unconditionally, publishing `0.0.0.0` and `0` as though they had been measured. `ecs.source_ip` is pushed into `related.ip`, so an alert taking that path carried a fabricated address in a correlation field.

Fixed as the issue proposed: an unspecified address and a zero port are now `None`.

## What validating it turned up

Running the built sensor on lab-ubuntu showed the live path (`build_network_event`) already dropped the unspecified address — but it fills the gap from `/proc/net`, and that lookup is resolved from `/proc/<pid>/fd/<fd>` well after the event. A process that closes and reuses the descriptor in between — what happy-eyeballs does on every dual-stack name — hands back a **different socket**, whose local address and protocol were then attributed to this connection.

In a `curl` run over 27 network alerts, **10 of the 25 populated sources came from another socket**, and those are only the ones detectable by an address family disagreeing with the destination:

```
MISMATCH 2a01:cb08:9431:2300:be24:11ff:fe52:be05 -> 172.66.147.243   network.type: ipv6
MISMATCH 2a01:cb08:9431:2300:be24:11ff:fe52:be05 -> 142.251.155.119  network.type: ipv6
... 8 more
```

That is the same defect the issue is about, in a worse form: a plausible address nothing downstream can tell apart from a measured one, poisoning `related.ip` and `network.type` exactly as `0.0.0.0` did. So `/proc` metadata is now accepted only when its remote end matches the connection the probe reported, comparing v4-mapped forms by their IPv4 address so a dual-stack socket reaching an IPv4 peer still matches. A zero local port from the same fallback is dropped for the same reason as the unspecified address.

## Measured, same workload

| | before | after |
|---|---|---|
| network alerts | 27 | 27 |
| source present | 25 | 6 |
| source from another socket (family mismatch) | 10 | 0 |
| `0.0.0.0` anywhere in output | — | none |
| `source.port` of 0 | — | none |

Source enrichment coverage drops from 25/27 to 6/27. That is the point: every rejected entry was a socket pointing at a different peer, so most of the old coverage was wrong. #301's two-phase connect capture is what restores the real values from the kernel.

## Changes

- `src/sensor/linux/events.rs` — `mapping::network_event_to_sensor` emits `None` for an unspecified source address and a zero source port; the `NetworkEvent` field docs now say why both arrive zeroed.
- `src/sensor/linux/ebpf.rs` — `socket_matches_connection` gates the `/proc` fallback on the remote end matching; v4-mapped comparison and normalization; zero port from the fallback dropped.
- `src/utils/mod.rs` — export `SocketMetadata` (Linux only).
- `docs/limitations.md` — the Linux network section now states that source fields are absent rather than zeroed, and why the `/proc` fill-in usually declines.

## Tests

- `mapping::network_event_to_sensor` asserted for the zeroed IPv4 and IPv6 cases (`tests/platform_mapping.rs`).
- `socket_metadata_from_a_reused_descriptor_is_rejected` covers the reused-descriptor, same-peer, wrong-port and dual-stack cases.
- `build_network_event_omits_zero_source_and_protocol_guessing` now also asserts the port is absent.
- ECS: `an_absent_source_ip_leaves_related_ip_to_the_destination` guards the `related.ip` criterion.

`cargo clippy --all-targets --all-features` clean and 476 tests passing on lab-ubuntu (Linux, the only target that compiles this code); 315 lib tests and clippy clean on macOS. Live sensor run performed as root on lab-ubuntu with a probe Sigma rule on `DestinationPort: 443` (rule not committed).