### PR TITLE
perf(cache): guarantee eviction headroom when timestamps tie

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,3 +102,8 @@ criterion = "0.8"
 [[bench]]
 name = "sigma_engine"
 harness = false
+
+# Bounded-cache eviction cost, measured with `cargo bench --bench cache_eviction`.
+[[bench]]
+name = "cache_eviction"
+harness = false

--- a/benches/cache_eviction.rs
+++ b/benches/cache_eviction.rs
@@ -1,0 +1,76 @@
+//! Eviction cost for the bounded, timestamp-ordered caches.
+//!
+//! Cache timestamps have second precision, so a burst of inserts usually shares
+//! one timestamp. This benchmark contrasts inserting into a cache that is at its
+//! cap (every insert may trigger a trim) with inserting into one that has spare
+//! capacity, using `DnsCache` as the representative implementation.
+//!
+//! ```sh
+//! cargo bench --bench cache_eviction
+//! ```
+
+use std::hint::black_box;
+use std::net::{IpAddr, Ipv4Addr};
+
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use rustinel::state::DnsCache;
+
+const CAPACITY: usize = 10_000;
+const INSERTS: u32 = 1_000;
+
+fn ip_for(index: u32) -> IpAddr {
+    IpAddr::V4(Ipv4Addr::from(index))
+}
+
+/// A cache holding `entries` mappings, all stamped within the same second.
+fn filled_cache(entries: u32) -> DnsCache {
+    let cache = DnsCache::with_limits(CAPACITY, 15 * 60);
+    for index in 0..entries {
+        cache.update(ip_for(index), "bench.example".to_string());
+    }
+    cache
+}
+
+fn bench_dns_inserts(c: &mut Criterion) {
+    let mut group = c.benchmark_group("dns_cache_insert");
+    group.throughput(criterion::Throughput::Elements(u64::from(INSERTS)));
+
+    // At capacity: each insert overflows the cap and may trigger eviction.
+    group.bench_function("at_capacity_same_second", |b| {
+        b.iter_batched(
+            || filled_cache(CAPACITY as u32),
+            |cache| {
+                for index in 0..INSERTS {
+                    cache.update(
+                        ip_for(CAPACITY as u32 + index),
+                        black_box("bench.example").to_string(),
+                    );
+                }
+                cache
+            },
+            BatchSize::LargeInput,
+        );
+    });
+
+    // Spare capacity: the same inserts with no eviction at all, as a baseline.
+    group.bench_function("with_spare_capacity", |b| {
+        b.iter_batched(
+            || filled_cache(CAPACITY as u32 - INSERTS),
+            |cache| {
+                for index in 0..INSERTS {
+                    cache.update(
+                        ip_for(CAPACITY as u32 + index),
+                        black_box("bench.example").to_string(),
+                    );
+                }
+                cache
+            },
+            BatchSize::LargeInput,
+        );
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_dns_inserts);
+criterion_main!(benches);

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -158,3 +158,31 @@ candidate bucket linearly.
 This isolates matching throughput only: it excludes normalization, alert
 serialization, IOC and YARA, and the sensor pipeline. Source:
 [benches/sigma_engine.rs](https://github.com/Karib0u/rustinel/blob/main/benches/sigma_engine.rs).
+
+## Cache Eviction Micro-Benchmark
+
+The `cache_eviction` Criterion benchmark measures insertion cost into a bounded
+timestamp-ordered cache at its capacity, using `DnsCache` as the representative
+implementation. The same eviction policy backs the file-hash, YARA verdict, and
+connection-state caches.
+
+```sh
+cargo bench --bench cache_eviction
+```
+
+Each iteration performs 1,000 inserts that all land in the same second, once
+into a cache already at its 10,000-entry cap and once into a cache with spare
+capacity. Cache timestamps have second precision, so a burst of events normally
+shares a single timestamp; the at-capacity case is what a burst actually costs.
+
+Indicative figures from a single macOS development machine, for 1,000 inserts.
+Re-run locally before quoting them:
+
+| Scenario | Per iteration |
+| --- | --- |
+| At capacity, same second | 233 µs |
+| Spare capacity | 74 µs |
+
+Eviction frees a quarter of the cap in one pass, so a trim is amortized over
+many subsequent inserts instead of running on each one. Source:
+[benches/cache_eviction.rs](https://github.com/Karib0u/rustinel/blob/main/benches/cache_eviction.rs).

--- a/src/ioc/hash.rs
+++ b/src/ioc/hash.rs
@@ -8,6 +8,7 @@ use std::io::Read;
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use crate::utils::cache::trim_to_headroom;
 use crate::utils::file_identity::{self, FileIdentity};
 
 const HASH_CACHE_MAX_ENTRIES: usize = 10_000;
@@ -108,22 +109,7 @@ impl HashCache {
     }
 
     fn trim(&mut self) {
-        if self.entries.len() <= self.max_entries {
-            return;
-        }
-
-        let mut timestamps: Vec<u64> = self.entries.values().map(|entry| entry.timestamp).collect();
-        timestamps.sort_unstable();
-        let cutoff = timestamps[self.entries.len() / 2];
-        self.entries.retain(|_, entry| entry.timestamp >= cutoff);
-
-        if self.entries.len() > self.max_entries {
-            let extra = self.entries.len() - self.max_entries;
-            let keys: Vec<FileIdentity> = self.entries.keys().take(extra).cloned().collect();
-            for key in keys {
-                self.entries.remove(&key);
-            }
-        }
+        trim_to_headroom(&mut self.entries, self.max_entries, |entry| entry.timestamp);
     }
 }
 

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -14,6 +14,7 @@ use yara_x::{Compiler, Rules, Scanner as XScanner};
 
 use crate::models::{MatchDebugLevel, ProcessCreationFields, YaraRuleMatch, YaraStringMatch};
 use crate::sensor::{SensorAction, SensorEvent, SensorEventHandler, SensorPayload};
+use crate::utils::cache::trim_to_headroom;
 use crate::utils::file_identity::{self, FileIdentity};
 use crate::utils::{hash_command_line, query_process_identity, ProcessIdentity};
 
@@ -160,22 +161,7 @@ impl YaraScanCache {
     }
 
     fn trim(&mut self) {
-        if self.entries.len() <= self.max_entries {
-            return;
-        }
-
-        let mut timestamps: Vec<u64> = self.entries.values().map(|entry| entry.timestamp).collect();
-        timestamps.sort_unstable();
-        let cutoff = timestamps[self.entries.len() / 2];
-        self.entries.retain(|_, entry| entry.timestamp >= cutoff);
-
-        if self.entries.len() > self.max_entries {
-            let extra = self.entries.len() - self.max_entries;
-            let keys: Vec<YaraFileIdentity> = self.entries.keys().take(extra).cloned().collect();
-            for key in keys {
-                self.entries.remove(&key);
-            }
-        }
+        trim_to_headroom(&mut self.entries, self.max_entries, |entry| entry.timestamp);
     }
 }
 

--- a/src/state/connection.rs
+++ b/src/state/connection.rs
@@ -4,6 +4,8 @@ use std::sync::atomic::AtomicU64;
 use std::sync::RwLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use crate::utils::cache::{trim_target, trim_to_headroom};
+
 fn now_secs() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -260,17 +262,30 @@ impl ConnectionAggregator {
     }
 
     fn trim_cache(&self, cache: &mut HashMap<ConnectionKey, ConnectionState>) {
-        let len = cache.len();
-        if len <= self.max_entries {
+        if cache.len() <= self.max_entries {
             return;
         }
 
         let now = now_secs();
         let last = self.last_cleanup.load(std::sync::atomic::Ordering::Relaxed);
 
-        // Avoid expensive trimming more than once per second, but still enforce cap.
-        if now.saturating_sub(last) < 1 {
-            let extra = cache.len().saturating_sub(self.max_entries);
+        // Avoid the timestamp-ordered pass more than once per second, but still
+        // enforce the cap -- and still free headroom, so the cheap path is not
+        // re-entered on every insertion while at capacity.
+        let claimed = now.saturating_sub(last) >= 1
+            && self
+                .last_cleanup
+                .compare_exchange(
+                    last,
+                    now,
+                    std::sync::atomic::Ordering::Relaxed,
+                    std::sync::atomic::Ordering::Relaxed,
+                )
+                .is_ok();
+
+        if !claimed {
+            let target = trim_target(self.max_entries);
+            let extra = cache.len().saturating_sub(target);
             let keys: Vec<ConnectionKey> = cache.keys().take(extra).cloned().collect();
             for key in keys {
                 cache.remove(&key);
@@ -278,38 +293,8 @@ impl ConnectionAggregator {
             return;
         }
 
-        if self
-            .last_cleanup
-            .compare_exchange(
-                last,
-                now,
-                std::sync::atomic::Ordering::Relaxed,
-                std::sync::atomic::Ordering::Relaxed,
-            )
-            .is_err()
-        {
-            let extra = cache.len().saturating_sub(self.max_entries);
-            let keys: Vec<ConnectionKey> = cache.keys().take(extra).cloned().collect();
-            for key in keys {
-                cache.remove(&key);
-            }
-            return;
-        }
-
-        // Remove oldest entries (by last_seen) until under limit
-        let mut timestamps: Vec<u64> = cache.values().map(|s| s.last_seen).collect();
-        timestamps.sort_unstable();
-        let cutoff = timestamps[len / 2];
-        cache.retain(|_, state| state.last_seen >= cutoff);
-
-        // If still over, remove by insertion order
-        if cache.len() > self.max_entries {
-            let extra = cache.len() - self.max_entries;
-            let keys: Vec<ConnectionKey> = cache.keys().take(extra).cloned().collect();
-            for key in keys {
-                cache.remove(&key);
-            }
-        }
+        // Drop the least recently seen entries, leaving room for further inserts.
+        trim_to_headroom(cache, self.max_entries, |state| state.last_seen);
     }
 }
 

--- a/src/state/dns.rs
+++ b/src/state/dns.rs
@@ -3,6 +3,8 @@ use std::net::IpAddr;
 use std::sync::RwLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use crate::utils::cache::trim_to_headroom;
+
 #[derive(Debug, Clone)]
 pub struct DnsEntry {
     pub hostname: String,
@@ -44,7 +46,7 @@ impl DnsCache {
         );
 
         if cache.len() > self.max_entries {
-            trim_dns_cache(&mut cache, self.max_entries);
+            trim_to_headroom(&mut cache, self.max_entries, |entry| entry.timestamp);
         }
     }
 
@@ -71,26 +73,6 @@ fn now_secs() -> u64 {
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs()
-}
-
-fn trim_dns_cache(cache: &mut HashMap<IpAddr, DnsEntry>, max_entries: usize) {
-    let len = cache.len();
-    if len <= max_entries {
-        return;
-    }
-
-    let mut timestamps: Vec<u64> = cache.values().map(|entry| entry.timestamp).collect();
-    timestamps.sort_unstable();
-    let cutoff = timestamps[len / 2];
-    cache.retain(|_, entry| entry.timestamp >= cutoff);
-
-    if cache.len() > max_entries {
-        let extra = cache.len() - max_entries;
-        let keys: Vec<IpAddr> = cache.keys().take(extra).cloned().collect();
-        for key in keys {
-            cache.remove(&key);
-        }
-    }
 }
 
 impl Default for DnsCache {

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -66,6 +66,39 @@ mod tests {
     }
 
     #[test]
+    fn dns_cache_trim_frees_headroom_for_same_second_inserts() {
+        // Every insert lands in the same second, so a median cutoff would evict
+        // nothing. The trim must still drop a quarter of the cap.
+        let cache = DnsCache::with_limits(100, 60);
+
+        for i in 0..101u32 {
+            let ip: IpAddr = format!("10.{}.{}.{}", i / 256, i % 256, 1).parse().unwrap();
+            cache.update(ip, format!("host{}.example", i));
+        }
+
+        assert_eq!(cache.count(), 75);
+
+        // The freed slots absorb the next inserts without trimming again.
+        for i in 101..126u32 {
+            let ip: IpAddr = format!("10.{}.{}.{}", i / 256, i % 256, 1).parse().unwrap();
+            cache.update(ip, format!("host{}.example", i));
+        }
+
+        assert_eq!(cache.count(), 100);
+    }
+
+    #[test]
+    fn dns_cache_stays_bounded_under_a_same_second_burst() {
+        let cache = DnsCache::with_limits(100, 60);
+
+        for i in 0..1_000u32 {
+            let ip: IpAddr = format!("10.{}.{}.{}", i / 256, i % 256, 1).parse().unwrap();
+            cache.update(ip, format!("host{}.example", i));
+            assert!(cache.count() <= 100);
+        }
+    }
+
+    #[test]
     fn dns_cache_trims_to_limit() {
         let cache = DnsCache::with_limits(2, 60);
         let ip1: IpAddr = "1.2.3.4".parse().unwrap();
@@ -171,6 +204,20 @@ mod tests {
             .unwrap();
         assert_eq!(meta.connection_count, 3);
         assert_eq!(meta.unique_pids.len(), 3);
+    }
+
+    #[test]
+    fn connection_aggregator_trim_frees_headroom_for_same_second_inserts() {
+        let aggregator = ConnectionAggregator::with_limits(100, 600);
+
+        for i in 0..101u32 {
+            let ip: IpAddr = format!("10.{}.{}.{}", i / 256, i % 256, 1).parse().unwrap();
+            aggregator.record("C:\\app.exe", ip, 443, Protocol::Tcp, 1234);
+        }
+
+        // Whichever path ran (timestamp-ordered or the once-per-second fallback),
+        // the cache is left below the cap with room to insert.
+        assert!(aggregator.count() <= 75);
     }
 
     #[test]

--- a/src/utils/cache.rs
+++ b/src/utils/cache.rs
@@ -1,0 +1,156 @@
+//! Shared eviction policy for the bounded, timestamp-ordered caches.
+//!
+//! Rustinel keeps several `HashMap` caches (DNS, file hashes, YARA verdicts,
+//! connection state) capped at a maximum entry count, with each entry carrying a
+//! second-precision timestamp. Trimming those maps back to exactly the cap makes
+//! every subsequent insertion at capacity trim again, and second-precision
+//! timestamps mean a burst usually shares a single timestamp, so a
+//! "drop everything older than the median" pass can remove nothing at all.
+//!
+//! [`trim_to_headroom`] instead evicts down to a target *below* the cap, so one
+//! trim buys headroom for many insertions, and it breaks timestamp ties instead
+//! of stalling on them.
+
+use std::collections::HashMap;
+use std::hash::{BuildHasher, Hash};
+
+/// Fraction of the cap that survives a trim, expressed as a divisor of the
+/// number of entries freed: `max / EVICTION_DIVISOR` entries are freed, i.e. the
+/// cache is trimmed to 75% of its cap.
+const EVICTION_DIVISOR: usize = 4;
+
+/// Number of entries a cache is trimmed down to when it exceeds `max_entries`.
+///
+/// Always at most `max_entries`, and strictly below it whenever the cap leaves
+/// room for that (`max_entries >= EVICTION_DIVISOR`).
+pub fn trim_target(max_entries: usize) -> usize {
+    max_entries - max_entries / EVICTION_DIVISOR
+}
+
+/// Evict the oldest entries of `map` until it holds at most [`trim_target`].
+///
+/// `timestamp` extracts the entry's age key (larger is newer). Entries older
+/// than the cutoff are dropped wholesale; when entries tie on the cutoff
+/// timestamp, enough of them are dropped to reach the target, so a trim always
+/// frees `max_entries / 4` slots regardless of how many timestamps are equal.
+///
+/// Runs in O(n) on average (`select_nth_unstable`) rather than O(n log n), and
+/// is a no-op while the map is within its cap.
+pub fn trim_to_headroom<K, V, S, F>(map: &mut HashMap<K, V, S>, max_entries: usize, timestamp: F)
+where
+    K: Eq + Hash + Clone,
+    S: BuildHasher,
+    F: Fn(&V) -> u64,
+{
+    let len = map.len();
+    if len <= max_entries {
+        return;
+    }
+
+    let target = trim_target(max_entries);
+    if target == 0 {
+        map.clear();
+        return;
+    }
+
+    let to_remove = len - target;
+    let mut timestamps: Vec<u64> = map.values().map(&timestamp).collect();
+    // The `to_remove`-th smallest timestamp is the oldest one that may survive;
+    // everything strictly below it must go.
+    let cutoff = *timestamps.select_nth_unstable(to_remove).1;
+    map.retain(|_, value| timestamp(value) >= cutoff);
+
+    // Whatever is still over target ties with the cutoff. Drop the surplus so a
+    // burst of same-second entries cannot defeat the trim.
+    if map.len() > target {
+        let surplus = map.len() - target;
+        let keys: Vec<K> = map
+            .iter()
+            .filter(|(_, value)| timestamp(value) == cutoff)
+            .take(surplus)
+            .map(|(key, _)| key.clone())
+            .collect();
+        for key in keys {
+            map.remove(&key);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn map_of(timestamps: &[u64]) -> HashMap<usize, u64> {
+        timestamps.iter().copied().enumerate().collect()
+    }
+
+    #[test]
+    fn trim_target_leaves_a_quarter_of_the_cap_free() {
+        assert_eq!(trim_target(100), 75);
+        assert_eq!(trim_target(4), 3);
+        assert_eq!(trim_target(1), 1);
+        assert_eq!(trim_target(0), 0);
+    }
+
+    #[test]
+    fn trim_is_a_no_op_within_the_cap() {
+        let mut map = map_of(&[1, 2, 3]);
+        trim_to_headroom(&mut map, 3, |ts| *ts);
+        assert_eq!(map.len(), 3);
+    }
+
+    #[test]
+    fn trim_frees_headroom_when_every_timestamp_is_equal() {
+        let mut map = map_of(&[7; 101]);
+        trim_to_headroom(&mut map, 100, |ts| *ts);
+        assert_eq!(map.len(), 75);
+    }
+
+    #[test]
+    fn trim_drops_the_oldest_entries_first() {
+        let mut map: HashMap<usize, u64> = (0..101).map(|i| (i, i as u64)).collect();
+        trim_to_headroom(&mut map, 100, |ts| *ts);
+        assert_eq!(map.len(), 75);
+        // The 26 oldest went; the 75 newest stayed.
+        assert!(map.keys().all(|key| *key >= 26));
+    }
+
+    #[test]
+    fn trim_breaks_ties_on_the_cutoff_timestamp() {
+        // 90 entries share the cutoff second, 11 are strictly newer.
+        let mut timestamps = vec![5u64; 90];
+        timestamps.extend(std::iter::repeat_n(9u64, 11));
+        let mut map = map_of(&timestamps);
+
+        trim_to_headroom(&mut map, 100, |ts| *ts);
+
+        assert_eq!(map.len(), 75);
+        // Every strictly newer entry survived; only cutoff-second entries were cut.
+        assert_eq!(map.values().filter(|ts| **ts == 9).count(), 11);
+    }
+
+    #[test]
+    fn one_trim_absorbs_many_subsequent_inserts() {
+        let mut map = map_of(&[1; 100]);
+        let mut trims = 0usize;
+
+        for key in 100..125 {
+            map.insert(key, 1);
+            if map.len() > 100 {
+                trims += 1;
+                trim_to_headroom(&mut map, 100, |ts| *ts);
+            }
+        }
+
+        // 25 inserts at capacity cost a single trim, not one per insert.
+        assert_eq!(trims, 1);
+        assert!(map.len() <= 100);
+    }
+
+    #[test]
+    fn trim_clears_a_zero_capacity_cache() {
+        let mut map = map_of(&[1, 2]);
+        trim_to_headroom(&mut map, 0, |ts| *ts);
+        assert!(map.is_empty());
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! Provides helper functions for path normalization and PE parsing.
 
+pub(crate) mod cache;
 pub(crate) mod file_identity;
 pub mod fs;
 pub mod log_rate_limiter;


### PR DESCRIPTION
## Summary

Closes #378.

The DNS, file-hash, YARA verdict, and connection-state caches each trimmed by collecting every timestamp, sorting them, retaining entries at or above the median, and then removing arbitrary entries down to exactly the cap.

Cache timestamps have second precision, so a burst of entries usually shares a single timestamp. The median retain then drops nothing, the fallback removes one entry, and the very next insertion repeats the whole collect-and-sort under the write lock.

All four now call a shared `utils::cache::trim_to_headroom`, which:

- partitions on the cutoff timestamp with `select_nth_unstable` (O(n) instead of O(n log n)),
- breaks ties on that cutoff, so equal timestamps cannot defeat the trim,
- evicts down to 75% of the cap, so one pass buys headroom for a quarter of the cap in later insertions.

The connection aggregator's once-per-second fast path targets the same level instead of the cap, so it too stops running on every insertion at capacity. Cache bounds and TTL semantics are unchanged.

### Measured

New `cache_eviction` Criterion benchmark, 1,000 inserts all landing in the same second, 10,000-entry cap:

| Scenario | Before | After |
| --- | --- | --- |
| At capacity, same second (macOS M1 Max) | 43.2 ms | 233 µs |
| Spare capacity baseline (macOS M1 Max) | 92.9 µs | 74.5 µs |

The before figure matches the ~38 ms reported in the issue. Same benchmark on lab-ubuntu (x86_64): 210 µs at capacity, 68 µs with spare capacity.

## Type of change
- [x] `bug` - bug fix

## Test plan
- [ ] Tested on Windows
- [x] Tested on Linux
- [x] Existing tests pass (`cargo test`)
- [x] New tests added (if applicable)

Validated on lab-ubuntu (Ubuntu 26.04, x86_64): full `cargo test --locked` green (394 lib tests plus integration suites, 0 failures), `cargo clippy --locked --all-targets` clean, `cargo bench --bench cache_eviction` as above. Same suites green on macOS.

New tests: unit tests for the shared helper (all-equal timestamps, tie-breaking on the cutoff, oldest-first ordering, one trim absorbing 25 further inserts, zero-capacity), plus DNS and connection-aggregator regression tests that a same-second burst leaves the cache below its cap with room to insert.

Not exercised on Windows; the change is platform-independent std code, and the affected caches are shared across all sensors.

## Checklist
- [ ] Label added to this PR
- [x] Docs updated (if behaviour changed)