### PR TITLE
fix(linux-ebpf): report truncated process image paths

### DIFF
--- a/docs/detection.md
+++ b/docs/detection.md
@@ -231,8 +231,8 @@ is not collected.
 Sigma evaluates the shared `NormalizedEvent` model using Sysmon-style field
 names.
 
-- **Process:** `Image`, `ImageSource`, `CommandLine`, `User`, `ProcessId`,
-  `ParentImage`, `ParentCommandLine`
+- **Process:** `Image`, `ImageSource`, `ImageTruncated`, `CommandLine`, `User`,
+  `ProcessId`, `ParentImage`, `ParentCommandLine`
 - **Network:** `DestinationIp`, `DestinationPort`, `SourceIp`, `SourcePort`,
   `DestinationHostname`, `Protocol`, `Initiated`
 - **File:** `TargetFilename`, `Image`, `ProcessId`, `User`, plus
@@ -268,9 +268,12 @@ Per-platform process notes:
   bytes, 32 arguments, and 127 bytes per argument. `Image` resolves from
   `/proc/<pid>/exe`, which is absolute and symlink-resolved, but short-lived
   processes fall back to the raw `execve()` argument, which may be relative and
-  is capped at 127 bytes. `ImageSource` distinguishes the two cases with `proc`
-  or `execve`. `ParentImage`, `ParentProcessId`, `ParentCommandLine`, and
-  `CurrentDirectory` are enriched from `/proc` and may be absent.
+  is capped at 255 bytes. When that fallback is cut, `ImageTruncated` is `true`
+  and ECS carries `edr.process.image_truncated`; the marker is absent when
+  `/proc` supplies the complete path. `ImageSource` distinguishes the two cases
+  with `proc` or `execve`. `ParentImage`, `ParentProcessId`,
+  `ParentCommandLine`, and `CurrentDirectory` are enriched from `/proc` and may
+  be absent.
 - **macOS:** ESF exec events carry `CommandLine`, `ParentImage`,
   `ParentProcessId`, and `CurrentDirectory` natively. `ParentCommandLine` is not
   provided, and `IntegrityLevel` is a Windows field with no macOS equivalent.

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -134,13 +134,12 @@ three platforms, but several Sysmon-style fields are unavailable.
 
 The Linux sensor covers process, network, file, and DNS.
 
-- **Image paths are truncated at 127 bytes, with no marker (silent risk).** A
-  binary at a long path is reported cut, and nothing distinguishes a truncated
-  path from a complete one, so every `Image|endswith` rule fails against it
-  silently ([#307](https://github.com/Karib0u/rustinel/issues/307)). `Image`
-  normally comes from `/proc/<pid>/exe` and is absolute and symlink-resolved,
-  but under burst the raw `execve()` argument is used instead, which is both
-  truncated and possibly relative
+- **The raw image-path fallback is capped at 255 bytes.** `Image` normally
+  comes from `/proc/<pid>/exe` and is absolute and symlink-resolved. Under a
+  burst the sensor may instead use the raw `execve()` argument; when its suffix
+  does not fit, `ImageTruncated` and `edr.process.image_truncated` mark the path
+  as incomplete ([#307](https://github.com/Karib0u/rustinel/issues/307)). The
+  raw argument may also be relative
   ([#308](https://github.com/Karib0u/rustinel/issues/308)).
 - **Kernel-captured argv is bounded.** Argv is snapshotted at `execve` entry, so
   a process that exits before the ring is drained still reports its command

--- a/docs/output.md
+++ b/docs/output.md
@@ -64,6 +64,7 @@ Format:
 | `edr.rule.severity` | Low, Medium, High, or Critical                                                                                                                                                                        |
 | `edr.rule.engine`   | `Sigma`, `Yara`, or `Ioc`                                                                                                                                                                             |
 | `edr.process.image_source` | Linux process image provenance: `proc` when resolved from `/proc/<pid>/exe`, or `execve` when the raw invocation string was used after that lookup lost the process lifetime race. |
+| `edr.process.image_truncated` | *(Linux process alerts only)* `true` when `process.executable` is a kernel-captured prefix whose suffix did not fit the 256-byte buffer. Absent when the path is complete or `/proc` supplied it. |
 | `event.count`       | *(rollup only)* Number of suppressed repeats this rollup represents, i.e. occurrences within the dedup window excluding the first. Absent on the live first emission, which represents a single event. Summing `event.count` across lines (absent = 1) gives the true event volume. |
 
 ### Windows Process Alert Example

--- a/ebpf/src/events.rs
+++ b/ebpf/src/events.rs
@@ -16,6 +16,9 @@
 /// userspace loader then falls back to `/proc/<pid>/cmdline`.
 pub const ARGV_CAPACITY: usize = 512;
 
+/// Bytes captured for the executable image, including the NUL terminator.
+pub const PROCESS_IMAGE_CAPACITY: usize = 256;
+
 /// Process lifecycle event.
 ///
 /// - kind 1 = exec (`sched_process_exec`)
@@ -32,17 +35,19 @@ pub struct ProcessEvent {
     pub _pad: u32,
     /// Null-terminated process name (`comm`, up to 15 chars).
     pub comm: [u8; 16],
-    /// Null-terminated executable path (up to 127 chars).
+    /// Null-terminated executable path (up to 255 bytes).
     ///
     /// Empty for exit events.
-    pub image: [u8; 128],
+    pub image: [u8; PROCESS_IMAGE_CAPACITY],
     /// Number of valid bytes in `args`. Zero when no argv was captured.
     pub args_len: u16,
     /// Number of argv entries captured in `args`.
     pub args_count: u16,
     /// 1 when argv did not fit the capture limits, 0 when complete.
     pub args_truncated: u8,
-    pub _pad1: [u8; 3],
+    /// 1 when `image` did not fit its capture buffer, 0 when complete.
+    pub image_truncated: u8,
+    pub _pad1: [u8; 2],
     /// Argv captured at `execve` entry, NUL-separated (no trailing NUL
     /// guaranteed). Only the first `args_len` bytes are meaningful.
     ///

--- a/ebpf/src/process.rs
+++ b/ebpf/src/process.rs
@@ -48,14 +48,12 @@ use aya_ebpf::{
     EbpfContext,
 };
 
-use crate::events::{ProcessEvent, ARGV_CAPACITY};
+use crate::events::{ProcessEvent, ARGV_CAPACITY, PROCESS_IMAGE_CAPACITY};
 
 /// Ring buffer shared with the userspace loader for process events.
 ///
-/// 2 MiB: carrying argv grew `ProcessEvent` from 160 to 680 bytes, so the
-/// previous 512 KiB held roughly a quarter as many events. Sizing up keeps
-/// the same burst headroom in *events*, which is what a `reserve` failure —
-/// a silently dropped process event — actually depends on.
+/// The 808-byte event leaves room for more than 2,500 queued events, including
+/// the measured 1,600-event burst that motivated the image-path fallback.
 #[map]
 pub static PROCESS_RING: RingBuf = RingBuf::with_byte_size(2 * 1024 * 1024, 0);
 
@@ -141,13 +139,14 @@ unsafe fn try_handle_exec(ctx: &TracePointContext) -> Result<u32, i64> {
     // High 16 bits = string length (including null terminator).
     let data_loc: u32 = ctx.read_at::<u32>(8)?;
     let str_offset = (data_loc & 0xFFFF) as usize;
+    let str_len = (data_loc >> 16) as usize;
     let fname_ptr = (ctx.as_ptr() as usize + str_offset) as *const u8;
 
     // Read comm and image into local buffers, then copy into ring-buffer entry.
     // Keep buffers small enough to stay within the 512-byte BPF stack limit —
     // `args` is copied straight from map memory for the same reason.
     let comm = bpf_get_current_comm().unwrap_or([0u8; 16]);
-    let mut image = [0u8; 128];
+    let mut image = [0u8; PROCESS_IMAGE_CAPACITY];
 
     // Read null-terminated executable path from kernel tracepoint data.
     // Ignore errors — an empty image is still a useful process event.
@@ -164,7 +163,8 @@ unsafe fn try_handle_exec(ctx: &TracePointContext) -> Result<u32, i64> {
     (*event)._pad = 0;
     (*event).comm = comm;
     (*event).image = image;
-    (*event)._pad1 = [0u8; 3];
+    (*event).image_truncated = (str_len > image.len()) as u8;
+    (*event)._pad1 = [0u8; 2];
 
     attach_pending_argv(event, old_pid);
 
@@ -312,11 +312,12 @@ unsafe fn try_handle_exit(_ctx: &TracePointContext) -> Result<u32, i64> {
     (*event).uid = uid;
     (*event)._pad = 0;
     (*event).comm = comm;
-    (*event).image = [0u8; 128];
+    (*event).image = [0u8; PROCESS_IMAGE_CAPACITY];
     (*event).args_len = 0;
     (*event).args_count = 0;
     (*event).args_truncated = 0;
-    (*event)._pad1 = [0u8; 3];
+    (*event).image_truncated = 0;
+    (*event)._pad1 = [0u8; 2];
 
     entry.submit(0);
 

--- a/src/alerts/dedup.rs
+++ b/src/alerts/dedup.rs
@@ -390,6 +390,7 @@ mod tests {
                 fields: EventFields::ProcessCreation(ProcessCreationFields {
                     image: Some(image.to_string()),
                     image_source: None,
+                    image_truncated: None,
                     command_line: None,
                     process_id: Some("42".to_string()),
                     process_start_time: None,

--- a/src/capture/writer.rs
+++ b/src/capture/writer.rs
@@ -417,6 +417,7 @@ mod tests {
             fields: EventFields::ProcessCreation(ProcessCreationFields {
                 image: Some(r"C:\Windows\System32\cmd.exe".to_string()),
                 image_source: None,
+                image_truncated: None,
                 original_file_name: None,
                 product: None,
                 description: None,

--- a/src/engine/alert.rs
+++ b/src/engine/alert.rs
@@ -203,6 +203,7 @@ level: high
             fields: EventFields::ProcessCreation(ProcessCreationFields {
                 image: Some(image.to_string()),
                 image_source: None,
+                image_truncated: None,
                 command_line: None,
                 process_id: None,
                 process_start_time: None,

--- a/src/engine/event.rs
+++ b/src/engine/event.rs
@@ -203,6 +203,7 @@ mod tests {
         let fields = ProcessCreationFields {
             image: Some("/usr/bin/curl".to_string()),
             image_source: None,
+            image_truncated: Some(true),
             original_file_name: None,
             product: None,
             description: None,
@@ -229,13 +230,19 @@ mod tests {
                 .and_then(|value| value.as_str().map(Cow::into_owned)),
             Some("curl http://example.test".to_string())
         );
+        assert_eq!(
+            adapter.get_field("ImageTruncated"),
+            Some(EventValue::Str(Cow::Borrowed("true")))
+        );
         let keys = adapter.field_keys();
         assert!(keys.iter().any(|key| key.as_ref() == "Image"));
+        assert!(keys.iter().any(|key| key.as_ref() == "ImageTruncated"));
         assert!(keys.iter().any(|key| key.as_ref() == "CommandLine"));
         // ProcessStartTime is numeric, so it is not a string value.
         let values = adapter.all_string_values();
         assert!(values.iter().any(|value| value.as_ref() == "/usr/bin/curl"));
         assert!(values.iter().any(|value| value.contains("example.test")));
+        assert!(values.iter().all(|value| value.as_ref() != "true"));
     }
 
     #[test]

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -716,6 +716,7 @@ detection:
             fields: EventFields::ProcessCreation(ProcessCreationFields {
                 image: Some(image.to_string()),
                 image_source: None,
+                image_truncated: None,
                 command_line: Some(command_line.to_string()),
                 process_id: Some("1234".to_string()),
                 process_start_time: None,

--- a/src/ioc/mod.rs
+++ b/src/ioc/mod.rs
@@ -220,6 +220,7 @@ impl IocEngine {
                 fields: EventFields::ProcessCreation(ProcessCreationFields {
                     image: Some(path.to_string()),
                     image_source: None,
+                    image_truncated: None,
                     original_file_name: None,
                     product: None,
                     description: None,

--- a/src/models/ecs/alert.rs
+++ b/src/models/ecs/alert.rs
@@ -102,6 +102,12 @@ pub struct EcsAlert {
         skip_serializing_if = "Option::is_none"
     )]
     pub edr_process_image_source: Option<String>,
+    /// True when `process.executable` is missing its captured suffix.
+    #[serde(
+        rename = "edr.process.image_truncated",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub edr_process_image_truncated: Option<bool>,
 
     #[serde(rename = "process.name", skip_serializing_if = "Option::is_none")]
     pub process_name: Option<String>,

--- a/src/models/ecs/mod.rs
+++ b/src/models/ecs/mod.rs
@@ -62,6 +62,7 @@ impl From<&Alert> for EcsAlert {
             edr_rule_engine: format!("{:?}", alert.engine),
             process_executable: None,
             edr_process_image_source: None,
+            edr_process_image_truncated: None,
             process_name: None,
             process_command_line: None,
             process_pid: None,
@@ -151,6 +152,7 @@ impl From<&Alert> for EcsAlert {
             EventFields::ProcessCreation(f) => {
                 ecs.process_executable = f.image.clone();
                 ecs.edr_process_image_source = f.image_source.clone();
+                ecs.edr_process_image_truncated = f.image_truncated;
                 ecs.process_command_line = f.command_line.clone();
                 ecs.process_pid = parse_u64(&f.process_id);
                 ecs.process_parent_executable = f.parent_image.clone();
@@ -437,6 +439,7 @@ mod tests {
                 fields: EventFields::ProcessCreation(ProcessCreationFields {
                     image: Some(r"C:\Windows\System32\cmd.exe".to_string()),
                     image_source: None,
+                    image_truncated: None,
                     command_line: Some("cmd.exe /c whoami".to_string()),
                     process_id: Some("1234".to_string()),
                     process_start_time: None,

--- a/src/models/event.rs
+++ b/src/models/event.rs
@@ -138,6 +138,9 @@ impl NormalizedEvent {
             EventFields::ProcessCreation(f) => match key {
                 "Image" => f.image.as_deref(),
                 "ImageSource" => f.image_source.as_deref(),
+                "ImageTruncated" => f
+                    .image_truncated
+                    .map(|value| if value { "true" } else { "false" }),
                 "OriginalFileName" => f.original_file_name.as_deref(),
                 "Product" => f.product.as_deref(),
                 "Description" => f.description.as_deref(),
@@ -390,6 +393,7 @@ mod round_trip_tests {
             fields: EventFields::ProcessCreation(ProcessCreationFields {
                 image: Some("/bin/zsh".to_string()),
                 image_source: None,
+                image_truncated: None,
                 original_file_name: Some("zsh".to_string()),
                 product: Some("shell".to_string()),
                 description: Some("Z shell".to_string()),
@@ -637,6 +641,7 @@ mod round_trip_tests {
             fields: EventFields::ProcessCreation(ProcessCreationFields {
                 image: Some(r"C:\Windows\System32\cmd.exe".to_string()),
                 image_source: None,
+                image_truncated: None,
                 command_line: None,
                 process_id: None,
                 process_start_time: None,
@@ -678,6 +683,7 @@ mod round_trip_tests {
         event.fields = EventFields::ProcessCreation(ProcessCreationFields {
             image: Some(image.to_string()),
             image_source: None,
+            image_truncated: None,
             command_line: None,
             process_id: None,
             process_start_time: None,

--- a/src/models/fields.rs
+++ b/src/models/fields.rs
@@ -75,6 +75,9 @@ pub struct ProcessCreationFields {
     /// for `/proc/<pid>/exe`, or `execve` for the raw kernel filename fallback.
     #[serde(rename = "ImageSource", skip_serializing_if = "Option::is_none")]
     pub image_source: Option<String>,
+    /// True when the sensor had to cut the end off `Image`.
+    #[serde(rename = "ImageTruncated", skip_serializing_if = "Option::is_none")]
+    pub image_truncated: Option<bool>,
 
     #[serde(rename = "OriginalFileName", skip_serializing_if = "Option::is_none")]
     pub original_file_name: Option<String>,

--- a/src/normalizer/mod.rs
+++ b/src/normalizer/mod.rs
@@ -487,6 +487,7 @@ mod tests {
             payload: SensorPayload::Process(ProcessCreationFields {
                 image: Some("/usr/bin/curl".to_string()),
                 image_source: None,
+                image_truncated: None,
                 original_file_name: None,
                 product: None,
                 description: None,
@@ -529,6 +530,7 @@ mod tests {
             payload: SensorPayload::Process(ProcessCreationFields {
                 image: None,
                 image_source: None,
+                image_truncated: None,
                 original_file_name: None,
                 product: None,
                 description: None,
@@ -655,6 +657,7 @@ mod tests {
             payload: SensorPayload::Process(ProcessCreationFields {
                 image: None,
                 image_source: None,
+                image_truncated: None,
                 original_file_name: None,
                 product: None,
                 description: None,

--- a/src/replay/output.rs
+++ b/src/replay/output.rs
@@ -198,6 +198,7 @@ mod tests {
                 fields: EventFields::ProcessCreation(ProcessCreationFields {
                     image: Some(r"C:\Windows\System32\powershell.exe".to_string()),
                     image_source: None,
+                    image_truncated: None,
                     original_file_name: None,
                     product: None,
                     description: None,

--- a/src/replay/recording.rs
+++ b/src/replay/recording.rs
@@ -228,6 +228,7 @@ mod tests {
             fields: EventFields::ProcessCreation(ProcessCreationFields {
                 image: Some(r"C:\Windows\System32\cmd.exe".to_string()),
                 image_source: None,
+                image_truncated: None,
                 original_file_name: None,
                 product: None,
                 description: None,

--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -676,6 +676,7 @@ mod tests {
                 fields: EventFields::ProcessCreation(ProcessCreationFields {
                     image: image.map(str::to_string),
                     image_source: None,
+                    image_truncated: None,
                     process_id: pid.map(str::to_string),
                     process_start_time: None,
                     command_line: None,

--- a/src/runtime/yara.rs
+++ b/src/runtime/yara.rs
@@ -110,6 +110,7 @@ pub fn build_yara_alert(
             fields: EventFields::ProcessCreation(ProcessCreationFields {
                 image: Some(path.to_string()),
                 image_source: None,
+                image_truncated: None,
                 original_file_name: None,
                 product: None,
                 description: None,
@@ -191,6 +192,7 @@ pub fn build_yara_memory_alert(
             fields: EventFields::ProcessCreation(ProcessCreationFields {
                 image: Some(image.to_string()),
                 image_source: None,
+                image_truncated: None,
                 original_file_name: None,
                 product: None,
                 description: None,

--- a/src/sensor/linux/ebpf.rs
+++ b/src/sensor/linux/ebpf.rs
@@ -423,12 +423,13 @@ fn drain_dns_ring(rb: &mut RingBuf<MapData>, tx: &Sender<SensorEvent>) {
 fn resolve_exec_image(
     proc_exe: Option<&str>,
     raw_filename: &str,
-) -> Option<(String, &'static str)> {
+    raw_truncated: bool,
+) -> Option<(String, &'static str, bool)> {
     if let Some(image) = proc_exe.filter(|value| !value.is_empty()) {
-        return Some((image.to_string(), "proc"));
+        return Some((image.to_string(), "proc", false));
     }
 
-    Some((raw_filename.to_string(), "execve")).filter(|(value, _)| !value.is_empty())
+    (!raw_filename.is_empty()).then(|| (raw_filename.to_string(), "execve", raw_truncated))
 }
 
 /// Pick the command line for an exec event.
@@ -455,9 +456,10 @@ fn build_process_event(ev: &ProcessEvent) -> Option<SensorEvent> {
     match ev.kind {
         PROCESS_EVENT_EXEC => {
             let details = query_process_details(ev.pid);
-            let (image, image_source) = resolve_exec_image(
+            let (image, image_source, image_truncated) = resolve_exec_image(
                 details.as_ref().and_then(|value| value.image.as_deref()),
                 &bytes_to_string(&ev.image),
+                ev.image_truncated != 0,
             )?;
 
             let now = SystemTime::now();
@@ -481,6 +483,7 @@ fn build_process_event(ev: &ProcessEvent) -> Option<SensorEvent> {
                 payload: SensorPayload::Process(ProcessCreationFields {
                     image: Some(image),
                     image_source: Some(image_source.to_string()),
+                    image_truncated: image_truncated.then_some(true),
                     original_file_name: None,
                     product: None,
                     description: None,
@@ -528,6 +531,7 @@ fn build_process_event(ev: &ProcessEvent) -> Option<SensorEvent> {
             payload: SensorPayload::Process(ProcessCreationFields {
                 image: None,
                 image_source: None,
+                image_truncated: None,
                 original_file_name: None,
                 product: None,
                 description: None,
@@ -942,7 +946,8 @@ mod tests {
             args_len: 0,
             args_count: 0,
             args_truncated: 0,
-            _pad1: [0u8; 3],
+            image_truncated: 0,
+            _pad1: [0u8; 2],
             args: [0u8; ARGV_CAPACITY],
         }
     }
@@ -1176,22 +1181,50 @@ mod tests {
     #[test]
     fn resolve_exec_image_prefers_proc_exe_over_raw_filename() {
         assert_eq!(
-            resolve_exec_image(Some("/tmp/malware"), "./malware"),
-            Some(("/tmp/malware".to_string(), "proc"))
+            resolve_exec_image(Some("/tmp/malware"), "./malware", true),
+            Some(("/tmp/malware".to_string(), "proc", false))
         );
     }
 
     #[test]
     fn resolve_exec_image_falls_back_to_raw_filename() {
         assert_eq!(
-            resolve_exec_image(None, "./malware"),
-            Some(("./malware".to_string(), "execve"))
+            resolve_exec_image(None, "./malware", false),
+            Some(("./malware".to_string(), "execve", false))
         );
         assert_eq!(
-            resolve_exec_image(Some(""), "/usr/bin/bash"),
-            Some(("/usr/bin/bash".to_string(), "execve"))
+            resolve_exec_image(Some(""), "/usr/bin/bash", false),
+            Some(("/usr/bin/bash".to_string(), "execve", false))
         );
-        assert_eq!(resolve_exec_image(None, ""), None);
+        assert_eq!(resolve_exec_image(None, "", false), None);
+    }
+
+    #[test]
+    fn resolve_exec_image_marks_only_a_truncated_raw_fallback() {
+        assert_eq!(
+            resolve_exec_image(None, "/very/long/prefix", true),
+            Some(("/very/long/prefix".to_string(), "execve", true))
+        );
+        assert_eq!(
+            resolve_exec_image(Some("/complete/path"), "/very/long/prefix", true),
+            Some(("/complete/path".to_string(), "proc", false))
+        );
+    }
+
+    #[test]
+    fn build_process_event_marks_an_overlong_raw_image_fallback() {
+        let image = format!("/{}", "deep/".repeat(64));
+        let mut raw = raw_process_event(PROCESS_EVENT_EXEC, u32::MAX, &image);
+        raw.image_truncated = 1;
+
+        let event = build_process_event(&raw).expect("raw image should build an event");
+        match event.payload {
+            SensorPayload::Process(fields) => {
+                assert_eq!(fields.image.as_deref().map(str::len), Some(255));
+                assert_eq!(fields.image_truncated, Some(true));
+            }
+            other => panic!("unexpected payload: {:?}", other),
+        }
     }
 
     #[test]

--- a/src/sensor/linux/events.rs
+++ b/src/sensor/linux/events.rs
@@ -12,6 +12,10 @@
 /// `ARGV_CAPACITY` in `ebpf/src/events.rs`.
 pub const ARGV_CAPACITY: usize = 512;
 
+/// Bytes captured for the executable image, including the NUL terminator.
+/// Mirrors `PROCESS_IMAGE_CAPACITY` in `ebpf/src/events.rs`.
+pub const PROCESS_IMAGE_CAPACITY: usize = 256;
+
 /// Process lifecycle event.
 ///
 /// - kind 1 = exec (`sched_process_exec`)
@@ -24,14 +28,16 @@ pub struct ProcessEvent {
     pub uid: u32,
     pub _pad: u32,
     pub comm: [u8; 16],
-    pub image: [u8; 128],
+    pub image: [u8; PROCESS_IMAGE_CAPACITY],
     /// Valid bytes in `args`; 0 when the kernel captured no argv.
     pub args_len: u16,
     /// Number of argv entries in `args`.
     pub args_count: u16,
     /// 1 when argv exceeded the kernel capture limits.
     pub args_truncated: u8,
-    pub _pad1: [u8; 3],
+    /// 1 when `image` exceeded its kernel capture buffer.
+    pub image_truncated: u8,
+    pub _pad1: [u8; 2],
     /// NUL-separated argv captured at `execve` entry.
     pub args: [u8; ARGV_CAPACITY],
 }
@@ -227,16 +233,17 @@ pub struct DnsEvent {
 // These catch accidental struct layout divergence at compile time.
 
 const _: () = assert!(
-    core::mem::size_of::<ProcessEvent>() == 680,
+    core::mem::size_of::<ProcessEvent>() == 808,
     "ProcessEvent layout changed — update ebpf/src/events.rs to match"
 );
 // The argv fields were appended after `image`; pin their offsets so a
 // reordering on either side fails the build instead of decoding garbage.
 const _: () = assert!(
-    core::mem::offset_of!(ProcessEvent, args_len) == 160
-        && core::mem::offset_of!(ProcessEvent, args_count) == 162
-        && core::mem::offset_of!(ProcessEvent, args_truncated) == 164
-        && core::mem::offset_of!(ProcessEvent, args) == 168,
+    core::mem::offset_of!(ProcessEvent, args_len) == 288
+        && core::mem::offset_of!(ProcessEvent, args_count) == 290
+        && core::mem::offset_of!(ProcessEvent, args_truncated) == 292
+        && core::mem::offset_of!(ProcessEvent, image_truncated) == 293
+        && core::mem::offset_of!(ProcessEvent, args) == 296,
     "ProcessEvent argv fields moved — update ebpf/src/events.rs to match"
 );
 // `ret` and `sock_type` took over slots that used to be explicit padding, so a
@@ -321,6 +328,7 @@ pub mod mapping {
             payload: SensorPayload::Process(ProcessCreationFields {
                 image: Some(bytes_to_string(&event.image)),
                 image_source: None,
+                image_truncated: (event.image_truncated != 0).then_some(true),
                 original_file_name: None,
                 product: None,
                 description: None,
@@ -492,11 +500,12 @@ mod tests {
             uid: 1000,
             _pad: 0,
             comm: [0u8; 16],
-            image: [0u8; 128],
+            image: [0u8; PROCESS_IMAGE_CAPACITY],
             args_len: 0,
             args_count: 0,
             args_truncated: 0,
-            _pad1: [0u8; 3],
+            image_truncated: 0,
+            _pad1: [0u8; 2],
             args: [0u8; ARGV_CAPACITY],
         };
         let argv = b"/bin/true\0--quiet\0";

--- a/src/sensor/macos/esf.rs
+++ b/src/sensor/macos/esf.rs
@@ -315,6 +315,7 @@ fn process_start_event(raw: RawExec) -> SensorEvent {
         payload: SensorPayload::Process(ProcessCreationFields {
             image: Some(raw.image),
             image_source: None,
+            image_truncated: None,
             original_file_name: None,
             product: None,
             description: None,
@@ -365,6 +366,7 @@ fn process_stop_event(pid: u32, user: String, event_time: SystemTime) -> SensorE
         payload: SensorPayload::Process(ProcessCreationFields {
             image: None,
             image_source: None,
+            image_truncated: None,
             original_file_name: None,
             product: None,
             description: None,

--- a/src/sensor/mod.rs
+++ b/src/sensor/mod.rs
@@ -323,6 +323,7 @@ mod tests {
         let payload = SensorPayload::Process(ProcessCreationFields {
             image: Some("/usr/bin/bash".to_string()),
             image_source: None,
+            image_truncated: None,
             original_file_name: None,
             product: None,
             description: None,

--- a/src/sensor/windows/enrichment.rs
+++ b/src/sensor/windows/enrichment.rs
@@ -63,6 +63,7 @@ mod tests {
         ProcessCreationFields {
             image: Some(image.to_string()),
             image_source: None,
+            image_truncated: None,
             original_file_name: None,
             product: None,
             description: None,

--- a/src/sensor/windows/etw/decode.rs
+++ b/src/sensor/windows/etw/decode.rs
@@ -248,6 +248,7 @@ pub(super) fn decode_process(
     let fields = ProcessCreationFields {
         image: image.clone(),
         image_source: None,
+        image_truncated: None,
         original_file_name: None,
         product: None,
         description: None,

--- a/tests/active_response.rs
+++ b/tests/active_response.rs
@@ -48,6 +48,7 @@ fn build_yara_alert(pid: u32, image: &str) -> Alert {
             fields: EventFields::ProcessCreation(ProcessCreationFields {
                 image: Some(image.to_string()),
                 image_source: None,
+                image_truncated: None,
                 original_file_name: None,
                 product: None,
                 description: None,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -128,6 +128,7 @@ pub fn process_start_event(platform: Platform) -> SensorEvent {
         payload: SensorPayload::Process(ProcessCreationFields {
             image: Some(image.to_string()),
             image_source: None,
+            image_truncated: None,
             original_file_name: Some("curl.exe".to_string()),
             product: Some("curl".to_string()),
             description: Some("test process".to_string()),

--- a/tests/dedup_integration.rs
+++ b/tests/dedup_integration.rs
@@ -33,6 +33,7 @@ fn make_alert(rule: &str, image: &str) -> Alert {
             fields: EventFields::ProcessCreation(ProcessCreationFields {
                 image: Some(image.to_string()),
                 image_source: None,
+                image_truncated: None,
                 command_line: None,
                 process_id: Some("42".to_string()),
                 process_start_time: None,

--- a/tests/ecs_contract.rs
+++ b/tests/ecs_contract.rs
@@ -130,6 +130,7 @@ fn ecs_category_coverage_maps_event_contract_fields() {
                 EventFields::ProcessCreation(ProcessCreationFields {
                     image: Some(r"C:\Windows\System32\cmd.exe".to_string()),
                     image_source: None,
+                    image_truncated: None,
                     command_line: Some("cmd.exe /c whoami".to_string()),
                     process_id: Some("111".to_string()),
                     process_start_time: None,
@@ -491,6 +492,7 @@ fn ecs_version_field_is_9_4_0() {
         EventFields::ProcessCreation(ProcessCreationFields {
             image: Some(r"C:\Windows\System32\cmd.exe".to_string()),
             image_source: None,
+            image_truncated: None,
             command_line: None,
             process_id: None,
             process_start_time: None,
@@ -509,6 +511,38 @@ fn ecs_version_field_is_9_4_0() {
         }),
     ));
     assert_ecs_field_eq(&json, "ecs.version", "9.4.0");
+}
+
+#[test]
+fn ecs_process_image_truncation_marker_is_preserved() {
+    let long_prefix = format!("/{}", "deep/".repeat(52));
+    let json = ecs_json(&alert(
+        EventCategory::Process,
+        1,
+        1,
+        EventFields::ProcessCreation(ProcessCreationFields {
+            image: Some(long_prefix),
+            image_source: None,
+            image_truncated: Some(true),
+            command_line: None,
+            process_id: Some("111".to_string()),
+            process_start_time: None,
+            parent_image: None,
+            parent_process_id: None,
+            parent_command_line: None,
+            current_directory: None,
+            integrity_level: None,
+            user: None,
+            original_file_name: None,
+            product: None,
+            description: None,
+            company: None,
+            file_version: None,
+            target_image: None,
+        }),
+    ));
+
+    assert_ecs_field_eq(&json, "edr.process.image_truncated", true);
 }
 
 #[test]
@@ -531,6 +565,7 @@ fn test_rule_id_mapping_and_omit_behavior() {
             fields: EventFields::ProcessCreation(ProcessCreationFields {
                 image: Some(r"C:\Windows\System32\cmd.exe".to_string()),
                 image_source: None,
+                image_truncated: None,
                 command_line: None,
                 process_id: None,
                 process_start_time: None,

--- a/tests/platform_mapping.rs
+++ b/tests/platform_mapping.rs
@@ -23,6 +23,7 @@ fn write_cstr<const N: usize>(dst: &mut [u8; N], value: &str) {
 fn linux_ebpf_raw_events_map_to_sensor_events() {
     use rustinel::sensor::linux::events::{
         mapping, DnsEvent, FileEvent, NetworkEvent, ProcessEvent, ARGV_CAPACITY, FILE_PATH_LEN,
+        PROCESS_IMAGE_CAPACITY,
     };
     use rustinel::sensor::linux::paths::{DirFdIndex, AT_FDCWD};
     use rustinel::sensor::{SensorAction, SensorPayload};
@@ -34,11 +35,12 @@ fn linux_ebpf_raw_events_map_to_sensor_events() {
         uid: 1000,
         _pad: 0,
         comm: [0; 16],
-        image: [0; 128],
+        image: [0; PROCESS_IMAGE_CAPACITY],
         args_len: 0,
         args_count: 0,
         args_truncated: 0,
-        _pad1: [0; 3],
+        image_truncated: 0,
+        _pad1: [0; 2],
         args: [0; ARGV_CAPACITY],
     };
     write_cstr(&mut process.image, "/usr/bin/curl");
@@ -56,6 +58,21 @@ fn linux_ebpf_raw_events_map_to_sensor_events() {
             fields.command_line.as_deref(),
             Some("/usr/bin/curl -sS https://example.test")
         ),
+        _ => panic!("expected process payload"),
+    }
+
+    let long_image = format!("/{}", "deep/".repeat(64));
+    write_cstr(&mut process.image, &long_image);
+    process.image_truncated = 1;
+    let mapped = mapping::process_event_to_sensor(&process);
+    match mapped.payload {
+        SensorPayload::Process(fields) => {
+            assert_eq!(
+                fields.image.as_deref().map(str::len),
+                Some(PROCESS_IMAGE_CAPACITY - 1)
+            );
+            assert_eq!(fields.image_truncated, Some(true));
+        }
         _ => panic!("expected process payload"),
     }
 

--- a/tests/reload.rs
+++ b/tests/reload.rs
@@ -698,6 +698,7 @@ fn build_critical_process_alert(pid: u32, image: &str) -> rustinel::models::Aler
             fields: EventFields::ProcessCreation(ProcessCreationFields {
                 image: Some(image.to_string()),
                 image_source: None,
+                image_truncated: None,
                 process_id: Some(pid.to_string()),
                 process_start_time: None,
                 command_line: None,

--- a/tests/sigma_corpus_compatibility.rs
+++ b/tests/sigma_corpus_compatibility.rs
@@ -259,6 +259,7 @@ fn process_event(timestamp: &str) -> NormalizedEvent {
         fields: EventFields::ProcessCreation(ProcessCreationFields {
             image: Some("/usr/bin/curl".to_string()),
             image_source: None,
+            image_truncated: None,
             command_line: None,
             process_id: Some("1234".to_string()),
             process_start_time: None,

--- a/tests/sigma_documents.rs
+++ b/tests/sigma_documents.rs
@@ -29,6 +29,7 @@ fn process_event(timestamp: &str, user: &str) -> NormalizedEvent {
         fields: EventFields::ProcessCreation(ProcessCreationFields {
             image: Some("/usr/bin/curl".to_string()),
             image_source: None,
+            image_truncated: None,
             command_line: Some("curl https://example.test".to_string()),
             process_id: Some("1234".to_string()),
             process_start_time: None,

--- a/tests/yara_disk.rs
+++ b/tests/yara_disk.rs
@@ -84,6 +84,7 @@ fn build_yara_alert(
             fields: EventFields::ProcessCreation(ProcessCreationFields {
                 image: Some(path.to_string()),
                 image_source: None,
+                image_truncated: None,
                 original_file_name: None,
                 product: None,
                 description: None,


### PR DESCRIPTION
## Summary

- raise the Linux eBPF process image capture limit from 127 to 255 bytes
- flag kernel image truncation and preserve it only when the raw fallback is used
- expose the marker as `ImageTruncated` and `edr.process.image_truncated`
- cover the wire mapping, fallback behavior, Sigma field access, and ECS output
- document the new limit and marker

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --locked --all-targets`
- Ubuntu 26.04, kernel 7.0: eBPF source build and targeted Linux tests
- Ubuntu 26.04 privileged live capture: tracepoints attached, a 523-byte executable path produced a 255-byte fallback with `ImageTruncated: true`, and 2,455 of 2,455 events were written with zero loss

Closes #307