### PR TITLE
fix(windows-etw): expose decoder and file attribution degradation in telemetry

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -175,10 +175,13 @@ pipeline drop counters.
 The `pipeline_telemetry` check reports how much telemetry the agent shed under
 load, per channel, from the snapshot the running agent writes - so a detection
 gap can be sized without searching the operational log. `--json` carries the
-raw per-channel counters under `telemetry`. On Windows the
-`registry_path_resolution` check reports the share of registry writes that
-reached the detectors with a key path, which is the one gap the channel counters
-cannot show. See [Pipeline Telemetry](configuration.md#pipeline-telemetry).
+raw per-channel counters under `telemetry`. On Windows, three further checks
+cover the gaps the channel counters cannot show, because they happen before any
+channel sees the event: `registry_path_resolution` and `file_path_attribution`
+report the share of registry writes and file events that reached the detectors
+with a path, and `etw_decode` reports records that failed to decode at all,
+named by provider and event version. See
+[Pipeline Telemetry](configuration.md#pipeline-telemetry).
 
 Exit codes are intended for automation:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -328,6 +328,58 @@ appears in no channel count.
 a 99.9% resolution rate. Writes by protected processes are the expected residue;
 see [Limitations](limitations.md).
 
+The `file_attribution` section is the file-side equivalent, for the same reason:
+`Write` and `SetInformation` name their target only by kernel pointer, so an
+event whose pointer the handle index cannot answer is discarded inside the
+sensor and appears in no channel count.
+
+| Field | Meaning |
+| --- | --- |
+| `attempted` | File events that needed a target path |
+| `resolved_from_event` | Those the event named itself |
+| `resolved_from_index` | Those the `FileObject`/`FileKey` index resolved |
+| `unresolved` | Those discarded for want of a path, which is the detection gap |
+| `index_capacity_evictions` | Index entries dropped at the per-index cap of 8192 |
+
+Evictions are the mechanism rather than the gap: a handle whose entry was
+evicted may never be written to again. They are reported apart so "raise the
+cap" and "the provider stopped naming its handles" can be told apart. `rustinel
+doctor` reports this as `file_path_attribution`, which warns below a 99%
+resolution rate.
+
+The `etw_decode` section covers the stage before either of those: a schema
+lookup that fails, a payload template that no longer matches the record, or a
+payload with no field a rule can select on all leave the channel counters
+looking perfectly healthy while detections quietly stop firing.
+
+| Field | Meaning |
+| --- | --- |
+| `records_received` | Records delivered to the ETW callback |
+| `records_filtered` | Records the router intentionally declined - not loss |
+| `records_indexed` | Records that fed a path index or were held for a late naming event |
+| `records_decoded` | Records that produced at least one event |
+| `records_unattributed` | Records dropped for want of a resolvable path |
+| `schema_errors` | Records whose provider schema could not be located |
+| `unsupported_layouts` | Records missing a property their payload requires |
+| `fieldless_payloads` | Payloads with nothing a rule could select on |
+| `events_emitted` | Events offered to the queue; exceeds `records_decoded` when a naming event replays held writes |
+| `failures` | The failure counts by provider, event ID, event version, and kind |
+| `unkeyed_failures` | Failures past the 32-key attribution cap, counted but not attributed |
+
+The first seven outcome counters partition `records_received`, so `rustinel
+doctor` can report a record that reached no outcome at all as
+`etw_decode_reconciliation`. `failures` is keyed on provider *names* from the
+subscription table rather than rendered GUIDs, and capped at 32 distinct keys,
+so a provider that starts failing across a wide spread of event IDs cannot grow
+the snapshot without bound. `rustinel doctor` reports the totals as
+`etw_decode`.
+
+These three sections stay separate from each other and from the two losses
+either side of them: ETW's own `EventsLost`, which counts records the kernel
+discarded before the callback ran and is reported in the agent log, and the
+channel counters above, which count events shed after it. The causes and the
+fixes differ, so nothing folds them together.
+
 ### Windows ETW delivery
 
 ETW's real-time session timer hands partially filled buffers to consumers once

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -68,7 +68,13 @@ three platforms, but several Sysmon-style fields are unavailable.
   starts cannot be attributed, and those events are dropped rather than emitted
   without a path. Long-lived holders such as database files and service logs stay
   unobserved until the handle is closed and reopened, which for some services
-  means until reboot. Counted as `unresolved_file_events`.
+  means until reboot. The `file_attribution` section of `telemetry.json` and the
+  `file_path_attribution` check in `rustinel doctor` report the live resolution
+  rate and the handle index's capacity evictions; the agent log samples the
+  drops as `unresolved_file_events`. First measurement, on an idle Windows 11
+  lab desktop over 45 seconds: 399 of 33,029 file events resolved (1.2%), with
+  no index evictions - so on a freshly started agent the gap is wide, and it is
+  handles older than the session rather than index pressure that causes it.
 - **A small share of registry writes is still unattributed (silent risk).**
   Registry keys open before the trace session are named from the kernel handle
   table at startup, which covered 5,908 of 6,644 open keys (88.9%) in 32 ms on a
@@ -82,6 +88,13 @@ three platforms, but several Sysmon-style fields are unavailable.
   section of `telemetry.json` and the `registry_path_resolution` check in
   `rustinel doctor` report the live rate, and the agent log carries the writing
   PID for the first events that fail.
+- **A provider that changes its event templates degrades silently (bounded,
+  counted).** ETW schemas are per-Windows-build, so a record whose schema cannot
+  be located, or whose payload is missing a property this build requires, is
+  dropped inside the callback with the channel counters still reporting a
+  healthy pipeline. The `etw_decode` section of `telemetry.json` and the
+  `etw_decode` check in `rustinel doctor` count these by provider, event ID, and
+  event version, and separate them from records the router filtered on purpose.
 - **Extreme process bursts can still be lost in the kernel.** Both
   ETW sessions use an explicitly sized buffer pool: 256 KB × 64-128 (32 MB
   ceiling) for the main session and 32 KB × 64-512 (16 MB ceiling) for the

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -461,6 +461,60 @@ The measured rate on a mixed workload is 98.7%. A rate well below that, or PIDs
 that are neither protected system processes nor short-lived key users, means the
 rundown missed keys it should have covered and is worth reporting.
 
+### A file rule did not fire on Windows
+
+File events have the same blind spot as registry writes, for the same reason:
+`Write` and `SetInformation` carry no name, only a `FileObject`/`FileKey` pair
+the sensor has to join to an earlier naming event. A handle that was already
+open when the agent started was never named, so its writes cannot be attributed
+and are dropped rather than emitted without a target:
+
+```text
+  [WARN] file_path_attribution: 412 file events had no recoverable path (96.10% resolved)
+      detail: file paths: 10141 of 10553 events resolved (96.10%), 9004 from the handle index, 0 index entries evicted at capacity
+```
+
+Long-lived holders - database files, service logs, the browser - stay unobserved
+until the handle is closed and reopened, so a freshly started agent starts blind
+on most of the machine's write traffic. On an idle Windows 11 lab desktop, a
+45-second run resolved 399 of 33,029 file events (1.2%): the residue is
+dominated by handles that predate the trace session, and the counters above are
+the first measurement of it. Treat the number as a trend on one host rather than
+a target - what matters is whether it improves as the agent runs and whether it
+falls after a Windows update.
+
+`index entries evicted at capacity` above zero is a different problem: the
+handle index holds 8192 entries per identifier, and it only fills when processes
+hold handles open without closing them. Evictions are not themselves a gap - the
+evicted handle may never be written to again - but sustained evictions alongside
+a falling resolution rate are the pair worth reporting.
+
+### Detections stopped firing but nothing was dropped
+
+A record that fails to decode never reaches a channel, so every drop counter
+stays at zero while the detections that needed those events quietly stop.
+`rustinel doctor` reports that stage on its own:
+
+```text
+  [WARN] etw_decode: 118 ETW records failed to decode (0.0042% of 2812004 received)
+      detail: Microsoft-Windows-Kernel-Registry event 5 v2: schema x118
+```
+
+The detail names the provider, event ID, and event *version*. A version this
+build has no template for is the usual cause after a Windows feature update, and
+that pair is what to include in a report. `unsupported_layout` means the record
+was described but a property the payload requires was absent; `fieldless` means
+a payload was built with nothing a rule could select on.
+
+Records the router declined on purpose - reads, queries, opens that created
+nothing - are counted as `records_filtered` and are deliberately not part of
+this rate. They are the bulk of ETW traffic and their volume is the design
+working.
+
+An `etw_decode_reconciliation` warning means records reached no outcome at all.
+A small, non-growing difference is the snapshot catching a record mid-decode; a
+growing one is a bug worth reporting.
+
 ### I see “dropping event” or “queue full” in logs
 
 These messages mean the agent is under backpressure somewhere in the pipeline.

--- a/src/doctor/telemetry.rs
+++ b/src/doctor/telemetry.rs
@@ -242,20 +242,30 @@ fn etw_decode_results(snapshot: &TelemetrySnapshot) -> Vec<DiagnosticResult> {
     // independently on the callback's hot path, so a snapshot taken mid-record
     // is legitimately off by a few.
     if !decode.is_reconciled() {
-        results.push(
-            DiagnosticResult::warn(
-                "etw_decode_reconciliation",
+        let classified = decode.classified();
+        let (message, fix) = if classified < decode.records_received {
+            (
                 format!(
                     "{} of {} ETW records are unaccounted for",
-                    decode.records_received.saturating_sub(decode.classified()),
+                    decode.records_received - classified,
                     decode.records_received,
                 ),
-                decode.describe(),
-            )
-            .with_fix(
                 "A small, non-growing difference is the snapshot catching a record mid-decode. A \
                  growing one is a decoder path that reports no outcome - please report it",
-            ),
+            )
+        } else {
+            (
+                format!(
+                    "ETW outcome count exceeds records received by {}",
+                    classified - decode.records_received,
+                ),
+                "A small, non-growing excess is a snapshot sampled across concurrent ETW updates. \
+                 A growing one means a decoder path reports more than one outcome - please report it",
+            )
+        };
+        results.push(
+            DiagnosticResult::warn("etw_decode_reconciliation", message, decode.describe())
+                .with_fix(fix),
         );
     }
 
@@ -510,6 +520,20 @@ mod tests {
         assert_eq!(results[1].id, "etw_decode_reconciliation");
         assert_eq!(results[1].status, DiagnosticStatus::Warn);
         assert!(results[1].message.contains("1000 of 10000"));
+    }
+
+    #[test]
+    fn excess_outcomes_are_reported_without_masking_the_difference() {
+        let mut snap = snapshot(vec![channel("sensor_events", 10, 0)]);
+        let mut decode = etw_decode(10_000, 0);
+        decode.records_filtered = 10_001;
+        snap.etw_decode = Some(decode);
+
+        let results = etw_decode_results(&snap);
+
+        assert_eq!(results[1].id, "etw_decode_reconciliation");
+        assert_eq!(results[1].status, DiagnosticStatus::Warn);
+        assert!(results[1].message.contains("exceeds records received by 1"));
     }
 
     #[test]

--- a/src/doctor/telemetry.rs
+++ b/src/doctor/telemetry.rs
@@ -44,6 +44,8 @@ pub(crate) fn telemetry_results(
     };
 
     let mut results = registry_results(&snapshot);
+    results.extend(file_attribution_results(&snapshot));
+    results.extend(etw_decode_results(&snapshot));
 
     let dropping = snapshot.dropping_channels();
     if dropping.is_empty() {
@@ -135,11 +137,139 @@ fn registry_results(snapshot: &TelemetrySnapshot) -> Vec<DiagnosticResult> {
     )]
 }
 
+/// Kernel-File path attribution, the file-side twin of [`registry_results`].
+///
+/// A file event whose `FileObject`/`FileKey` resolves to no path is discarded
+/// inside the ETW callback, so like the registry gap it appears in no channel
+/// drop count. Empty on platforms without the ETW file sensor.
+fn file_attribution_results(snapshot: &TelemetrySnapshot) -> Vec<DiagnosticResult> {
+    let Some(files) = snapshot.file_attribution.as_ref() else {
+        return Vec::new();
+    };
+
+    // Writes through handles opened before the sensor started are unresolvable
+    // by construction, so a small residue is expected on any agent that has
+    // not been running long. The threshold is the registry one: below it, the
+    // gap is large enough to cost detections.
+    const TARGET_RATE_PCT: f64 = 99.0;
+
+    let rate = files.resolution_rate_pct();
+    if files.unresolved == 0 || rate >= TARGET_RATE_PCT {
+        return vec![DiagnosticResult::pass(
+            "file_path_attribution",
+            files.describe(),
+        )];
+    }
+
+    let fix = if files.index_capacity_evictions > 0 {
+        "Those events reached no rule. The handle index also evicted entries at its capacity, \
+         which is what a process holding many handles open looks like - see \
+         docs/troubleshooting.md"
+    } else {
+        "Those events reached no rule. Writes through handles opened before the agent started \
+         are expected here; a rate that stays low after a restart means naming events are being \
+         lost - see docs/troubleshooting.md"
+    };
+
+    vec![DiagnosticResult::warn(
+        "file_path_attribution",
+        format!(
+            "{} file events had no recoverable path ({:.2}% resolved)",
+            files.unresolved, rate,
+        ),
+        files.describe(),
+    )
+    .with_fix(fix)]
+}
+
+/// ETW decoder degradation.
+///
+/// A schema lookup that fails, a payload template that no longer matches, or a
+/// payload with nothing a rule can select on all produce a healthy-looking
+/// pipeline with fewer detections in it (#394). Empty on platforms without the
+/// ETW sensor.
+fn etw_decode_results(snapshot: &TelemetrySnapshot) -> Vec<DiagnosticResult> {
+    let Some(decode) = snapshot.etw_decode.as_ref() else {
+        return Vec::new();
+    };
+
+    let mut results = Vec::new();
+
+    if decode.failed() > 0 {
+        let detail = decode
+            .failures
+            .iter()
+            .take(5)
+            .map(|failure| {
+                format!(
+                    "{} event {} v{}: {} x{}",
+                    failure.provider,
+                    failure.event_id,
+                    failure.version,
+                    failure.failure,
+                    failure.count
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("; ");
+
+        results.push(
+            DiagnosticResult::warn(
+                "etw_decode",
+                format!(
+                    "{} ETW records failed to decode ({:.4}% of {} received)",
+                    decode.failed(),
+                    decode.failure_rate_pct(),
+                    decode.records_received,
+                ),
+                if detail.is_empty() {
+                    decode.describe()
+                } else {
+                    detail
+                },
+            )
+            .with_fix(
+                "Those records produced no event, so their rules could not fire. A provider and \
+                 event version that appear here changed under this build - report them with the \
+                 Windows build number; see docs/troubleshooting.md",
+            ),
+        );
+    } else {
+        results.push(DiagnosticResult::pass("etw_decode", decode.describe()));
+    }
+
+    // Only meaningful as a persistent mismatch: the counters are incremented
+    // independently on the callback's hot path, so a snapshot taken mid-record
+    // is legitimately off by a few.
+    if !decode.is_reconciled() {
+        results.push(
+            DiagnosticResult::warn(
+                "etw_decode_reconciliation",
+                format!(
+                    "{} of {} ETW records are unaccounted for",
+                    decode.records_received.saturating_sub(decode.classified()),
+                    decode.records_received,
+                ),
+                decode.describe(),
+            )
+            .with_fix(
+                "A small, non-growing difference is the snapshot catching a record mid-decode. A \
+                 growing one is a decoder path that reports no outcome - please report it",
+            ),
+        );
+    }
+
+    results
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::doctor::inspect::DiagnosticStatus;
-    use crate::telemetry::{ChannelSnapshot, RegistrySnapshot};
+    use crate::telemetry::{
+        ChannelSnapshot, EtwDecodeFailureSnapshot, EtwDecodeSnapshot, FileAttributionSnapshot,
+        RegistrySnapshot,
+    };
 
     fn snapshot(channels: Vec<ChannelSnapshot>) -> TelemetrySnapshot {
         TelemetrySnapshot {
@@ -151,6 +281,8 @@ mod tests {
             sensor_events_by_category: Vec::new(),
             windows_process_command_line: None,
             registry: None,
+            file_attribution: None,
+            etw_decode: None,
         }
     }
 
@@ -241,6 +373,143 @@ mod tests {
             naming_failed: 40,
             snapshot_keys: 5_879,
         }
+    }
+
+    fn file_attribution(resolved: u64, unresolved: u64, evictions: u64) -> FileAttributionSnapshot {
+        FileAttributionSnapshot {
+            attempted: resolved + unresolved,
+            resolved_from_event: resolved,
+            resolved_from_index: 0,
+            unresolved,
+            index_capacity_evictions: evictions,
+        }
+    }
+
+    fn etw_decode(received: u64, schema_errors: u64) -> EtwDecodeSnapshot {
+        EtwDecodeSnapshot {
+            records_received: received,
+            records_filtered: received.saturating_sub(schema_errors),
+            records_indexed: 0,
+            records_decoded: 0,
+            records_unattributed: 0,
+            schema_errors,
+            unsupported_layouts: 0,
+            fieldless_payloads: 0,
+            events_emitted: 0,
+            failures: vec![EtwDecodeFailureSnapshot {
+                provider: "Microsoft-Windows-Kernel-Registry".to_string(),
+                event_id: 5,
+                version: 2,
+                failure: "schema".to_string(),
+                count: schema_errors,
+            }],
+            unkeyed_failures: 0,
+        }
+    }
+
+    /// The file-side twin of the registry gap: these events are discarded
+    /// inside the ETW callback, so no channel counter can show them (#394).
+    #[test]
+    fn unattributed_file_events_are_reported_as_their_own_gap() {
+        let mut snap = snapshot(vec![channel("sensor_events", 10_000, 0)]);
+        snap.file_attribution = Some(file_attribution(900, 100, 0));
+
+        let results = file_attribution_results(&snap);
+
+        assert_eq!(results[0].id, "file_path_attribution");
+        assert_eq!(results[0].status, DiagnosticStatus::Warn);
+        assert!(results[0].message.contains("100 file events"));
+        assert!(results[0].message.contains("90.00% resolved"));
+        assert!(results[0]
+            .fix
+            .as_deref()
+            .expect("fix")
+            .contains("opened before the agent started"));
+    }
+
+    /// Evictions and unresolved events have different fixes, so the advice has
+    /// to name the one that is actually happening.
+    #[test]
+    fn index_evictions_change_the_suggested_fix() {
+        let mut snap = snapshot(vec![channel("sensor_events", 10, 0)]);
+        snap.file_attribution = Some(file_attribution(900, 100, 4_096));
+
+        let results = file_attribution_results(&snap);
+
+        assert!(results[0]
+            .fix
+            .as_deref()
+            .expect("fix")
+            .contains("evicted entries at its capacity"));
+    }
+
+    #[test]
+    fn a_file_resolution_rate_at_target_passes() {
+        let mut snap = snapshot(vec![channel("sensor_events", 10, 0)]);
+        snap.file_attribution = Some(file_attribution(10_000, 1, 0));
+
+        let results = file_attribution_results(&snap);
+
+        assert_eq!(results[0].status, DiagnosticStatus::Pass);
+    }
+
+    #[test]
+    fn a_snapshot_without_windows_counters_adds_no_diagnostic() {
+        // Linux and macOS have no ETW sensor, and snapshots written before
+        // #394 carry neither section.
+        let snap = snapshot(vec![channel("sensor_events", 10, 0)]);
+
+        assert!(file_attribution_results(&snap).is_empty());
+        assert!(etw_decode_results(&snap).is_empty());
+    }
+
+    /// The whole point of #394: records that fail to decode leave the channel
+    /// counters looking healthy, so the failure needs a check of its own that
+    /// names the provider and event version to report.
+    #[test]
+    fn decode_failures_are_reported_with_their_bounded_key() {
+        let mut snap = snapshot(vec![channel("sensor_events", 10_000, 0)]);
+        snap.etw_decode = Some(etw_decode(10_000, 25));
+
+        let results = etw_decode_results(&snap);
+
+        assert_eq!(results[0].id, "etw_decode");
+        assert_eq!(results[0].status, DiagnosticStatus::Warn);
+        assert!(results[0]
+            .message
+            .contains("25 ETW records failed to decode"));
+        assert_eq!(
+            results[0].detail.as_deref(),
+            Some("Microsoft-Windows-Kernel-Registry event 5 v2: schema x25")
+        );
+        // Reconciles, so the second check must not fire.
+        assert_eq!(results.len(), 1);
+    }
+
+    #[test]
+    fn a_decoder_with_no_failures_passes() {
+        let mut snap = snapshot(vec![channel("sensor_events", 10, 0)]);
+        snap.etw_decode = Some(etw_decode(10_000, 0));
+
+        let results = etw_decode_results(&snap);
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].status, DiagnosticStatus::Pass);
+        assert!(results[0].message.contains("10000 records received"));
+    }
+
+    #[test]
+    fn records_that_reach_no_outcome_are_reported_separately() {
+        let mut snap = snapshot(vec![channel("sensor_events", 10, 0)]);
+        let mut decode = etw_decode(10_000, 0);
+        decode.records_filtered = 9_000;
+        snap.etw_decode = Some(decode);
+
+        let results = etw_decode_results(&snap);
+
+        assert_eq!(results[1].id, "etw_decode_reconciliation");
+        assert_eq!(results[1].status, DiagnosticStatus::Warn);
+        assert!(results[1].message.contains("1000 of 10000"));
     }
 
     #[test]

--- a/src/sensor/windows/etw/decode.rs
+++ b/src/sensor/windows/etw/decode.rs
@@ -19,7 +19,9 @@ use crate::models::{
 use crate::sensor::integrity_level::integrity_level_from_sid;
 use crate::sensor::network_events::classify_kernel_network_event;
 use crate::sensor::{Platform, ProcessStartKey, SensorAction, SensorEvent, SensorPayload};
-use crate::telemetry::RegistryPathSource;
+use crate::telemetry::{
+    EtwDecodeFailure, EtwDecodeFailureKey, RegistryPathSource, ETW_DECODE, WINDOWS_FILE_ATTRIBUTION,
+};
 use crate::utils::{convert_nt_to_dos, query_process_command_line};
 use ferrisetw::parser::Parser;
 use ferrisetw::schema_locator::SchemaLocator;
@@ -67,16 +69,45 @@ pub(super) struct DecodedEtwEvent {
     pub(super) payload: SensorPayload,
 }
 
+/// Attribute a decode failure to a bounded provider/event/version key.
+///
+/// The provider comes from the subscription table rather than the record's
+/// GUID, so the key space is bounded by what this build enables; see
+/// [`crate::telemetry::EtwDecodeFailureKey`].
+fn record_failure(record: &EventRecord, state: &EtwState, failure: EtwDecodeFailure) {
+    ETW_DECODE.record_failure(EtwDecodeFailureKey {
+        provider: state.routing.provider_name(record.provider_id()),
+        event_id: record.event_id(),
+        version: record.version(),
+        failure,
+    });
+}
+
+/// Decode one ETW record, accounting for what became of it.
+///
+/// Every record is classified into exactly one outcome. The paths that produce
+/// no event record their own reason - filtered, indexed, unattributed, or one
+/// of the three failures - and this function records the ones that do, so the
+/// totals reconcile against `records_received` and a decoder that quietly
+/// stops producing events cannot hide behind healthy channel counters (#394).
 pub(super) fn decode_record(
     record: &EventRecord,
     schema_locator: &SchemaLocator,
     state: &EtwState,
 ) -> DecodedEtwEvents {
-    if record.provider_id() == state.routing.kernel_registry_guid {
-        return decode_kernel_registry_record(record, schema_locator, state);
-    }
+    ETW_DECODE.record_received();
 
-    DecodedEtwEvents::single(decode_single_record(record, schema_locator, state))
+    let decoded = if record.provider_id() == state.routing.kernel_registry_guid {
+        decode_kernel_registry_record(record, schema_locator, state)
+    } else {
+        DecodedEtwEvents::single(decode_single_record(record, schema_locator, state))
+    };
+
+    let produced = decoded.replayed.len() + usize::from(decoded.primary.is_some());
+    if produced > 0 {
+        ETW_DECODE.record_decoded(produced);
+    }
+    decoded
 }
 
 pub(super) fn decode_single_record(
@@ -88,10 +119,16 @@ pub(super) fn decode_single_record(
         return decode_kernel_file_record(record, schema_locator, state);
     }
 
-    let (category, action) = state.routing.route(record)?;
+    let Some((category, action)) = state.routing.route(record) else {
+        // Intentional: the router declined this record. Volume here is the
+        // provider allowlist working, not a gap, so it is never a failure.
+        ETW_DECODE.record_filtered();
+        return None;
+    };
     let schema = match schema_locator.event_schema(record) {
         Ok(schema) => schema,
         Err(err) => {
+            record_failure(record, state, EtwDecodeFailure::Schema);
             trace!(
                 "Failed to get ETW schema for provider {:?} event {}: {:?}",
                 record.provider_id(),
@@ -117,12 +154,21 @@ pub(super) fn decode_single_record(
             unreachable!("event log categories use the event log sources")
         }
         EventCategory::Task => decode_task(&parser, record),
-    }?;
+    };
+
+    // A payload the template could not fill is a template this build does not
+    // know, not an empty event: the record arrived, and its version says which
+    // layout it used.
+    let Some(decoded) = decoded else {
+        record_failure(record, state, EtwDecodeFailure::UnsupportedLayout);
+        return None;
+    };
 
     // A payload without fields cannot satisfy a Sigma selection. Provider
     // allowlists should prevent these records, but keep this loss-free guard at
     // the decode boundary so manifest drift cannot reintroduce fieldless noise.
     if !has_matchable_fields(&decoded.payload) {
+        record_failure(record, state, EtwDecodeFailure::Fieldless);
         return None;
     }
 
@@ -299,11 +345,15 @@ pub(super) fn decode_kernel_file_record(
     // Checked before the schema lookup: the FILEIO keyword needed for Close
     // and SetInformation also delivers every read and query on the machine,
     // and decoding those would be pure overhead.
-    let route = kernel_file_route(record.event_id())?;
+    let Some(route) = kernel_file_route(record.event_id()) else {
+        ETW_DECODE.record_filtered();
+        return None;
+    };
 
     let schema = match schema_locator.event_schema(record) {
         Ok(schema) => schema,
         Err(err) => {
+            record_failure(record, state, EtwDecodeFailure::Schema);
             trace!(
                 "Failed to get Kernel-File schema for event {}: {:?}",
                 record.event_id(),
@@ -324,43 +374,78 @@ pub(super) fn decode_kernel_file_record(
     // produce telemetry - a Create both reports a creation and teaches us the
     // path for the writes that follow on that handle.
     if let Some(path) = named_path.as_deref() {
-        state.paths().learn(file_object, file_key, path);
+        let mut paths = state.paths();
+        paths.learn(file_object, file_key, path);
+        // Republished on the naming path only: evictions can only happen on an
+        // insert, and this keeps the pathless hot path free of the extra load.
+        WINDOWS_FILE_ATTRIBUTION.set_index_capacity_evictions(paths.capacity_evictions());
     }
 
     let action = match route {
-        KernelFileRoute::Index => return None,
+        KernelFileRoute::Index => {
+            ETW_DECODE.record_indexed();
+            return None;
+        }
         KernelFileRoute::EvictObject => {
             if let Some(object) = file_object {
                 state.paths().forget_object(object);
             }
+            ETW_DECODE.record_indexed();
             return None;
         }
         KernelFileRoute::EvictKey => {
             if let Some(key) = file_key {
                 state.paths().forget_key(key);
             }
+            ETW_DECODE.record_indexed();
             return None;
         }
         // Event ID 12 fires for every handle request, including plain opens;
         // the disposition says whether anything was actually created.
         KernelFileRoute::Emit(SensorAction::Create) => {
-            refine_file_create_action(&parser, SensorAction::Create)?
+            // A disposition that reports an open rather than a creation is the
+            // filter doing its job, not a decode failure.
+            match refine_file_create_action(&parser, SensorAction::Create) {
+                Some(action) => action,
+                None => {
+                    ETW_DECODE.record_filtered();
+                    return None;
+                }
+            }
         }
         KernelFileRoute::Emit(action) => action,
-        KernelFileRoute::SetInformation => set_information_action(&parser)?,
+        // An information class this build does not report on is filtered, not
+        // an unsupported layout: the property was read, it just said "read" or
+        // "rename target" rather than a state change worth an event.
+        KernelFileRoute::SetInformation => match set_information_action(&parser) {
+            Some(action) => action,
+            None => {
+                ETW_DECODE.record_filtered();
+                return None;
+            }
+        },
     };
 
     // A file event with no path cannot match a rule - essentially every file
     // rule keys on TargetFilename - so an unresolvable event is dropped rather
     // than sent on to occupy space in a bounded channel.
     let raw_path = match named_path {
-        Some(path) => path,
+        Some(path) => {
+            WINDOWS_FILE_ATTRIBUTION.record_resolved(false);
+            path
+        }
         None => match state.paths().resolve(file_object, file_key) {
-            Some(path) => path.to_string(),
+            Some(path) => {
+                WINDOWS_FILE_ATTRIBUTION.record_resolved(true);
+                path.to_string()
+            }
             None => {
                 // Counted rather than silently discarded: this is the sensor's
                 // blind spot, and its size is the only way to know whether an
-                // endpoint is quiet or unobserved.
+                // endpoint is quiet or unobserved. The persistent count lives
+                // in `telemetry.json`; the in-process one only spaces the log.
+                ETW_DECODE.record_unattributed();
+                WINDOWS_FILE_ATTRIBUTION.record_unresolved();
                 let unresolved = state.unresolved_file_events.fetch_add(1, Ordering::Relaxed) + 1;
                 if unresolved == 1 || unresolved.is_multiple_of(1000) {
                     debug!(
@@ -373,24 +458,9 @@ pub(super) fn decode_kernel_file_record(
         },
     };
 
-    let mappings = field_maps::file_event_mappings();
-    let fields = FileEventFields {
-        source_filename: None,
-        target_filename: Some(convert_nt_to_dos(&raw_path)),
-        process_id: try_get_uint(&parser, mappings.get_etw_field("ProcessId")?),
-        image: try_get_string(&parser, mappings.get_etw_field("Image")?)
-            .map(|path| convert_nt_to_dos(&path)),
-        // Kernel-File reports which information class was set, never the
-        // values, so unlike Sysmon Event ID 2 these stay empty on Windows.
-        creation_utc_time: try_get_string(&parser, mappings.get_etw_field("CreationUtcTime")?),
-        previous_creation_utc_time: try_get_string(
-            &parser,
-            mappings.get_etw_field("PreviousCreationUtcTime")?,
-        ),
-        user: try_get_string(&parser, mappings.get_etw_field("User")?),
-        // ETW delivers whole paths or none at all; there is no capture buffer
-        // to overflow on Windows.
-        path_truncated: None,
+    let Some(fields) = file_event_fields(&parser, &raw_path) else {
+        record_failure(record, state, EtwDecodeFailure::UnsupportedLayout);
+        return None;
     };
 
     let pid = parse_optional_u32(fields.process_id.as_deref()).or(Some(record.process_id()));
@@ -405,6 +475,33 @@ pub(super) fn decode_kernel_file_record(
         timestamp: filetime_to_system_time(record.raw_timestamp()),
         process_start_key: None,
         payload: SensorPayload::File(fields),
+    })
+}
+
+/// Build the file payload for an event whose path is already resolved.
+///
+/// Extracted so a missing field mapping is one `None` the caller can attribute
+/// as an unsupported layout, rather than a `?` that returns from the middle of
+/// the decode with no record of why.
+fn file_event_fields(parser: &Parser, raw_path: &str) -> Option<FileEventFields> {
+    let mappings = field_maps::file_event_mappings();
+    Some(FileEventFields {
+        source_filename: None,
+        target_filename: Some(convert_nt_to_dos(raw_path)),
+        process_id: try_get_uint(parser, mappings.get_etw_field("ProcessId")?),
+        image: try_get_string(parser, mappings.get_etw_field("Image")?)
+            .map(|path| convert_nt_to_dos(&path)),
+        // Kernel-File reports which information class was set, never the
+        // values, so unlike Sysmon Event ID 2 these stay empty on Windows.
+        creation_utc_time: try_get_string(parser, mappings.get_etw_field("CreationUtcTime")?),
+        previous_creation_utc_time: try_get_string(
+            parser,
+            mappings.get_etw_field("PreviousCreationUtcTime")?,
+        ),
+        user: try_get_string(parser, mappings.get_etw_field("User")?),
+        // ETW delivers whole paths or none at all; there is no capture buffer
+        // to overflow on Windows.
+        path_truncated: None,
     })
 }
 
@@ -425,12 +522,14 @@ pub(super) fn decode_kernel_registry_record(
     // Checked before the schema lookup so unrouted events cost only an
     // integer match.
     let Some(route) = kernel_registry_route(record.event_id()) else {
+        ETW_DECODE.record_filtered();
         return DecodedEtwEvents::default();
     };
 
     let schema = match schema_locator.event_schema(record) {
         Ok(schema) => schema,
         Err(err) => {
+            record_failure(record, state, EtwDecodeFailure::Schema);
             trace!(
                 "Failed to get Kernel-Registry schema for event {}: {:?}",
                 record.event_id(),
@@ -494,12 +593,19 @@ pub(super) fn decode_kernel_registry_record(
                 None
             };
 
+            // A naming event that emitted nothing did its real job: it taught
+            // the index a path, and possibly replayed writes waiting on it.
+            if primary.is_none() && replayed.is_empty() {
+                ETW_DECODE.record_indexed();
+            }
+
             DecodedEtwEvents { primary, replayed }
         }
         KernelRegistryRoute::Evict => {
             if let Some(object) = key_object {
                 state.registry_paths().forget_at(object, event_at);
             }
+            ETW_DECODE.record_indexed();
             DecodedEtwEvents::default()
         }
         KernelRegistryRoute::Emit(action) => {
@@ -520,6 +626,7 @@ pub(super) fn decode_kernel_registry_record(
                 });
 
             let Some(event) = pending_registry_event(&parser, record, action, value_name) else {
+                record_failure(record, state, EtwDecodeFailure::UnsupportedLayout);
                 return DecodedEtwEvents::default();
             };
 
@@ -530,10 +637,16 @@ pub(super) fn decode_kernel_registry_record(
                 }
                 None => {
                     if let Some(object) = key_object.filter(|object| *object != 0) {
+                        // Held for the naming event that has not arrived yet:
+                        // deferred, not lost. Whatever the queue had to shed to
+                        // make room is what the registry counters record.
                         let dropped = state.pending_registry_events().insert(object, event);
                         record_unresolved_registry_events(dropped, record.process_id());
+                        ETW_DECODE.record_indexed();
                     } else {
+                        // No key object at all, so nothing can ever name it.
                         record_unresolved_registry_events(1, record.process_id());
+                        ETW_DECODE.record_unattributed();
                     }
                     DecodedEtwEvents::default()
                 }

--- a/src/sensor/windows/etw/decode.rs
+++ b/src/sensor/windows/etw/decode.rs
@@ -26,7 +26,6 @@ use crate::utils::{convert_nt_to_dos, query_process_command_line};
 use ferrisetw::parser::Parser;
 use ferrisetw::schema_locator::SchemaLocator;
 use ferrisetw::EventRecord;
-use std::sync::atomic::Ordering;
 use tracing::{debug, trace};
 
 /// Map the sensor's index tier onto the telemetry module's, which is platform
@@ -443,10 +442,9 @@ pub(super) fn decode_kernel_file_record(
                 // Counted rather than silently discarded: this is the sensor's
                 // blind spot, and its size is the only way to know whether an
                 // endpoint is quiet or unobserved. The persistent count lives
-                // in `telemetry.json`; the in-process one only spaces the log.
+                // in `telemetry.json` and also spaces the log.
                 ETW_DECODE.record_unattributed();
-                WINDOWS_FILE_ATTRIBUTION.record_unresolved();
-                let unresolved = state.unresolved_file_events.fetch_add(1, Ordering::Relaxed) + 1;
+                let unresolved = WINDOWS_FILE_ATTRIBUTION.record_unresolved();
                 if unresolved == 1 || unresolved.is_multiple_of(1000) {
                     debug!(
                         unresolved_file_events = unresolved,

--- a/src/sensor/windows/etw/providers.rs
+++ b/src/sensor/windows/etw/providers.rs
@@ -220,7 +220,10 @@ impl EtwProviders {
         ]
     }
 
-    #[cfg(test)]
+    /// Every provider this build subscribes to, across both sessions.
+    ///
+    /// The names are what [`super::routing::EtwRouting::provider_name`] labels
+    /// decode failures with, which is what keeps that label space bounded.
     pub(super) fn all() -> Vec<EtwProvider> {
         vec![
             Self::kernel_process(),

--- a/src/sensor/windows/etw/routing.rs
+++ b/src/sensor/windows/etw/routing.rs
@@ -306,6 +306,10 @@ pub(super) struct EtwRouting {
     pub(super) kernel_registry_guid: GUID,
     pub(super) powershell_guid: GUID,
     pub(super) guid_to_category: HashMap<GUID, EventCategory>,
+    /// Subscribed provider GUIDs to their manifest names. Decode failures are
+    /// labelled from this table rather than from a rendered GUID, so the label
+    /// space cannot grow past the providers this build enables.
+    guid_to_name: HashMap<GUID, &'static str>,
 }
 
 impl EtwRouting {
@@ -321,13 +325,32 @@ impl EtwRouting {
         guid_to_category.insert(EtwProviders::wmi_activity().guid, EventCategory::Wmi);
         guid_to_category.insert(EtwProviders::task_scheduler().guid, EventCategory::Task);
 
+        let guid_to_name = EtwProviders::all()
+            .into_iter()
+            .map(|provider| (provider.guid, provider.name))
+            .collect();
+
         Self {
             kernel_process_guid: EtwProviders::kernel_process().guid,
             kernel_file_guid: EtwProviders::kernel_file().guid,
             kernel_registry_guid: EtwProviders::kernel_registry().guid,
             powershell_guid: EtwProviders::powershell().guid,
             guid_to_category,
+            guid_to_name,
         }
+    }
+
+    /// The manifest name of a subscribed provider.
+    ///
+    /// A GUID that is not subscribed collapses to one shared label. Rendering
+    /// it instead would make the failure label space unbounded, which is the
+    /// thing this table exists to prevent; an unsubscribed provider reaching
+    /// the callback is a session-configuration bug, not a decode statistic.
+    pub(super) fn provider_name(&self, guid: GUID) -> &'static str {
+        self.guid_to_name
+            .get(&guid)
+            .copied()
+            .unwrap_or("unsubscribed")
     }
 
     pub(super) fn route(&self, record: &EventRecord) -> Option<(EventCategory, SensorAction)> {

--- a/src/sensor/windows/etw/state.rs
+++ b/src/sensor/windows/etw/state.rs
@@ -178,10 +178,11 @@ pub(super) struct EtwState {
     /// through them cannot be attributed until the handle is reopened. Dropping
     /// them is the right policy - a pathless event matches no rule - but without
     /// a count there is no way to tell a quiet endpoint from a blind one.
-    /// Registry resolution is accounted for in `telemetry.json` instead, by
-    /// [`crate::telemetry::REGISTRY`]: it needs more than a drop count because the
-    /// resolution rate and the share the startup key rundown rescued are what
-    /// say whether the sensor still has a blind spot (#341).
+    /// This counter only spaces the log line. The persistent accounting - the
+    /// resolution rate, which tier answered, and the index's capacity
+    /// evictions - is in `telemetry.json` under
+    /// [`crate::telemetry::WINDOWS_FILE_ATTRIBUTION`] (#394), alongside the
+    /// registry equivalent in [`crate::telemetry::REGISTRY`] (#341).
     pub(super) unresolved_file_events: AtomicU64,
 }
 

--- a/src/sensor/windows/etw/state.rs
+++ b/src/sensor/windows/etw/state.rs
@@ -6,7 +6,6 @@ use super::routing::EtwRouting;
 use crate::models::RegistryEventFields;
 use crate::sensor::{Platform, SensorAction, SensorEvent, SensorNormalization, SensorPayload};
 use std::collections::{HashMap, VecDeque};
-use std::sync::atomic::AtomicU64;
 use std::sync::{Mutex, MutexGuard};
 use std::time::SystemTime;
 
@@ -172,18 +171,6 @@ pub(super) struct EtwState {
     pub(super) file_paths: Mutex<FilePathCache>,
     pub(super) registry_paths: Mutex<RegistryPathCache>,
     pub(super) pending_registry_events: Mutex<PendingRegistryEvents>,
-    /// File events dropped because neither identifier resolved to a path.
-    ///
-    /// Handles opened before the sensor started were never indexed, so writes
-    /// through them cannot be attributed until the handle is reopened. Dropping
-    /// them is the right policy - a pathless event matches no rule - but without
-    /// a count there is no way to tell a quiet endpoint from a blind one.
-    /// This counter only spaces the log line. The persistent accounting - the
-    /// resolution rate, which tier answered, and the index's capacity
-    /// evictions - is in `telemetry.json` under
-    /// [`crate::telemetry::WINDOWS_FILE_ATTRIBUTION`] (#394), alongside the
-    /// registry equivalent in [`crate::telemetry::REGISTRY`] (#341).
-    pub(super) unresolved_file_events: AtomicU64,
 }
 
 impl EtwState {
@@ -193,7 +180,6 @@ impl EtwState {
             file_paths: Mutex::new(FilePathCache::new()),
             registry_paths: Mutex::new(RegistryPathCache::new()),
             pending_registry_events: Mutex::new(PendingRegistryEvents::new()),
-            unresolved_file_events: AtomicU64::new(0),
         }
     }
 

--- a/src/sensor/windows/file_paths.rs
+++ b/src/sensor/windows/file_paths.rs
@@ -54,6 +54,14 @@ pub(super) struct BoundedIndex {
     order: VecDeque<(u64, u64)>,
     capacity: usize,
     next_seq: u64,
+    /// Live entries dropped to stay under `capacity`.
+    ///
+    /// The cap only binds when processes hold handles open without closing
+    /// them, and an evicted handle is one whose later writes can no longer be
+    /// attributed. Counting the evictions separates that cause from the
+    /// unresolved events it produces, which is the difference between "raise
+    /// the cap" and "the provider stopped naming its handles".
+    capacity_evictions: u64,
 }
 
 impl BoundedIndex {
@@ -63,6 +71,7 @@ impl BoundedIndex {
             order: VecDeque::new(),
             capacity,
             next_seq: 0,
+            capacity_evictions: 0,
         }
     }
 
@@ -96,6 +105,7 @@ impl BoundedIndex {
                     // the newer entry that reused the key.
                     if self.entries.get(&oldest).is_some_and(|e| e.seq == seq) {
                         self.entries.remove(&oldest);
+                        self.capacity_evictions = self.capacity_evictions.saturating_add(1);
                     }
                 }
                 None => break,
@@ -117,6 +127,10 @@ impl BoundedIndex {
 
     pub(super) fn forget(&mut self, key: u64) {
         self.entries.remove(&key);
+    }
+
+    pub(super) fn capacity_evictions(&self) -> u64 {
+        self.capacity_evictions
     }
 
     #[cfg(test)]
@@ -175,6 +189,18 @@ impl FilePathCache {
     /// Drop the entry for a name that has left the kernel's name cache.
     pub(super) fn forget_key(&mut self, file_key: u64) {
         self.by_key.forget(file_key);
+    }
+
+    /// Entries both indexes dropped to stay under their cap.
+    ///
+    /// Read by the decoder after each naming event and republished to
+    /// [`crate::telemetry::WINDOWS_FILE_ATTRIBUTION`]; keeping the count here
+    /// leaves the eviction path free of atomics and the index testable on its
+    /// own.
+    pub(super) fn capacity_evictions(&self) -> u64 {
+        self.by_object
+            .capacity_evictions()
+            .saturating_add(self.by_key.capacity_evictions())
     }
 
     /// Total live entries across both indexes.
@@ -258,6 +284,12 @@ mod tests {
         }
 
         assert_eq!(cache.len(), capacity * 2, "both indexes stay at capacity");
+        // Every insert past the cap evicts one live entry from each index, and
+        // that is the count `rustinel doctor` reads back.
+        assert_eq!(
+            cache.capacity_evictions(),
+            2 * (capacity as u64 * 100 - capacity as u64),
+        );
         // The most recent entry survives; the oldest has been evicted.
         let newest = capacity as u64 * 100 - 1;
         assert!(cache.resolve(Some(newest), None).is_some());
@@ -342,6 +374,11 @@ mod tests {
         }
 
         assert_eq!(index.len(), 0);
+        assert_eq!(
+            index.capacity_evictions(),
+            0,
+            "a forgotten handle is not a capacity eviction"
+        );
         assert!(
             index.order.len() <= capacity * 2 + 1,
             "ordering queue compacts instead of growing without bound, was {}",

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -14,6 +14,7 @@
 
 mod snapshot;
 
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{LazyLock, Mutex};
 use std::time::{Duration, Instant};
@@ -25,9 +26,9 @@ use tracing::warn;
 use crate::utils::LogRateLimiter;
 
 pub use snapshot::{
-    snapshot_path, spawn_reporter, write_final_snapshot, ChannelSnapshot,
-    ProcessCommandLineSnapshot, RegistrySnapshot, SensorEventCategorySnapshot, TelemetrySnapshot,
-    SNAPSHOT_FILE_NAME,
+    snapshot_path, spawn_reporter, write_final_snapshot, ChannelSnapshot, EtwDecodeFailureSnapshot,
+    EtwDecodeSnapshot, FileAttributionSnapshot, ProcessCommandLineSnapshot, RegistrySnapshot,
+    SensorEventCategorySnapshot, TelemetrySnapshot, SNAPSHOT_FILE_NAME,
 };
 
 use crate::models::EventCategory;
@@ -321,6 +322,349 @@ impl ProcessCommandLineCounters {
             captured: self.captured.load(Ordering::Relaxed),
             missed: self.missed.load(Ordering::Relaxed),
         })
+    }
+}
+
+/// Windows Kernel-File path attribution accounting.
+///
+/// The Kernel-File events that carry write semantics name their target only by
+/// kernel pointer, so the sensor joins them to an earlier naming event through
+/// a bounded index. A write whose pointer the index cannot answer is discarded
+/// inside the ETW callback, before any channel sees it — exactly the shape of
+/// the registry gap #341 measured, and previously visible only as a private
+/// `AtomicU64` and a rate-limited `debug!` line.
+///
+/// Splitting the two resolved tiers matters: an event that carried its own
+/// name never depended on the index, so a fall in `resolved_from_index`
+/// against a steady `resolved_from_event` points at the index rather than at
+/// the provider. `index_capacity_evictions` is the index's own failure mode —
+/// handles held open past [`crate::sensor`]'s per-index cap — and stays apart
+/// from `unresolved`, which is the resulting detection gap.
+#[derive(Debug, Default)]
+pub struct FileAttributionCounters {
+    attempted: AtomicU64,
+    resolved_from_event: AtomicU64,
+    resolved_from_index: AtomicU64,
+    unresolved: AtomicU64,
+    index_capacity_evictions: AtomicU64,
+}
+
+/// Process-wide file attribution accounting. Idle outside Windows.
+pub static WINDOWS_FILE_ATTRIBUTION: FileAttributionCounters = FileAttributionCounters::new();
+
+impl FileAttributionCounters {
+    const fn new() -> Self {
+        Self {
+            attempted: AtomicU64::new(0),
+            resolved_from_event: AtomicU64::new(0),
+            resolved_from_index: AtomicU64::new(0),
+            unresolved: AtomicU64::new(0),
+            index_capacity_evictions: AtomicU64::new(0),
+        }
+    }
+
+    /// A file event reached the detectors with a path. `from_index` separates
+    /// the events that needed the pointer index from the ones that carried
+    /// their own name.
+    pub fn record_resolved(&self, from_index: bool) {
+        self.attempted.fetch_add(1, Ordering::Relaxed);
+        if from_index {
+            self.resolved_from_index.fetch_add(1, Ordering::Relaxed);
+        } else {
+            self.resolved_from_event.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    /// A file event was dropped because neither identifier resolved to a path.
+    /// Returns the running total, which the caller uses to space its log line.
+    pub fn record_unresolved(&self) -> u64 {
+        self.attempted.fetch_add(1, Ordering::Relaxed);
+        self.unresolved.fetch_add(1, Ordering::Relaxed) + 1
+    }
+
+    /// Publish the index's cumulative capacity evictions.
+    ///
+    /// A store rather than an increment: the index owns the count and this is
+    /// a republication of it, which keeps the eviction path free of atomics
+    /// and keeps the index unit-testable without process-wide state.
+    pub fn set_index_capacity_evictions(&self, evictions: u64) {
+        self.index_capacity_evictions
+            .store(evictions, Ordering::Relaxed);
+    }
+
+    /// Point-in-time view, or `None` when no file event has been attributed.
+    pub fn snapshot(&self) -> Option<FileAttributionSnapshot> {
+        let attempted = self.attempted.load(Ordering::Relaxed);
+        if attempted == 0 {
+            return None;
+        }
+        Some(FileAttributionSnapshot {
+            attempted,
+            resolved_from_event: self.resolved_from_event.load(Ordering::Relaxed),
+            resolved_from_index: self.resolved_from_index.load(Ordering::Relaxed),
+            unresolved: self.unresolved.load(Ordering::Relaxed),
+            index_capacity_evictions: self.index_capacity_evictions.load(Ordering::Relaxed),
+        })
+    }
+
+    /// Reset every counter. Test-only, for the same reason as
+    /// [`ChannelCounters::reset`].
+    #[cfg(test)]
+    pub fn reset(&self) {
+        self.attempted.store(0, Ordering::Relaxed);
+        self.resolved_from_event.store(0, Ordering::Relaxed);
+        self.resolved_from_index.store(0, Ordering::Relaxed);
+        self.unresolved.store(0, Ordering::Relaxed);
+        self.index_capacity_evictions.store(0, Ordering::Relaxed);
+    }
+}
+
+/// Why a routed ETW record produced no sensor event.
+///
+/// Only failures are named here. A record the router declined, or one whose
+/// whole job was to feed a path index, is not a failure and is counted apart —
+/// see [`EtwDecodeCounters`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum EtwDecodeFailure {
+    /// `SchemaLocator` could not describe the record, so no property of it is
+    /// readable. Provider manifests are per-build, so this is what a provider
+    /// that changed under an agent looks like.
+    Schema,
+    /// The record was described but a property the payload requires was
+    /// absent: the template this build knows is not the one that arrived.
+    UnsupportedLayout,
+    /// A payload was built and every field a rule could select on was empty.
+    Fieldless,
+}
+
+impl EtwDecodeFailure {
+    /// Stable identifier used in snapshots and doctor output.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            EtwDecodeFailure::Schema => "schema",
+            EtwDecodeFailure::UnsupportedLayout => "unsupported_layout",
+            EtwDecodeFailure::Fieldless => "fieldless",
+        }
+    }
+}
+
+/// What a decode failure is attributed to.
+///
+/// `provider` is a `&'static str` from the subscription table rather than a
+/// rendered GUID, and the event ID and version come from the record header, so
+/// the label space is bounded by the providers this build subscribes to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct EtwDecodeFailureKey {
+    pub provider: &'static str,
+    pub event_id: u16,
+    pub version: u8,
+    pub failure: EtwDecodeFailure,
+}
+
+/// Distinct failure keys retained before attribution stops.
+///
+/// The keys are already bounded by the provider allowlist, so this is a second
+/// bound rather than the only one: it caps the memory a provider that starts
+/// emitting a wide spread of event IDs can take, and caps the size of the
+/// snapshot an operator has to read. Failures past the cap are still counted,
+/// just not attributed — `unkeyed_failures` says how many.
+const ETW_DECODE_FAILURE_KEYS: usize = 32;
+
+/// Failure keys and their counts, capped at [`ETW_DECODE_FAILURE_KEYS`].
+#[derive(Debug, Default)]
+struct BoundedFailureKeys {
+    counts: HashMap<EtwDecodeFailureKey, u64>,
+    unkeyed: u64,
+}
+
+impl BoundedFailureKeys {
+    fn record(&mut self, key: EtwDecodeFailureKey) {
+        if let Some(count) = self.counts.get_mut(&key) {
+            *count = count.saturating_add(1);
+            return;
+        }
+        if self.counts.len() >= ETW_DECODE_FAILURE_KEYS {
+            self.unkeyed = self.unkeyed.saturating_add(1);
+            return;
+        }
+        self.counts.insert(key, 1);
+    }
+
+    /// Worst first, then by key, so the snapshot is stable across writes.
+    fn snapshot(&self) -> Vec<EtwDecodeFailureSnapshot> {
+        let mut failures: Vec<(EtwDecodeFailureKey, u64)> = self
+            .counts
+            .iter()
+            .map(|(key, count)| (*key, *count))
+            .collect();
+        failures.sort_by_key(|(key, count)| (std::cmp::Reverse(*count), *key));
+        failures
+            .into_iter()
+            .map(|(key, count)| EtwDecodeFailureSnapshot {
+                provider: key.provider.to_string(),
+                event_id: key.event_id,
+                version: key.version,
+                failure: key.failure.as_str().to_string(),
+                count,
+            })
+            .collect()
+    }
+}
+
+/// Windows ETW decoder accounting.
+///
+/// Every record the callback sees is classified into exactly one outcome, so
+/// the totals reconcile against `records_received` and a silent decoder
+/// regression cannot hide behind healthy channel counters. The outcomes are
+/// deliberately not all losses:
+///
+/// - `records_filtered` is intentional — the router declined the record, or a
+///   disposition said an open was not a creation. Volume here is the design
+///   working, not a gap.
+/// - `records_indexed` is a record whose job was to teach or evict a path, or
+///   a registry write held for a naming event that has not arrived yet.
+/// - `records_decoded` produced at least one event; `events_emitted` counts
+///   the events, which is larger whenever a naming event replays writes.
+/// - `records_unattributed` is the file and registry attribution gap: the
+///   record was understood and dropped for want of a path.
+/// - the three failure totals are decoder degradation, and each is attributed
+///   to a bounded provider/event/version key.
+///
+/// This is deliberately separate from ETW's own `EventsLost`, which counts
+/// records the kernel discarded before the callback ran, and from the channel
+/// counters, which count events shed after it. The three losses have different
+/// causes and different fixes, so nothing here folds them together.
+#[derive(Debug, Default)]
+pub struct EtwDecodeCounters {
+    records_received: AtomicU64,
+    records_filtered: AtomicU64,
+    records_indexed: AtomicU64,
+    records_decoded: AtomicU64,
+    records_unattributed: AtomicU64,
+    schema_errors: AtomicU64,
+    unsupported_layouts: AtomicU64,
+    fieldless_payloads: AtomicU64,
+    events_emitted: AtomicU64,
+    failures: Mutex<Option<BoundedFailureKeys>>,
+}
+
+/// Process-wide ETW decoder accounting. Idle outside Windows.
+pub static ETW_DECODE: EtwDecodeCounters = EtwDecodeCounters::new();
+
+impl EtwDecodeCounters {
+    const fn new() -> Self {
+        Self {
+            records_received: AtomicU64::new(0),
+            records_filtered: AtomicU64::new(0),
+            records_indexed: AtomicU64::new(0),
+            records_decoded: AtomicU64::new(0),
+            records_unattributed: AtomicU64::new(0),
+            schema_errors: AtomicU64::new(0),
+            unsupported_layouts: AtomicU64::new(0),
+            fieldless_payloads: AtomicU64::new(0),
+            events_emitted: AtomicU64::new(0),
+            failures: Mutex::new(None),
+        }
+    }
+
+    /// A record reached the ETW callback.
+    pub fn record_received(&self) {
+        self.records_received.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// A record was intentionally not turned into an event.
+    pub fn record_filtered(&self) {
+        self.records_filtered.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// A record maintained a path index or was held for a late naming event.
+    pub fn record_indexed(&self) {
+        self.records_indexed.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// A record produced `events` sensor events.
+    pub fn record_decoded(&self, events: usize) {
+        self.records_decoded.fetch_add(1, Ordering::Relaxed);
+        self.events_emitted
+            .fetch_add(events as u64, Ordering::Relaxed);
+    }
+
+    /// A record was understood but dropped for want of a resolvable path.
+    pub fn record_unattributed(&self) {
+        self.records_unattributed.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// A record failed to decode, attributed to a bounded key.
+    pub fn record_failure(&self, key: EtwDecodeFailureKey) {
+        let total = match key.failure {
+            EtwDecodeFailure::Schema => &self.schema_errors,
+            EtwDecodeFailure::UnsupportedLayout => &self.unsupported_layouts,
+            EtwDecodeFailure::Fieldless => &self.fieldless_payloads,
+        };
+        total.fetch_add(1, Ordering::Relaxed);
+
+        // Recovered rather than propagated: this runs inside an OS-invoked ETW
+        // callback, where unwinding would take the sensor down, and the
+        // attribution table is reporting state the decoder does not read back.
+        let mut failures = self
+            .failures
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        failures
+            .get_or_insert_with(BoundedFailureKeys::default)
+            .record(key);
+    }
+
+    /// Point-in-time view, or `None` when no record has been decoded.
+    pub fn snapshot(&self) -> Option<EtwDecodeSnapshot> {
+        let records_received = self.records_received.load(Ordering::Relaxed);
+        if records_received == 0 {
+            return None;
+        }
+        let failures = self
+            .failures
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let (attributed, unkeyed) = match failures.as_ref() {
+            Some(keys) => (keys.snapshot(), keys.unkeyed),
+            None => (Vec::new(), 0),
+        };
+        Some(EtwDecodeSnapshot {
+            records_received,
+            records_filtered: self.records_filtered.load(Ordering::Relaxed),
+            records_indexed: self.records_indexed.load(Ordering::Relaxed),
+            records_decoded: self.records_decoded.load(Ordering::Relaxed),
+            records_unattributed: self.records_unattributed.load(Ordering::Relaxed),
+            schema_errors: self.schema_errors.load(Ordering::Relaxed),
+            unsupported_layouts: self.unsupported_layouts.load(Ordering::Relaxed),
+            fieldless_payloads: self.fieldless_payloads.load(Ordering::Relaxed),
+            events_emitted: self.events_emitted.load(Ordering::Relaxed),
+            failures: attributed,
+            unkeyed_failures: unkeyed,
+        })
+    }
+
+    /// Reset every counter. Test-only, for the same reason as
+    /// [`ChannelCounters::reset`].
+    #[cfg(test)]
+    pub fn reset(&self) {
+        for counter in [
+            &self.records_received,
+            &self.records_filtered,
+            &self.records_indexed,
+            &self.records_decoded,
+            &self.records_unattributed,
+            &self.schema_errors,
+            &self.unsupported_layouts,
+            &self.fieldless_payloads,
+            &self.events_emitted,
+        ] {
+            counter.store(0, Ordering::Relaxed);
+        }
+        *self
+            .failures
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
     }
 }
 
@@ -621,6 +965,285 @@ mod tests {
         assert_eq!(snapshot.snapshot_keys, 0);
     }
 
+    /// A decoder driven by injected faults, without an ETW session.
+    ///
+    /// `EventRecord` and `SchemaLocator` are opaque OS-owned handles that
+    /// cannot be constructed in a unit test, so the decoder's *classification*
+    /// is exercised here through the same counter API the ETW callback calls,
+    /// with the faults chosen by the caller. What this pins down is the part a
+    /// live capture cannot check by inspection: that every record lands in
+    /// exactly one outcome and that the totals reconcile.
+    struct DecoderHarness {
+        decode: EtwDecodeCounters,
+        files: FileAttributionCounters,
+        queued: u64,
+    }
+
+    /// What the provider is doing to one record.
+    enum InjectedFault {
+        None,
+        /// The router declined it.
+        Filtered,
+        /// It only fed a path index.
+        Indexed,
+        /// Its path could not be recovered, so it was dropped.
+        Unattributed,
+        Failure(EtwDecodeFailure),
+    }
+
+    impl DecoderHarness {
+        fn new() -> Self {
+            Self {
+                decode: EtwDecodeCounters::new(),
+                files: FileAttributionCounters::new(),
+                queued: 0,
+            }
+        }
+
+        /// Feed one record whose decode hits `fault`, emitting `events` on the
+        /// clean path.
+        fn feed(
+            &mut self,
+            provider: &'static str,
+            event_id: u16,
+            version: u8,
+            fault: InjectedFault,
+            events: usize,
+        ) {
+            self.decode.record_received();
+            match fault {
+                InjectedFault::Filtered => self.decode.record_filtered(),
+                InjectedFault::Indexed => self.decode.record_indexed(),
+                InjectedFault::Unattributed => {
+                    self.decode.record_unattributed();
+                    self.files.record_unresolved();
+                }
+                InjectedFault::None if provider == "Microsoft-Windows-Kernel-File" => {
+                    self.files.record_resolved(true);
+                    self.decode.record_decoded(events);
+                    self.queued += events as u64;
+                }
+                InjectedFault::Failure(failure) => {
+                    self.decode.record_failure(EtwDecodeFailureKey {
+                        provider,
+                        event_id,
+                        version,
+                        failure,
+                    })
+                }
+                InjectedFault::None => {
+                    self.decode.record_decoded(events);
+                    self.queued += events as u64;
+                }
+            }
+        }
+    }
+
+    /// The counters exist to answer "is the decoder still producing events?",
+    /// and that answer is only trustworthy if every record is accounted for.
+    #[test]
+    fn injected_decode_faults_reconcile_with_received_and_queued_records() {
+        let mut harness = DecoderHarness::new();
+
+        // A healthy provider, a naming event that replays two held writes, and
+        // one of each degradation the decoder can suffer.
+        harness.feed(
+            "Microsoft-Windows-Kernel-Process",
+            1,
+            3,
+            InjectedFault::None,
+            1,
+        );
+        harness.feed(
+            "Microsoft-Windows-Kernel-Registry",
+            1,
+            0,
+            InjectedFault::None,
+            3,
+        );
+        harness.feed(
+            "Microsoft-Windows-Kernel-File",
+            15,
+            0,
+            InjectedFault::Filtered,
+            0,
+        );
+        harness.feed(
+            "Microsoft-Windows-Kernel-File",
+            10,
+            0,
+            InjectedFault::Indexed,
+            0,
+        );
+        harness.feed(
+            "Microsoft-Windows-Kernel-File",
+            16,
+            0,
+            InjectedFault::Unattributed,
+            0,
+        );
+        harness.feed(
+            "Microsoft-Windows-DNS-Client",
+            3020,
+            0,
+            InjectedFault::Failure(EtwDecodeFailure::Schema),
+            0,
+        );
+        harness.feed(
+            "Microsoft-Windows-Kernel-Process",
+            1,
+            9,
+            InjectedFault::Failure(EtwDecodeFailure::UnsupportedLayout),
+            0,
+        );
+        harness.feed(
+            "Microsoft-Windows-PowerShell",
+            4104,
+            1,
+            InjectedFault::Failure(EtwDecodeFailure::Fieldless),
+            0,
+        );
+
+        let snapshot = harness.decode.snapshot().expect("records were received");
+
+        assert_eq!(snapshot.records_received, 8);
+        assert_eq!(snapshot.records_filtered, 1);
+        assert_eq!(snapshot.records_indexed, 1);
+        assert_eq!(snapshot.records_decoded, 2);
+        assert_eq!(snapshot.records_unattributed, 1);
+        assert_eq!(snapshot.schema_errors, 1);
+        assert_eq!(snapshot.unsupported_layouts, 1);
+        assert_eq!(snapshot.fieldless_payloads, 1);
+        assert!(
+            snapshot.is_reconciled(),
+            "every record must land in exactly one outcome: {snapshot:?}"
+        );
+        // A naming event replays the writes that were waiting on it, so more
+        // events reach the queue than there were decoded records.
+        assert_eq!(snapshot.events_emitted, 4);
+        assert_eq!(snapshot.events_emitted, harness.queued);
+
+        // Intentional filtering is not loss, and does not inflate the rate an
+        // operator reads as decoder degradation.
+        assert_eq!(snapshot.failed(), 3);
+        assert!((snapshot.failure_rate_pct() - 37.5).abs() < f64::EPSILON);
+
+        // Only the Kernel-File records touch path attribution, and the write
+        // that could not be named is the one gap no channel counter can show.
+        let files = harness
+            .files
+            .snapshot()
+            .expect("file events were attributed");
+        assert_eq!(files.attempted, 1);
+        assert_eq!(files.unresolved, 1);
+        assert_eq!(files.resolution_rate_pct(), 0.0);
+    }
+
+    /// The events a decoded record produces have to reach the queue, and the
+    /// two counters are kept by different modules — so reconcile them.
+    #[tokio::test]
+    async fn emitted_events_reconcile_with_the_sensor_queue() {
+        let _guard = counter_guard();
+        let mut harness = DecoderHarness::new();
+        let (tx, _rx) = tokio::sync::mpsc::channel::<u8>(2);
+
+        for _ in 0..5 {
+            harness.feed(
+                "Microsoft-Windows-Kernel-Process",
+                1,
+                3,
+                InjectedFault::None,
+                1,
+            );
+            let _ = try_send(ChannelId::SensorEvents, &tx, 1);
+        }
+
+        let snapshot = harness.decode.snapshot().expect("records were received");
+        let channel = ChannelId::SensorEvents.counters();
+
+        assert_eq!(snapshot.events_emitted, 5);
+        assert_eq!(
+            snapshot.events_emitted,
+            channel.accepted() + channel.dropped(),
+            "every emitted event is either queued or shed, never neither"
+        );
+        // The queue shed three of them, and that is a different gap from any
+        // of the decoder's: the record decoded fine.
+        assert_eq!(channel.dropped(), 3);
+        assert_eq!(snapshot.failed(), 0);
+    }
+
+    /// A provider that starts failing across a wide spread of event IDs must
+    /// not be able to grow the snapshot without bound.
+    #[test]
+    fn decode_failure_keys_are_bounded_and_ranked() {
+        let counters = EtwDecodeCounters::new();
+
+        for event_id in 0..(ETW_DECODE_FAILURE_KEYS as u16 * 4) {
+            counters.record_received();
+            counters.record_failure(EtwDecodeFailureKey {
+                provider: "Microsoft-Windows-Kernel-File",
+                event_id,
+                version: 0,
+                failure: EtwDecodeFailure::Schema,
+            });
+        }
+        // One key fails far more often than the rest, and must lead.
+        for _ in 0..100 {
+            counters.record_received();
+            counters.record_failure(EtwDecodeFailureKey {
+                provider: "Microsoft-Windows-Kernel-File",
+                event_id: 0,
+                version: 0,
+                failure: EtwDecodeFailure::Schema,
+            });
+        }
+
+        let snapshot = counters.snapshot().expect("records were received");
+
+        assert_eq!(snapshot.failures.len(), ETW_DECODE_FAILURE_KEYS);
+        assert_eq!(snapshot.failures[0].event_id, 0);
+        assert_eq!(snapshot.failures[0].count, 101);
+        assert_eq!(
+            snapshot.failures[0].provider,
+            "Microsoft-Windows-Kernel-File"
+        );
+        // Nothing is lost by the cap: the failures past it are still counted,
+        // just not attributed.
+        assert_eq!(snapshot.unkeyed_failures, 96);
+        assert_eq!(
+            snapshot.failed(),
+            snapshot.failures.iter().map(|f| f.count).sum::<u64>() + snapshot.unkeyed_failures
+        );
+    }
+
+    /// Absent counters must stay absent rather than reporting a perfect run:
+    /// Linux and macOS have no ETW decoder at all.
+    #[test]
+    fn idle_windows_counters_report_nothing() {
+        assert!(EtwDecodeCounters::new().snapshot().is_none());
+        assert!(FileAttributionCounters::new().snapshot().is_none());
+    }
+
+    /// The index owns the eviction count; telemetry republishes it. A store
+    /// rather than an increment means a republication cannot double-count.
+    #[test]
+    fn index_capacity_evictions_are_republished_not_accumulated() {
+        let counters = FileAttributionCounters::new();
+        counters.record_resolved(true);
+
+        counters.set_index_capacity_evictions(12);
+        counters.set_index_capacity_evictions(12);
+        counters.set_index_capacity_evictions(30);
+
+        let snapshot = counters.snapshot().expect("a file event was attributed");
+        assert_eq!(snapshot.index_capacity_evictions, 30);
+        // Evictions are the mechanism, not the gap: they must not be mistaken
+        // for events that failed to resolve.
+        assert_eq!(snapshot.unresolved, 0);
+        assert_eq!(snapshot.resolution_rate_pct(), 100.0);
+    }
+
     /// Serializes tests that assert on the process-wide statics.
     fn counter_guard() -> std::sync::MutexGuard<'static, ()> {
         static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
@@ -628,6 +1251,8 @@ mod tests {
         for channel in ChannelId::ALL {
             channel.counters().reset();
         }
+        ETW_DECODE.reset();
+        WINDOWS_FILE_ATTRIBUTION.reset();
         // The warning limiter is process-wide too. Reset it alongside the
         // counters so tests cannot inherit a channel's rate-limit window.
         let mut limiter = DROP_WARNINGS

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -330,19 +330,18 @@ impl ProcessCommandLineCounters {
 /// The Kernel-File events that carry write semantics name their target only by
 /// kernel pointer, so the sensor joins them to an earlier naming event through
 /// a bounded index. A write whose pointer the index cannot answer is discarded
-/// inside the ETW callback, before any channel sees it — exactly the shape of
+/// inside the ETW callback, before any channel sees it - exactly the shape of
 /// the registry gap #341 measured, and previously visible only as a private
 /// `AtomicU64` and a rate-limited `debug!` line.
 ///
 /// Splitting the two resolved tiers matters: an event that carried its own
 /// name never depended on the index, so a fall in `resolved_from_index`
 /// against a steady `resolved_from_event` points at the index rather than at
-/// the provider. `index_capacity_evictions` is the index's own failure mode —
-/// handles held open past [`crate::sensor`]'s per-index cap — and stays apart
+/// the provider. `index_capacity_evictions` is the index's own failure mode -
+/// handles held open past [`crate::sensor`]'s per-index cap - and stays apart
 /// from `unresolved`, which is the resulting detection gap.
 #[derive(Debug, Default)]
 pub struct FileAttributionCounters {
-    attempted: AtomicU64,
     resolved_from_event: AtomicU64,
     resolved_from_index: AtomicU64,
     unresolved: AtomicU64,
@@ -355,7 +354,6 @@ pub static WINDOWS_FILE_ATTRIBUTION: FileAttributionCounters = FileAttributionCo
 impl FileAttributionCounters {
     const fn new() -> Self {
         Self {
-            attempted: AtomicU64::new(0),
             resolved_from_event: AtomicU64::new(0),
             resolved_from_index: AtomicU64::new(0),
             unresolved: AtomicU64::new(0),
@@ -367,7 +365,6 @@ impl FileAttributionCounters {
     /// the events that needed the pointer index from the ones that carried
     /// their own name.
     pub fn record_resolved(&self, from_index: bool) {
-        self.attempted.fetch_add(1, Ordering::Relaxed);
         if from_index {
             self.resolved_from_index.fetch_add(1, Ordering::Relaxed);
         } else {
@@ -378,7 +375,6 @@ impl FileAttributionCounters {
     /// A file event was dropped because neither identifier resolved to a path.
     /// Returns the running total, which the caller uses to space its log line.
     pub fn record_unresolved(&self) -> u64 {
-        self.attempted.fetch_add(1, Ordering::Relaxed);
         self.unresolved.fetch_add(1, Ordering::Relaxed) + 1
     }
 
@@ -394,15 +390,20 @@ impl FileAttributionCounters {
 
     /// Point-in-time view, or `None` when no file event has been attributed.
     pub fn snapshot(&self) -> Option<FileAttributionSnapshot> {
-        let attempted = self.attempted.load(Ordering::Relaxed);
+        let resolved_from_event = self.resolved_from_event.load(Ordering::Relaxed);
+        let resolved_from_index = self.resolved_from_index.load(Ordering::Relaxed);
+        let unresolved = self.unresolved.load(Ordering::Relaxed);
+        let attempted = resolved_from_event
+            .saturating_add(resolved_from_index)
+            .saturating_add(unresolved);
         if attempted == 0 {
             return None;
         }
         Some(FileAttributionSnapshot {
             attempted,
-            resolved_from_event: self.resolved_from_event.load(Ordering::Relaxed),
-            resolved_from_index: self.resolved_from_index.load(Ordering::Relaxed),
-            unresolved: self.unresolved.load(Ordering::Relaxed),
+            resolved_from_event,
+            resolved_from_index,
+            unresolved,
             index_capacity_evictions: self.index_capacity_evictions.load(Ordering::Relaxed),
         })
     }
@@ -411,7 +412,6 @@ impl FileAttributionCounters {
     /// [`ChannelCounters::reset`].
     #[cfg(test)]
     pub fn reset(&self) {
-        self.attempted.store(0, Ordering::Relaxed);
         self.resolved_from_event.store(0, Ordering::Relaxed);
         self.resolved_from_index.store(0, Ordering::Relaxed);
         self.unresolved.store(0, Ordering::Relaxed);
@@ -422,7 +422,7 @@ impl FileAttributionCounters {
 /// Why a routed ETW record produced no sensor event.
 ///
 /// Only failures are named here. A record the router declined, or one whose
-/// whole job was to feed a path index, is not a failure and is counted apart —
+/// whole job was to feed a path index, is not a failure and is counted apart -
 /// see [`EtwDecodeCounters`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum EtwDecodeFailure {
@@ -467,7 +467,7 @@ pub struct EtwDecodeFailureKey {
 /// bound rather than the only one: it caps the memory a provider that starts
 /// emitting a wide spread of event IDs can take, and caps the size of the
 /// snapshot an operator has to read. Failures past the cap are still counted,
-/// just not attributed — `unkeyed_failures` says how many.
+/// just not attributed - `unkeyed_failures` says how many.
 const ETW_DECODE_FAILURE_KEYS: usize = 32;
 
 /// Failure keys and their counts, capped at [`ETW_DECODE_FAILURE_KEYS`].
@@ -518,7 +518,7 @@ impl BoundedFailureKeys {
 /// regression cannot hide behind healthy channel counters. The outcomes are
 /// deliberately not all losses:
 ///
-/// - `records_filtered` is intentional — the router declined the record, or a
+/// - `records_filtered` is intentional - the router declined the record, or a
 ///   disposition said an open was not a creation. Volume here is the design
 ///   working, not a gap.
 /// - `records_indexed` is a record whose job was to teach or evict a path, or
@@ -1140,7 +1140,7 @@ mod tests {
     }
 
     /// The events a decoded record produces have to reach the queue, and the
-    /// two counters are kept by different modules — so reconcile them.
+    /// two counters are kept by different modules - so reconcile them.
     #[tokio::test]
     async fn emitted_events_reconcile_with_the_sensor_queue() {
         let _guard = counter_guard();
@@ -1237,6 +1237,7 @@ mod tests {
         counters.set_index_capacity_evictions(30);
 
         let snapshot = counters.snapshot().expect("a file event was attributed");
+        assert_eq!(snapshot.attempted, 1);
         assert_eq!(snapshot.index_capacity_evictions, 30);
         // Evictions are the mechanism, not the gap: they must not be mistaken
         // for events that failed to resolve.

--- a/src/telemetry/snapshot.rs
+++ b/src/telemetry/snapshot.rs
@@ -123,7 +123,7 @@ pub struct FileAttributionSnapshot {
     /// Those dropped because neither identifier resolved to a path.
     pub unresolved: u64,
     /// Index entries evicted because a handle was held past the per-index cap.
-    /// Not itself a gap — the evicted handle may never be written to again —
+    /// Not itself a gap - the evicted handle may never be written to again -
     /// but it is the mechanism that produces one, so it is reported apart.
     pub index_capacity_evictions: u64,
 }

--- a/src/telemetry/snapshot.rs
+++ b/src/telemetry/snapshot.rs
@@ -108,6 +108,175 @@ pub struct RegistrySnapshot {
     pub snapshot_keys: usize,
 }
 
+/// Windows Kernel-File path attribution at a point in time.
+///
+/// Windows only, and absent from the snapshot on other platforms and before a
+/// file event has been decoded.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FileAttributionSnapshot {
+    /// File events that needed a target path.
+    pub attempted: u64,
+    /// Those the event named itself, without consulting the pointer index.
+    pub resolved_from_event: u64,
+    /// Those the `FileObject`/`FileKey` index resolved.
+    pub resolved_from_index: u64,
+    /// Those dropped because neither identifier resolved to a path.
+    pub unresolved: u64,
+    /// Index entries evicted because a handle was held past the per-index cap.
+    /// Not itself a gap — the evicted handle may never be written to again —
+    /// but it is the mechanism that produces one, so it is reported apart.
+    pub index_capacity_evictions: u64,
+}
+
+impl FileAttributionSnapshot {
+    /// File events that reached the detectors with a path.
+    pub fn resolved(&self) -> u64 {
+        self.resolved_from_event
+            .saturating_add(self.resolved_from_index)
+    }
+
+    /// Share of file events that reached the detectors with a path.
+    pub fn resolution_rate_pct(&self) -> f64 {
+        let seen = self.resolved().saturating_add(self.unresolved);
+        if seen == 0 {
+            return 100.0;
+        }
+        (self.resolved() as f64 / seen as f64) * 100.0
+    }
+
+    /// One-line operator summary.
+    pub fn describe(&self) -> String {
+        format!(
+            "file paths: {} of {} events resolved ({:.2}%), {} from the handle index, {} index entries evicted at capacity",
+            self.resolved(),
+            self.resolved().saturating_add(self.unresolved),
+            self.resolution_rate_pct(),
+            self.resolved_from_index,
+            self.index_capacity_evictions,
+        )
+    }
+}
+
+/// One decode failure key and how often it fired.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EtwDecodeFailureSnapshot {
+    /// Provider name from the subscription table, never a rendered GUID.
+    pub provider: String,
+    pub event_id: u16,
+    /// Event template version from the record header. A version this build has
+    /// no template for is the usual cause of `unsupported_layout`.
+    pub version: u8,
+    /// `schema`, `unsupported_layout`, or `fieldless`.
+    pub failure: String,
+    pub count: u64,
+}
+
+/// Windows ETW decoder accounting at a point in time.
+///
+/// Windows only, and absent from the snapshot on other platforms and before
+/// the ETW sensor has decoded a record.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EtwDecodeSnapshot {
+    /// Records delivered to the ETW callback.
+    pub records_received: u64,
+    /// Records the router intentionally declined. Not loss.
+    pub records_filtered: u64,
+    /// Records that maintained a path index or were held for a naming event.
+    pub records_indexed: u64,
+    /// Records that produced at least one sensor event.
+    pub records_decoded: u64,
+    /// Records dropped for want of a resolvable path.
+    pub records_unattributed: u64,
+    /// Records whose provider schema could not be located.
+    pub schema_errors: u64,
+    /// Records missing a property their payload requires.
+    pub unsupported_layouts: u64,
+    /// Payloads built with no field a rule could select on.
+    pub fieldless_payloads: u64,
+    /// Sensor events offered to the queue. Exceeds `records_decoded` whenever
+    /// a naming event replays writes that were waiting on it.
+    pub events_emitted: u64,
+    /// Failures by bounded provider/event/version key, worst first.
+    #[serde(default)]
+    pub failures: Vec<EtwDecodeFailureSnapshot>,
+    /// Failures that arrived after the key table was full, so they are counted
+    /// in the totals but attributed to no key.
+    #[serde(default)]
+    pub unkeyed_failures: u64,
+}
+
+impl EtwDecodeSnapshot {
+    /// Records that failed to decode, across all three failure modes.
+    pub fn failed(&self) -> u64 {
+        self.schema_errors
+            .saturating_add(self.unsupported_layouts)
+            .saturating_add(self.fieldless_payloads)
+    }
+
+    /// Share of received records that failed to decode.
+    pub fn failure_rate_pct(&self) -> f64 {
+        if self.records_received == 0 {
+            return 0.0;
+        }
+        (self.failed() as f64 / self.records_received as f64) * 100.0
+    }
+
+    /// Whether every received record is accounted for by exactly one outcome.
+    ///
+    /// The counters are incremented independently on a hot path, so a snapshot
+    /// taken mid-record can be off by one; a persistent mismatch means an
+    /// outcome the decoder does not classify, which is the state this whole
+    /// section exists to make impossible.
+    pub fn is_reconciled(&self) -> bool {
+        self.classified() == self.records_received
+    }
+
+    /// Records attributed to an outcome.
+    pub fn classified(&self) -> u64 {
+        [
+            self.records_filtered,
+            self.records_indexed,
+            self.records_decoded,
+            self.records_unattributed,
+            self.schema_errors,
+            self.unsupported_layouts,
+            self.fieldless_payloads,
+        ]
+        .into_iter()
+        .fold(0u64, u64::saturating_add)
+    }
+
+    /// One-line operator summary.
+    pub fn describe(&self) -> String {
+        let worst = self
+            .failures
+            .first()
+            .map(|failure| {
+                format!(
+                    ", worst {} event {} v{} {} x{}",
+                    failure.provider,
+                    failure.event_id,
+                    failure.version,
+                    failure.failure,
+                    failure.count
+                )
+            })
+            .unwrap_or_default();
+        format!(
+            "etw decode: {} records received, {} decoded into {} events, {} filtered, {} indexed, {} unattributed, {} failed ({:.4}%){}",
+            self.records_received,
+            self.records_decoded,
+            self.events_emitted,
+            self.records_filtered,
+            self.records_indexed,
+            self.records_unattributed,
+            self.failed(),
+            self.failure_rate_pct(),
+            worst,
+        )
+    }
+}
+
 /// Sensor queue traffic for one normalized event category.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SensorEventCategorySnapshot {
@@ -182,6 +351,14 @@ pub struct TelemetrySnapshot {
     /// registry sensor, and on snapshots written before #341.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub registry: Option<RegistrySnapshot>,
+    /// Kernel-File path attribution. Absent on platforms without the ETW file
+    /// sensor, and on snapshots written before #394.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub file_attribution: Option<FileAttributionSnapshot>,
+    /// ETW decoder outcomes. Absent on platforms without the ETW sensor, and
+    /// on snapshots written before #394.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub etw_decode: Option<EtwDecodeSnapshot>,
 }
 
 impl TelemetrySnapshot {
@@ -199,6 +376,8 @@ impl TelemetrySnapshot {
             sensor_events_by_category: super::sensor_event_category_snapshots(),
             windows_process_command_line: super::WINDOWS_PROCESS_COMMAND_LINE.snapshot(),
             registry: super::REGISTRY.snapshot(),
+            file_attribution: super::WINDOWS_FILE_ATTRIBUTION.snapshot(),
+            etw_decode: super::ETW_DECODE.snapshot(),
         }
     }
 
@@ -367,6 +546,8 @@ mod tests {
             sensor_events_by_category: Vec::new(),
             windows_process_command_line: None,
             registry: None,
+            file_attribution: None,
+            etw_decode: None,
         }
     }
 
@@ -426,11 +607,114 @@ mod tests {
         assert_eq!(fidelity.capture_rate_pct(), 75.0);
     }
 
+    fn file_attribution(resolved_from_index: u64, unresolved: u64) -> FileAttributionSnapshot {
+        FileAttributionSnapshot {
+            attempted: resolved_from_index + unresolved + 10,
+            resolved_from_event: 10,
+            resolved_from_index,
+            unresolved,
+            index_capacity_evictions: 4,
+        }
+    }
+
+    #[test]
+    fn file_resolution_rate_counts_both_resolved_tiers() {
+        let files = file_attribution(80, 10);
+
+        assert_eq!(files.resolved(), 90);
+        assert_eq!(files.resolution_rate_pct(), 90.0);
+        assert!(files
+            .describe()
+            .contains("90 of 100 events resolved (90.00%)"));
+        assert!(files.describe().contains("4 index entries evicted"));
+    }
+
+    /// An idle file sensor must read as "nothing to attribute", not as a gap.
+    #[test]
+    fn a_file_sensor_that_saw_nothing_reports_full_resolution() {
+        let idle = FileAttributionSnapshot {
+            attempted: 0,
+            resolved_from_event: 0,
+            resolved_from_index: 0,
+            unresolved: 0,
+            index_capacity_evictions: 0,
+        };
+
+        assert_eq!(idle.resolution_rate_pct(), 100.0);
+    }
+
+    /// Intentional filtering is the bulk of ETW traffic, so it must not count
+    /// against the decoder the way a schema failure does.
+    #[test]
+    fn filtered_records_do_not_inflate_the_decode_failure_rate() {
+        let decode = EtwDecodeSnapshot {
+            records_received: 1_000,
+            records_filtered: 800,
+            records_indexed: 100,
+            records_decoded: 90,
+            records_unattributed: 5,
+            schema_errors: 3,
+            unsupported_layouts: 1,
+            fieldless_payloads: 1,
+            events_emitted: 120,
+            failures: Vec::new(),
+            unkeyed_failures: 0,
+        };
+
+        assert_eq!(decode.failed(), 5);
+        assert!((decode.failure_rate_pct() - 0.5).abs() < f64::EPSILON);
+        assert!(decode.is_reconciled());
+        assert!(decode.describe().contains("800 filtered"));
+    }
+
+    /// A decoder path that reports no outcome is exactly the hidden
+    /// degradation this section exists to surface, so the mismatch is visible
+    /// in the snapshot rather than needing to be derived by hand.
+    #[test]
+    fn an_unclassified_record_fails_reconciliation() {
+        let decode = EtwDecodeSnapshot {
+            records_received: 10,
+            records_filtered: 4,
+            records_indexed: 0,
+            records_decoded: 5,
+            records_unattributed: 0,
+            schema_errors: 0,
+            unsupported_layouts: 0,
+            fieldless_payloads: 0,
+            events_emitted: 5,
+            failures: Vec::new(),
+            unkeyed_failures: 0,
+        };
+
+        assert_eq!(decode.classified(), 9);
+        assert!(!decode.is_reconciled());
+    }
+
     #[test]
     fn a_snapshot_round_trips_through_the_file() {
         let temp = tempfile::tempdir().expect("tempdir");
         let path = snapshot_path(temp.path());
-        let written = snapshot(vec![channel("sensor_events", 5, 2)]);
+        let mut written = snapshot(vec![channel("sensor_events", 5, 2)]);
+        written.file_attribution = Some(file_attribution(80, 10));
+        written.etw_decode = Some(EtwDecodeSnapshot {
+            records_received: 10,
+            records_filtered: 4,
+            records_indexed: 1,
+            records_decoded: 3,
+            records_unattributed: 1,
+            schema_errors: 1,
+            unsupported_layouts: 0,
+            fieldless_payloads: 0,
+            events_emitted: 5,
+            failures: vec![EtwDecodeFailureSnapshot {
+                provider: "Microsoft-Windows-DNS-Client".to_string(),
+                event_id: 3020,
+                version: 0,
+                failure: "schema".to_string(),
+                count: 1,
+            }],
+            unkeyed_failures: 0,
+        });
 
         written.write_to(&path).expect("write snapshot");
         let read = TelemetrySnapshot::read_from(&path).expect("read snapshot");

--- a/tests/telemetry_backpressure.rs
+++ b/tests/telemetry_backpressure.rs
@@ -150,6 +150,8 @@ fn snapshot_with(channels: Vec<ChannelSnapshot>) -> TelemetrySnapshot {
         sensor_events_by_category: Vec::new(),
         windows_process_command_line: None,
         registry: None,
+        file_attribution: None,
+        etw_decode: None,
     }
 }
 


### PR DESCRIPTION
Closes #394.

## The gap

Two classes of event are discarded inside the ETW callback, before any bounded channel sees them:

- A record whose schema lookup fails returns after a `trace!` line ([decode.rs](https://github.com/Karib0u/rustinel/blob/e805befcc463b0310b6a87af5aba4f0cd6ecc681/src/sensor/windows/etw/decode.rs#L98)). Same for a payload missing a required property, or one with no field a rule can select on.
- A file event whose `FileObject`/`FileKey` resolves to no path was counted only in a private `AtomicU64` on `EtwState` plus a rate-limited `debug!`.

Either can hollow out detections while `sensor_events` reports zero drops. This is the file-side and decoder-side twin of what #341 did for registry writes.

## What changed

Two new sections in `telemetry.json`, added alongside the existing registry, channel and command-line accounting rather than replacing any of it.

`file_attribution` — `attempted`, `resolved_from_event`, `resolved_from_index`, `unresolved`, `index_capacity_evictions`. The two resolved tiers are split because a fall in index resolutions against steady event-named ones points at the index rather than the provider. Evictions are the *mechanism* and are reported apart from `unresolved`, which is the resulting gap — that is the difference between "raise the cap" and "the provider stopped naming its handles". The count is kept by `BoundedIndex` itself and republished on the naming path, which leaves the eviction path free of atomics and the index unit-testable on its own.

`etw_decode` — every record is classified into exactly one outcome:

| outcome | meaning |
| --- | --- |
| `records_filtered` | the router declined it, or a disposition said an open was not a creation — **not loss** |
| `records_indexed` | fed a path index, or was held for a naming event that has not arrived |
| `records_decoded` | produced at least one event (`events_emitted` is larger when a naming event replays held writes) |
| `records_unattributed` | understood, then dropped for want of a path |
| `schema_errors` / `unsupported_layouts` / `fieldless_payloads` | decoder degradation |

The seven partition `records_received`, so a decoder path that reports *no* outcome is itself visible — doctor surfaces that as `etw_decode_reconciliation`.

Failures are attributed to a `{provider, event_id, version, kind}` key. `provider` is a `&'static str` from the subscription table, never a rendered GUID, and the table is capped at 32 distinct keys with the overflow counted as `unkeyed_failures` — so a provider that starts failing across a wide spread of event IDs cannot grow the snapshot without bound. The event *version* is in the key because a Windows feature update shipping a new template is the expected cause.

Kernel-buffer `EventsLost`, sensor queue drops and this decode accounting stay three separate numbers throughout.

`rustinel doctor` gains `file_path_attribution`, `etw_decode` and `etw_decode_reconciliation`.

## Tests

- Fault-injected decoder harness in `src/telemetry`: `EventRecord` and `SchemaLocator` are opaque OS handles that cannot be built in a unit test, so the harness drives the same counter API the callback calls, with the fault per record chosen by the test. It asserts the outcomes partition `records_received` and that `events_emitted` reconciles with the sensor channel's `accepted + dropped`.
- Bounded-key test: 128 distinct failing event IDs collapse to 32 keys plus 96 `unkeyed_failures`, worst key first, with nothing lost from the totals.
- `file_paths.rs` asserts capacity evictions are counted and that a `forget` is not one.
- Doctor tests for each new check, including that evictions change the suggested fix.

## Verification

macOS: `cargo test`, `cargo clippy --all-targets -- -D clippy::all`, `cargo fmt --check` all clean.

lab-windows (the sensor code does not compile on macOS): `cargo check --locked --all-targets`, `cargo clippy --locked --all-targets -- -D clippy::all` and the full `cargo test --locked` suite all pass.

Live 45-second agent run on that box, reconciling exactly — `5369 + 19341 + 1295 + 32630 = 58635` received:

```json
"file_attribution": {
  "attempted": 33029, "resolved_from_event": 153, "resolved_from_index": 246,
  "unresolved": 32630, "index_capacity_evictions": 0
},
"etw_decode": {
  "records_received": 58635, "records_filtered": 5369, "records_indexed": 19341,
  "records_decoded": 1295, "records_unattributed": 32630,
  "schema_errors": 0, "unsupported_layouts": 0, "fieldless_payloads": 0,
  "events_emitted": 1295, "failures": [], "unkeyed_failures": 0
}
```

## Reviewer note — this immediately found something

That run is the first measurement of the file attribution gap: **399 of 33,029 file events resolved, 1.2%**, with zero index evictions. So it is handles older than the trace session, not index pressure. `docs/limitations.md` already said writes through pre-existing handles are invisible; it did not say the share was this large.

I have recorded the figure in the docs as a single short measurement on one idle lab desktop rather than a baseline — I did not get a longer run. Closing that gap is a sensor change and out of scope here; this PR is the instrumentation that makes it visible. `file_path_attribution` will warn on Windows hosts until it is addressed, which is accurate but worth knowing before merge.