### PR TITLE
fix(linux-ebpf): emit connections at connect() exit, not entry

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -179,13 +179,17 @@ The Linux sensor covers process, network, file, and DNS.
 - **Network is outbound `connect()` only.** No inbound or `accept()` visibility,
   so every event carries `Initiated: true` and a rule selecting
   `Initiated: 'false'` has nothing to match on Linux — inbound connections are
-  absent rather than misreported. Because capture is at syscall entry, failed
-  connections are reported as connections, and `SourceIp`/`SourcePort` are not
-  yet assigned — they are **reported as absent**, never as `0.0.0.0`/`0`. A
-  `/proc/net` lookup fills them in when it provably describes the same
-  connection, which under happy-eyeballs it usually does not, so most Linux
-  network events carry no source address or port until the two-phase connect
-  capture lands ([#301](https://github.com/Karib0u/rustinel/issues/301)). Only
+  absent rather than misreported. Capture is split across syscall entry and
+  exit, so a `connect()` that is refused, unreachable, or times out is dropped
+  instead of being reported as a connection. A non-blocking connect is the
+  exception: it returns `EINPROGRESS` immediately and its outcome is delivered
+  on the socket long after the syscall returns, so it is reported when the
+  attempt starts and a later asynchronous failure is not retracted.
+  `SourceIp`/`SourcePort` are **reported as absent**, never as `0.0.0.0`/`0`:
+  the syscall never carries them and the probe does not read the bound address
+  back out of the socket. A `/proc/net` lookup fills them in when it provably
+  describes the same connection, which under happy-eyeballs it usually does
+  not, so most Linux network events carry no source address or port. Only
   AF_INET and AF_INET6.
 - **`Protocol` is absent for sockets created before the sensor started.** The
   transport comes from the type the socket was created with, so `socket(2)` is

--- a/ebpf/src/events.rs
+++ b/ebpf/src/events.rs
@@ -50,6 +50,36 @@ pub struct ProcessEvent {
     pub args: [u8; ARGV_CAPACITY],
 }
 
+/// `connect(2)` succeeded — the connection is established.
+pub const CONNECT_RESULT_OK: i32 = 0;
+
+/// `-EINPROGRESS`: a non-blocking `connect(2)` has been started and the
+/// handshake is under way. Every asynchronous client returns this, so it must
+/// count as a connection.
+pub const CONNECT_RESULT_EINPROGRESS: i32 = -115;
+
+/// `-EINTR`: a signal interrupted the wait. The kernel completes the connect
+/// in the background, so this is an attempt that was made, not one that
+/// failed.
+pub const CONNECT_RESULT_EINTR: i32 = -4;
+
+/// Whether a `connect(2)` return value describes a connection that was
+/// established or is under way.
+///
+/// Everything else — `ECONNREFUSED`, `EHOSTUNREACH`, `ETIMEDOUT`,
+/// `ENETUNREACH`, and the rest — is a failed attempt and is not a connection.
+/// `EALREADY` and `EISCONN` are excluded for a different reason: they report a
+/// connect that an earlier call already emitted.
+///
+/// **Mirrored in `src/sensor/linux/events.rs`** — keep both copies in step.
+#[inline(always)]
+pub fn connect_result_is_connection(result: i32) -> bool {
+    matches!(
+        result,
+        CONNECT_RESULT_OK | CONNECT_RESULT_EINPROGRESS | CONNECT_RESULT_EINTR
+    )
+}
+
 /// The sensor did not watch this socket being created, so its type is not
 /// known. Userspace reports no `Protocol` rather than guessing one.
 pub const SOCK_TYPE_UNKNOWN: u8 = 0;
@@ -60,8 +90,9 @@ pub const SOCK_STREAM: u8 = 1;
 /// `SOCK_DGRAM` — UDP for AF_INET and AF_INET6.
 pub const SOCK_DGRAM: u8 = 2;
 
-/// Outbound connection event. Emitted by `handle_connect` on
-/// `syscalls/sys_enter_connect`.
+/// Outbound connection event. Queued by `handle_connect` on
+/// `syscalls/sys_enter_connect` and emitted by `handle_connect_exit` on
+/// `syscalls/sys_exit_connect`, which drops attempts that never connected.
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NetworkEvent {
@@ -71,7 +102,10 @@ pub struct NetworkEvent {
     pub uid: u32,
     /// Socket file descriptor supplied to `connect(2)`.
     pub fd: i32,
-    pub _pad0: u32,
+    /// `connect(2)` return value: 0, or the negative errno of a connect that
+    /// is still under way. Failed attempts are never emitted, so this is
+    /// always one of the values [`connect_result_is_connection`] accepts.
+    pub ret: i32,
     /// Destination port in **host** byte order.
     pub dport: u16,
     /// Source port (best-effort; may be 0 before bind completes).

--- a/ebpf/src/main.rs
+++ b/ebpf/src/main.rs
@@ -10,7 +10,8 @@
 //! | `handle_exit`         | `sched/sched_process_exit`  | cache cleanup   |
 //! | `handle_execve`       | `syscalls/sys_enter_execve` | capture argv    |
 //! | `handle_execveat`     | `syscalls/sys_enter_execveat`| capture argv   |
-//! | `handle_connect`      | `syscalls/sys_enter_connect`| Event 3         |
+//! | `handle_connect`      | `syscalls/sys_enter_connect`| queue Event 3   |
+//! | `handle_connect_exit` | `syscalls/sys_exit_connect` | emit Event 3    |
 //! | `handle_socket`       | `syscalls/sys_enter_socket` | capture type    |
 //! | `handle_socket_exit`  | `syscalls/sys_exit_socket`  | index fd type   |
 //! | `handle_openat`       | `syscalls/sys_enter_openat` | queue Event 11  |

--- a/ebpf/src/network.rs
+++ b/ebpf/src/network.rs
@@ -1,10 +1,18 @@
 //! Network connection eBPF programs.
 //!
-//! `handle_connect` attaches to `syscalls/sys_enter_connect`. It fires when a
-//! process calls `connect(2)`, covering both TCP and UDP outbound connections.
-//! Reading the sockaddr at the syscall entry point gives us the destination
-//! before the kernel acts on it, while still running in full task context so
-//! `bpf_get_current_pid_tgid()` is valid.
+//! A `connect(2)` is captured across `syscalls/sys_enter_connect` and
+//! `syscalls/sys_exit_connect`, because neither point alone can describe the
+//! event. The destination sockaddr lives in user memory that is only
+//! guaranteed readable while the syscall is on its way in, so entry is where
+//! it has to be read; entry also runs in full task context, so
+//! `bpf_get_current_pid_tgid()` is valid. Whether a connection was made is
+//! only known at exit — hooking entry alone reports `ECONNREFUSED`,
+//! `EHOSTUNREACH`, and `ETIMEDOUT` as connections.
+//!
+//! `handle_connect` therefore stashes the candidate in a per-thread map and
+//! `handle_connect_exit` emits it only when the return value says a connection
+//! was established or is under way. Everything else is dropped in the kernel,
+//! so a failed attempt never reaches the ring buffer, let alone a rule.
 //!
 //! `connect(2)` itself never says which transport it speaks — that was decided
 //! when the socket was created. So `socket(2)` is watched as well and the type
@@ -34,6 +42,9 @@
 //!   offset 24: uservaddr           (u64 — pointer to user-space sockaddr)
 //!   offset 32: addrlen             (i32)
 //!
+//! sys_exit_connect tracepoint format (same header):
+//!   offset 16: ret                 (i64)
+//!
 //! sys_enter_socket tracepoint format (same header):
 //!   offset 16: family              (i64)
 //!   offset 24: type                (i64 — socket type OR'd with SOCK_* flags)
@@ -49,7 +60,7 @@ use aya_ebpf::{
     programs::TracePointContext,
 };
 
-use crate::events::{NetworkEvent, SOCK_TYPE_UNKNOWN};
+use crate::events::{connect_result_is_connection, NetworkEvent, SOCK_TYPE_UNKNOWN};
 
 /// AF_INET (IPv4).
 const AF_INET: u16 = 2;
@@ -101,10 +112,26 @@ static SOCKET_PENDING: HashMap<u32, u8> = HashMap::with_max_entries(16_384, 0);
 #[map]
 static SOCKET_TYPES: LruHashMap<u64, u8> = LruHashMap::with_max_entries(16_384, 0);
 
-/// Tracepoint handler for `syscalls/sys_enter_connect`.
+/// Connect candidate a thread is currently inside, keyed by TID.
+///
+/// A thread is inside exactly one `connect(2)` at a time, so one slot per
+/// thread is enough to carry the event from entry to exit. At 56 bytes per
+/// entry this map costs well under a megabyte of kernel memory.
+#[map]
+static NETWORK_PENDING: HashMap<u32, NetworkEvent> = HashMap::with_max_entries(16_384, 0);
+
+/// Tracepoint handler for `syscalls/sys_enter_connect`, where the destination
+/// is still readable.
 #[tracepoint]
 pub fn handle_connect(ctx: TracePointContext) -> u32 {
     unsafe { try_handle_connect(&ctx) }.unwrap_or(1)
+}
+
+/// Tracepoint handler for `syscalls/sys_exit_connect`, where the outcome of
+/// the attempt is finally known.
+#[tracepoint]
+pub fn handle_connect_exit(ctx: TracePointContext) -> u32 {
+    unsafe { try_handle_connect_exit(&ctx) }.unwrap_or(1)
 }
 
 /// Tracepoint handler for `syscalls/sys_enter_socket`, where the socket type
@@ -183,7 +210,15 @@ unsafe fn try_handle_socket_exit(ctx: &TracePointContext) -> Result<u32, i64> {
 #[inline(always)]
 unsafe fn try_handle_connect(ctx: &TracePointContext) -> Result<u32, i64> {
     // pid_tgid: high 32 bits = TGID (POSIX PID), low 32 bits = kernel thread ID.
-    let pid = (bpf_get_current_pid_tgid() >> 32) as u32;
+    let pid_tgid = bpf_get_current_pid_tgid();
+    let pid = (pid_tgid >> 32) as u32;
+    let tid = pid_tgid as u32;
+
+    // A thread cannot be inside two syscalls at once, so anything still
+    // pending belongs to a connect whose exit never ran — a task killed
+    // mid-syscall. Drop it before this syscall's exit can emit it.
+    let _ = NETWORK_PENDING.remove(&tid);
+
     let uid = bpf_get_current_uid_gid() as u32;
     let fd = ctx.read_at::<i64>(16)? as i32;
 
@@ -198,7 +233,6 @@ unsafe fn try_handle_connect(ctx: &TracePointContext) -> Result<u32, i64> {
 
     let mut daddr = [0u8; 16];
     let dport: u16;
-    let sport: u16 = 0; // source port not yet assigned at connect() entry
 
     match family {
         AF_INET => {
@@ -225,20 +259,46 @@ unsafe fn try_handle_connect(ctx: &TracePointContext) -> Result<u32, i64> {
         None => SOCK_TYPE_UNKNOWN,
     };
 
+    let event = NetworkEvent {
+        pid,
+        uid,
+        fd,
+        // Filled in by the exit handler, which is the only place the outcome
+        // is known.
+        ret: 0,
+        dport,
+        // Source address and port are still unassigned here and are not read
+        // back at exit either; userspace fills them from the socket.
+        sport: 0,
+        af: family,
+        sock_type,
+        _pad1: 0,
+        daddr,
+        saddr: [0u8; 16],
+    };
+    let _ = NETWORK_PENDING.insert(&tid, &event, 0);
+
+    Ok(0)
+}
+
+#[inline(always)]
+unsafe fn try_handle_connect_exit(ctx: &TracePointContext) -> Result<u32, i64> {
+    let ret = ctx.read_at::<i64>(16)? as i32;
+    let tid = bpf_get_current_pid_tgid() as u32;
+
+    let Some(pending) = NETWORK_PENDING.get(&tid) else {
+        return Ok(0);
+    };
+    let mut event = *pending;
+    let _ = NETWORK_PENDING.remove(&tid);
+
+    if !connect_result_is_connection(ret) {
+        return Ok(0);
+    }
+    event.ret = ret;
+
     if let Some(mut entry) = NETWORK_RING.reserve::<NetworkEvent>(0) {
-        entry.write(NetworkEvent {
-            pid,
-            uid,
-            fd,
-            _pad0: 0,
-            dport,
-            sport,
-            af: family,
-            sock_type,
-            _pad1: 0,
-            daddr,
-            saddr: [0u8; 16],
-        });
+        entry.write(event);
         entry.submit(0);
     }
 

--- a/src/sensor/linux/ebpf.rs
+++ b/src/sensor/linux/ebpf.rs
@@ -36,8 +36,8 @@ use crate::utils::{
 };
 
 use super::events::{
-    bytes_to_string, parse_event, DnsEvent, FileEvent, FileEventHeader, FileIndexEvent,
-    NetworkEvent, ProcessEvent,
+    bytes_to_string, connect_result_is_connection, parse_event, DnsEvent, FileEvent,
+    FileEventHeader, FileIndexEvent, NetworkEvent, ProcessEvent,
 };
 use super::paths::{resolve_at_path, resolve_indexable_dir_path, truncation_marker, DirFdIndex};
 
@@ -120,7 +120,15 @@ impl Sensor for EbpfSensor {
             "syscalls",
             "sys_enter_execveat",
         )?;
+        // Entry captures the destination while the sockaddr is still readable;
+        // exit is what decides whether the attempt became a connection.
         attach_tracepoint(&mut bpf, "handle_connect", "syscalls", "sys_enter_connect")?;
+        attach_tracepoint(
+            &mut bpf,
+            "handle_connect_exit",
+            "syscalls",
+            "sys_exit_connect",
+        )?;
         // `connect()` does not name its transport; the socket type is only
         // visible while `socket()` runs, and its descriptor only on return.
         attach_tracepoint(&mut bpf, "handle_socket", "syscalls", "sys_enter_socket")?;
@@ -536,6 +544,13 @@ fn build_process_event(ev: &ProcessEvent) -> Option<SensorEvent> {
 }
 
 fn build_network_event(ev: &NetworkEvent) -> Option<SensorEvent> {
+    // The kernel emits only attempts that connected, so this rejects nothing
+    // in practice. It is the decode-side half of that contract: a refused or
+    // unreachable destination is an attempt, not a connection, and a rule
+    // matching "connection to suspicious IP" must not fire on one.
+    if !connect_result_is_connection(ev.ret) {
+        return None;
+    }
     if ev.dport == 0 {
         return None;
     }
@@ -1198,7 +1213,7 @@ mod tests {
             pid: 77,
             uid: 1000,
             fd: -1,
-            _pad0: 0,
+            ret: 0,
             dport: 443,
             sport: 0,
             af: 2,
@@ -1231,7 +1246,7 @@ mod tests {
             // A closed descriptor, so `/proc/net` cannot supply a protocol and
             // only the kernel-side socket type can answer.
             fd: -1,
-            _pad0: 0,
+            ret: 0,
             dport: 53,
             sport: 0,
             af: 2,
@@ -1261,7 +1276,7 @@ mod tests {
             pid: 88,
             uid: 1000,
             fd: -1,
-            _pad0: 0,
+            ret: 0,
             dport: 8443,
             sport: 5353,
             af: 10,
@@ -1317,12 +1332,75 @@ mod tests {
     }
 
     #[test]
+    fn build_network_event_drops_failed_connect_attempts() {
+        let mut daddr = [0u8; 16];
+        daddr[..4].copy_from_slice(&[198, 51, 100, 10]);
+
+        // -ECONNREFUSED, -EHOSTUNREACH, -ETIMEDOUT: an attempt was made, no
+        // connection was established.
+        for result in [-111, -113, -110] {
+            let raw = NetworkEvent {
+                pid: 77,
+                uid: 1000,
+                fd: -1,
+                ret: result,
+                dport: 443,
+                sport: 0,
+                af: 2,
+                sock_type: 0,
+                _pad1: 0,
+                daddr,
+                saddr: [0u8; 16],
+            };
+
+            assert!(
+                build_network_event(&raw).is_none(),
+                "connect() returning {result} is not a connection"
+            );
+        }
+    }
+
+    #[test]
+    fn build_network_event_keeps_connects_still_in_progress() {
+        let mut daddr = [0u8; 16];
+        daddr[..4].copy_from_slice(&[198, 51, 100, 10]);
+
+        // -EINPROGRESS is how every non-blocking client starts a connection,
+        // and -EINTR leaves the kernel completing one in the background.
+        for result in [0, -115, -4] {
+            let raw = NetworkEvent {
+                pid: 77,
+                uid: 1000,
+                fd: -1,
+                ret: result,
+                dport: 443,
+                sport: 0,
+                af: 2,
+                sock_type: 0,
+                _pad1: 0,
+                daddr,
+                saddr: [0u8; 16],
+            };
+
+            let event = build_network_event(&raw)
+                .unwrap_or_else(|| panic!("connect() returning {result} is a connection"));
+            match event.payload {
+                SensorPayload::Network(fields) => {
+                    assert_eq!(fields.destination_ip.as_deref(), Some("198.51.100.10"));
+                    assert_eq!(fields.initiated, Some(true));
+                }
+                other => panic!("unexpected payload: {:?}", other),
+            }
+        }
+    }
+
+    #[test]
     fn build_network_event_rejects_unspecified_destination() {
         let raw = NetworkEvent {
             pid: 77,
             uid: 1000,
             fd: -1,
-            _pad0: 0,
+            ret: 0,
             dport: 443,
             sport: 0,
             af: 2,

--- a/src/sensor/linux/events.rs
+++ b/src/sensor/linux/events.rs
@@ -62,6 +62,32 @@ impl ProcessEvent {
     }
 }
 
+/// `connect(2)` succeeded — the connection is established.
+pub const CONNECT_RESULT_OK: i32 = 0;
+
+/// `-EINPROGRESS`: a non-blocking `connect(2)` is under way.
+pub const CONNECT_RESULT_EINPROGRESS: i32 = -115;
+
+/// `-EINTR`: a signal interrupted the wait; the kernel completes the connect
+/// in the background.
+pub const CONNECT_RESULT_EINTR: i32 = -4;
+
+/// Whether a `connect(2)` return value describes a connection that was
+/// established or is under way.
+///
+/// **Mirrors `connect_result_is_connection` in `ebpf/src/events.rs`.** The
+/// kernel already drops everything this rejects, so the check here is the
+/// decode-side half of the same contract: an event that reaches userspace
+/// carrying a failure code did not come from the emit path this file
+/// describes, and reporting it as a connection is exactly the defect
+/// [#301](https://github.com/Karib0u/rustinel/issues/301) fixed.
+pub fn connect_result_is_connection(result: i32) -> bool {
+    matches!(
+        result,
+        CONNECT_RESULT_OK | CONNECT_RESULT_EINPROGRESS | CONNECT_RESULT_EINTR
+    )
+}
+
 /// The kernel did not watch this socket being created, so its type is not
 /// known. Mirrors `SOCK_TYPE_UNKNOWN` in `ebpf/src/events.rs`.
 pub const SOCK_TYPE_UNKNOWN: u8 = 0;
@@ -72,8 +98,9 @@ pub const SOCK_STREAM: u8 = 1;
 /// `SOCK_DGRAM` — UDP for AF_INET and AF_INET6.
 pub const SOCK_DGRAM: u8 = 2;
 
-/// Outbound connection event. Produced by `handle_connect`
-/// (`syscalls/sys_enter_connect`).
+/// Outbound connection event. Produced by `handle_connect_exit`
+/// (`syscalls/sys_exit_connect`), which emits only the attempts that
+/// connected.
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NetworkEvent {
@@ -81,7 +108,9 @@ pub struct NetworkEvent {
     pub uid: u32,
     /// Connected socket file descriptor.
     pub fd: i32,
-    pub _pad0: u32,
+    /// `connect(2)` return value — always one of the values
+    /// [`connect_result_is_connection`] accepts.
+    pub ret: i32,
     /// Destination port in host byte order.
     pub dport: u16,
     /// Source port. Zero until the kernel binds the socket, which has not
@@ -210,8 +239,13 @@ const _: () = assert!(
         && core::mem::offset_of!(ProcessEvent, args) == 168,
     "ProcessEvent argv fields moved — update ebpf/src/events.rs to match"
 );
+// `ret` and `sock_type` took over slots that used to be explicit padding, so a
+// stale copy of either side would decode zeros there and pass every event off
+// as a successful connect of unknown transport. Pin both offsets so that fails
+// the build instead.
 const _: () = assert!(
     core::mem::size_of::<NetworkEvent>() == 56
+        && core::mem::offset_of!(NetworkEvent, ret) == 12
         && core::mem::offset_of!(NetworkEvent, sock_type) == 22,
     "NetworkEvent layout changed — update ebpf/src/events.rs to match"
 );
@@ -490,7 +524,7 @@ mod tests {
             pid: 42,
             uid: 1000,
             fd: 3,
-            _pad0: 0,
+            ret: 0,
             dport: 53,
             sport: 0,
             af: 2,

--- a/tests/platform_mapping.rs
+++ b/tests/platform_mapping.rs
@@ -68,7 +68,7 @@ fn linux_ebpf_raw_events_map_to_sensor_events() {
         pid: 42,
         uid: 1000,
         fd: 3,
-        _pad0: 0,
+        ret: 0,
         dport: 443,
         sport: 51324,
         af: 2,


### PR DESCRIPTION
## Summary

Closes #301.

The Linux network hook attached to `syscalls/sys_enter_connect` only, so the
return value of `connect(2)` was never observed and `ECONNREFUSED`,
`EHOSTUNREACH`, and `ETIMEDOUT` were all reported as connections. Every Linux
`network_connection` rule was inflated with attempts that never completed — a
rule matching "connection to suspicious IP" fired on a refused attempt.

Capture is now split the way the file hooks already are:

- **entry** reads the destination sockaddr — only guaranteed readable while the
  syscall is on its way in — and stashes the candidate in a per-thread map
  (`NETWORK_PENDING`, keyed by TID, same shape as `FILE_PENDING`);
- **exit** reads the return value and emits only when it says a connection was
  established or is under way: `0`, `EINPROGRESS`, `EINTR`. Everything else is
  dropped in the kernel, so a failed attempt never reaches the ring buffer.
  `EALREADY` and `EISCONN` are dropped for a different reason — they report a
  connect an earlier call already emitted.

The return value rides in the slot that used to be explicit padding
(`_pad0` → `ret`), so `NetworkEvent` keeps its 56-byte layout; the offset is
pinned by a compile-time assertion so a half-updated mirror fails the build
instead of decoding every event as a success. `build_network_event` holds the
same contract on decode.

Scope is kept to the acceptance criteria: failed attempts are dropped, not
re-emitted under a distinct action. `SourceIp`/`SourcePort` are untouched —
reaching exit does not by itself hand the probe the bound address, and reading
it out of the socket needs a hook on the socket struct (CO-RE on `inet_sock`),
which this crate has no bindings for. That is worth its own change; #401's
match-validated `/proc/net` enrichment stands until then, and the limitations
doc now says so plainly instead of pointing at this issue.

### Known limit, now documented

A **non-blocking** connect returns `EINPROGRESS` immediately and its outcome is
delivered on the socket long after the syscall returns, so it is reported when
the attempt starts and a later asynchronous failure is not retracted. Seeing
that would need a hook on the socket state change, not the syscall.
`docs/limitations.md` now says so.

## Type of change
- [x] `bug` - bug fix

## Test plan
- [ ] Tested on Windows <!-- not applicable: Linux eBPF only -->
- [x] Tested on Linux
- [x] Existing tests pass (`cargo test`)
- [x] New tests added (if applicable)

**Unit** — `build_network_event_drops_failed_connect_attempts`
(-ECONNREFUSED / -EHOSTUNREACH / -ETIMEDOUT → no event) and
`build_network_event_keeps_connects_still_in_progress`
(0 / -EINPROGRESS / -EINTR → event). Full suite green on Linux
(`cargo test --locked --all-targets`, 353 lib + all integration tests),
`cargo clippy --all-targets --all-features -D warnings` and `cargo fmt --check`
clean.

**Live, on a kernel 7.0 VM** — the eBPF object loads and both programs attach
(the verifier accepts them; CI only compiles the object, it never loads it).
`rustinel capture`, 5 blocking connects to an open port and 5 to a closed one:

| Destination | `connect(2)` | Before | After |
| --- | --- | --- | --- |
| `192.168.1.27:22` (open) | connected | 5 events | **5 events** |
| `192.168.1.27:9` (closed) | `ECONNREFUSED` | **5 events** | **0 events** |

A second run covering the non-blocking path (open and closed destinations, 3
each) emitted 3 and 3 — the documented `EINPROGRESS` behaviour, and the check
that the fix does not silently drop the way every asynchronous client connects.

**Rebased onto #400 and #401**, which landed on the same hook. `NetworkEvent` now
carries both new fields in what used to be padding (`ret` at 12, `sock_type` at
22) and stays 56 bytes; the socket-type lookup happens at entry and rides in the
pending slot. Rebuilt, re-tested, and re-run live on the merged code — both
programs attach, and the transport survives the new exit path:

| Call | Outcome | Events | `Protocol` |
| --- | --- | --- | --- |
| blocking TCP → `:22` | connected | 5 | `tcp` |
| blocking TCP → `:9` | `ECONNREFUSED` | **0** | — |
| non-blocking TCP → `:12345` | `EINPROGRESS` | 3 | `tcp` |
| UDP `connect` → `:5353` | returns 0 | 3 | `udp` |

(Re-run once more after the #401 rebase, with the same counts; the short-lived
test sockets carry no `SourceIp`/`SourcePort`, which is #401's behaviour.)

## Checklist
- [ ] Label added to this PR
- [x] Docs updated (if behaviour changed)
