### PR TITLE
feat(linux-ebpf): report process image source

### DIFF
--- a/docs/detection.md
+++ b/docs/detection.md
@@ -231,8 +231,8 @@ is not collected.
 Sigma evaluates the shared `NormalizedEvent` model using Sysmon-style field
 names.
 
-- **Process:** `Image`, `CommandLine`, `User`, `ProcessId`, `ParentImage`,
-  `ParentCommandLine`
+- **Process:** `Image`, `ImageSource`, `CommandLine`, `User`, `ProcessId`,
+  `ParentImage`, `ParentCommandLine`
 - **Network:** `DestinationIp`, `DestinationPort`, `SourceIp`, `SourcePort`,
   `DestinationHostname`, `Protocol`, `Initiated`
 - **File:** `TargetFilename`, `Image`, `ProcessId`, `User`, plus
@@ -268,7 +268,8 @@ Per-platform process notes:
   bytes, 32 arguments, and 127 bytes per argument. `Image` resolves from
   `/proc/<pid>/exe`, which is absolute and symlink-resolved, but short-lived
   processes fall back to the raw `execve()` argument, which may be relative and
-  is capped at 127 bytes. `ParentImage`, `ParentProcessId`, `ParentCommandLine`, and
+  is capped at 127 bytes. `ImageSource` distinguishes the two cases with `proc`
+  or `execve`. `ParentImage`, `ParentProcessId`, `ParentCommandLine`, and
   `CurrentDirectory` are enriched from `/proc` and may be absent.
 - **macOS:** ESF exec events carry `CommandLine`, `ParentImage`,
   `ParentProcessId`, and `CurrentDirectory` natively. `ParentCommandLine` is not

--- a/docs/output.md
+++ b/docs/output.md
@@ -63,6 +63,7 @@ Format:
 | `rule.id`           | Optional detection rule identifier, unique amongs the rustinel rules. Formatted as: `sigma::<uuid>` for Sigma, `yara::<id>` for YARA (if metadata ID is defined), or `ioc::<type>::<value>` for IOCs. |
 | `edr.rule.severity` | Low, Medium, High, or Critical                                                                                                                                                                        |
 | `edr.rule.engine`   | `Sigma`, `Yara`, or `Ioc`                                                                                                                                                                             |
+| `edr.process.image_source` | Linux process image provenance: `proc` when resolved from `/proc/<pid>/exe`, or `execve` when the raw invocation string was used after that lookup lost the process lifetime race. |
 | `event.count`       | *(rollup only)* Number of suppressed repeats this rollup represents, i.e. occurrences within the dedup window excluding the first. Absent on the live first emission, which represents a single event. Summing `event.count` across lines (absent = 1) gives the true event volume. |
 
 ### Windows Process Alert Example
@@ -111,6 +112,7 @@ Format:
   "host.os.type": "linux",
   "host.os.family": "linux",
   "process.executable": "/usr/bin/whoami",
+  "edr.process.image_source": "proc",
   "process.name": "whoami",
   "user.name": "root"
 }

--- a/src/alerts/dedup.rs
+++ b/src/alerts/dedup.rs
@@ -389,6 +389,7 @@ mod tests {
                 opcode: 1,
                 fields: EventFields::ProcessCreation(ProcessCreationFields {
                     image: Some(image.to_string()),
+                    image_source: None,
                     command_line: None,
                     process_id: Some("42".to_string()),
                     process_start_time: None,

--- a/src/capture/writer.rs
+++ b/src/capture/writer.rs
@@ -416,6 +416,7 @@ mod tests {
             opcode: 1,
             fields: EventFields::ProcessCreation(ProcessCreationFields {
                 image: Some(r"C:\Windows\System32\cmd.exe".to_string()),
+                image_source: None,
                 original_file_name: None,
                 product: None,
                 description: None,

--- a/src/engine/alert.rs
+++ b/src/engine/alert.rs
@@ -202,6 +202,7 @@ level: high
             opcode: 1,
             fields: EventFields::ProcessCreation(ProcessCreationFields {
                 image: Some(image.to_string()),
+                image_source: None,
                 command_line: None,
                 process_id: None,
                 process_start_time: None,

--- a/src/engine/event.rs
+++ b/src/engine/event.rs
@@ -202,6 +202,7 @@ mod tests {
     fn typed_process_fields_expose_sigma_names() {
         let fields = ProcessCreationFields {
             image: Some("/usr/bin/curl".to_string()),
+            image_source: None,
             original_file_name: None,
             product: None,
             description: None,

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -616,6 +616,7 @@ detection:
             opcode: 1,
             fields: EventFields::ProcessCreation(ProcessCreationFields {
                 image: Some(image.to_string()),
+                image_source: None,
                 command_line: Some(command_line.to_string()),
                 process_id: Some("1234".to_string()),
                 process_start_time: None,

--- a/src/ioc/mod.rs
+++ b/src/ioc/mod.rs
@@ -219,6 +219,7 @@ impl IocEngine {
                 opcode: 1,
                 fields: EventFields::ProcessCreation(ProcessCreationFields {
                     image: Some(path.to_string()),
+                    image_source: None,
                     original_file_name: None,
                     product: None,
                     description: None,

--- a/src/models/ecs/alert.rs
+++ b/src/models/ecs/alert.rs
@@ -95,6 +95,14 @@ pub struct EcsAlert {
     #[serde(rename = "process.executable", skip_serializing_if = "Option::is_none")]
     pub process_executable: Option<String>,
 
+    /// Linux source used to populate `process.executable`: `proc` for the
+    /// resolved `/proc/<pid>/exe` path, or `execve` for the raw filename.
+    #[serde(
+        rename = "edr.process.image_source",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub edr_process_image_source: Option<String>,
+
     #[serde(rename = "process.name", skip_serializing_if = "Option::is_none")]
     pub process_name: Option<String>,
 

--- a/src/models/ecs/mod.rs
+++ b/src/models/ecs/mod.rs
@@ -61,6 +61,7 @@ impl From<&Alert> for EcsAlert {
             edr_rule_severity: format!("{:?}", alert.severity),
             edr_rule_engine: format!("{:?}", alert.engine),
             process_executable: None,
+            edr_process_image_source: None,
             process_name: None,
             process_command_line: None,
             process_pid: None,
@@ -149,6 +150,7 @@ impl From<&Alert> for EcsAlert {
         match &alert.event.fields {
             EventFields::ProcessCreation(f) => {
                 ecs.process_executable = f.image.clone();
+                ecs.edr_process_image_source = f.image_source.clone();
                 ecs.process_command_line = f.command_line.clone();
                 ecs.process_pid = parse_u64(&f.process_id);
                 ecs.process_parent_executable = f.parent_image.clone();
@@ -434,6 +436,7 @@ mod tests {
                 opcode: 1,
                 fields: EventFields::ProcessCreation(ProcessCreationFields {
                     image: Some(r"C:\Windows\System32\cmd.exe".to_string()),
+                    image_source: None,
                     command_line: Some("cmd.exe /c whoami".to_string()),
                     process_id: Some("1234".to_string()),
                     process_start_time: None,

--- a/src/models/event.rs
+++ b/src/models/event.rs
@@ -137,6 +137,7 @@ impl NormalizedEvent {
         match &self.fields {
             EventFields::ProcessCreation(f) => match key {
                 "Image" => f.image.as_deref(),
+                "ImageSource" => f.image_source.as_deref(),
                 "OriginalFileName" => f.original_file_name.as_deref(),
                 "Product" => f.product.as_deref(),
                 "Description" => f.description.as_deref(),
@@ -388,6 +389,7 @@ mod round_trip_tests {
             opcode: 1,
             fields: EventFields::ProcessCreation(ProcessCreationFields {
                 image: Some("/bin/zsh".to_string()),
+                image_source: None,
                 original_file_name: Some("zsh".to_string()),
                 product: Some("shell".to_string()),
                 description: Some("Z shell".to_string()),
@@ -634,6 +636,7 @@ mod round_trip_tests {
             opcode: 1,
             fields: EventFields::ProcessCreation(ProcessCreationFields {
                 image: Some(r"C:\Windows\System32\cmd.exe".to_string()),
+                image_source: None,
                 command_line: None,
                 process_id: None,
                 process_start_time: None,
@@ -674,6 +677,7 @@ mod round_trip_tests {
         event.opcode = 1;
         event.fields = EventFields::ProcessCreation(ProcessCreationFields {
             image: Some(image.to_string()),
+            image_source: None,
             command_line: None,
             process_id: None,
             process_start_time: None,

--- a/src/models/fields.rs
+++ b/src/models/fields.rs
@@ -71,6 +71,11 @@ pub struct ProcessCreationFields {
     #[serde(rename = "Image", skip_serializing_if = "Option::is_none")]
     pub image: Option<String>,
 
+    /// Source used to populate `Image` on Linux process-start events: `proc`
+    /// for `/proc/<pid>/exe`, or `execve` for the raw kernel filename fallback.
+    #[serde(rename = "ImageSource", skip_serializing_if = "Option::is_none")]
+    pub image_source: Option<String>,
+
     #[serde(rename = "OriginalFileName", skip_serializing_if = "Option::is_none")]
     pub original_file_name: Option<String>,
 

--- a/src/normalizer/mod.rs
+++ b/src/normalizer/mod.rs
@@ -486,6 +486,7 @@ mod tests {
             }),
             payload: SensorPayload::Process(ProcessCreationFields {
                 image: Some("/usr/bin/curl".to_string()),
+                image_source: None,
                 original_file_name: None,
                 product: None,
                 description: None,
@@ -527,6 +528,7 @@ mod tests {
             }),
             payload: SensorPayload::Process(ProcessCreationFields {
                 image: None,
+                image_source: None,
                 original_file_name: None,
                 product: None,
                 description: None,
@@ -652,6 +654,7 @@ mod tests {
             }),
             payload: SensorPayload::Process(ProcessCreationFields {
                 image: None,
+                image_source: None,
                 original_file_name: None,
                 product: None,
                 description: None,

--- a/src/replay/output.rs
+++ b/src/replay/output.rs
@@ -197,6 +197,7 @@ mod tests {
                 opcode: 1,
                 fields: EventFields::ProcessCreation(ProcessCreationFields {
                     image: Some(r"C:\Windows\System32\powershell.exe".to_string()),
+                    image_source: None,
                     original_file_name: None,
                     product: None,
                     description: None,

--- a/src/replay/recording.rs
+++ b/src/replay/recording.rs
@@ -227,6 +227,7 @@ mod tests {
             opcode: 1,
             fields: EventFields::ProcessCreation(ProcessCreationFields {
                 image: Some(r"C:\Windows\System32\cmd.exe".to_string()),
+                image_source: None,
                 original_file_name: None,
                 product: None,
                 description: None,

--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -675,6 +675,7 @@ mod tests {
                 opcode: 1,
                 fields: EventFields::ProcessCreation(ProcessCreationFields {
                     image: image.map(str::to_string),
+                    image_source: None,
                     process_id: pid.map(str::to_string),
                     process_start_time: None,
                     command_line: None,

--- a/src/runtime/yara.rs
+++ b/src/runtime/yara.rs
@@ -109,6 +109,7 @@ pub fn build_yara_alert(
             opcode: 1,
             fields: EventFields::ProcessCreation(ProcessCreationFields {
                 image: Some(path.to_string()),
+                image_source: None,
                 original_file_name: None,
                 product: None,
                 description: None,
@@ -189,6 +190,7 @@ pub fn build_yara_memory_alert(
             opcode: 1,
             fields: EventFields::ProcessCreation(ProcessCreationFields {
                 image: Some(image.to_string()),
+                image_source: None,
                 original_file_name: None,
                 product: None,
                 description: None,

--- a/src/sensor/linux/ebpf.rs
+++ b/src/sensor/linux/ebpf.rs
@@ -412,11 +412,15 @@ fn drain_dns_ring(rb: &mut RingBuf<MapData>, tx: &Sender<SensorEvent>) {
 /// symlink-resolved, and immune to the caller's `chdir`. The raw kernel string
 /// stays as a fallback for short-lived processes that exit before the userspace
 /// ring drain gets to `/proc`.
-fn resolve_exec_image(proc_exe: Option<&str>, raw_filename: &str) -> Option<String> {
-    proc_exe
-        .filter(|value| !value.is_empty())
-        .map(str::to_string)
-        .or_else(|| Some(raw_filename.to_string()).filter(|value| !value.is_empty()))
+fn resolve_exec_image(
+    proc_exe: Option<&str>,
+    raw_filename: &str,
+) -> Option<(String, &'static str)> {
+    if let Some(image) = proc_exe.filter(|value| !value.is_empty()) {
+        return Some((image.to_string(), "proc"));
+    }
+
+    Some((raw_filename.to_string(), "execve")).filter(|(value, _)| !value.is_empty())
 }
 
 /// Pick the command line for an exec event.
@@ -443,7 +447,7 @@ fn build_process_event(ev: &ProcessEvent) -> Option<SensorEvent> {
     match ev.kind {
         PROCESS_EVENT_EXEC => {
             let details = query_process_details(ev.pid);
-            let image = resolve_exec_image(
+            let (image, image_source) = resolve_exec_image(
                 details.as_ref().and_then(|value| value.image.as_deref()),
                 &bytes_to_string(&ev.image),
             )?;
@@ -468,6 +472,7 @@ fn build_process_event(ev: &ProcessEvent) -> Option<SensorEvent> {
                 }),
                 payload: SensorPayload::Process(ProcessCreationFields {
                     image: Some(image),
+                    image_source: Some(image_source.to_string()),
                     original_file_name: None,
                     product: None,
                     description: None,
@@ -514,6 +519,7 @@ fn build_process_event(ev: &ProcessEvent) -> Option<SensorEvent> {
             process_start_key: None,
             payload: SensorPayload::Process(ProcessCreationFields {
                 image: None,
+                image_source: None,
                 original_file_name: None,
                 product: None,
                 description: None,
@@ -1045,6 +1051,7 @@ mod tests {
         match event.payload {
             SensorPayload::Process(fields) => {
                 assert_eq!(fields.image.as_deref(), Some("/usr/bin/bash"));
+                assert_eq!(fields.image_source.as_deref(), Some("execve"));
                 assert_eq!(
                     fields.process_id.as_deref(),
                     Some(DEAD_PID.to_string().as_str())
@@ -1066,6 +1073,7 @@ mod tests {
         match event.payload {
             SensorPayload::Process(fields) => {
                 assert_eq!(fields.image.as_deref(), expected.to_str());
+                assert_eq!(fields.image_source.as_deref(), Some("proc"));
             }
             other => panic!("unexpected payload: {:?}", other),
         }
@@ -1153,20 +1161,20 @@ mod tests {
     #[test]
     fn resolve_exec_image_prefers_proc_exe_over_raw_filename() {
         assert_eq!(
-            resolve_exec_image(Some("/tmp/malware"), "./malware").as_deref(),
-            Some("/tmp/malware")
+            resolve_exec_image(Some("/tmp/malware"), "./malware"),
+            Some(("/tmp/malware".to_string(), "proc"))
         );
     }
 
     #[test]
     fn resolve_exec_image_falls_back_to_raw_filename() {
         assert_eq!(
-            resolve_exec_image(None, "./malware").as_deref(),
-            Some("./malware")
+            resolve_exec_image(None, "./malware"),
+            Some(("./malware".to_string(), "execve"))
         );
         assert_eq!(
-            resolve_exec_image(Some(""), "/usr/bin/bash").as_deref(),
-            Some("/usr/bin/bash")
+            resolve_exec_image(Some(""), "/usr/bin/bash"),
+            Some(("/usr/bin/bash".to_string(), "execve"))
         );
         assert_eq!(resolve_exec_image(None, ""), None);
     }

--- a/src/sensor/linux/events.rs
+++ b/src/sensor/linux/events.rs
@@ -286,6 +286,7 @@ pub mod mapping {
             }),
             payload: SensorPayload::Process(ProcessCreationFields {
                 image: Some(bytes_to_string(&event.image)),
+                image_source: None,
                 original_file_name: None,
                 product: None,
                 description: None,

--- a/src/sensor/macos/esf.rs
+++ b/src/sensor/macos/esf.rs
@@ -314,6 +314,7 @@ fn process_start_event(raw: RawExec) -> SensorEvent {
         }),
         payload: SensorPayload::Process(ProcessCreationFields {
             image: Some(raw.image),
+            image_source: None,
             original_file_name: None,
             product: None,
             description: None,
@@ -363,6 +364,7 @@ fn process_stop_event(pid: u32, user: String, event_time: SystemTime) -> SensorE
         process_start_key: None,
         payload: SensorPayload::Process(ProcessCreationFields {
             image: None,
+            image_source: None,
             original_file_name: None,
             product: None,
             description: None,

--- a/src/sensor/mod.rs
+++ b/src/sensor/mod.rs
@@ -322,6 +322,7 @@ mod tests {
     fn payload_category_matches_variant() {
         let payload = SensorPayload::Process(ProcessCreationFields {
             image: Some("/usr/bin/bash".to_string()),
+            image_source: None,
             original_file_name: None,
             product: None,
             description: None,

--- a/src/sensor/windows/enrichment.rs
+++ b/src/sensor/windows/enrichment.rs
@@ -62,6 +62,7 @@ mod tests {
     fn process_fields(image: &str) -> ProcessCreationFields {
         ProcessCreationFields {
             image: Some(image.to_string()),
+            image_source: None,
             original_file_name: None,
             product: None,
             description: None,

--- a/src/sensor/windows/etw/decode.rs
+++ b/src/sensor/windows/etw/decode.rs
@@ -247,6 +247,7 @@ pub(super) fn decode_process(
 
     let fields = ProcessCreationFields {
         image: image.clone(),
+        image_source: None,
         original_file_name: None,
         product: None,
         description: None,

--- a/tests/active_response.rs
+++ b/tests/active_response.rs
@@ -47,6 +47,7 @@ fn build_yara_alert(pid: u32, image: &str) -> Alert {
             opcode: 1,
             fields: EventFields::ProcessCreation(ProcessCreationFields {
                 image: Some(image.to_string()),
+                image_source: None,
                 original_file_name: None,
                 product: None,
                 description: None,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -127,6 +127,7 @@ pub fn process_start_event(platform: Platform) -> SensorEvent {
         }),
         payload: SensorPayload::Process(ProcessCreationFields {
             image: Some(image.to_string()),
+            image_source: None,
             original_file_name: Some("curl.exe".to_string()),
             product: Some("curl".to_string()),
             description: Some("test process".to_string()),

--- a/tests/dedup_integration.rs
+++ b/tests/dedup_integration.rs
@@ -32,6 +32,7 @@ fn make_alert(rule: &str, image: &str) -> Alert {
             opcode: 1,
             fields: EventFields::ProcessCreation(ProcessCreationFields {
                 image: Some(image.to_string()),
+                image_source: None,
                 command_line: None,
                 process_id: Some("42".to_string()),
                 process_start_time: None,

--- a/tests/ecs_contract.rs
+++ b/tests/ecs_contract.rs
@@ -13,7 +13,7 @@ use rustinel::models::{
     PowerShellModuleFields, PowerShellScriptFields, ProcessCreationFields, RegistryEventFields,
     SecurityAuditFields, ServiceCreationFields, TaskCreationFields, WmiEventFields,
 };
-use rustinel::sensor::Platform;
+use rustinel::sensor::{Platform, SensorPayload};
 use serde_json::json;
 
 fn security_audit_fields(pairs: &[(&str, &str)]) -> SecurityAuditFields {
@@ -43,6 +43,30 @@ fn alert(category: EventCategory, event_id: u16, opcode: u8, fields: EventFields
             process_context: None,
         },
         match_details: None,
+    }
+}
+
+#[test]
+fn linux_process_image_source_survives_normalization_and_maps_to_ecs() {
+    for source in ["proc", "execve"] {
+        let fixture = TestNormalizer::new(false);
+        let mut event = process_start_event(Platform::Linux);
+        let SensorPayload::Process(fields) = &mut event.payload else {
+            panic!("expected process payload");
+        };
+        fields.image_source = Some(source.to_string());
+
+        let normalized = fixture
+            .normalizer
+            .normalize(&event)
+            .expect("normalize Linux process start");
+        assert_eq!(normalized.get_field("ImageSource"), Some(source));
+
+        let mut alert = alert(EventCategory::Process, 1, 1, normalized.fields);
+        alert.event.platform = Platform::Linux;
+        alert.event.provider = "ebpf".to_string();
+        let json = ecs_json(&alert);
+        assert_ecs_field_eq(&json, "edr.process.image_source", source);
     }
 }
 
@@ -105,6 +129,7 @@ fn ecs_category_coverage_maps_event_contract_fields() {
                 1,
                 EventFields::ProcessCreation(ProcessCreationFields {
                     image: Some(r"C:\Windows\System32\cmd.exe".to_string()),
+                    image_source: None,
                     command_line: Some("cmd.exe /c whoami".to_string()),
                     process_id: Some("111".to_string()),
                     process_start_time: None,
@@ -465,6 +490,7 @@ fn ecs_version_field_is_9_4_0() {
         1,
         EventFields::ProcessCreation(ProcessCreationFields {
             image: Some(r"C:\Windows\System32\cmd.exe".to_string()),
+            image_source: None,
             command_line: None,
             process_id: None,
             process_start_time: None,
@@ -504,6 +530,7 @@ fn test_rule_id_mapping_and_omit_behavior() {
             opcode: 1,
             fields: EventFields::ProcessCreation(ProcessCreationFields {
                 image: Some(r"C:\Windows\System32\cmd.exe".to_string()),
+                image_source: None,
                 command_line: None,
                 process_id: None,
                 process_start_time: None,

--- a/tests/reload.rs
+++ b/tests/reload.rs
@@ -697,6 +697,7 @@ fn build_critical_process_alert(pid: u32, image: &str) -> rustinel::models::Aler
             opcode: 1,
             fields: EventFields::ProcessCreation(ProcessCreationFields {
                 image: Some(image.to_string()),
+                image_source: None,
                 process_id: Some(pid.to_string()),
                 process_start_time: None,
                 command_line: None,

--- a/tests/sigma_corpus_compatibility.rs
+++ b/tests/sigma_corpus_compatibility.rs
@@ -249,6 +249,7 @@ fn process_event(timestamp: &str) -> NormalizedEvent {
         opcode: 1,
         fields: EventFields::ProcessCreation(ProcessCreationFields {
             image: Some("/usr/bin/curl".to_string()),
+            image_source: None,
             command_line: None,
             process_id: Some("1234".to_string()),
             process_start_time: None,

--- a/tests/sigma_documents.rs
+++ b/tests/sigma_documents.rs
@@ -28,6 +28,7 @@ fn process_event(timestamp: &str, user: &str) -> NormalizedEvent {
         opcode: 1,
         fields: EventFields::ProcessCreation(ProcessCreationFields {
             image: Some("/usr/bin/curl".to_string()),
+            image_source: None,
             command_line: Some("curl https://example.test".to_string()),
             process_id: Some("1234".to_string()),
             process_start_time: None,

--- a/tests/yara_disk.rs
+++ b/tests/yara_disk.rs
@@ -83,6 +83,7 @@ fn build_yara_alert(
             opcode: 1,
             fields: EventFields::ProcessCreation(ProcessCreationFields {
                 image: Some(path.to_string()),
+                image_source: None,
                 original_file_name: None,
                 product: None,
                 description: None,


### PR DESCRIPTION
## Summary

- add `ImageSource` to Linux process-start events with `proc` and `execve` provenance values
- expose the marker as `edr.process.image_source` in ECS alerts
- document the field and cover both resolution paths plus normalization and ECS mapping

Closes #308

## Type of change

- [x] `feat` / `enhancement` - new feature
- [ ] `bug` - bug fix
- [ ] `refactor` - refactoring, no behaviour change
- [ ] `documentation` - docs only
- [ ] `ci` - CI and release changes
- [ ] `dependencies` - dependency update

## Test plan

- [ ] Tested on Windows
- [x] Tested on Linux
- [x] Existing tests pass (`cargo test`)
- [x] New tests added (if applicable)

Additional validation:

- `cargo fmt --all -- --check`
- `cargo test --all-targets`
- Ubuntu lab: Linux eBPF resolver unit tests
- Ubuntu lab: `cargo clippy --locked --all-targets -- -D clippy::all`
- Ubuntu lab: production eBPF object build with pinned nightly toolchain

## Checklist

- [x] Label added to this PR
- [x] Docs updated (if behaviour changed)