### PR TITLE
perf(macos-network): batch socket ownership attribution

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -229,7 +229,9 @@ would succeed.
   script, WMI, service, or task equivalents.
 - **Network and DNS attribution is best-effort.** Telemetry comes from
   `/dev/bpf` capture rather than a per-process hook, so connections are matched
-  to processes by port (racy), DNS events are not attributed at all, and capture
+  to processes by port (racy) against a socket inventory rebuilt at most every
+  250 ms — so a connection whose socket opens and closes inside that window can
+  go unattributed — DNS events are not attributed at all, and capture
   binds to a single interface (default `en0`, override with
   `RUSTINEL_BPF_INTERFACE`). A wire capture also cannot say who opened the
   connection, so `Initiated` is left absent and rules selecting on it — either

--- a/src/sensor/macos/bpf.rs
+++ b/src/sensor/macos/bpf.rs
@@ -425,10 +425,17 @@ fn run_capture(device: BpfDevice, tx: Sender<SensorEvent>, shutdown: Arc<AtomicB
 /// process, perform the libproc socket lookup off the capture thread, and
 /// forward the (now best-effort attributed) event to the pipeline. Exits when
 /// the capture thread drops its sender.
+///
+/// Each wake-up drains everything already queued and resolves the whole batch
+/// against one [`socket::SocketOwnerCache`], so a burst of connections costs
+/// one system-wide scan rather than one per connection.
 fn run_attribution_worker(rx: Receiver<AttributionJob>, tx: Sender<SensorEvent>) {
-    while let Ok(mut job) = rx.recv() {
-        apply_socket_owner(&mut job.event, job.local_port, job.remote_port);
-        try_send(&tx, job.event);
+    let mut cache = socket::SocketOwnerCache::new(socket::INVENTORY_TTL);
+    while let Ok(job) = rx.recv() {
+        for mut job in std::iter::once(job).chain(rx.try_iter()) {
+            apply_socket_owner(&mut cache, &mut job.event, job.local_port, job.remote_port);
+            try_send(&tx, job.event);
+        }
     }
 }
 
@@ -506,11 +513,16 @@ fn enqueue_attribution(
 }
 
 /// Best-effort: attribute a connection event to its owning process by matching
-/// the connection's ports against open sockets. Failures leave the event
-/// unattributed (the normalizer still enriches by destination). Runs on the
-/// attribution worker, never on the capture thread.
-fn apply_socket_owner(event: &mut SensorEvent, local_port: u16, remote_port: u16) {
-    let Some(owner) = socket::find_tcp_socket_owner(local_port, remote_port) else {
+/// the connection's ports against the cached socket inventory. Failures leave
+/// the event unattributed (the normalizer still enriches by destination). Runs
+/// on the attribution worker, never on the capture thread.
+fn apply_socket_owner(
+    cache: &mut socket::SocketOwnerCache,
+    event: &mut SensorEvent,
+    local_port: u16,
+    remote_port: u16,
+) {
+    let Some(owner) = cache.find_tcp_socket_owner(local_port, remote_port) else {
         return;
     };
     event.pid = Some(owner.pid);

--- a/src/sensor/macos/socket.rs
+++ b/src/sensor/macos/socket.rs
@@ -4,11 +4,20 @@
 //! this module maps a connection back to a PID by scanning every process's
 //! socket descriptors (the macOS equivalent of walking `/proc/net` on Linux).
 //!
-//! This is inherently best-effort and racy: the socket may have closed by the
-//! time we scan, and the scan is `O(processes x descriptors)`. It is therefore
-//! used only for TCP connection initiations (one lookup per connection), not
-//! for every DNS query. The NetworkExtension framework is the future
+//! A single scan is `O(processes x descriptors)`, so it is never run per
+//! connection. One scan builds a [`SocketTable`] indexing *every* live TCP
+//! socket by its port pair, and [`SocketOwnerCache`] reuses that table for a
+//! bounded interval. A burst of queued connections therefore shares one
+//! traversal, and a lookup miss answers from the current table instead of
+//! rescanning.
+//!
+//! Attribution stays inherently best-effort and racy: the socket may have
+//! closed before the scan, and a connection seen just after a scan is answered
+//! from a table that predates it. The NetworkExtension framework is the future
 //! high-fidelity alternative that carries the owning PID with each flow.
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
 
 use libc::c_int;
 use libproc::file_info::{pidfdinfo, ListFDs, ProcFDType};
@@ -20,19 +29,94 @@ use libproc::processes::{pids_by_type, ProcFilter};
 /// descriptors than this may not be matched (rare in practice).
 const MAX_FDS: usize = 1024;
 
+/// How long a socket table is reused before a lookup may rebuild it. Bounds
+/// the scan rate to one traversal per interval no matter how many connections
+/// are queued, which is what keeps a burst (and its misses) from turning into
+/// a rescan per connection.
+pub(super) const INVENTORY_TTL: Duration = Duration::from_millis(250);
+
 /// Owner of a captured connection.
 pub(super) struct SocketOwner {
     pub pid: u32,
     pub image: Option<String>,
 }
 
-/// Find the process owning a TCP connection identified by its local and remote
-/// ports. Returns `None` when no live socket matches or inspection is denied.
+/// Every live TCP socket on the system, keyed by `(local_port, remote_port)`,
+/// as observed by one system-wide scan.
 ///
-/// Matching on the local (ephemeral) port plus remote port is reliable because
-/// the local port is effectively unique to a single active connection.
-pub(super) fn find_tcp_socket_owner(local_port: u16, remote_port: u16) -> Option<SocketOwner> {
+/// The local (ephemeral) port plus remote port is effectively unique to a
+/// single active connection, which is what makes the pair a usable key.
+pub(super) struct SocketTable {
+    owners: HashMap<(u16, u16), i32>,
+}
+
+impl SocketTable {
+    /// The PID owning the socket with this port pair, if the scan saw one.
+    fn owner_pid(&self, local_port: u16, remote_port: u16) -> Option<i32> {
+        self.owners.get(&(local_port, remote_port)).copied()
+    }
+}
+
+/// A [`SocketTable`] reused across lookups for [`INVENTORY_TTL`].
+///
+/// A lookup rebuilds the table only when the current one has expired, so the
+/// scan rate is bounded by the TTL rather than by connection volume. Misses
+/// are answered from the table in hand: a connection the scan did not see
+/// stays unattributed until the next rebuild is due.
+pub(super) struct SocketOwnerCache {
+    table: Option<(Instant, SocketTable)>,
+    ttl: Duration,
+}
+
+impl SocketOwnerCache {
+    pub fn new(ttl: Duration) -> Self {
+        Self { table: None, ttl }
+    }
+
+    /// Find the process owning a TCP connection identified by its local and
+    /// remote ports. Returns `None` when no scanned socket matches or when the
+    /// scan itself is denied.
+    pub fn find_tcp_socket_owner(
+        &mut self,
+        local_port: u16,
+        remote_port: u16,
+    ) -> Option<SocketOwner> {
+        let pid = self.owner_pid(local_port, remote_port, Instant::now(), scan_tcp_sockets)?;
+        Some(SocketOwner {
+            pid: pid as u32,
+            image: pidpath(pid).ok(),
+        })
+    }
+
+    /// Table lookup behind [`Self::find_tcp_socket_owner`], with the clock and
+    /// the scan injected so tests can count traversals.
+    fn owner_pid(
+        &mut self,
+        local_port: u16,
+        remote_port: u16,
+        now: Instant,
+        scan: impl FnOnce() -> Option<SocketTable>,
+    ) -> Option<i32> {
+        let expired = match &self.table {
+            Some((built_at, _)) => now.duration_since(*built_at) >= self.ttl,
+            None => true,
+        };
+        if expired {
+            if let Some(table) = scan() {
+                self.table = Some((now, table));
+            }
+        }
+        let (_, table) = self.table.as_ref()?;
+        table.owner_pid(local_port, remote_port)
+    }
+}
+
+/// Walk every process's socket descriptors once, indexing the TCP sockets by
+/// port pair. Returns `None` only when the process list itself is unavailable;
+/// processes and descriptors that cannot be inspected are skipped.
+fn scan_tcp_sockets() -> Option<SocketTable> {
     let pids = pids_by_type(ProcFilter::All).ok()?;
+    let mut owners = HashMap::new();
     for pid in pids {
         if pid == 0 {
             continue;
@@ -48,29 +132,30 @@ pub(super) fn find_tcp_socket_owner(local_port: u16, remote_port: u16) -> Option
             let Ok(socket) = pidfdinfo::<SocketFDInfo>(pid, fd.proc_fd) else {
                 continue;
             };
-            if tcp_ports_match(&socket, local_port, remote_port) {
-                return Some(SocketOwner {
-                    pid: pid as u32,
-                    image: pidpath(pid).ok(),
-                });
+            if let Some(ports) = tcp_ports(&socket) {
+                // First writer wins: the earliest process seen owning a port
+                // pair is kept, matching the old scan's first-match return.
+                owners.entry(ports).or_insert(pid);
             }
         }
     }
-    None
+    Some(SocketTable { owners })
 }
 
-/// Whether a socket descriptor is a TCP socket with the given local and remote
-/// ports.
-fn tcp_ports_match(socket: &SocketFDInfo, local_port: u16, remote_port: u16) -> bool {
+/// The `(local_port, remote_port)` pair of a TCP socket descriptor, or `None`
+/// for any other socket kind.
+fn tcp_ports(socket: &SocketFDInfo) -> Option<(u16, u16)> {
     let info = &socket.psi;
     if !matches!(SocketInfoKind::from(info.soi_kind), SocketInfoKind::Tcp) {
-        return false;
+        return None;
     }
     // SAFETY: soi_kind == Tcp guarantees the TCP arm of the proto union is the
     // active variant, so reading pri_tcp is sound.
     let in_info = unsafe { info.soi_proto.pri_tcp.tcpsi_ini };
-    port_from_network(in_info.insi_lport) == local_port
-        && port_from_network(in_info.insi_fport) == remote_port
+    Some((
+        port_from_network(in_info.insi_lport),
+        port_from_network(in_info.insi_fport),
+    ))
 }
 
 /// Convert a port stored in network byte order (low 16 bits of a `c_int`) to a
@@ -81,6 +166,9 @@ fn port_from_network(port: c_int) -> u16 {
 
 #[cfg(test)]
 mod tests {
+    use std::cell::Cell;
+    use std::net::{TcpListener, TcpStream};
+
     use super::*;
     use libproc::net_info::{InSockInfo, TcpSockInfo};
 
@@ -100,18 +188,123 @@ mod tests {
         socket
     }
 
+    fn table(entries: &[((u16, u16), i32)]) -> SocketTable {
+        SocketTable {
+            owners: entries.iter().copied().collect(),
+        }
+    }
+
     #[test]
     fn matches_tcp_socket_by_ports() {
         let socket = tcp_socket(51324, 443);
-        assert!(tcp_ports_match(&socket, 51324, 443));
-        assert!(!tcp_ports_match(&socket, 51324, 80));
-        assert!(!tcp_ports_match(&socket, 1234, 443));
+        assert_eq!(tcp_ports(&socket), Some((51324, 443)));
     }
 
     #[test]
     fn ignores_non_tcp_sockets() {
         let mut socket = tcp_socket(51324, 443);
         socket.psi.soi_kind = SocketInfoKind::In as c_int;
-        assert!(!tcp_ports_match(&socket, 51324, 443));
+        assert_eq!(tcp_ports(&socket), None);
+    }
+
+    #[test]
+    fn connection_burst_shares_one_scan() {
+        let scans = Cell::new(0);
+        let mut cache = SocketOwnerCache::new(INVENTORY_TTL);
+        let now = Instant::now();
+
+        // A burst of distinct connections, all within the TTL: one traversal
+        // serves every lookup, hit or miss.
+        for local_port in 50_000u16..50_500 {
+            let owner = cache.owner_pid(local_port, 443, now, || {
+                scans.set(scans.get() + 1);
+                Some(table(&[((50_000, 443), 42), ((50_001, 443), 99)]))
+            });
+            let expected = match local_port {
+                50_000 => Some(42),
+                50_001 => Some(99),
+                _ => None,
+            };
+            assert_eq!(owner, expected, "port {local_port}");
+        }
+
+        assert_eq!(scans.get(), 1);
+    }
+
+    #[test]
+    fn misses_do_not_rescan_within_the_ttl() {
+        let scans = Cell::new(0);
+        let mut cache = SocketOwnerCache::new(INVENTORY_TTL);
+        let start = Instant::now();
+        let scan = || {
+            scans.set(scans.get() + 1);
+            Some(table(&[]))
+        };
+
+        assert_eq!(cache.owner_pid(50_000, 443, start, scan), None);
+        let just_before_expiry = start + INVENTORY_TTL - Duration::from_millis(1);
+        assert_eq!(cache.owner_pid(50_001, 443, just_before_expiry, scan), None);
+
+        assert_eq!(scans.get(), 1);
+    }
+
+    #[test]
+    fn rebuilds_after_the_ttl_expires() {
+        let scans = Cell::new(0);
+        let mut cache = SocketOwnerCache::new(INVENTORY_TTL);
+        let start = Instant::now();
+
+        assert_eq!(
+            cache.owner_pid(50_000, 443, start, || {
+                scans.set(scans.get() + 1);
+                Some(table(&[]))
+            }),
+            None
+        );
+        // The socket opened after the first scan is found once the table is
+        // due for a rebuild.
+        assert_eq!(
+            cache.owner_pid(50_000, 443, start + INVENTORY_TTL, || {
+                scans.set(scans.get() + 1);
+                Some(table(&[((50_000, 443), 7)]))
+            }),
+            Some(7)
+        );
+
+        assert_eq!(scans.get(), 2);
+    }
+
+    #[test]
+    fn keeps_the_previous_table_when_a_scan_fails() {
+        let mut cache = SocketOwnerCache::new(INVENTORY_TTL);
+        let start = Instant::now();
+
+        assert_eq!(
+            cache.owner_pid(50_000, 443, start, || Some(table(&[((50_000, 443), 7)]))),
+            Some(7)
+        );
+        assert_eq!(
+            cache.owner_pid(50_000, 443, start + INVENTORY_TTL, || None),
+            Some(7)
+        );
+    }
+
+    /// End-to-end check of the real libproc scan: a live loopback connection
+    /// this process owns must be attributed back to this process.
+    #[test]
+    fn scan_attributes_a_live_loopback_connection() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback listener");
+        let server_port = listener.local_addr().expect("listener addr").port();
+        let client = TcpStream::connect(("127.0.0.1", server_port)).expect("connect to listener");
+        let accepted = listener.accept().expect("accept connection").0;
+        let local_port = client.local_addr().expect("client addr").port();
+
+        let mut cache = SocketOwnerCache::new(INVENTORY_TTL);
+        let owner = cache
+            .find_tcp_socket_owner(local_port, server_port)
+            .expect("live connection is attributed");
+
+        assert_eq!(owner.pid, std::process::id());
+        drop(accepted);
     }
 }


### PR DESCRIPTION
Closes #376

## Problem

Each queued macOS TCP connection called `find_tcp_socket_owner`, which enumerated every process, listed up to 1,024 descriptors per process, and queried every socket descriptor. The traversal ran once per connection, and a miss cost the *complete* walk. Under connection churn the serial attribution worker spent most of its time rebuilding the same system-wide information.

## Change

- `scan_tcp_sockets()` walks the process/descriptor space once and builds a `SocketTable` indexing **every** live TCP socket by its `(local_port, remote_port)` pair.
- `SocketOwnerCache` reuses that table for `INVENTORY_TTL` (250 ms). A lookup rebuilds only when the table has expired, so the scan rate is bounded by the TTL rather than by connection volume, and a miss is answered from the table in hand instead of rescanning.
- The attribution worker drains everything already queued on each wake-up (`recv()` then `try_iter()`) and resolves the whole batch against one cache — a burst shares one traversal. Misses forward the event unattributed, as before.
- `pidpath()` moved to the lookup path, so a scan no longer resolves an image per socket — only per attributed connection.

Port matching behavior is unchanged: same TCP-kind check, same network-order comparison, and the first process seen owning a port pair still wins (matching the old first-match return).

## Measured

A full scan takes ~4.6 ms unprivileged on an idle Mac (185 sockets); as root it inspects considerably more. Previously that was paid per connection; now it is capped at four per second no matter how many connections are queued.

## Tests

`src/sensor/macos/socket.rs` (all run on macOS CI):

- `connection_burst_shares_one_scan` — 500 distinct connections, hits and misses, resolve from **one** counted traversal.
- `misses_do_not_rescan_within_the_ttl` — a miss inside the TTL does not trigger a second scan.
- `rebuilds_after_the_ttl_expires` — a socket opened after the first scan is found once the table is due.
- `keeps_the_previous_table_when_a_scan_fails` — a failed scan does not drop working attribution.
- `scan_attributes_a_live_loopback_connection` — end-to-end against the real libproc scan: a live loopback connection is attributed back to this process (ran 15x, stable).

`cargo fmt --check`, `cargo clippy --all-targets` and `cargo test --lib` (345 tests) all pass locally on macOS.

## Docs

`docs/limitations.md` now states the 250 ms inventory window, since a connection whose socket opens and closes inside it can go unattributed — the one behavioral trade-off of the cache.