### PR TITLE
perf(linux-ebpf): bound the procfs socket scan per drain batch, not per event

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,3 +102,9 @@ criterion = "0.8"
 [[bench]]
 name = "sigma_engine"
 harness = false
+
+# Linux network-event socket attribution, measured with
+# `cargo bench --bench linux_socket_lookup`. A no-op on other platforms.
+[[bench]]
+name = "linux_socket_lookup"
+harness = false

--- a/benches/linux_socket_lookup.rs
+++ b/benches/linux_socket_lookup.rs
@@ -1,0 +1,163 @@
+//! Burst benchmark for Linux network-event socket attribution.
+//!
+//! ```sh
+//! cargo bench --bench linux_socket_lookup
+//! ```
+//!
+//! Resolving one connect's local address means reading the socket inode from
+//! `/proc/<pid>/fd/<fd>` and finding it in the system-wide
+//! `/proc/net/{tcp,tcp6,udp,udp6}` tables. The tables are unindexed, so the
+//! second half of that costs a pass over every socket on the host.
+//!
+//! The two benchmarks are the two ways of paying it for a burst of events that
+//! arrive together, as a drain of the network ring buffer does:
+//!
+//! * `per_event_scan` gives each event its own inventory, which is the cost
+//!   model of scanning the tables once per event.
+//! * `batch_inventory` scans once for the whole burst and answers every event
+//!   from that snapshot, which is what the sensor does per drain batch.
+//!
+//! Both read every table, so neither benefits from the family and transport
+//! narrowing the sensor applies, and the gap between them is scan work
+//! removed, and it widens with both the burst size and the number of sockets
+//! on the host. The harness prints the scan counts each arm paid so the ratio
+//! is readable without inferring it from the timings.
+//!
+//! Linux only: there is no `/proc/net` to scan anywhere else.
+
+fn main() {
+    #[cfg(target_os = "linux")]
+    linux::main();
+
+    #[cfg(not(target_os = "linux"))]
+    eprintln!("linux_socket_lookup: skipped, /proc/net exists only on Linux");
+}
+
+#[cfg(target_os = "linux")]
+mod linux {
+    use std::hint::black_box;
+    use std::net::{TcpListener, TcpStream};
+    use std::os::fd::AsRawFd;
+    use std::time::Duration;
+
+    use criterion::{BenchmarkId, Criterion};
+    use rustinel::utils::{SocketInventory, SocketTableSet};
+
+    /// Connected sockets to attribute in one burst. Chosen to be larger than a
+    /// quiet drain and smaller than a pathological one, so the amortisation is
+    /// visible without the setup dominating the run.
+    const BURST: usize = 256;
+
+    /// Sockets held open by the benchmark itself, on top of whatever the host
+    /// already has. They are what makes a table scan cost something, so the
+    /// arms are compared against a table that is not almost empty.
+    struct Burst {
+        _listener: TcpListener,
+        _accepted: Vec<TcpStream>,
+        clients: Vec<TcpStream>,
+    }
+
+    fn burst() -> Burst {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind loopback listener");
+        let addr = listener.local_addr().expect("listener addr");
+
+        let mut clients = Vec::with_capacity(BURST);
+        let mut accepted = Vec::with_capacity(BURST);
+        for _ in 0..BURST {
+            clients.push(TcpStream::connect(addr).expect("connect"));
+            accepted.push(listener.accept().expect("accept").0);
+        }
+
+        Burst {
+            _listener: listener,
+            _accepted: accepted,
+            clients,
+        }
+    }
+
+    /// A policy that never refuses a refresh, so the batch arm is measured on
+    /// the amortisation itself rather than on a wall-clock floor that would
+    /// make the result depend on how fast the machine ran the loop.
+    fn inventory() -> SocketInventory {
+        SocketInventory::with_refresh_policy(Duration::ZERO, Duration::from_secs(3600), 0)
+    }
+
+    pub fn main() {
+        let mut criterion = Criterion::default().configure_from_args();
+        let burst = burst();
+        let pid = std::process::id();
+        let fds: Vec<i32> = burst
+            .clients
+            .iter()
+            .map(|client| client.as_raw_fd())
+            .collect();
+
+        report_scan_counts(pid, &fds);
+
+        let mut group = criterion.benchmark_group("linux_socket_lookup");
+        group.throughput(criterion::Throughput::Elements(fds.len() as u64));
+
+        group.bench_function(BenchmarkId::new("per_event_scan", fds.len()), |b| {
+            b.iter(|| {
+                for fd in &fds {
+                    let mut sockets = inventory();
+                    sockets.refresh_if_due(SocketTableSet::EVERY);
+                    black_box(sockets.lookup(pid, *fd));
+                }
+            });
+        });
+
+        group.bench_function(BenchmarkId::new("batch_inventory", fds.len()), |b| {
+            b.iter(|| {
+                let mut sockets = inventory();
+                sockets.refresh_if_due(SocketTableSet::EVERY);
+                for fd in &fds {
+                    black_box(sockets.lookup(pid, *fd));
+                }
+            });
+        });
+
+        group.finish();
+        criterion.final_summary();
+    }
+
+    /// Print the table scans each arm pays for one burst, and assert both
+    /// resolve every socket: an arm that answers fewer of them is faster for
+    /// the wrong reason and its timing means nothing.
+    fn report_scan_counts(pid: u32, fds: &[i32]) {
+        let mut per_event_scans = 0;
+        let mut per_event_resolved = 0;
+        for fd in fds {
+            let mut sockets = inventory();
+            sockets.refresh_if_due(SocketTableSet::EVERY);
+            per_event_resolved += usize::from(sockets.lookup(pid, *fd).is_some());
+            per_event_scans += sockets.scans();
+        }
+
+        let mut batched = inventory();
+        batched.refresh_if_due(SocketTableSet::EVERY);
+        let mut batch_resolved = 0;
+        for fd in fds {
+            batch_resolved += usize::from(batched.lookup(pid, *fd).is_some());
+        }
+
+        assert_eq!(
+            per_event_resolved,
+            fds.len(),
+            "per-event arm failed to resolve every socket"
+        );
+        assert_eq!(
+            batch_resolved,
+            fds.len(),
+            "batch arm failed to resolve every socket"
+        );
+
+        println!(
+            "linux_socket_lookup: {} sockets in the snapshot; {} events cost {} table scans per-event vs {} batched",
+            batched.len(),
+            fds.len(),
+            per_event_scans,
+            batched.scans(),
+        );
+    }
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -380,6 +380,38 @@ discarded before the callback ran and is reported in the agent log, and the
 channel counters above, which count events shed after it. The causes and the
 fixes differ, so nothing folds them together.
 
+On Linux the snapshot carries a `socket_lookup` section. The `connect(2)`
+tracepoints carry the destination but not the local address the kernel
+assigned, so `source.ip`, `source.port`, and `network.transport` are resolved
+from a snapshot of `/proc/net/{tcp,tcp6,udp,udp6}` keyed by socket inode. An
+event that cannot be resolved still reaches the rules with its destination,
+pid, and user, so this is a fidelity gap rather than loss - and it appears in
+no channel count.
+
+| Field | Meaning |
+| --- | --- |
+| `attempted` | Network events that needed a local address, transport, or both |
+| `resolved` | Those the socket snapshot answered for the peer the probe saw |
+| `mismatched` | Those whose entry named a different peer, i.e. the descriptor was closed and reused between the syscall and the drain |
+| `unresolved` | Those no snapshot listed at all |
+| `table_scans` | Passes over the four procfs tables paid for all of the above |
+
+`table_scans` is the cost side. The tables are system-wide and unindexed, so a
+scan is proportional to every socket on the host, and connection churn inflates
+that with `TIME_WAIT` entries. One scan serves a whole drain batch, and the next
+is held off until four times the last scan's measured cost has passed - a
+budget, so the attribution can never take more than a quarter of the thread that
+drains the ring, whatever the event rate or the size of the tables.
+
+That budget is why `resolved` falls under sustained churn: a socket opened
+between two scans is not in either of them, and the event is emitted with its
+source address and transport absent rather than delaying the ring. Ordinary
+outbound traffic - tens of connections a second - resolves essentially all of
+it. `rustinel doctor` reports this as `network_socket_attribution`, which warns
+below a 95% resolution rate; on a host that opens hundreds of connections a
+second, expect that warning and read it as the cost of keeping the events
+themselves.
+
 ### Windows ETW delivery
 
 ETW's real-time session timer hands partially filled buffers to consumers once

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -201,8 +201,17 @@ The Linux sensor covers process, network, file, and DNS.
   the syscall never carries them and the probe does not read the bound address
   back out of the socket. A `/proc/net` lookup fills them in when it provably
   describes the same connection, which under happy-eyeballs it usually does
-  not, so most Linux network events carry no source address or port. Only
-  AF_INET and AF_INET6.
+  not, so most Linux network events carry no source address or port. That
+  lookup answers from a snapshot of the socket tables taken once per drain
+  batch, on a scan budget capped at a quarter of the draining thread, rather
+  than re-reading them per event. A socket opened between two scans is in
+  neither, so under sustained connection churn most events go unresolved:
+  measured on a 400-connections-per-second workload, about half carried a source
+  address, against essentially all of an ordinary tens-per-second one. That is
+  the deliberate trade for not losing the events themselves — the same workload
+  lost three quarters of its network events outright before #375 — and the
+  `socket_lookup` section of `telemetry.json` reports where it lands.
+  Only AF_INET and AF_INET6.
 - **`Protocol` is absent for sockets created before the sensor started.** The
   transport comes from the type the socket was created with, so `socket(2)` is
   watched and the type indexed by descriptor. A descriptor the sensor never

--- a/src/doctor/telemetry.rs
+++ b/src/doctor/telemetry.rs
@@ -46,6 +46,7 @@ pub(crate) fn telemetry_results(
     let mut results = registry_results(&snapshot);
     results.extend(file_attribution_results(&snapshot));
     results.extend(etw_decode_results(&snapshot));
+    results.extend(socket_lookup_results(&snapshot));
 
     let dropping = snapshot.dropping_channels();
     if dropping.is_empty() {
@@ -182,6 +183,55 @@ fn file_attribution_results(snapshot: &TelemetrySnapshot) -> Vec<DiagnosticResul
     .with_fix(fix)]
 }
 
+/// Linux network local-address attribution.
+///
+/// The `connect(2)` tracepoints carry no local address, so `source.ip`,
+/// `source.port`, and `network.transport` come from a snapshot of the procfs
+/// socket tables. An event the snapshot cannot answer for still reaches the
+/// rules with its destination, pid, and user, so this is a narrower gap than
+/// the two above - but a rule selecting on a source port stops matching, and
+/// nothing in the channel counters says so. Empty on platforms without the
+/// eBPF sensor.
+fn socket_lookup_results(snapshot: &TelemetrySnapshot) -> Vec<DiagnosticResult> {
+    let Some(sockets) = snapshot.socket_lookup.as_ref() else {
+        return Vec::new();
+    };
+
+    // Lower than the path-attribution targets because the missing fields cost
+    // less: a short-lived socket closed before the drain is unresolvable by
+    // construction, and connection churn is the normal reason for it.
+    const TARGET_RATE_PCT: f64 = 95.0;
+
+    let rate = sockets.resolution_rate_pct();
+    if rate >= TARGET_RATE_PCT {
+        return vec![DiagnosticResult::pass(
+            "network_socket_attribution",
+            sockets.describe(),
+        )];
+    }
+
+    let fix = if sockets.mismatched > sockets.unresolved {
+        "Those events carry no source address or transport. Most answers named a different peer, \
+         which is a descriptor closed and reused between the syscall and the drain - happy \
+         eyeballs does this on every dual-stack name - see docs/troubleshooting.md"
+    } else {
+        "Those events carry no source address or transport. Sockets closed before the sensor \
+         drained the ring cannot be resolved at all; sustained connection churn is the usual \
+         cause - see docs/troubleshooting.md"
+    };
+
+    vec![DiagnosticResult::warn(
+        "network_socket_attribution",
+        format!(
+            "{} network events had no measurable source address ({:.2}% resolved)",
+            sockets.attempted.saturating_sub(sockets.resolved),
+            rate,
+        ),
+        sockets.describe(),
+    )
+    .with_fix(fix)]
+}
+
 /// ETW decoder degradation.
 ///
 /// A schema lookup that fails, a payload template that no longer matches, or a
@@ -278,7 +328,7 @@ mod tests {
     use crate::doctor::inspect::DiagnosticStatus;
     use crate::telemetry::{
         ChannelSnapshot, EtwDecodeFailureSnapshot, EtwDecodeSnapshot, FileAttributionSnapshot,
-        RegistrySnapshot,
+        RegistrySnapshot, SocketLookupSnapshot,
     };
 
     fn snapshot(channels: Vec<ChannelSnapshot>) -> TelemetrySnapshot {
@@ -293,6 +343,7 @@ mod tests {
             registry: None,
             file_attribution: None,
             etw_decode: None,
+            socket_lookup: None,
         }
     }
 
@@ -415,6 +466,51 @@ mod tests {
             }],
             unkeyed_failures: 0,
         }
+    }
+
+    fn socket_lookup(resolved: u64, mismatched: u64, unresolved: u64) -> SocketLookupSnapshot {
+        SocketLookupSnapshot {
+            attempted: resolved + mismatched + unresolved,
+            resolved,
+            mismatched,
+            unresolved,
+            table_scans: 12,
+        }
+    }
+
+    /// The eBPF network gap: the event still reaches the rules, but without
+    /// the source address, so nothing in the channel counters shows it (#375).
+    #[test]
+    fn unattributed_network_sources_are_reported_as_their_own_gap() {
+        let mut snap = snapshot(vec![channel("sensor_events", 10_000, 0)]);
+        snap.socket_lookup = Some(socket_lookup(800, 100, 100));
+
+        let results = socket_lookup_results(&snap);
+
+        assert_eq!(results[0].id, "network_socket_attribution");
+        assert_eq!(results[0].status, DiagnosticStatus::Warn);
+        assert!(results[0].message.contains("200 network events"));
+    }
+
+    /// Scan cost is reported on a healthy run too: it is the number the
+    /// per-event lookup existed to bound, and it is only readable here.
+    #[test]
+    fn a_healthy_socket_lookup_still_reports_its_scan_cost() {
+        let mut snap = snapshot(vec![channel("sensor_events", 10_000, 0)]);
+        snap.socket_lookup = Some(socket_lookup(10_000, 0, 1));
+
+        let results = socket_lookup_results(&snap);
+
+        assert_eq!(results[0].id, "network_socket_attribution");
+        assert_eq!(results[0].status, DiagnosticStatus::Pass);
+        assert!(results[0].message.contains("12 table scans"));
+    }
+
+    /// Absent on Windows and macOS, where there is no eBPF network sensor.
+    #[test]
+    fn a_snapshot_without_socket_lookups_reports_nothing() {
+        let snap = snapshot(vec![channel("sensor_events", 10_000, 0)]);
+        assert!(socket_lookup_results(&snap).is_empty());
     }
 
     /// The file-side twin of the registry gap: these events are discarded

--- a/src/sensor/linux/ebpf.rs
+++ b/src/sensor/linux/ebpf.rs
@@ -32,7 +32,7 @@ use crate::sensor::{
     SensorPayload,
 };
 use crate::utils::{
-    lookup_username_by_uid, query_process_details, query_socket_metadata, SocketMetadata,
+    lookup_username_by_uid, query_process_details, SocketInventory, SocketMetadata, SocketTableSet,
 };
 
 use super::events::{
@@ -267,6 +267,10 @@ async fn run_ring_poll(
     let mut dns_fd: AsyncFd<RingBuf<MapData>> = AsyncFd::new(dns_ring)?;
     let mut unresolved_file_events: u64 = 0;
     let mut dir_fds = DirFdIndex::new();
+    // Owned by the poll loop, like `dir_fds`: one snapshot serves every event
+    // in a drain batch, and its refresh policy only works if it outlives the
+    // batch that took it.
+    let mut sockets = SocketInventory::new();
 
     loop {
         if shutdown.load(Ordering::Relaxed) {
@@ -285,7 +289,7 @@ async fn run_ring_poll(
 
             Ok(mut guard) = network_fd.readable_mut() => {
                 let rb: &mut RingBuf<MapData> = guard.get_inner_mut();
-                drain_network_ring(rb, &tx);
+                drain_network_ring(rb, &tx, &mut sockets);
                 guard.clear_ready();
             }
 
@@ -325,16 +329,71 @@ fn drain_process_ring(rb: &mut RingBuf<MapData>, tx: &Sender<SensorEvent>) {
     }
 }
 
-fn drain_network_ring(rb: &mut RingBuf<MapData>, tx: &Sender<SensorEvent>) {
+/// Drain the network ring.
+///
+/// Events are decoded into `batch` first and only attributed once the ring is
+/// empty. That ordering is the point: the socket snapshot has to be taken after
+/// the batch's `connect()` calls have happened, or it describes a moment before
+/// the sockets it is being asked about existed. Attributing as each event is
+/// decoded would either read the procfs tables per event — the cost this
+/// exists to remove — or answer every event from a snapshot that predates it.
+///
+/// `sockets` is the shared snapshot, owned by the poll loop so its refresh
+/// floor spans batches; see [`SocketInventory`].
+fn drain_network_ring(
+    rb: &mut RingBuf<MapData>,
+    tx: &Sender<SensorEvent>,
+    sockets: &mut SocketInventory,
+) {
+    // A ring buffer holds a bounded number of events, so a batch is bounded
+    // too. The cap is a second bound, on the memory a single drain can hold
+    // and on how long an event waits before being sent: past it the batch is
+    // attributed and flushed, and draining continues.
+    const MAX_BATCH: usize = 4096;
+
+    let mut batch: Vec<PendingNetworkEvent> = Vec::new();
     while let Some(item) = rb.next() {
         let bytes: &[u8] = &item;
         let Some(ev) = parse_event::<NetworkEvent>(bytes) else {
             warn!("network ring: short read ({} bytes)", bytes.len());
             continue;
         };
-        if let Some(sensor_event) = build_network_event(&ev) {
-            try_send(tx, sensor_event);
+        if let Some(pending) = decode_network_event(&ev) {
+            batch.push(pending);
         }
+        if batch.len() >= MAX_BATCH {
+            flush_network_batch(&mut batch, tx, sockets);
+        }
+    }
+    flush_network_batch(&mut batch, tx, sockets);
+    crate::telemetry::LINUX_SOCKET_LOOKUP.set_table_scans(sockets.scans());
+}
+
+/// Attribute a decoded batch against one socket snapshot and send it on.
+///
+/// The batch is sent in the order it was decoded, so an event that needed a
+/// lookup does not overtake one that did not.
+fn flush_network_batch(
+    batch: &mut Vec<PendingNetworkEvent>,
+    tx: &Sender<SensorEvent>,
+    sockets: &mut SocketInventory,
+) {
+    if batch.is_empty() {
+        return;
+    }
+    // Only the tables this batch's sockets can live in. A batch of IPv4 TCP
+    // connects - what most batches are - narrows four reads to one.
+    let tables = batch
+        .iter()
+        .filter_map(|pending| pending.lookup.as_ref())
+        .fold(SocketTableSet::default(), |set, lookup| {
+            set.union(lookup.tables)
+        });
+    if !tables.is_empty() {
+        sockets.refresh_if_due(tables);
+    }
+    for pending in batch.drain(..) {
+        try_send(tx, resolve_network_event(pending, sockets));
     }
 }
 
@@ -553,7 +612,28 @@ fn build_process_event(ev: &ProcessEvent) -> Option<SensorEvent> {
     }
 }
 
-fn build_network_event(ev: &NetworkEvent) -> Option<SensorEvent> {
+/// A decoded network event and, when the kernel event did not carry every
+/// field, the socket lookup that would complete it.
+///
+/// Decoding and attribution are split so the procfs snapshot can be taken once
+/// for a whole batch; see [`drain_network_ring`].
+struct PendingNetworkEvent {
+    event: SensorEvent,
+    lookup: Option<PendingSocketLookup>,
+}
+
+/// What a pending event needs looked up, and what the answer has to match.
+struct PendingSocketLookup {
+    pid: u32,
+    fd: i32,
+    destination_ip: String,
+    destination_port: u16,
+    /// The procfs tables that can describe this socket, from the family and
+    /// transport the kernel event already carries.
+    tables: SocketTableSet,
+}
+
+fn decode_network_event(ev: &NetworkEvent) -> Option<PendingNetworkEvent> {
     // The kernel emits only attempts that connected, so this rejects nothing
     // in practice. It is the decode-side half of that contract: a refused or
     // unreachable destination is an attempt, not a connection, and a rule
@@ -597,70 +677,115 @@ fn build_network_event(ev: &NetworkEvent) -> Option<SensorEvent> {
         _ => return None,
     };
 
-    // `/proc` is read after the fact, so it may describe a different socket
-    // than the one this event captured; see `socket_matches_connection`.
-    let socket_metadata = query_socket_metadata(ev.pid, ev.fd)
-        .filter(|value| socket_matches_connection(value, &destination_ip, ev.dport));
-    let user = resolved_linux_user(ev.uid);
-    let source_ip = source_ip.or_else(|| {
-        socket_metadata
-            .as_ref()
-            .and_then(|value| filter_unspecified_ip(value.source_ip.clone()))
+    let source_port = (ev.sport > 0).then(|| ev.sport.to_string());
+    // The kernel-side socket type is authoritative: it is recorded when the
+    // socket is created, while `/proc/net` is read after the event is drained
+    // and answers for whatever the descriptor points at then.
+    let protocol = ev.transport().map(str::to_string);
+
+    // Everything the snapshot could contribute is a fallback for a field the
+    // kernel event may already carry. When it carries all three there is
+    // nothing left to look up, and the procfs work is skipped outright.
+    let lookup = (source_ip.is_none() || source_port.is_none() || protocol.is_none()).then(|| {
+        PendingSocketLookup {
+            pid: ev.pid,
+            fd: ev.fd,
+            destination_ip: destination_ip.clone(),
+            destination_port: ev.dport,
+            tables: SocketTableSet::for_socket(ev.af, ev.transport()),
+        }
+    });
+
+    Some(PendingNetworkEvent {
+        event: SensorEvent {
+            platform: Platform::Linux,
+            provider: "ebpf",
+            action: SensorAction::Connect,
+            normalization: SensorNormalization {
+                event_id: EVENT_ID_NETWORK_CONNECT,
+                action_code: 0,
+            },
+            pid: Some(ev.pid),
+            timestamp: SystemTime::now(),
+            process_start_key: None,
+            payload: SensorPayload::Network(NetworkConnectionFields {
+                destination_ip: Some(destination_ip),
+                source_ip,
+                destination_port: Some(ev.dport.to_string()),
+                source_port,
+                process_id: Some(ev.pid.to_string()),
+                // Enriched by the normalizer from ProcessCache if PID is known.
+                image: None,
+                user: Some(resolved_linux_user(ev.uid)),
+                destination_hostname: None,
+                protocol,
+                // The probe hooks `connect()` only, so every captured
+                // connection is one this host opened. `accept()` is not
+                // hooked, so no inbound connection can reach here and be
+                // mislabelled.
+                initiated: Some(true),
+            }),
+        },
+        lookup,
+    })
+}
+
+/// Fill in whatever the kernel event left absent from the socket snapshot.
+///
+/// A field the kernel measured is never overwritten, and a lookup that finds
+/// nothing leaves the event exactly as decoded — attribution is best-effort by
+/// design, and an absent source address is the documented Linux behaviour.
+fn resolve_network_event(
+    mut pending: PendingNetworkEvent,
+    sockets: &SocketInventory,
+) -> SensorEvent {
+    let Some(lookup) = pending.lookup.take() else {
+        return pending.event;
+    };
+    let Some(metadata) = resolve_socket_metadata(sockets, &lookup) else {
+        return pending.event;
+    };
+    let SensorPayload::Network(fields) = &mut pending.event.payload else {
+        return pending.event;
+    };
+
+    if fields.source_ip.is_none() {
+        fields.source_ip = filter_unspecified_ip(metadata.source_ip)
             // A v4-mapped local address belongs to an IPv4 connection; keeping
             // the `::ffff:` form would make `network.type` disagree with the
             // destination it is paired with.
             .map(|value| match value.parse::<IpAddr>() {
                 Ok(address) => unmap_ipv4(address).to_string(),
                 Err(_) => value,
-            })
-    });
-    let source_port = if ev.sport > 0 {
-        Some(ev.sport.to_string())
-    } else {
+            });
+    }
+    if fields.source_port.is_none() {
         // An unbound socket can still be listed with a local port of 0. That
         // is a placeholder, not a measurement, so it is dropped like the
         // unspecified source address above.
-        socket_metadata
-            .as_ref()
-            .and_then(|value| value.source_port)
+        fields.source_port = metadata
+            .source_port
             .filter(|port| *port > 0)
-            .map(|port| port.to_string())
-    };
+            .map(|port| port.to_string());
+    }
+    if fields.protocol.is_none() {
+        fields.protocol = metadata.protocol;
+    }
 
-    Some(SensorEvent {
-        platform: Platform::Linux,
-        provider: "ebpf",
-        action: SensorAction::Connect,
-        normalization: SensorNormalization {
-            event_id: EVENT_ID_NETWORK_CONNECT,
-            action_code: 0,
-        },
-        pid: Some(ev.pid),
-        timestamp: SystemTime::now(),
-        process_start_key: None,
-        payload: SensorPayload::Network(NetworkConnectionFields {
-            destination_ip: Some(destination_ip),
-            source_ip,
-            destination_port: Some(ev.dport.to_string()),
-            source_port,
-            process_id: Some(ev.pid.to_string()),
-            // Enriched by the normalizer from ProcessCache if PID is known.
-            image: None,
-            user: Some(user),
-            destination_hostname: None,
-            // The kernel-side socket type is authoritative: it is recorded when
-            // the socket is created, while `/proc/net` is read after the event
-            // is drained and answers for whatever the descriptor points at then.
-            protocol: ev
-                .transport()
-                .map(str::to_string)
-                .or_else(|| socket_metadata.and_then(|value| value.protocol)),
-            // The probe hooks `connect()` only, so every captured connection
-            // is one this host opened. `accept()` is not hooked, so no inbound
-            // connection can reach here and be mislabelled.
-            initiated: Some(true),
-        }),
-    })
+    pending.event
+}
+
+/// Decode and attribute one event against `sockets`.
+///
+/// The production path splits these two steps across a batch; this is the
+/// single-event form the unit tests assert on.
+#[cfg(test)]
+fn build_network_event(ev: &NetworkEvent, sockets: &mut SocketInventory) -> Option<SensorEvent> {
+    let pending = decode_network_event(ev)?;
+    if let Some(lookup) = pending.lookup.as_ref() {
+        sockets.refresh_if_due(lookup.tables);
+    }
+    Some(resolve_network_event(pending, sockets))
 }
 
 fn build_file_event(
@@ -800,6 +925,29 @@ fn unix_epoch_nanos(timestamp: SystemTime) -> u64 {
         .duration_since(SystemTime::UNIX_EPOCH)
         .map(|duration| duration.as_nanos() as u64)
         .unwrap_or(0)
+}
+
+/// Look the connect's socket up in `sockets` and record the outcome.
+///
+/// The three outcomes are kept apart because they fail for different reasons:
+/// a miss means the snapshot did not list the socket, while a mismatch means it
+/// did and described a different peer, i.e. the descriptor was recycled between
+/// the syscall and the drain.
+fn resolve_socket_metadata(
+    sockets: &SocketInventory,
+    lookup: &PendingSocketLookup,
+) -> Option<SocketMetadata> {
+    let counters = &crate::telemetry::LINUX_SOCKET_LOOKUP;
+    let Some(metadata) = sockets.lookup(lookup.pid, lookup.fd) else {
+        counters.record_unresolved();
+        return None;
+    };
+    if !socket_matches_connection(&metadata, &lookup.destination_ip, lookup.destination_port) {
+        counters.record_mismatched();
+        return None;
+    }
+    counters.record_resolved();
+    Some(metadata)
 }
 
 /// Does this `/proc/net` entry describe the connection the probe reported?
@@ -1264,7 +1412,8 @@ mod tests {
             saddr: [0u8; 16],
         };
 
-        let event = build_network_event(&raw).expect("network event should build");
+        let event = build_network_event(&raw, &mut SocketInventory::new())
+            .expect("network event should build");
         match event.payload {
             SensorPayload::Network(fields) => {
                 assert_eq!(fields.destination_ip.as_deref(), Some("198.51.100.10"));
@@ -1297,14 +1446,16 @@ mod tests {
             saddr: [0u8; 16],
         };
 
-        let event = build_network_event(&raw).expect("udp connect should build");
+        let event = build_network_event(&raw, &mut SocketInventory::new())
+            .expect("udp connect should build");
         match event.payload {
             SensorPayload::Network(fields) => assert_eq!(fields.protocol.as_deref(), Some("udp")),
             other => panic!("unexpected payload: {:?}", other),
         }
 
         raw.sock_type = 1; // SOCK_STREAM
-        let event = build_network_event(&raw).expect("tcp connect should build");
+        let event = build_network_event(&raw, &mut SocketInventory::new())
+            .expect("tcp connect should build");
         match event.payload {
             SensorPayload::Network(fields) => assert_eq!(fields.protocol.as_deref(), Some("tcp")),
             other => panic!("unexpected payload: {:?}", other),
@@ -1327,7 +1478,8 @@ mod tests {
             saddr: Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 0x20).octets(),
         };
 
-        let event = build_network_event(&raw).expect("ipv6 network event should build");
+        let event = build_network_event(&raw, &mut SocketInventory::new())
+            .expect("ipv6 network event should build");
         match event.payload {
             SensorPayload::Network(fields) => {
                 assert_eq!(fields.destination_ip.as_deref(), Some("2001:db8::10"));
@@ -1395,7 +1547,7 @@ mod tests {
             };
 
             assert!(
-                build_network_event(&raw).is_none(),
+                build_network_event(&raw, &mut SocketInventory::new()).is_none(),
                 "connect() returning {result} is not a connection"
             );
         }
@@ -1423,7 +1575,7 @@ mod tests {
                 saddr: [0u8; 16],
             };
 
-            let event = build_network_event(&raw)
+            let event = build_network_event(&raw, &mut SocketInventory::new())
                 .unwrap_or_else(|| panic!("connect() returning {result} is a connection"));
             match event.payload {
                 SensorPayload::Network(fields) => {
@@ -1451,7 +1603,7 @@ mod tests {
             saddr: [0u8; 16],
         };
 
-        assert!(build_network_event(&raw).is_none());
+        assert!(build_network_event(&raw, &mut SocketInventory::new()).is_none());
     }
 
     #[test]

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -28,7 +28,7 @@ use crate::utils::LogRateLimiter;
 pub use snapshot::{
     snapshot_path, spawn_reporter, write_final_snapshot, ChannelSnapshot, EtwDecodeFailureSnapshot,
     EtwDecodeSnapshot, FileAttributionSnapshot, ProcessCommandLineSnapshot, RegistrySnapshot,
-    SensorEventCategorySnapshot, TelemetrySnapshot, SNAPSHOT_FILE_NAME,
+    SensorEventCategorySnapshot, SocketLookupSnapshot, TelemetrySnapshot, SNAPSHOT_FILE_NAME,
 };
 
 use crate::models::EventCategory;
@@ -416,6 +416,98 @@ impl FileAttributionCounters {
         self.resolved_from_index.store(0, Ordering::Relaxed);
         self.unresolved.store(0, Ordering::Relaxed);
         self.index_capacity_evictions.store(0, Ordering::Relaxed);
+    }
+}
+
+/// Linux network-event local-address attribution.
+///
+/// A `connect(2)` tracepoint carries the destination but not the local address
+/// the stack assigned, so the sensor resolves that from a snapshot of the
+/// procfs socket tables. The snapshot can fail to answer in two different ways
+/// and they are counted apart: `unresolved` is a socket no snapshot listed,
+/// `mismatched` is a snapshot entry describing a different peer, which is a
+/// recycled descriptor rather than a missing one. Neither drops the event -
+/// the destination, pid, and user come from the kernel - so this is fidelity
+/// accounting, not loss accounting.
+///
+/// `table_scans` is the cost side: the number of passes over the procfs tables
+/// the attribution has paid for. It is the number that used to follow the
+/// event rate; see [`crate::utils::SocketInventory`].
+#[derive(Debug, Default)]
+pub struct SocketLookupCounters {
+    resolved: AtomicU64,
+    mismatched: AtomicU64,
+    unresolved: AtomicU64,
+    table_scans: AtomicU64,
+}
+
+/// Process-wide network attribution accounting. Idle outside Linux.
+pub static LINUX_SOCKET_LOOKUP: SocketLookupCounters = SocketLookupCounters::new();
+
+impl SocketLookupCounters {
+    const fn new() -> Self {
+        Self {
+            resolved: AtomicU64::new(0),
+            mismatched: AtomicU64::new(0),
+            unresolved: AtomicU64::new(0),
+            table_scans: AtomicU64::new(0),
+        }
+    }
+
+    /// The snapshot named the socket and its peer was the one the probe saw.
+    pub fn record_resolved(&self) {
+        self.resolved.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// The snapshot named the socket but described a different peer, so the
+    /// answer was discarded rather than attributed to this connection.
+    pub fn record_mismatched(&self) {
+        self.mismatched.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// No snapshot listed the socket.
+    pub fn record_unresolved(&self) {
+        self.unresolved.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Publish the inventory's cumulative table scans.
+    ///
+    /// A store rather than an increment, for the same reason as
+    /// [`FileAttributionCounters::set_index_capacity_evictions`]: the inventory
+    /// owns the count, which keeps its refresh path free of atomics and lets it
+    /// be unit-tested without process-wide state.
+    pub fn set_table_scans(&self, scans: u64) {
+        self.table_scans.store(scans, Ordering::Relaxed);
+    }
+
+    /// Point-in-time view, or `None` when no network event has been attributed.
+    pub fn snapshot(&self) -> Option<SocketLookupSnapshot> {
+        let resolved = self.resolved.load(Ordering::Relaxed);
+        let mismatched = self.mismatched.load(Ordering::Relaxed);
+        let unresolved = self.unresolved.load(Ordering::Relaxed);
+        let attempted = resolved
+            .saturating_add(mismatched)
+            .saturating_add(unresolved);
+        if attempted == 0 {
+            return None;
+        }
+        Some(SocketLookupSnapshot {
+            attempted,
+            resolved,
+            mismatched,
+            unresolved,
+            table_scans: self.table_scans.load(Ordering::Relaxed),
+        })
+    }
+
+    /// Reset every counter. Test-only, for the same reason as
+    /// [`ChannelCounters::reset`].
+    #[cfg(test)]
+    pub fn reset(&self) {
+        self.resolved.store(0, Ordering::Relaxed);
+        self.mismatched.store(0, Ordering::Relaxed);
+        self.unresolved.store(0, Ordering::Relaxed);
+        self.table_scans.store(0, Ordering::Relaxed);
     }
 }
 
@@ -1223,6 +1315,31 @@ mod tests {
     fn idle_windows_counters_report_nothing() {
         assert!(EtwDecodeCounters::new().snapshot().is_none());
         assert!(FileAttributionCounters::new().snapshot().is_none());
+        assert!(SocketLookupCounters::new().snapshot().is_none());
+    }
+
+    /// A scan the inventory paid for is a cost, not a failed attribution: it
+    /// must not be read as an event that lost its source address.
+    #[test]
+    fn socket_table_scans_are_republished_apart_from_the_gap() {
+        let counters = SocketLookupCounters::new();
+        counters.record_resolved();
+        counters.record_resolved();
+        counters.record_mismatched();
+        counters.record_unresolved();
+
+        counters.set_table_scans(3);
+        counters.set_table_scans(3);
+        counters.set_table_scans(7);
+
+        let snapshot = counters.snapshot().expect("a network event was attributed");
+        assert_eq!(snapshot.attempted, 4);
+        assert_eq!(snapshot.resolved, 2);
+        assert_eq!(snapshot.mismatched, 1);
+        assert_eq!(snapshot.unresolved, 1);
+        assert_eq!(snapshot.table_scans, 7);
+        assert_eq!(snapshot.resolution_rate_pct(), 50.0);
+        assert_eq!(snapshot.scans_per_thousand(), 1750.0);
     }
 
     /// The index owns the eviction count; telemetry republishes it. A store

--- a/src/telemetry/snapshot.rs
+++ b/src/telemetry/snapshot.rs
@@ -157,6 +157,58 @@ impl FileAttributionSnapshot {
     }
 }
 
+/// Linux network-event local-address attribution at a point in time.
+///
+/// Linux only, and absent from the snapshot on other platforms and before a
+/// network event has been attributed.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SocketLookupSnapshot {
+    /// Network events that needed a local address, transport, or both.
+    pub attempted: u64,
+    /// Those the socket snapshot answered for the peer the probe saw.
+    pub resolved: u64,
+    /// Those whose snapshot entry described a different peer, i.e. the
+    /// descriptor was recycled between the syscall and the drain.
+    pub mismatched: u64,
+    /// Those no snapshot listed at all.
+    pub unresolved: u64,
+    /// Passes over `/proc/net/{tcp,tcp6,udp,udp6}` paid for the above. Bounded
+    /// by the inventory's refresh floor rather than by the event rate.
+    pub table_scans: u64,
+}
+
+impl SocketLookupSnapshot {
+    /// Share of network events whose local address was measured.
+    pub fn resolution_rate_pct(&self) -> f64 {
+        if self.attempted == 0 {
+            return 100.0;
+        }
+        (self.resolved as f64 / self.attempted as f64) * 100.0
+    }
+
+    /// Table scans per thousand attributed events. The ratio the per-event
+    /// scan pinned at 1000 and the inventory exists to drive down.
+    pub fn scans_per_thousand(&self) -> f64 {
+        if self.attempted == 0 {
+            return 0.0;
+        }
+        (self.table_scans as f64 / self.attempted as f64) * 1000.0
+    }
+
+    /// One-line operator summary.
+    pub fn describe(&self) -> String {
+        format!(
+            "socket lookups: {} of {} events resolved ({:.2}%), {} peer mismatches, {} table scans ({:.2} per 1000 events)",
+            self.resolved,
+            self.attempted,
+            self.resolution_rate_pct(),
+            self.mismatched,
+            self.table_scans,
+            self.scans_per_thousand(),
+        )
+    }
+}
+
 /// One decode failure key and how often it fired.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EtwDecodeFailureSnapshot {
@@ -359,6 +411,11 @@ pub struct TelemetrySnapshot {
     /// on snapshots written before #394.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub etw_decode: Option<EtwDecodeSnapshot>,
+    /// Linux network local-address attribution and its procfs scan cost.
+    /// Absent on platforms without the eBPF sensor, and on snapshots written
+    /// before #375.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub socket_lookup: Option<SocketLookupSnapshot>,
 }
 
 impl TelemetrySnapshot {
@@ -378,6 +435,7 @@ impl TelemetrySnapshot {
             registry: super::REGISTRY.snapshot(),
             file_attribution: super::WINDOWS_FILE_ATTRIBUTION.snapshot(),
             etw_decode: super::ETW_DECODE.snapshot(),
+            socket_lookup: super::LINUX_SOCKET_LOOKUP.snapshot(),
         }
     }
 
@@ -548,6 +606,7 @@ mod tests {
             registry: None,
             file_attribution: None,
             etw_decode: None,
+            socket_lookup: None,
         }
     }
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -30,7 +30,7 @@ pub use process::{
     validate_process_identity, ProcessIdentity,
 };
 #[cfg(target_os = "linux")]
-pub use socket::{query_socket_metadata, SocketMetadata};
+pub use socket::{SocketInventory, SocketMetadata, SocketTableSet};
 pub use time::now_timestamp_string;
 #[cfg(windows)]
 pub use user::lookup_account_sid;

--- a/src/utils/socket.rs
+++ b/src/utils/socket.rs
@@ -1,7 +1,35 @@
 //! Linux socket inspection helpers.
+//!
+//! The kernel's `connect(2)` tracepoints carry the destination the caller
+//! asked for, but not the local address the stack assigned — that is decided
+//! inside the syscall, and neither tracepoint can see it. The only place
+//! userspace can read it back is `/proc/net/{tcp,tcp6,udp,udp6}`, keyed by the
+//! socket inode behind `/proc/<pid>/fd/<fd>`.
+//!
+//! Those tables are system-wide and unindexed, so resolving one socket by
+//! re-reading them costs a scan proportional to every socket on the host. Done
+//! once per network event, that cost scales with events multiplied by sockets
+//! and lands on the thread draining the ring buffer, where it turns into lost
+//! events rather than a slow lookup.
+//!
+//! [`SocketInventory`] separates the two halves. Scanning is
+//! [`SocketInventory::refresh_if_due`], which the caller runs once per batch of
+//! events; answering is [`SocketInventory::lookup`], which reads the snapshot
+//! and never scans. A drain batch of any size therefore costs at most one pass
+//! over the tables.
+//!
+//! Where in the batch the scan goes is the whole design. Scanning per event
+//! resolves each connect against a table read after it, which is why the old
+//! code was accurate; scanning *before* a batch resolves it against a table
+//! read before the batch's connects happened, which is accurate for nothing.
+//! The scan therefore goes after the ring has been drained and before the
+//! events are sent, where one read describes every socket the batch asks
+//! about.
 
+use std::collections::HashMap;
 use std::fs;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::time::{Duration, Instant};
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct SocketMetadata {
@@ -12,27 +40,302 @@ pub struct SocketMetadata {
     pub protocol: Option<String>,
 }
 
-/// Query socket metadata for a file descriptor owned by `pid`.
+/// The `/proc/net` tables an inventory can read, with the protocol each one
+/// names and whether its addresses are 32 hex characters wide. The position in
+/// this array is the bit a [`SocketTableSet`] sets for it.
+const PROC_NET_TABLES: [(&str, &str, bool); 4] = [
+    ("/proc/net/tcp", "tcp", false),
+    ("/proc/net/tcp6", "tcp", true),
+    ("/proc/net/udp", "udp", false),
+    ("/proc/net/udp6", "udp", true),
+];
+
+/// AF_INET, as the `connect(2)` probe reports it.
+const AF_INET: u16 = 2;
+/// AF_INET6, as the `connect(2)` probe reports it.
+const AF_INET6: u16 = 10;
+
+/// Which of the four tables a scan has to read.
 ///
-/// Works for any pid, including the current process. Uses `readlink` on
-/// `/proc/{pid}/fd/{fd}` to get the socket inode, then looks it up in
-/// `/proc/net/tcp{,6}` and `/proc/net/udp{,6}`. This avoids `open(2)` on
-/// the procfs fd symlink, which returns `ENXIO` for sockets.
-pub fn query_socket_metadata(pid: u32, fd: i32) -> Option<SocketMetadata> {
-    if pid == 0 || fd < 0 {
-        return None;
+/// A socket lives in exactly one of them, and the kernel event already says
+/// which: its address family picks the width and its socket type picks the
+/// transport. Reading the one table that can hold the answer instead of all
+/// four is the same attribution for a quarter of the cost - and because the
+/// scan budget is a share of time, a cheaper scan is also a scan that may
+/// repeat sooner.
+///
+/// An event that names neither falls back to whatever it does name, and to all
+/// four if it names nothing.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SocketTableSet(u8);
+
+impl SocketTableSet {
+    /// Every table, for a socket whose family and transport are both unknown.
+    pub const EVERY: Self = Self(0b1111);
+
+    /// The tables that can describe a socket of this address family and
+    /// transport, as the kernel event reported them.
+    pub fn for_socket(address_family: u16, transport: Option<&str>) -> Self {
+        let mut mask = 0u8;
+        for (index, (_, protocol, ipv6)) in PROC_NET_TABLES.iter().enumerate() {
+            let family_matches = match address_family {
+                AF_INET => !ipv6,
+                AF_INET6 => *ipv6,
+                _ => true,
+            };
+            let transport_matches = transport.is_none_or(|value| value == *protocol);
+            if family_matches && transport_matches {
+                mask |= 1 << index;
+            }
+        }
+        // A family the probe does not report leaves nothing to narrow by; an
+        // empty set would silently resolve nothing at all.
+        if mask == 0 {
+            return Self::EVERY;
+        }
+        Self(mask)
     }
 
-    let inode = read_socket_inode(pid, fd)?;
+    pub fn union(self, other: Self) -> Self {
+        Self(self.0 | other.0)
+    }
 
-    lookup_proc_net("/proc/net/tcp", inode, "tcp", false)
-        .or_else(|| lookup_proc_net("/proc/net/tcp6", inode, "tcp", true))
-        .or_else(|| lookup_proc_net("/proc/net/udp", inode, "udp", false))
-        .or_else(|| lookup_proc_net("/proc/net/udp6", inode, "udp", true))
+    pub fn is_empty(self) -> bool {
+        self.0 == 0
+    }
+
+    fn contains(self, index: usize) -> bool {
+        self.0 & (1 << index) != 0
+    }
+}
+
+/// Sanity floor between two scans of the socket tables.
+///
+/// The real governor is [`SCAN_DUTY_DIVISOR`], which is proportional to what a
+/// scan costs. This is only a guard against a cost measurement that rounds to
+/// nothing — a clock with coarse resolution, or four tables so small the read
+/// is faster than it can be timed — which would otherwise leave no floor at
+/// all.
+const MIN_REFRESH_INTERVAL: Duration = Duration::from_millis(1);
+
+/// How much of the drain thread a scan is allowed to claim, as a divisor: one
+/// part scanning to `SCAN_DUTY_DIVISOR - 1` parts everything else.
+///
+/// A fixed floor bounds how *often* the tables are read but not what a read
+/// costs, and that cost is the number of sockets on the host. Connection churn
+/// is exactly the workload that inflates it: twenty thousand closed connects
+/// leave a `TIME_WAIT` backlog that a scan then walks in full, so a floor that
+/// was cheap on an idle host becomes the same CPU sink it replaced.
+///
+/// Timing the last scan and holding the next one off for a multiple of it
+/// bounds the share of the drain thread attribution can take at one part in
+/// `SCAN_DUTY_DIVISOR`, whatever the table grows to and however many events
+/// arrive. That bound is what makes the cost independent of the event rate;
+/// everything else is the fidelity it buys.
+///
+/// A fixed floor was tried first and rejected: it is a worse trade in both
+/// directions. Ten milliseconds is far too slow to refresh when the tables are
+/// small — a host opening 400 connections a second resolved 8% of them — and
+/// far too fast when they are large, where it was measured spending seconds of
+/// CPU per burst. The effective floor is the product clamped into
+/// [`MIN_REFRESH_INTERVAL`]..=[`MAX_SNAPSHOT_AGE`].
+///
+/// Four is a measured point on the curve, not a round number. Against a
+/// 20 000-connect burst and a paced 400/s workload on the same host, where the
+/// unbounded per-event scan this replaces cost 9.3 s of CPU and lost three
+/// quarters of the burst to the ring buffer:
+///
+/// | divisor | burst CPU | 400/s attributed | 400/s CPU |
+/// |---------|-----------|------------------|-----------|
+/// | 8       | 1.0 s     | 27%              | 150 ms    |
+/// | **4**   | **2.2 s** | **45%**          | **230 ms**|
+/// | 2       | 3.1 s     | 65%              | 330 ms    |
+/// | ∞ (old) | 9.3 s     | ~100%            | 510 ms    |
+///
+/// The burst is what the ring buffer cannot survive, so the budget is set
+/// nearer the cheap end; attribution is best-effort by design and its shortfall
+/// is reported, while a lost event is neither.
+const SCAN_DUTY_DIVISOR: u32 = 4;
+
+/// Longest a snapshot is consulted before being scanned again.
+///
+/// Inode numbers are recycled, so an entry that outlives its socket can
+/// describe a different one. Callers filter an answer against the destination
+/// the kernel reported, but bounding the age keeps that filter from being the
+/// only thing standing between a recycled inode and a wrong local address.
+const MAX_SNAPSHOT_AGE: Duration = Duration::from_secs(1);
+
+/// One socket as `/proc/net` describes it.
+///
+/// Addresses are kept parsed rather than as the `String`s [`SocketMetadata`]
+/// carries: a refresh indexes every socket on the host, and all but a handful
+/// are never looked up, so the formatting is deferred to the lookup that hits.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SocketEntry {
+    source_ip: IpAddr,
+    source_port: u16,
+    destination_ip: IpAddr,
+    destination_port: u16,
+    protocol: &'static str,
+}
+
+impl SocketEntry {
+    fn to_metadata(self) -> SocketMetadata {
+        SocketMetadata {
+            source_ip: Some(self.source_ip.to_string()),
+            source_port: Some(self.source_port),
+            destination_ip: Some(self.destination_ip.to_string()),
+            destination_port: Some(self.destination_port),
+            protocol: Some(self.protocol.to_string()),
+        }
+    }
+}
+
+/// A snapshot of the host's IP sockets, keyed by inode.
+///
+/// Not `Sync`, and deliberately not shared: it belongs to the thread draining
+/// the network ring, so a lookup costs no synchronisation and the refresh
+/// policy answers to one batch of events at a time.
+#[derive(Debug)]
+pub struct SocketInventory {
+    entries: HashMap<u64, SocketEntry>,
+    refreshed_at: Option<Instant>,
+    /// How long the last scan took. The budget the effective floor is derived
+    /// from; see [`SCAN_DUTY_DIVISOR`].
+    last_scan_cost: Duration,
+    min_refresh_interval: Duration,
+    max_snapshot_age: Duration,
+    scan_duty_divisor: u32,
+    scans: u64,
+}
+
+impl Default for SocketInventory {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SocketInventory {
+    pub fn new() -> Self {
+        Self::with_refresh_policy(MIN_REFRESH_INTERVAL, MAX_SNAPSHOT_AGE, SCAN_DUTY_DIVISOR)
+    }
+
+    /// Build an inventory with an explicit refresh policy.
+    ///
+    /// Exists for tests and benchmarks, which need the policy pinned to make a
+    /// scan count reproducible rather than a function of how fast the machine
+    /// got through the loop and how many sockets it happened to have open. A
+    /// `scan_duty_divisor` of zero turns the cost-proportional widening off and
+    /// leaves the fixed floor alone.
+    pub fn with_refresh_policy(
+        min_refresh_interval: Duration,
+        max_snapshot_age: Duration,
+        scan_duty_divisor: u32,
+    ) -> Self {
+        Self {
+            entries: HashMap::new(),
+            refreshed_at: None,
+            last_scan_cost: Duration::ZERO,
+            min_refresh_interval,
+            max_snapshot_age,
+            scan_duty_divisor,
+            scans: 0,
+        }
+    }
+
+    /// Local address and transport of the socket `fd` names in `pid`, or
+    /// `None` when the current snapshot does not describe it.
+    ///
+    /// Answers from the snapshot alone and never scans, so a burst of lookups
+    /// costs a `readlink` each and nothing more. Taking the snapshot is
+    /// [`refresh_if_due`](Self::refresh_if_due)'s job, and the caller places
+    /// that call — after a batch of events has been decoded, when every socket
+    /// the batch asks about already exists.
+    ///
+    /// The inode still comes from a `readlink` on `/proc/<pid>/fd/<fd>`, which
+    /// is one syscall against one process and does not grow with the number of
+    /// sockets on the host. What the snapshot removes is the table scan behind
+    /// it.
+    pub fn lookup(&self, pid: u32, fd: i32) -> Option<SocketMetadata> {
+        if pid == 0 || fd < 0 {
+            return None;
+        }
+        let inode = read_socket_inode(pid, fd)?;
+        self.entries.get(&inode).map(|entry| entry.to_metadata())
+    }
+
+    /// Take a new snapshot if the refresh floor allows one.
+    ///
+    /// Call this once per batch of events that need attribution, before
+    /// resolving them: one scan then answers the whole batch, and it is taken
+    /// after the batch's connects have happened rather than before, which is
+    /// the difference between resolving a burst and missing it.
+    ///
+    /// Returns whether a scan was taken.
+    pub fn refresh_if_due(&mut self, tables: SocketTableSet) -> bool {
+        if tables.is_empty() {
+            return false;
+        }
+        let floor = self.effective_refresh_floor();
+        if self.age().is_some_and(|age| age < floor) {
+            return false;
+        }
+        self.refresh(tables);
+        true
+    }
+
+    /// Table scans this inventory has performed. The number the per-event
+    /// lookup existed to bound.
+    pub fn scans(&self) -> u64 {
+        self.scans
+    }
+
+    /// Sockets in the current snapshot.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    fn age(&self) -> Option<Duration> {
+        self.refreshed_at.map(|at| at.elapsed())
+    }
+
+    /// The floor a batch refresh has to clear, widened when the last scan
+    /// was expensive. See [`SCAN_DUTY_DIVISOR`].
+    fn effective_refresh_floor(&self) -> Duration {
+        (self.last_scan_cost * self.scan_duty_divisor)
+            .clamp(self.min_refresh_interval, self.max_snapshot_age)
+    }
+
+    /// Re-read the requested tables into the snapshot.
+    ///
+    /// The snapshot then describes those tables and nothing else, so a lookup
+    /// against a table this scan skipped misses rather than answering from a
+    /// stale one. The map is cleared rather than rebuilt so a steady-state host
+    /// stops reallocating it, and a table that cannot be read is skipped: a
+    /// missing `/proc/net/tcp6` on a kernel built without IPv6 is not a reason
+    /// to lose the other three.
+    fn refresh(&mut self, tables: SocketTableSet) {
+        let started = Instant::now();
+        self.entries.clear();
+        for (index, (path, protocol, ipv6)) in PROC_NET_TABLES.into_iter().enumerate() {
+            if tables.contains(index) {
+                index_proc_net(path, protocol, ipv6, &mut self.entries);
+            }
+        }
+        let finished = Instant::now();
+        self.last_scan_cost = finished.saturating_duration_since(started);
+        self.refreshed_at = Some(finished);
+        self.scans = self.scans.saturating_add(1);
+    }
 }
 
 /// Resolve the socket inode from `/proc/{pid}/fd/{fd}`.
 ///
+/// Uses `readlink` rather than `open(2)`, which returns `ENXIO` for a socket.
 /// The symlink target is `"socket:[inode]"` for socket fds.
 fn read_socket_inode(pid: u32, fd: i32) -> Option<u64> {
     let link = fs::read_link(format!("/proc/{pid}/fd/{fd}")).ok()?;
@@ -41,49 +344,73 @@ fn read_socket_inode(pid: u32, fd: i32) -> Option<u64> {
     inner.strip_suffix(']')?.parse().ok()
 }
 
-/// Scan a `/proc/net/{tcp,tcp6,udp,udp6}` file for a matching inode and
-/// return its local and remote address as `SocketMetadata`.
+/// Index one `/proc/net/{tcp,tcp6,udp,udp6}` table by socket inode.
 ///
 /// Field layout (whitespace-separated, 0-indexed, header skipped):
 ///   0: sl   1: local_addr   2: rem_addr   3: state   …   9: inode
 ///
 /// Addresses are printed as `XXXXXXXX:PPPP` (IPv4) or
 /// `XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:PPPP` (IPv6) in host byte order.
-fn lookup_proc_net(path: &str, inode: u64, protocol: &str, ipv6: bool) -> Option<SocketMetadata> {
-    let content = fs::read_to_string(path).ok()?;
+///
+/// A line that does not parse is skipped rather than aborting the table: the
+/// tables grow columns between kernel releases, and one unreadable row must
+/// not cost the rest of the host's sockets.
+fn index_proc_net(
+    path: &str,
+    protocol: &'static str,
+    ipv6: bool,
+    entries: &mut HashMap<u64, SocketEntry>,
+) {
+    let Ok(content) = fs::read_to_string(path) else {
+        return;
+    };
 
     for line in content.lines().skip(1) {
-        let mut iter = line.split_whitespace();
-        let _sl = iter.next()?;
-        let local = iter.next()?;
-        let remote = iter.next()?;
-        let _state = iter.next()?;
-        // tx_queue:rx_queue, tr:tm, retrnsmt, uid, timeout
-        for _ in 0..5 {
-            iter.next()?;
+        if let Some((inode, entry)) = parse_proc_net_line(line, protocol, ipv6) {
+            entries.insert(inode, entry);
         }
-        let line_inode: u64 = match iter.next()?.parse() {
-            Ok(n) => n,
-            Err(_) => continue,
-        };
+    }
+}
 
-        if line_inode != inode {
-            continue;
-        }
+fn parse_proc_net_line(
+    line: &str,
+    protocol: &'static str,
+    ipv6: bool,
+) -> Option<(u64, SocketEntry)> {
+    let mut iter = line.split_whitespace();
+    let _sl = iter.next()?;
+    let local = iter.next()?;
+    let remote = iter.next()?;
+    let _state = iter.next()?;
+    // tx_queue:rx_queue, tr:tm, retrnsmt, uid, timeout
+    for _ in 0..5 {
+        iter.next()?;
+    }
+    let inode: u64 = iter.next()?.parse().ok()?;
 
-        let (src_ip, src_port) = parse_addr(local, ipv6)?;
-        let (dst_ip, dst_port) = parse_addr(remote, ipv6)?;
-
-        return Some(SocketMetadata {
-            source_ip: Some(src_ip.to_string()),
-            source_port: Some(src_port),
-            destination_ip: Some(dst_ip.to_string()),
-            destination_port: Some(dst_port),
-            protocol: Some(protocol.to_string()),
-        });
+    // A socket in `TIME_WAIT` or `FIN_WAIT2` has been detached from its
+    // descriptor and is listed with inode 0. No `/proc/<pid>/fd` link can name
+    // it, so it can never be looked up - and under connection churn these are
+    // most of the table. Rejecting them on the integer before parsing two
+    // addresses is what keeps a scan proportional to live sockets rather than
+    // to the churn backlog.
+    if inode == 0 {
+        return None;
     }
 
-    None
+    let (source_ip, source_port) = parse_addr(local, ipv6)?;
+    let (destination_ip, destination_port) = parse_addr(remote, ipv6)?;
+
+    Some((
+        inode,
+        SocketEntry {
+            source_ip,
+            source_port,
+            destination_ip,
+            destination_port,
+            protocol,
+        },
+    ))
 }
 
 fn parse_addr(s: &str, ipv6: bool) -> Option<(IpAddr, u16)> {
@@ -130,20 +457,29 @@ mod tests {
     use std::net::{TcpListener, TcpStream};
     use std::os::fd::AsRawFd;
 
-    #[test]
-    fn query_socket_metadata_reads_connected_tcp_socket() {
-        let listener = match TcpListener::bind(("127.0.0.1", 0)) {
-            Ok(listener) => listener,
-            Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => return,
+    /// Bind a loopback listener, or `None` where the sandbox forbids it.
+    fn loopback_listener() -> Option<TcpListener> {
+        match TcpListener::bind(("127.0.0.1", 0)) {
+            Ok(listener) => Some(listener),
+            Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => None,
             Err(err) => panic!("listener bind: {err}"),
+        }
+    }
+
+    #[test]
+    fn lookup_reads_connected_tcp_socket() {
+        let Some(listener) = loopback_listener() else {
+            return;
         };
         let listener_addr = listener.local_addr().expect("listener addr");
 
         let client = TcpStream::connect(listener_addr).expect("client connect");
         let (_server, _) = listener.accept().expect("accept");
 
-        let client_fd = client.as_raw_fd();
-        let metadata = query_socket_metadata(std::process::id(), client_fd)
+        let mut inventory = SocketInventory::new();
+        assert!(inventory.refresh_if_due(SocketTableSet::EVERY));
+        let metadata = inventory
+            .lookup(std::process::id(), client.as_raw_fd())
             .expect("connected client socket should resolve");
 
         assert_eq!(metadata.protocol.as_deref(), Some("tcp"));
@@ -154,5 +490,203 @@ mod tests {
             metadata.source_port,
             Some(client.local_addr().expect("client addr").port())
         );
+    }
+
+    /// The drain-batch case the inventory exists for: one scan, then as many
+    /// lookups as the batch holds.
+    #[test]
+    fn one_scan_answers_a_whole_batch() {
+        let Some(listener) = loopback_listener() else {
+            return;
+        };
+        let listener_addr = listener.local_addr().expect("listener addr");
+
+        let clients: Vec<TcpStream> = (0..16)
+            .map(|_| {
+                let client = TcpStream::connect(listener_addr).expect("client connect");
+                let (_server, _) = listener.accept().expect("accept");
+                client
+            })
+            .collect();
+
+        let mut inventory = SocketInventory::new();
+        inventory.refresh_if_due(SocketTableSet::EVERY);
+        for client in &clients {
+            assert!(inventory
+                .lookup(std::process::id(), client.as_raw_fd())
+                .is_some());
+        }
+
+        assert_eq!(
+            inventory.scans(),
+            1,
+            "lookups must answer from the snapshot rather than scan for themselves"
+        );
+    }
+
+    /// A socket created after the last scan resolves once the batch it belongs
+    /// to refreshes — which is why the caller refreshes after draining, not
+    /// before.
+    #[test]
+    fn a_socket_newer_than_the_snapshot_resolves_at_the_next_refresh() {
+        let Some(listener) = loopback_listener() else {
+            return;
+        };
+        let listener_addr = listener.local_addr().expect("listener addr");
+
+        let mut inventory =
+            SocketInventory::with_refresh_policy(Duration::ZERO, Duration::from_secs(60), 0);
+        assert!(inventory.refresh_if_due(SocketTableSet::EVERY));
+
+        let client = TcpStream::connect(listener_addr).expect("client connect");
+        let (_server, _) = listener.accept().expect("accept");
+        let pid = std::process::id();
+        let fd = client.as_raw_fd();
+
+        assert!(
+            inventory.lookup(pid, fd).is_none(),
+            "the snapshot predates the socket, so it cannot describe it"
+        );
+        assert!(inventory.refresh_if_due(SocketTableSet::EVERY));
+        assert!(
+            inventory.lookup(pid, fd).is_some(),
+            "the refresh that follows the batch must pick it up"
+        );
+    }
+
+    #[test]
+    fn the_floor_caps_how_often_a_batch_can_scan() {
+        let mut inventory = SocketInventory::with_refresh_policy(
+            Duration::from_secs(60),
+            Duration::from_secs(60),
+            0,
+        );
+        assert!(
+            inventory.refresh_if_due(SocketTableSet::EVERY),
+            "the first batch has no snapshot"
+        );
+        for _ in 0..64 {
+            assert!(!inventory.refresh_if_due(SocketTableSet::EVERY));
+        }
+        assert_eq!(inventory.scans(), 1);
+    }
+
+    #[test]
+    fn a_table_set_names_only_the_table_that_can_hold_the_socket() {
+        // /proc/net/tcp alone: index 0 of PROC_NET_TABLES.
+        assert_eq!(
+            SocketTableSet::for_socket(2, Some("tcp")),
+            SocketTableSet(0b0001)
+        );
+        // /proc/net/udp6 alone: index 3.
+        assert_eq!(
+            SocketTableSet::for_socket(10, Some("udp")),
+            SocketTableSet(0b1000)
+        );
+        // A socket opened before the sensor started names no transport, so
+        // both tables of its family stay in play.
+        assert_eq!(SocketTableSet::for_socket(2, None), SocketTableSet(0b0101));
+        // A family the probe does not report narrows nothing.
+        assert_eq!(SocketTableSet::for_socket(0, None), SocketTableSet::EVERY);
+    }
+
+    /// A scan reads what it was asked for, so a lookup against a table it
+    /// skipped must miss rather than answer from the previous snapshot.
+    #[test]
+    fn a_narrowed_scan_does_not_answer_for_the_tables_it_skipped() {
+        let Some(listener) = loopback_listener() else {
+            return;
+        };
+        let listener_addr = listener.local_addr().expect("listener addr");
+        let client = TcpStream::connect(listener_addr).expect("client connect");
+        let (_server, _) = listener.accept().expect("accept");
+
+        let mut inventory =
+            SocketInventory::with_refresh_policy(Duration::ZERO, Duration::from_secs(60), 0);
+        let pid = std::process::id();
+        let fd = client.as_raw_fd();
+
+        inventory.refresh_if_due(SocketTableSet::for_socket(2, Some("udp")));
+        assert!(inventory.lookup(pid, fd).is_none());
+
+        inventory.refresh_if_due(SocketTableSet::for_socket(2, Some("tcp")));
+        assert!(inventory.lookup(pid, fd).is_some());
+    }
+
+    #[test]
+    fn an_expensive_scan_widens_the_refresh_floor() {
+        let mut inventory = SocketInventory::new();
+
+        inventory.last_scan_cost = Duration::from_micros(500);
+        assert_eq!(
+            inventory.effective_refresh_floor(),
+            Duration::from_millis(2),
+            "a cheap scan may repeat often, because repeating it costs little"
+        );
+
+        inventory.last_scan_cost = Duration::ZERO;
+        assert_eq!(
+            inventory.effective_refresh_floor(),
+            MIN_REFRESH_INTERVAL,
+            "a cost that rounds to nothing still leaves a floor"
+        );
+
+        inventory.last_scan_cost = Duration::from_millis(25);
+        assert_eq!(
+            inventory.effective_refresh_floor(),
+            Duration::from_millis(100),
+            "a 25 ms scan may repeat at most every 100 ms, i.e. a quarter of the thread"
+        );
+
+        inventory.last_scan_cost = Duration::from_secs(10);
+        assert_eq!(
+            inventory.effective_refresh_floor(),
+            MAX_SNAPSHOT_AGE,
+            "the ceiling keeps a pathological table from freezing the snapshot"
+        );
+    }
+
+    /// Turning the widening off must leave the fixed floor exactly as it was,
+    /// because that is what the tests and the benchmark pin.
+    #[test]
+    fn a_zero_duty_divisor_leaves_the_fixed_floor_alone() {
+        let mut inventory = SocketInventory::with_refresh_policy(
+            Duration::from_millis(7),
+            Duration::from_secs(1),
+            0,
+        );
+        inventory.last_scan_cost = Duration::from_millis(25);
+
+        assert_eq!(
+            inventory.effective_refresh_floor(),
+            Duration::from_millis(7)
+        );
+    }
+
+    #[test]
+    fn parses_an_ipv4_table_line() {
+        let line = "   1: 0100007F:0016 0200007F:9C40 01 00000000:00000000 00:00000000 00000000     0        0 4242 1 0000000000000000 20 0 0 10 0";
+        let (inode, entry) = parse_proc_net_line(line, "tcp", false).expect("line should parse");
+
+        assert_eq!(inode, 4242);
+        assert_eq!(entry.source_ip.to_string(), "127.0.0.1");
+        assert_eq!(entry.source_port, 22);
+        assert_eq!(entry.destination_ip.to_string(), "127.0.0.2");
+        assert_eq!(entry.destination_port, 40_000);
+        assert_eq!(entry.protocol, "tcp");
+    }
+
+    /// The churn backlog: detached sockets no descriptor can name, and most of
+    /// the table on a host that has been opening connections.
+    #[test]
+    fn skips_a_socket_with_no_descriptor_behind_it() {
+        let time_wait = "   2: 0100007F:0016 0200007F:9C40 06 00000000:00000000 03:00000C1B 00000000     0        0 0 0 0000000000000000";
+        assert!(parse_proc_net_line(time_wait, "tcp", false).is_none());
+    }
+
+    #[test]
+    fn skips_a_line_it_cannot_parse() {
+        assert!(parse_proc_net_line("  sl  local_address rem_address", "tcp", false).is_none());
+        assert!(parse_proc_net_line("", "tcp", false).is_none());
     }
 }

--- a/tests/telemetry_backpressure.rs
+++ b/tests/telemetry_backpressure.rs
@@ -152,6 +152,7 @@ fn snapshot_with(channels: Vec<ChannelSnapshot>) -> TelemetrySnapshot {
         registry: None,
         file_attribution: None,
         etw_decode: None,
+        socket_lookup: None,
     }
 }
 


### PR DESCRIPTION
Closes #375.

## The problem

Every Linux network event called `query_socket_metadata(pid, fd)`, which read `/proc/net/tcp`, `tcp6`, `udp`, and `udp6` and linearly scanned them for the socket's inode. Those tables are system-wide and unindexed, so the cost was events × sockets, paid on the thread draining the ring buffer — and a miss scanned all four.

Measured on lab-ubuntu, a 20 000-connect burst cost the agent **9.3 s of CPU** and lost **three quarters of its network events** to ring-buffer overflow. That loss shows up in no channel counter, because the events never reached userspace.

## The change

`SocketInventory` splits scanning from answering:

- `refresh_if_due()` takes one snapshot of the tables, keyed by inode.
- `lookup(pid, fd)` reads that snapshot and never scans — a `readlink` and a hash lookup.

`drain_network_ring` decodes a whole ring drain into a batch, takes at most one snapshot for it, then attributes and sends the batch in order. **The snapshot goes after the drain deliberately**: taken before, it describes a moment when the batch's sockets did not yet exist, which is accurate for nothing.

Three things bound the scan:

1. **One scan per drain batch**, whatever the batch holds.
2. **A budget, not a fixed interval.** The next scan waits four times what the last one measured, so attribution can never take more than a quarter of the draining thread, however large the tables grow. A fixed floor was tried first and is a worse trade at both ends — 10 ms is far too slow to refresh when the tables are small (8% attributed at 400 conn/s) and far too fast when connection churn has filled them with `TIME_WAIT` (seconds of CPU per burst).
3. **Only the tables that can hold the socket.** The kernel event already carries the address family and the socket type, so an IPv4 TCP batch reads one table instead of four.

`TIME_WAIT` rows are rejected on the inode before their addresses are parsed — no descriptor can name them, and under churn they are most of the table.

## Measured (lab-ubuntu, 4 vCPU, against `7c32d20`)

| workload | | CPU | network events kept | source attributed |
| --- | --- | --- | --- | --- |
| 20 000-connect burst | before | 9.3 s | 4 988 / 20 000 | — |
| | **after** | **2.1 s** | **20 000 / 20 000** | — |
| 400 conn/s, paced | before | 510 ms | all | ~100% |
| | **after** | **230 ms** | all | **45%** |
| 40 conn/s, paced | before | — | all | 400 / 400 |
| | **after** | — | all | **400 / 400** |

Table scans went from one per event to **84 for 20 000 events**. No channel drops in any run.

**The honest trade:** ordinary outbound traffic is attributed exactly as before. Under sustained churn, a socket opened between two scans is in neither, so its `source.ip`/`source.port` are reported absent — which is how a lookup miss has always been reported, and which the docs already describe as the normal Linux case. The events themselves survive, which they did not before. The duty divisor was picked from a measured curve (8 → 1.0 s burst / 27% at 400 conn/s; **4 → 2.2 s / 45%**; 2 → 3.1 s / 65%; unbounded → 9.3 s / ~100%), set nearer the cheap end because a lost event is unrecoverable and a missing source field is reported.

## Visibility

The shortfall is no longer invisible. `telemetry.json` gains a `socket_lookup` section — `attempted`, `resolved`, `mismatched` (a descriptor recycled between the syscall and the drain), `unresolved`, and `table_scans` — and `rustinel doctor` reports it as `network_socket_attribution`, warning below a 95% resolution rate. `docs/configuration.md` and `docs/limitations.md` document the section and the trade.

## Benchmark

`benches/linux_socket_lookup` measures the two cost models directly (Linux-only; a no-op elsewhere):

```
linux_socket_lookup: 529 sockets in the snapshot; 256 events cost 256 table scans per-event vs 1 batched
per_event_scan/256    time: [382.00 ms 382.84 ms 383.69 ms]
batch_inventory/256   time: [1.9904 ms 1.9916 ms 1.9930 ms]
```

## Verification

- `cargo clippy --all-targets` and `cargo test` clean on macOS and on lab-ubuntu (Ubuntu 26.04, kernel 7.0), 11 new unit tests in `utils::socket`.
- Live eBPF runs on lab-ubuntu with a real compiled eBPF object for every number in the tables above, each repeated.