### PR TITLE
perf(ioc): index wildcard domain suffixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,3 +102,8 @@ criterion = "0.8"
 [[bench]]
 name = "sigma_engine"
 harness = false
+
+# Wildcard-domain IOC matching, measured with `cargo bench --bench ioc_domains`.
+[[bench]]
+name = "ioc_domains"
+harness = false

--- a/benches/ioc_domains.rs
+++ b/benches/ioc_domains.rs
@@ -1,0 +1,99 @@
+//! Throughput benchmark for wildcard-domain IOC matching.
+//!
+//! Wildcard indicators (`*.example.com`) are indexed by suffix, so lookup cost
+//! should track hostname depth, not feed size. The small and 100,000-entry
+//! feeds below are the two ends of that comparison: threat feeds of the latter
+//! size are common, and the previous linear scan made every eligible event pay
+//! for the whole feed.
+//!
+//! ```sh
+//! cargo bench --bench ioc_domains
+//! ```
+
+use std::hint::black_box;
+use std::path::{Path, PathBuf};
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use rustinel::config::IocConfig;
+use rustinel::ioc::IocEngine;
+use rustinel::models::{DnsQueryFields, EventCategory, EventFields, NormalizedEvent};
+use rustinel::sensor::Platform;
+use tempfile::TempDir;
+
+const SMALL_FEED: usize = 100;
+const LARGE_FEED: usize = 100_000;
+
+/// A wildcard feed of `count` distinct suffixes, none of which match the
+/// hostnames benchmarked below, plus one indicator that does.
+fn write_feed(dir: &Path, count: usize) -> PathBuf {
+    let mut feed = String::from("# IOC Type: Domains\n");
+    for i in 0..count {
+        feed.push_str(&format!("*.feed{i}.invalid;bench\n"));
+    }
+    feed.push_str("*.malware.test;bench hit\n");
+
+    let path = dir.join("domains.txt");
+    std::fs::write(&path, feed).expect("write domain feed");
+    path
+}
+
+fn engine_with_feed(dir: &Path, count: usize) -> IocEngine {
+    let domains_path = write_feed(dir, count);
+    IocEngine::load(&IocConfig {
+        enabled: true,
+        hashes_path: dir.join("hashes.txt"),
+        ips_path: dir.join("ips.txt"),
+        domains_path,
+        paths_regex_path: dir.join("paths.txt"),
+        default_severity: "high".to_string(),
+        max_file_size_mb: 0,
+        hash_allowlist_paths: Vec::new(),
+    })
+}
+
+fn dns_event(query_name: &str) -> NormalizedEvent {
+    NormalizedEvent {
+        timestamp: "2025-01-01T00:00:00Z".to_string(),
+        platform: Platform::Linux,
+        provider: "bench".to_string(),
+        category: EventCategory::Dns,
+        event_id: 22,
+        event_id_string: "22".to_string(),
+        opcode: 0,
+        fields: EventFields::DnsQuery(DnsQueryFields {
+            query_name: Some(query_name.to_string()),
+            query_results: None,
+            record_type: None,
+            query_status: None,
+            process_id: None,
+            image: None,
+        }),
+        process_context: None,
+    }
+}
+
+fn bench_domain_matching(c: &mut Criterion) {
+    let mut group = c.benchmark_group("ioc_domain_match");
+
+    for count in [SMALL_FEED, LARGE_FEED] {
+        let dir = TempDir::new().expect("temp dir");
+        let engine = engine_with_feed(dir.path(), count);
+
+        // The common case: an ordinary hostname no indicator covers, which
+        // used to walk the entire feed before concluding nothing matched.
+        let miss = dns_event("cdn.assets.example.org");
+        group.bench_with_input(BenchmarkId::new("miss", count), &count, |b, _| {
+            b.iter(|| black_box(engine.check_event(black_box(&miss))));
+        });
+
+        let hit = dns_event("beacon.c2.malware.test");
+        group.bench_with_input(BenchmarkId::new("hit", count), &count, |b, _| {
+            b.iter(|| black_box(engine.check_event(black_box(&hit))));
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_domain_matching);
+criterion_main!(benches);

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -158,3 +158,33 @@ candidate bucket linearly.
 This isolates matching throughput only: it excludes normalization, alert
 serialization, IOC and YARA, and the sensor pipeline. Source:
 [benches/sigma_engine.rs](https://github.com/Karib0u/rustinel/blob/main/benches/sigma_engine.rs).
+
+## Wildcard Domain IOC Micro-Benchmark
+
+The `ioc_domains` Criterion benchmark measures `IocEngine::check_event` against
+a wildcard domain feed (`*.example.com` indicators), which is the IOC path whose
+cost used to scale with feed size.
+
+```sh
+cargo bench --bench ioc_domains
+```
+
+Each iteration matches one DNS event against a feed of 100 or 100,000 wildcard
+indicators, once for a hostname no indicator covers (`miss`, the common case)
+and once for a hostname one indicator covers (`hit`).
+
+Indicative figures from a single macOS development machine. Re-run locally
+before quoting them:
+
+| Scenario | 100 indicators | 100,000 indicators |
+| --- | --- | --- |
+| `miss` | 112 ns | 102 ns |
+| `hit` | 669 ns | 682 ns |
+
+Cost tracks the hostname's DNS label count, not the size of the feed: wildcard
+suffixes are indexed, so a hostname only looks up its own suffixes. Before that
+index, the same two scenarios cost 6.3 µs and 8.1 ms respectively, because every
+eligible event scanned the whole feed.
+
+Source:
+[benches/ioc_domains.rs](https://github.com/Karib0u/rustinel/blob/main/benches/ioc_domains.rs).

--- a/src/ioc/load.rs
+++ b/src/ioc/load.rs
@@ -221,9 +221,15 @@ pub(crate) fn load_domains(path: &Path) -> DomainIocs {
         }
 
         if normalized.starts_with('.') {
-            let suffix = normalized.trim_start_matches('.').to_string();
-            if !suffix.is_empty() {
-                iocs.suffix.push((suffix, meta));
+            let suffix = normalized.trim_start_matches('.');
+            if !suffix.is_empty() && !iocs.suffix.insert(suffix, meta) {
+                warn!(
+                    target: "ioc",
+                    path = %source,
+                    line = line_no,
+                    value = %value,
+                    "Too many wildcard domain indicators, skipping"
+                );
             }
         } else {
             iocs.exact.insert(normalized, meta);

--- a/src/ioc/matchers.rs
+++ b/src/ioc/matchers.rs
@@ -1,5 +1,5 @@
 use super::alert::{build_match, push_match_unique};
-use super::types::{IocKind, IocMatch};
+use super::types::{IocKind, IocMatch, IocMeta};
 use super::IocEngine;
 use crate::models::{EventFields, NormalizedEvent};
 use std::collections::HashSet;
@@ -38,15 +38,38 @@ impl IocEngine {
             );
         }
 
-        for (suffix, meta) in &self.domain_iocs.suffix {
-            if host == *suffix || host.ends_with(&format!(".{}", suffix)) {
-                let indicator = format!(".{}", suffix);
-                push_match_unique(
-                    matches,
-                    seen,
-                    build_match(IocKind::Domain, &indicator, &host, meta),
-                );
+        // Wildcard indicators are indexed by suffix, so only the hostname's own
+        // label boundaries are probed: `a.b.example.com` looks up
+        // `a.b.example.com`, `b.example.com`, `example.com`, `com`. Work scales
+        // with hostname depth instead of feed size, and no temporary string is
+        // built for a lookup.
+        let mut hits: Vec<(u32, &str, &IocMeta)> = Vec::new();
+        let mut offset = 0;
+        loop {
+            let suffix = &host[offset..];
+            hits.extend(
+                self.domain_iocs
+                    .suffix
+                    .lookup(suffix)
+                    .map(|(order, meta)| (order, suffix, meta)),
+            );
+            match suffix.find('.') {
+                Some(idx) => offset += idx + 1,
+                None => break,
             }
+        }
+
+        // Restore feed order, which is what the linear scan produced when a
+        // hostname hit several overlapping indicators.
+        hits.sort_unstable_by_key(|(order, _, _)| *order);
+
+        for (_, suffix, meta) in hits {
+            let indicator = format!(".{}", suffix);
+            push_match_unique(
+                matches,
+                seen,
+                build_match(IocKind::Domain, &indicator, &host, meta),
+            );
         }
     }
 

--- a/src/ioc/mod.rs
+++ b/src/ioc/mod.rs
@@ -254,14 +254,14 @@ mod tests {
     #[test]
     fn test_domain_suffix_match() {
         let mut domains = DomainIocs::default();
-        domains.suffix.push((
-            "example.com".to_string(),
+        domains.suffix.insert(
+            "example.com",
             IocMeta {
                 comment: None,
                 source: "test".to_string(),
                 line: 1,
             },
-        ));
+        );
 
         let engine = IocEngine {
             enabled: true,
@@ -296,6 +296,96 @@ mod tests {
         let matches = engine.check_event(&event);
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].kind, IocKind::Domain);
+    }
+
+    fn suffix_engine(suffixes: &[(&str, usize)]) -> IocEngine {
+        let mut domains = DomainIocs::default();
+        for (suffix, line) in suffixes {
+            domains.suffix.insert(
+                suffix,
+                IocMeta {
+                    comment: None,
+                    source: "test".to_string(),
+                    line: *line,
+                },
+            );
+        }
+
+        IocEngine {
+            enabled: true,
+            severity: AlertSeverity::High,
+            hash_iocs: HashIocs::default(),
+            ip_iocs: IpIocs::default(),
+            domain_iocs: domains,
+            path_iocs: PathIocs::default(),
+            max_file_size_bytes: 0,
+            hash_allowlist_paths: Vec::new(),
+        }
+    }
+
+    fn dns_event(query_name: &str) -> NormalizedEvent {
+        NormalizedEvent {
+            timestamp: "2025-01-01T00:00:00Z".to_string(),
+            platform: Platform::Windows,
+            provider: "etw".to_string(),
+            category: EventCategory::Dns,
+            event_id: 22,
+            event_id_string: "22".to_string(),
+            opcode: 0,
+            fields: EventFields::DnsQuery(crate::models::DnsQueryFields {
+                query_name: Some(query_name.to_string()),
+                query_results: None,
+                record_type: None,
+                query_status: None,
+                process_id: None,
+                image: None,
+            }),
+            process_context: None,
+        }
+    }
+
+    #[test]
+    fn test_domain_suffix_matches_the_suffix_itself() {
+        let engine = suffix_engine(&[("example.com", 1)]);
+        let matches = engine.check_event(&dns_event("example.com"));
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].indicator, ".example.com");
+        assert_eq!(matches[0].observed, "example.com");
+    }
+
+    #[test]
+    fn test_domain_suffix_requires_a_label_boundary() {
+        let engine = suffix_engine(&[("example.com", 1)]);
+        assert!(engine.check_event(&dns_event("notexample.com")).is_empty());
+        assert!(engine
+            .check_event(&dns_event("example.com.evil"))
+            .is_empty());
+    }
+
+    #[test]
+    fn test_overlapping_domain_suffixes_report_in_feed_order() {
+        // `com` is loaded after `example.com`, so it is reported second, as the
+        // linear scan over the feed used to do.
+        let engine = suffix_engine(&[("example.com", 7), ("com", 9)]);
+        let matches = engine.check_event(&dns_event("a.b.example.com"));
+        let indicators: Vec<&str> = matches.iter().map(|m| m.indicator.as_str()).collect();
+        assert_eq!(indicators, vec![".example.com", ".com"]);
+    }
+
+    #[test]
+    fn test_duplicate_domain_suffix_lines_each_report() {
+        // The same suffix on two feed lines stays two matches: they differ by
+        // the reported source line, as before the suffix index.
+        let engine = suffix_engine(&[("example.com", 3), ("example.com", 12)]);
+        let matches = engine.check_event(&dns_event("host.example.com"));
+        let lines: Vec<usize> = matches.iter().map(|m| m.line).collect();
+        assert_eq!(lines, vec![3, 12]);
+    }
+
+    #[test]
+    fn test_domain_suffix_stats_count_every_line() {
+        let engine = suffix_engine(&[("example.com", 1), ("example.com", 2), ("evil.test", 3)]);
+        assert_eq!(engine.stats().domain_suffix, 3);
     }
 
     #[test]

--- a/src/ioc/types.rs
+++ b/src/ioc/types.rs
@@ -56,10 +56,99 @@ pub(crate) struct IpIocs {
     pub(crate) cidr: Vec<(IpNetwork, IocMeta)>,
 }
 
+/// Wildcard (`*.example.com` / `.example.com`) domain indicators, indexed by
+/// their normalized suffix so a hostname is matched by walking its own DNS
+/// label boundaries instead of scanning the whole feed.
+///
+/// Feeds routinely carry millions of suffixes, so the layout stays flat: every
+/// indicator lives in `entries`, and `heads` maps a suffix to the first and
+/// last entry of its chain. The same suffix can appear on several feed lines
+/// and each line keeps its own metadata, so those lines are chained through
+/// `next` in feed order. An entry's position in `entries` is its feed order,
+/// which lets a hostname's hits be restored to feed order after lookup.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct SuffixIndex {
+    heads: HashMap<Box<str>, SuffixChainEnds>,
+    entries: Vec<SuffixEntry>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SuffixChainEnds {
+    first: u32,
+    last: u32,
+}
+
+#[derive(Debug, Clone)]
+struct SuffixEntry {
+    meta: IocMeta,
+    /// The next feed line carrying this same suffix, if any.
+    next: Option<u32>,
+}
+
+impl SuffixIndex {
+    /// Adds one indicator. Returns `false` when the index is full, which takes
+    /// more than four billion suffixes and so never happens in practice.
+    pub(crate) fn insert(&mut self, suffix: &str, meta: IocMeta) -> bool {
+        let Ok(position) = u32::try_from(self.entries.len()) else {
+            return false;
+        };
+
+        self.entries.push(SuffixEntry { meta, next: None });
+
+        match self.heads.get_mut(suffix) {
+            Some(ends) => {
+                self.entries[ends.last as usize].next = Some(position);
+                ends.last = position;
+            }
+            None => {
+                self.heads.insert(
+                    suffix.into(),
+                    SuffixChainEnds {
+                        first: position,
+                        last: position,
+                    },
+                );
+            }
+        }
+
+        true
+    }
+
+    /// Number of indicators loaded, counting repeated suffixes separately.
+    pub(crate) fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Every indicator registered for `suffix`, in feed order, paired with its
+    /// feed position.
+    pub(crate) fn lookup(&self, suffix: &str) -> SuffixChain<'_> {
+        SuffixChain {
+            index: self,
+            next: self.heads.get(suffix).map(|ends| ends.first),
+        }
+    }
+}
+
+pub(crate) struct SuffixChain<'a> {
+    index: &'a SuffixIndex,
+    next: Option<u32>,
+}
+
+impl<'a> Iterator for SuffixChain<'a> {
+    type Item = (u32, &'a IocMeta);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let position = self.next?;
+        let entry = &self.index.entries[position as usize];
+        self.next = entry.next;
+        Some((position, &entry.meta))
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct DomainIocs {
     pub(crate) exact: HashMap<String, IocMeta>,
-    pub(crate) suffix: Vec<(String, IocMeta)>,
+    pub(crate) suffix: SuffixIndex,
 }
 
 #[derive(Debug, Clone, Default)]


### PR DESCRIPTION
Closes #377.

## Problem

Wildcard domain indicators (`*.example.com` / `.example.com`) were kept in a flat `Vec`, so every DNS / network-connection / WMI event carrying a hostname compared it against the whole feed, allocating a `format!(".{suffix}")` temporary per comparison ([src/ioc/matchers.rs:67](https://github.com/Karib0u/rustinel/blob/main/src/ioc/matchers.rs#L67)).

I reproduced this with the Radegast "Malware domains" pack a user reported trouble with — 2,121,596 wildcard suffixes:

- **~170 ms of CPU per eligible event.** A single DNS query stalls the detection path for a sixth of a second; the engine is effectively unusable with a real feed of this size.

## Fix

Index the suffixes and walk the hostname's own DNS label boundaries: `a.b.example.com` looks up `a.b.example.com`, `b.example.com`, `example.com`, `com`. Work scales with hostname depth instead of feed size, and a lookup allocates nothing — a string is built only for an actual match.

The index is deliberately flat, since these feeds run to millions of entries: one entry vector plus a per-suffix chain, so repeated feed lines each keep their own metadata. An entry's position in the vector is its feed order, and a hostname's hits are sorted back into that order before being reported, so overlapping and duplicate indicators produce exactly what the linear scan produced.

## Measurements

`cargo bench --bench ioc_domains`, macOS/arm64 (before = the same benchmark run on `main`):

| Scenario | Before | After |
| --- | --- | --- |
| miss, 100 indicators | 6.27 µs | 112 ns |
| hit, 100 indicators | 6.92 µs | 669 ns |
| miss, 100,000 indicators | 8.06 ms | 102 ns |
| hit, 100,000 indicators | 8.07 ms | 682 ns |

Cost is now flat across feed size. With the full Radegast pack loaded through `IocEngine`, per-event matching goes from ~170 ms to ~128 ns, and the matches themselves are unchanged (`sub.0-0.fr` → `.0-0.fr`, `0-0.fr` → `.0-0.fr`, ordinary hostnames → none).

Trade-offs, both one-off and paid at startup, measured on the same 2.1M-entry pack:

- Load time 0.83 s → 1.43 s.
- RSS 574 MB → 672 MB (+17%). An earlier `HashMap<String, Vec<_>>` shape cost 1.26 GB, which is why the layout is flat.

## Acceptance criteria

- [x] Wildcard matching does not iterate over the complete suffix feed.
- [x] No temporary string is allocated per suffix comparison.
- [x] Exact and wildcard matching semantics remain unchanged.
- [x] Duplicate and overlapping indicators preserve current output behavior — covered by new unit tests for feed-order reporting across overlapping suffixes and for duplicate lines each reporting their own source line.
- [x] Benchmarks for small and 100,000-entry wildcard feeds (`benches/ioc_domains.rs`), documented in `docs/benchmarking.md`.

## Testing

- `cargo test` — 345 unit tests plus all integration binaries pass.
- `cargo clippy --all-targets` — clean.
- `cargo fmt --all`.
- `cargo bench --bench ioc_domains` on this branch and on `main`.
- Real-feed run of `IocEngine::load` + `check_event` against the 57 MB Radegast pack.

## Not addressed

`IocMeta` clones the source-path `String` per indicator, so the 2.1M-entry pack keeps ~2.1M copies of the same path. That is a pre-existing memory cost, unrelated to the matching hot path, and left for a separate change.