### PR TITLE
feat(engine): report rules loaded without a backing collector

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -168,9 +168,17 @@ sudo rustinel doctor --config /etc/rustinel/config.toml
 
 Doctor reports `pass`, `warn`, or `fail` for configuration discovery and parsing,
 resolved paths, writable log and alert directories, installed rules pack state,
-pack compatibility and checksum metadata, Sigma, YARA, and IOC parsing, native
+pack compatibility and checksum metadata, Sigma, YARA, and IOC parsing, Sigma
+rules left inert by a missing collector, native
 service state, active-response safety, platform telemetry prerequisites, and
 pipeline drop counters.
+
+The `sigma_rules_inert` check reports how many loaded Sigma rules have no
+backing collector on this platform - they parse, they count toward the rule
+total, and they can never fire - grouped by the telemetry category that is
+missing. The same summary is logged once at rule load. Rule count is not
+coverage; see [Sigma Coverage](coverage.md) and
+[Limitations](limitations.md#detection-engine-sigma).
 
 The `pipeline_telemetry` check reports how much telemetry the agent shed under
 load, per channel, from the snapshot the running agent writes - so a detection

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -14,7 +14,7 @@ full rather than hide them.
 | --- | --- |
 | Process events carry no hashes (`Hashes` / `Imphash`) | Windows |
 | Several modelled process fields are never populated | Windows |
-| Rules are silently inert when no collector backs their logsource | Engine |
+| Rules are inert when no collector backs their logsource (counted, not prevented) | Engine |
 | Telemetry is dropped under burst load (counted, not prevented) | Pipeline |
 | Writes through handles or keys opened before startup are invisible | Windows |
 | Security channel events depend on audit policy Rustinel does not set | Windows |
@@ -237,7 +237,11 @@ would succeed.
 - **Rules are inert without a backing collector (silent risk).** Rules for a
   product or category the running platform does not collect load successfully
   and never fire. On Linux and macOS a large share of a Windows-oriented ruleset
-  is dead weight. **Do not read rule count as coverage.** See
+  is dead weight. **Do not read rule count as coverage.** The count is now
+  reported rather than silent: rule loading logs how many rules have no backing
+  collector, grouped by the missing telemetry category, and `rustinel doctor`
+  repeats it as the `sigma_rules_inert` check. Rules whose logsource names
+  another product are skipped at load instead, and counted separately. See
   [Sigma Coverage](coverage.md) for the measured share of SigmaHQ that can fire
   per platform; per-rule diagnostics are tracked by
   [#184](https://github.com/Karib0u/rustinel/issues/184).

--- a/src/doctor/rules.rs
+++ b/src/doctor/rules.rs
@@ -1,5 +1,6 @@
 use crate::config::{AppConfig, InstallPlatform};
 use crate::doctor::inspect::{DiagnosticResult, ResolvedPaths, RulePackDiagnostic};
+use crate::engine::EngineStats;
 use semver::{Version, VersionReq};
 use serde::Deserialize;
 use std::path::{Path, PathBuf};
@@ -202,7 +203,7 @@ pub(crate) fn rule_validation_results(
     let mut results = Vec::new();
 
     if cfg.scanner.sigma_enabled {
-        results.push(validate_sigma_rules(cfg, platform));
+        results.extend(validate_sigma_rules(cfg, platform));
     } else {
         results.push(DiagnosticResult::pass(
             "sigma_rules_parse",
@@ -239,19 +240,21 @@ fn sensor_platform(platform: InstallPlatform) -> crate::sensor::Platform {
     }
 }
 
-fn validate_sigma_rules(cfg: &AppConfig, platform: InstallPlatform) -> DiagnosticResult {
+/// Parse the configured Sigma pack once, and report both whether it loaded and
+/// how much of it is inert on this platform.
+fn validate_sigma_rules(cfg: &AppConfig, platform: InstallPlatform) -> Vec<DiagnosticResult> {
     let mut engine = crate::engine::Engine::new_for_platform_with_match_debug(
         sensor_platform(platform),
         cfg.alerts.match_debug,
     );
 
     if let Err(err) = engine.load_rules(&cfg.scanner.sigma_rules_path) {
-        return DiagnosticResult::fail(
+        return vec![DiagnosticResult::fail(
             "sigma_rules_parse",
             "Sigma rule loading failed",
             format!("{err}"),
         )
-        .with_fix("Fix unreadable or invalid Sigma rule files");
+        .with_fix("Fix unreadable or invalid Sigma rule files")];
     }
 
     let stats = engine.stats();
@@ -263,7 +266,7 @@ fn validate_sigma_rules(cfg: &AppConfig, platform: InstallPlatform) -> Diagnosti
             .map(|(path, err)| format!("{path}: {err}"))
             .collect::<Vec<_>>()
             .join("; ");
-        return DiagnosticResult::fail(
+        return vec![DiagnosticResult::fail(
             "sigma_rules_parse",
             format!(
                 "{} Sigma rule files failed to parse",
@@ -271,10 +274,31 @@ fn validate_sigma_rules(cfg: &AppConfig, platform: InstallPlatform) -> Diagnosti
             ),
             detail,
         )
-        .with_fix("Fix the listed Sigma rules or remove them from the active pack");
+        .with_fix("Fix the listed Sigma rules or remove them from the active pack")];
     }
 
-    if !stats.unsupported_rules.is_empty() {
+    if stats.total_rules == 0 {
+        return vec![DiagnosticResult::warn(
+            "sigma_rules_parse",
+            "No Sigma rules loaded",
+            cfg.scanner.sigma_rules_path.display().to_string(),
+        )
+        .with_fix(
+            "Install a rules pack or point scanner.sigma_rules_path at rules/current/sigma",
+        )];
+    }
+
+    let mut results = Vec::new();
+
+    if stats.unsupported_rules.is_empty() {
+        results.push(DiagnosticResult::pass(
+            "sigma_rules_parse",
+            format!(
+                "Loaded {} Sigma rules with {} inactive collector rules",
+                stats.total_rules, stats.inactive_collector_rules
+            ),
+        ));
+    } else {
         let detail = stats
             .unsupported_rules
             .iter()
@@ -287,33 +311,47 @@ fn validate_sigma_rules(cfg: &AppConfig, platform: InstallPlatform) -> Diagnosti
             })
             .collect::<Vec<_>>()
             .join("; ");
-        return DiagnosticResult::warn(
-            "sigma_rules_unsupported",
+        results.push(
+            DiagnosticResult::warn(
+                "sigma_rules_unsupported",
+                format!(
+                    "{} Sigma documents were dropped because their references are unavailable",
+                    stats.unsupported_rules.len()
+                ),
+                detail,
+            )
+            .with_fix("Restore the referenced rules or remove the dependent documents"),
+        );
+    }
+
+    results.push(inert_rules_diagnostic(&stats));
+    results
+}
+
+/// Report the rules that loaded but wait on telemetry this platform never
+/// produces. They inflate the rule count without adding coverage, so name the
+/// missing categories rather than leaving the operator to infer them.
+pub(crate) fn inert_rules_diagnostic(stats: &EngineStats) -> DiagnosticResult {
+    match stats.inactive_collector_summary() {
+        None => DiagnosticResult::pass(
+            "sigma_rules_inert",
             format!(
-                "{} Sigma documents were dropped because their references are unavailable",
-                stats.unsupported_rules.len()
+                "All {} loaded Sigma rules have a backing collector",
+                stats.total_rules
             ),
-            detail,
-        )
-        .with_fix("Restore the referenced rules or remove the dependent documents");
-    }
-
-    if stats.total_rules == 0 {
-        return DiagnosticResult::warn(
-            "sigma_rules_parse",
-            "No Sigma rules loaded",
-            cfg.scanner.sigma_rules_path.display().to_string(),
-        )
-        .with_fix("Install a rules pack or point scanner.sigma_rules_path at rules/current/sigma");
-    }
-
-    DiagnosticResult::pass(
-        "sigma_rules_parse",
-        format!(
-            "Loaded {} Sigma rules with {} inactive collector rules",
-            stats.total_rules, stats.inactive_collector_rules
         ),
-    )
+        Some(categories) => DiagnosticResult::warn(
+            "sigma_rules_inert",
+            format!(
+                "{} of {} loaded Sigma rules have no backing collector and cannot fire",
+                stats.inactive_collector_rules, stats.total_rules
+            ),
+            format!("missing telemetry: {categories}"),
+        )
+        .with_fix(
+            "Drop the rules for these categories, or see docs/limitations.md for why the telemetry is unavailable",
+        ),
+    }
 }
 
 fn validate_yara_rules(cfg: &AppConfig) -> DiagnosticResult {
@@ -453,4 +491,63 @@ where
     }
 
     DiagnosticResult::pass(id, format!("{checked} {label} entries parsed"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::doctor::inspect::DiagnosticStatus;
+    use std::collections::BTreeMap;
+
+    fn stats_with_inert(total_rules: usize, inert: &[(&str, usize)]) -> EngineStats {
+        let categories = inert
+            .iter()
+            .map(|(category, count)| ((*category).to_string(), *count))
+            .collect::<BTreeMap<String, usize>>();
+
+        EngineStats {
+            total_rules,
+            rule_files_found: total_rules,
+            rules_by_category: Default::default(),
+            rules_by_logsource: Default::default(),
+            deferred_logsource_rules: Default::default(),
+            unknown_logsource_rules: Default::default(),
+            failed_rules: Vec::new(),
+            unsupported_rules: Vec::new(),
+            skipped_product_rules: 0,
+            skipped_deferred_rules: 0,
+            skipped_unknown_logsource_rules: 0,
+            inactive_collector_rules: categories.values().sum(),
+            inactive_collector_categories: categories,
+            inactive_collector_logsources: BTreeMap::new(),
+        }
+    }
+
+    #[test]
+    fn doctor_names_the_missing_telemetry_categories() {
+        let result =
+            inert_rules_diagnostic(&stats_with_inert(10, &[("file_change", 3), ("dns", 1)]));
+
+        assert_eq!(result.id, "sigma_rules_inert");
+        assert_eq!(result.status, DiagnosticStatus::Warn);
+        assert!(
+            result.message.contains("4 of 10"),
+            "message should size the gap: {}",
+            result.message
+        );
+        assert_eq!(
+            result.detail.as_deref(),
+            Some("missing telemetry: file_change (3), dns (1)")
+        );
+        assert!(result.fix.is_some());
+    }
+
+    #[test]
+    fn doctor_passes_when_every_rule_is_backed() {
+        let result = inert_rules_diagnostic(&stats_with_inert(10, &[]));
+
+        assert_eq!(result.id, "sigma_rules_inert");
+        assert_eq!(result.status, DiagnosticStatus::Pass);
+        assert_eq!(result.detail, None);
+    }
 }

--- a/src/engine/loader.rs
+++ b/src/engine/loader.rs
@@ -150,6 +150,16 @@ impl Engine {
             stats.unsupported_rules.len()
         );
 
+        // Inert rules are the quiet failure: they load, they inflate the rule
+        // count, and they can never match. Name the telemetry they wait on.
+        if let Some(categories) = stats.inactive_collector_summary() {
+            warn!(
+                inert_rules = stats.inactive_collector_rules,
+                categories = %categories,
+                "Loaded rules have no backing collector on this platform and cannot fire"
+            );
+        }
+
         for unsupported in &stats.unsupported_rules {
             warn!(
                 source = %unsupported.source_path,

--- a/src/engine/logsource.rs
+++ b/src/engine/logsource.rs
@@ -77,6 +77,22 @@ impl LogSourceKey {
                 .unwrap_or(true)
     }
 
+    /// The telemetry category this logsource needs, used to group rules that
+    /// loaded without a backing collector. Sigma's `category` is the natural
+    /// name; rules that route on `service` alone (the generic DNS logsource,
+    /// for one) fall back to it, and a product-only logsource to the product.
+    pub fn telemetry_category(&self) -> String {
+        if let Some(category) = &self.category {
+            return category.clone();
+        }
+        if let Some(service) = &self.service {
+            return format!("service:{service}");
+        }
+        self.product
+            .clone()
+            .unwrap_or_else(|| "<empty logsource>".to_string())
+    }
+
     pub fn display(&self) -> String {
         let mut parts = Vec::new();
 
@@ -479,6 +495,10 @@ impl Engine {
                 collector_active: false,
             } => {
                 self.inactive_collector_rules += 1;
+                *self
+                    .inactive_collector_counts
+                    .entry(logsource.clone())
+                    .or_default() += 1;
             }
             RuleLoadDecision::Load {
                 collector_active: true,

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -117,6 +117,10 @@ pub struct Engine {
     /// Unknown logsource counts by normalized tuple.
     unknown_logsource_counts: HashMap<LogSourceKey, usize>,
 
+    /// Loaded-but-inert rule counts by normalized tuple: the logsource is one
+    /// Rustinel understands, but no collector on this platform feeds it.
+    inactive_collector_counts: HashMap<LogSourceKey, usize>,
+
     /// Controls whether match debug details are attached to alerts.
     match_debug: MatchDebugLevel,
 }
@@ -161,6 +165,7 @@ impl Engine {
             inactive_collector_rules: 0,
             deferred_logsource_counts: HashMap::new(),
             unknown_logsource_counts: HashMap::new(),
+            inactive_collector_counts: HashMap::new(),
             match_debug,
         }
     }
@@ -278,14 +283,22 @@ mod tests {
 
     /// Load one rule from a temporary file, exercising the real loader.
     fn engine_with_rule(platform: Platform, rule_yaml: &str) -> Engine {
+        engine_with_rules(platform, &[rule_yaml])
+    }
+
+    /// Load several rules from one temporary directory through the real loader.
+    fn engine_with_rules(platform: Platform, rules_yaml: &[&str]) -> Engine {
         let dir = tempfile::tempdir().expect("temporary rule directory");
-        std::fs::write(dir.path().join("rule.yml"), rule_yaml).expect("write rule");
+        for (index, rule_yaml) in rules_yaml.iter().enumerate() {
+            std::fs::write(dir.path().join(format!("rule{index}.yml")), rule_yaml)
+                .expect("write rule");
+        }
         let mut engine = Engine::new_for_platform(platform);
         engine.load_rules(dir.path()).expect("rules should load");
         assert_eq!(
             engine.stats().failed_rules,
             Vec::<(String, String)>::new(),
-            "the fixture rule should load cleanly"
+            "the fixture rules should load cleanly"
         );
         engine
     }
@@ -433,6 +446,92 @@ level: medium
         let stats = engine.stats();
         assert_eq!(stats.total_rules, 1, "the rule still loads");
         assert_eq!(stats.inactive_collector_rules, 1);
+    }
+
+    #[test]
+    fn inert_rules_are_grouped_by_missing_telemetry_category() {
+        let engine = engine_with_rules(
+            Platform::Linux,
+            &[
+                r#"title: Linux Timestomp
+logsource:
+  product: linux
+  service: sysmon
+  category: file_change
+detection:
+  selection:
+    TargetFilename|endswith: ".sh"
+  condition: selection
+"#,
+                r#"title: Linux Timestomp Two
+logsource:
+  product: linux
+  service: sysmon
+  category: file_change
+detection:
+  selection:
+    TargetFilename|endswith: ".py"
+  condition: selection
+"#,
+                r#"title: Linux DNS Network
+logsource:
+  product: linux
+  service: dns
+detection:
+  selection:
+    query|contains: evil.example
+  condition: selection
+"#,
+                r#"title: Linux Process
+logsource:
+  product: linux
+  service: sysmon
+  category: process_creation
+detection:
+  selection:
+    Image|endswith: bash
+  condition: selection
+"#,
+            ],
+        );
+
+        let stats = engine.stats();
+        assert_eq!(stats.total_rules, 4, "every rule still loads");
+        assert_eq!(stats.inactive_collector_rules, 3);
+        assert_eq!(
+            stats.inactive_collector_categories,
+            std::collections::BTreeMap::from([
+                ("file_change".to_string(), 2),
+                ("service:dns".to_string(), 1),
+            ])
+        );
+        assert_eq!(
+            stats.inactive_collector_summary().as_deref(),
+            Some("file_change (2), service:dns (1)"),
+            "the summary orders the largest telemetry gap first"
+        );
+    }
+
+    #[test]
+    fn a_fully_backed_ruleset_reports_no_inert_rules() {
+        let engine = engine_with_rule(
+            Platform::Linux,
+            r#"title: Linux Process
+logsource:
+  product: linux
+  service: sysmon
+  category: process_creation
+detection:
+  selection:
+    Image|endswith: bash
+  condition: selection
+"#,
+        );
+
+        let stats = engine.stats();
+        assert_eq!(stats.inactive_collector_rules, 0);
+        assert!(stats.inactive_collector_categories.is_empty());
+        assert_eq!(stats.inactive_collector_summary(), None);
     }
 
     #[test]

--- a/src/engine/stats.rs
+++ b/src/engine/stats.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 
 use super::Engine;
@@ -66,6 +66,20 @@ impl Engine {
             skipped_deferred_rules: self.skipped_deferred_rules,
             skipped_unknown_logsource_rules: self.skipped_unknown_logsource_rules,
             inactive_collector_rules: self.inactive_collector_rules,
+            inactive_collector_categories: self.inactive_collector_counts.iter().fold(
+                BTreeMap::new(),
+                |mut categories, (logsource, count)| {
+                    *categories
+                        .entry(logsource.telemetry_category())
+                        .or_default() += count;
+                    categories
+                },
+            ),
+            inactive_collector_logsources: self
+                .inactive_collector_counts
+                .iter()
+                .map(|(key, count)| (key.display(), *count))
+                .collect(),
         }
     }
 }
@@ -88,4 +102,37 @@ pub struct EngineStats {
     pub skipped_deferred_rules: usize,
     pub skipped_unknown_logsource_rules: usize,
     pub inactive_collector_rules: usize,
+    /// Inert rule counts grouped by the telemetry category no collector feeds.
+    pub inactive_collector_categories: BTreeMap<String, usize>,
+    /// Inert rule counts by full logsource, for detailed diagnostics.
+    #[allow(dead_code)] // Used by companion binaries outside the library crate.
+    pub inactive_collector_logsources: BTreeMap<String, usize>,
+}
+
+impl EngineStats {
+    /// A `category (n)` list of the telemetry categories whose rules loaded
+    /// without a backing collector, ordered by rule count. `None` when every
+    /// loaded rule is backed.
+    pub fn inactive_collector_summary(&self) -> Option<String> {
+        if self.inactive_collector_categories.is_empty() {
+            return None;
+        }
+
+        let mut categories = self
+            .inactive_collector_categories
+            .iter()
+            .collect::<Vec<_>>();
+        // Largest gap first; ties keep the map's alphabetical order.
+        categories.sort_by(|(left_name, left), (right_name, right)| {
+            right.cmp(left).then_with(|| left_name.cmp(right_name))
+        });
+
+        Some(
+            categories
+                .into_iter()
+                .map(|(category, count)| format!("{category} ({count})"))
+                .collect::<Vec<_>>()
+                .join(", "),
+        )
+    }
 }

--- a/src/runtime/pipeline.rs
+++ b/src/runtime/pipeline.rs
@@ -89,6 +89,14 @@ impl LivePipeline {
                     unsupported_rules = stats.unsupported_rules.len(),
                     "Sigma engine initialized"
                 );
+                if let Some(categories) = stats.inactive_collector_summary() {
+                    warn!(
+                        target: TARGET_CONSOLE,
+                        inert_rules = stats.inactive_collector_rules,
+                        categories = %categories,
+                        "Sigma rules loaded without a backing collector and cannot fire"
+                    );
+                }
                 for (logsource, count) in stats.rules_by_logsource {
                     info!(logsource = %logsource, count, "Sigma rules loaded");
                 }

--- a/tests/sigma_corpus_compatibility.rs
+++ b/tests/sigma_corpus_compatibility.rs
@@ -49,6 +49,8 @@ struct PlatformSummary {
     rules_by_logsource: BTreeMap<String, usize>,
     deferred_logsources: BTreeMap<String, usize>,
     unknown_logsources: BTreeMap<String, usize>,
+    /// Loaded rules with no backing collector, by missing telemetry category.
+    inactive_collector_categories: BTreeMap<String, usize>,
     failures: Vec<RuleFailure>,
 }
 
@@ -116,8 +118,14 @@ fn scan_platform(corpus_dir: &Path, platform: Platform) -> anyhow::Result<Platfo
         skipped_deferred_rules,
         skipped_unknown_logsource_rules,
         inactive_collector_rules,
+        inactive_collector_categories,
+        inactive_collector_logsources: _,
     } = engine.stats();
 
+    anyhow::ensure!(
+        inactive_collector_categories.values().sum::<usize>() == inactive_collector_rules,
+        "inactive collector categories do not account for all {inactive_collector_rules} inert rules"
+    );
     anyhow::ensure!(
         inactive_collector_rules <= total_rules,
         "inactive collector count {inactive_collector_rules} exceeds loaded count {total_rules}"
@@ -187,6 +195,7 @@ fn scan_platform(corpus_dir: &Path, platform: Platform) -> anyhow::Result<Platfo
         rules_by_logsource: rules_by_logsource.into_iter().collect(),
         deferred_logsources: deferred_logsource_rules.into_iter().collect(),
         unknown_logsources: unknown_logsource_rules.into_iter().collect(),
+        inactive_collector_categories,
         failures,
     })
 }


### PR DESCRIPTION
Closes #141.

## Problem

A Sigma rule whose logsource Rustinel understands, but which no collector on the running platform feeds, loads successfully and can never fire — `file_change` on Linux and macOS, the generic `service: dns` network logsource, most of the Windows service/category combinations that no ETW session backs. The engine already counted these (`inactive_collector_rules`), but the count was a bare total: nothing said *which* telemetry the rules were waiting on, so the rule count silently overstated coverage.

## Change

- The engine now tracks inert rules per logsource tuple and groups them by the missing telemetry category (`EngineStats::inactive_collector_categories`, plus a full-logsource breakdown for diagnostics). Sigma's `category` names the group; a logsource routing on `service` alone falls back to `service:<name>`.
- `EngineStats::inactive_collector_summary()` renders `file_change (2), service:dns (1)`, largest gap first.
- Rule loading logs that summary once as a warning, and the live pipeline repeats it on the console at startup next to the rule totals.
- `rustinel doctor` gains a `sigma_rules_inert` check: `pass` when every loaded rule is backed, `warn` naming the missing categories and sizing the gap (`4 of 10 loaded Sigma rules have no backing collector and cannot fire`) otherwise. `validate_sigma_rules` now returns several results from the single rule-pack load rather than one, so the check costs no extra parse.
- The SigmaHQ corpus compatibility summary carries the per-category breakdown, and asserts the categories account for every inert rule. The checked-in baseline schema (`rule_files_found` + verdicts) is unchanged.
- `docs/limitations.md` and `docs/cli.md` record that the gap is now reported rather than silent.

## Tests

- `inert_rules_are_grouped_by_missing_telemetry_category` — four rules through the real loader on Linux; three are inert, grouped 2/1 across `file_change` and `service:dns`, with the summary ordered by count.
- `a_fully_backed_ruleset_reports_no_inert_rules` — no categories, no summary.
- `doctor_names_the_missing_telemetry_categories` / `doctor_passes_when_every_rule_is_backed`.
- `cargo test` and `cargo clippy --all-targets` are clean on macOS. The Linux/Windows sensor code paths are untouched.