### PR TITLE
fix(linux-ebpf): capture legacy and openat2 file syscall variants

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -128,10 +128,10 @@ The Linux sensor loads eBPF programs with Aya and currently covers:
 - DNS queries observed from userspace `sendto`, `sendmsg`, and `sendmmsg` calls. The eBPF program emits a bounded raw DNS payload and userspace parses `QueryName`, keeping string parsing out of the verifier-sensitive in-kernel path. Linux DNS response answers are not parsed yet, so `QueryResults` remains unavailable on Linux.
 
 The loader attaches a mix of tracepoints and kprobes: `sched_process_exec` and
-`sched_process_exit`, enter/exit pairs on `execve`, `execveat`, `openat`,
-`unlinkat`, `renameat`, and `renameat2`, entry hooks on `connect`, `sendto`,
-`sendmsg`, and `sendmmsg`, and a `vfs_create` kprobe. The authoritative list is
-in `src/sensor/linux/`.
+`sched_process_exit`, enter/exit pairs on `open`, `openat`, `openat2`, `creat`,
+`unlink`, `unlinkat`, `rename`, `renameat`, `renameat2`, `mkdir`, `mkdirat`, and
+`rmdir`, entry hooks on `connect`, `sendto`, `sendmsg`, and `sendmmsg`, and a
+`vfs_create` kprobe. The authoritative list is in `src/sensor/linux/`.
 
 Requirements for the Linux sensor are kernel 5.8+, BTF, and eBPF privileges.
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -164,9 +164,9 @@ The Linux sensor covers process, network, file, and DNS.
   carries `PathTruncated` naming which side was cut. Since truncation removes
   the end of the path, `|endswith` rules and extension IOCs are what it defeats.
 - **File events whose path cannot be placed are dropped (bounded, counted).**
-  `openat`, `unlinkat`, and `renameat*` name their target with a directory
-  descriptor plus a possibly relative name, and the kernel does not expose the
-  resolved path. A process that exits before the drain leaves a name that
+  The `*at` file syscalls name their target with a directory descriptor plus a
+  possibly relative name, and the kernel does not expose the resolved path. A
+  process that exits before the drain leaves a name that
   neither `/proc/<pid>/cwd` nor the descriptor index can place, and it is
   dropped rather than reported as though `passwd` were `/etc/passwd`. Counted as
   `unresolved_file_events`.

--- a/ebpf/src/file.rs
+++ b/ebpf/src/file.rs
@@ -2,22 +2,25 @@
 //!
 //! We split create/delete handling across syscall entry and exit:
 //!
-//! - `syscalls/sys_enter_openat` queues create candidates when `O_CREAT` is set.
+//! - `syscalls/sys_enter_open`, `openat`, `openat2`, and `creat` queue create
+//!   candidates when `O_CREAT` is set or implied.
 //! - `vfs_create` marks candidates that actually created a new inode.
-//! - `syscalls/sys_exit_openat` emits create events only when the syscall succeeds.
-//! - `syscalls/sys_enter_unlinkat` queues delete candidates.
-//! - `syscalls/sys_exit_unlinkat` emits delete events only when the syscall succeeds.
-//! - `syscalls/sys_enter_renameat*` queues rename candidates.
-//! - `syscalls/sys_exit_renameat*` emits rename events only when the syscall succeeds.
+//! - The matching exit tracepoint emits create events only when the syscall succeeds.
+//! - `syscalls/sys_enter_unlink`, `unlinkat`, and `rmdir` queue delete
+//!   candidates, then emit them only on successful exit.
+//! - `syscalls/sys_enter_rename`, `renameat`, and `renameat2` queue rename
+//!   candidates, then emit them only on successful exit.
+//! - `syscalls/sys_enter_mkdir` and `mkdirat` queue directory creates, then emit
+//!   them only on successful exit.
 //!
-//! This keeps the Linux MVP narrow while avoiding false positives from failed
-//! syscalls or `openat(O_CREAT)` calls that never complete successfully.
+//! This avoids false positives from failed syscalls or open-with-create calls
+//! that never complete successfully.
 //!
-//! Every one of these syscalls takes its pathname as a `*at` argument pair: a
-//! directory descriptor plus a name that may be relative to it. The descriptor
-//! is captured alongside the name so userspace can rebuild the absolute path —
-//! without it, `openat(dirfd, "passwd")` and `openat(AT_FDCWD, "passwd")` are
-//! indistinguishable strings that name different files.
+//! The `*at` syscalls take their pathname as a directory descriptor plus a name
+//! that may be relative to it. The descriptor is captured alongside the name so
+//! userspace can rebuild the absolute path. Legacy path-only syscalls are
+//! represented with `AT_FDCWD`, since their relative names use the current
+//! working directory.
 //!
 //! Successful directory opens are reported too, under a kind the drain loop
 //! consumes rather than forwarding. They are what lets a descriptor be named at
@@ -68,7 +71,7 @@
 use aya_ebpf::{
     helpers::{
         bpf_get_current_comm, bpf_get_current_pid_tgid, bpf_get_current_uid_gid, bpf_ktime_get_ns,
-        bpf_probe_read_user_str_bytes,
+        bpf_probe_read_user, bpf_probe_read_user_str_bytes,
     },
     macros::{kprobe, map, tracepoint},
     maps::{HashMap, LruHashMap, PerCpuArray, RingBuf},
@@ -94,6 +97,8 @@ const O_DIRECTORY: u64 = 0x1_0000;
 /// The caller wants a handle to the location, not the contents. `O_PATH`
 /// descriptors are legal `*at` directory descriptors.
 const O_PATH: u64 = 0x20_0000;
+/// Relative paths used by legacy path-only syscalls resolve against the CWD.
+const AT_FDCWD: i32 = -100;
 
 const FILE_KIND_CREATE: u32 = 1;
 const FILE_KIND_DELETE: u32 = 2;
@@ -114,9 +119,9 @@ pub static FILE_RING: RingBuf = RingBuf::with_byte_size(1024 * 1024, 0);
 
 /// Per-thread pending file operation, keyed by TID.
 ///
-/// A thread is inside exactly one syscall at a time, so `openat`, `unlinkat`,
-/// and `renameat*` share one slot per thread instead of one map each. At a
-/// `FileEvent` of ~1 KiB that is the difference between 17 MiB and 51 MiB of
+/// A thread is inside exactly one syscall at a time, so all tracked file syscall
+/// variants share one slot per thread instead of one map per operation. At a
+/// `FileEvent` of ~1 KiB, each additional map would cost roughly 17 MiB of
 /// kernel memory.
 #[map]
 static FILE_PENDING: HashMap<u32, FileEvent> = HashMap::with_max_entries(16_384, 0);
@@ -135,7 +140,7 @@ static FILE_PENDING: HashMap<u32, FileEvent> = HashMap::with_max_entries(16_384,
 #[map]
 static FILE_SCRATCH: PerCpuArray<FileEvent> = PerCpuArray::with_max_entries(1, 0);
 
-/// Per-thread marker that `vfs_create` ran for the pending open.
+/// Per-thread marker that `vfs_create` ran for the pending open variant.
 #[map]
 static OPENAT_CREATED: HashMap<u32, u8> = HashMap::with_max_entries(16_384, 0);
 
@@ -167,7 +172,25 @@ pub fn handle_openat(ctx: TracePointContext) -> u32 {
     unsafe { try_handle_openat(&ctx) }.unwrap_or(1)
 }
 
-/// Mark a queued `openat(O_CREAT)` as a real create when the kernel reaches
+/// Queue a potential file event for legacy `open`.
+#[tracepoint]
+pub fn handle_open(ctx: TracePointContext) -> u32 {
+    unsafe { try_handle_open(&ctx) }.unwrap_or(1)
+}
+
+/// Queue a potential file-create event for legacy `creat`.
+#[tracepoint]
+pub fn handle_creat(ctx: TracePointContext) -> u32 {
+    unsafe { try_handle_creat(&ctx) }.unwrap_or(1)
+}
+
+/// Queue a potential file event for `openat2`.
+#[tracepoint]
+pub fn handle_openat2(ctx: TracePointContext) -> u32 {
+    unsafe { try_handle_openat2(&ctx) }.unwrap_or(1)
+}
+
+/// Mark a queued open-with-create as a real create when the kernel reaches
 /// `vfs_create`.
 #[kprobe(function = "vfs_create")]
 pub fn handle_vfs_create(ctx: ProbeContext) -> u32 {
@@ -177,7 +200,25 @@ pub fn handle_vfs_create(ctx: ProbeContext) -> u32 {
 /// Emit a file-create event only after `openat` succeeds.
 #[tracepoint]
 pub fn handle_openat_exit(ctx: TracePointContext) -> u32 {
-    unsafe { try_handle_openat_exit(&ctx) }.unwrap_or(1)
+    unsafe { try_handle_open_exit(&ctx) }.unwrap_or(1)
+}
+
+/// Emit a legacy `open` file event only after the syscall succeeds.
+#[tracepoint]
+pub fn handle_open_exit(ctx: TracePointContext) -> u32 {
+    unsafe { try_handle_open_exit(&ctx) }.unwrap_or(1)
+}
+
+/// Emit a legacy `creat` event only after the syscall succeeds.
+#[tracepoint]
+pub fn handle_creat_exit(ctx: TracePointContext) -> u32 {
+    unsafe { try_handle_open_exit(&ctx) }.unwrap_or(1)
+}
+
+/// Emit an `openat2` file event only after the syscall succeeds.
+#[tracepoint]
+pub fn handle_openat2_exit(ctx: TracePointContext) -> u32 {
+    unsafe { try_handle_open_exit(&ctx) }.unwrap_or(1)
 }
 
 /// Queue a potential file-delete event for `unlinkat`.
@@ -189,7 +230,19 @@ pub fn handle_unlinkat(ctx: TracePointContext) -> u32 {
 /// Emit a file-delete event only after `unlinkat` succeeds.
 #[tracepoint]
 pub fn handle_unlinkat_exit(ctx: TracePointContext) -> u32 {
-    unsafe { try_handle_unlinkat_exit(&ctx) }.unwrap_or(1)
+    unsafe { try_handle_file_operation_exit(&ctx, FILE_KIND_DELETE) }.unwrap_or(1)
+}
+
+/// Queue a potential file-delete event for legacy `unlink`.
+#[tracepoint]
+pub fn handle_unlink(ctx: TracePointContext) -> u32 {
+    unsafe { try_handle_legacy_file_event(&ctx, FILE_KIND_DELETE) }.unwrap_or(1)
+}
+
+/// Emit a file-delete event only after legacy `unlink` succeeds.
+#[tracepoint]
+pub fn handle_unlink_exit(ctx: TracePointContext) -> u32 {
+    unsafe { try_handle_file_operation_exit(&ctx, FILE_KIND_DELETE) }.unwrap_or(1)
 }
 
 /// Queue a potential file-rename event for `renameat`.
@@ -201,7 +254,7 @@ pub fn handle_renameat(ctx: TracePointContext) -> u32 {
 /// Emit a file-rename event only after `renameat` succeeds.
 #[tracepoint]
 pub fn handle_renameat_exit(ctx: TracePointContext) -> u32 {
-    unsafe { try_handle_renameat_exit(&ctx) }.unwrap_or(1)
+    unsafe { try_handle_file_operation_exit(&ctx, FILE_KIND_RENAME) }.unwrap_or(1)
 }
 
 /// Queue a potential file-rename event for `renameat2`.
@@ -213,7 +266,55 @@ pub fn handle_renameat2(ctx: TracePointContext) -> u32 {
 /// Emit a file-rename event only after `renameat2` succeeds.
 #[tracepoint]
 pub fn handle_renameat2_exit(ctx: TracePointContext) -> u32 {
-    unsafe { try_handle_renameat_exit(&ctx) }.unwrap_or(1)
+    unsafe { try_handle_file_operation_exit(&ctx, FILE_KIND_RENAME) }.unwrap_or(1)
+}
+
+/// Queue a potential file-rename event for legacy `rename`.
+#[tracepoint]
+pub fn handle_rename(ctx: TracePointContext) -> u32 {
+    unsafe { try_handle_rename(&ctx) }.unwrap_or(1)
+}
+
+/// Emit a file-rename event only after legacy `rename` succeeds.
+#[tracepoint]
+pub fn handle_rename_exit(ctx: TracePointContext) -> u32 {
+    unsafe { try_handle_file_operation_exit(&ctx, FILE_KIND_RENAME) }.unwrap_or(1)
+}
+
+/// Queue a potential directory-create event for legacy `mkdir`.
+#[tracepoint]
+pub fn handle_mkdir(ctx: TracePointContext) -> u32 {
+    unsafe { try_handle_legacy_file_event(&ctx, FILE_KIND_CREATE) }.unwrap_or(1)
+}
+
+/// Emit a directory-create event only after legacy `mkdir` succeeds.
+#[tracepoint]
+pub fn handle_mkdir_exit(ctx: TracePointContext) -> u32 {
+    unsafe { try_handle_file_operation_exit(&ctx, FILE_KIND_CREATE) }.unwrap_or(1)
+}
+
+/// Queue a potential directory-create event for `mkdirat`.
+#[tracepoint]
+pub fn handle_mkdirat(ctx: TracePointContext) -> u32 {
+    unsafe { queue_file_event(&ctx, FILE_KIND_CREATE) }.unwrap_or(1)
+}
+
+/// Emit a directory-create event only after `mkdirat` succeeds.
+#[tracepoint]
+pub fn handle_mkdirat_exit(ctx: TracePointContext) -> u32 {
+    unsafe { try_handle_file_operation_exit(&ctx, FILE_KIND_CREATE) }.unwrap_or(1)
+}
+
+/// Queue a potential directory-delete event for `rmdir`.
+#[tracepoint]
+pub fn handle_rmdir(ctx: TracePointContext) -> u32 {
+    unsafe { try_handle_legacy_file_event(&ctx, FILE_KIND_DELETE) }.unwrap_or(1)
+}
+
+/// Emit a directory-delete event only after `rmdir` succeeds.
+#[tracepoint]
+pub fn handle_rmdir_exit(ctx: TracePointContext) -> u32 {
+    unsafe { try_handle_file_operation_exit(&ctx, FILE_KIND_DELETE) }.unwrap_or(1)
 }
 
 /// Invalidate an indexed descriptor before it can be closed and reused.
@@ -362,14 +463,49 @@ unsafe fn try_reset_dir_index(_ctx: &TracePointContext) -> Result<u32, i64> {
 #[inline(always)]
 unsafe fn try_handle_openat(ctx: &TracePointContext) -> Result<u32, i64> {
     let flags: u64 = ctx.read_at::<u64>(32)?;
+    let dfd = ctx.read_at::<i64>(16)? as i32;
+    let path_ptr = ctx.read_at::<u64>(24)?;
+    try_queue_open(flags, dfd, path_ptr)
+}
+
+#[inline(always)]
+unsafe fn try_handle_open(ctx: &TracePointContext) -> Result<u32, i64> {
+    let path_ptr = ctx.read_at::<u64>(16)?;
+    let flags = ctx.read_at::<u64>(24)?;
+    try_queue_open(flags, AT_FDCWD, path_ptr)
+}
+
+#[inline(always)]
+unsafe fn try_handle_creat(ctx: &TracePointContext) -> Result<u32, i64> {
+    let path_ptr = ctx.read_at::<u64>(16)?;
+    let tid = bpf_get_current_pid_tgid() as u32;
+    let _ = OPENAT_CREATED.remove(&tid);
+    queue_file_event_from_args(AT_FDCWD, path_ptr, FILE_KIND_CREATE)
+}
+
+#[inline(always)]
+unsafe fn try_handle_openat2(ctx: &TracePointContext) -> Result<u32, i64> {
+    let dfd = ctx.read_at::<i64>(16)? as i32;
+    let path_ptr = ctx.read_at::<u64>(24)?;
+    let how_ptr = ctx.read_at::<u64>(32)?;
+    if how_ptr == 0 {
+        return Ok(0);
+    }
+    // `flags` is the first u64 in `struct open_how`.
+    let flags = bpf_probe_read_user::<u64>(how_ptr as *const u64)?;
+    try_queue_open(flags, dfd, path_ptr)
+}
+
+#[inline(always)]
+unsafe fn try_queue_open(flags: u64, dfd: i32, path_ptr: u64) -> Result<u32, i64> {
     let tid = bpf_get_current_pid_tgid() as u32;
     if flags & O_CREAT != 0 {
         let _ = OPENAT_CREATED.remove(&tid);
-        return queue_file_event(ctx, FILE_KIND_CREATE);
+        return queue_file_event_from_args(dfd, path_ptr, FILE_KIND_CREATE);
     }
 
     if flags & (O_WRONLY | O_RDWR | O_TRUNC | O_APPEND) != 0 {
-        return queue_file_event(ctx, FILE_KIND_CHANGE);
+        return queue_file_event_from_args(dfd, path_ptr, FILE_KIND_CHANGE);
     }
 
     // A directory open is not a file event, but it is the only moment at which
@@ -378,28 +514,28 @@ unsafe fn try_handle_openat(ctx: &TracePointContext) -> Result<u32, i64> {
     // drained answers for whatever the number points at *then*, and a process
     // that walks a tree recycles fd numbers faster than that.
     if flags & (O_DIRECTORY | O_PATH) != 0 {
-        return queue_file_event(ctx, FILE_KIND_DIR_OPEN);
+        return queue_file_event_from_args(dfd, path_ptr, FILE_KIND_DIR_OPEN);
     }
 
     // A read-only open queues nothing, and the thread cannot be inside another
     // tracked syscall while it enters this one, so anything still pending is a
     // leftover from a task that was killed mid-syscall and never reached its
-    // exit tracepoint. Drop it here so the next `sys_exit_openat` cannot emit
-    // a stale path.
+    // exit tracepoint. Drop it here so this open variant cannot leave a stale
+    // path.
     let _ = FILE_PENDING.remove(&tid);
     Ok(0)
 }
 
 #[inline(always)]
-unsafe fn try_handle_openat_exit(ctx: &TracePointContext) -> Result<u32, i64> {
+unsafe fn try_handle_open_exit(ctx: &TracePointContext) -> Result<u32, i64> {
     let ret: i64 = ctx.read_at::<i64>(16)?;
     let tid = bpf_get_current_pid_tgid() as u32;
     // Clean up the vfs_create marker regardless.
     let _ = OPENAT_CREATED.remove(&tid);
-    // Emit for any successful openat(O_CREAT) — matches Sysmon Event ID 11 semantics,
-    // which fires on any file creation/open-with-create, not only brand-new inodes.
-    // The vfs_create kprobe path is kept for potential future filtering but is no
-    // longer required to gate the event.
+    // Emit for any successful open-with-create. This matches Sysmon Event ID 11
+    // semantics, which fire on any open-with-create, not only brand-new inodes.
+    // The vfs_create kprobe path is kept for potential future filtering but is
+    // no longer required to gate the event.
     if ret >= 0 {
         let fd = ret as i32;
         let pid = (bpf_get_current_pid_tgid() >> 32) as u32;
@@ -430,14 +566,15 @@ unsafe fn try_handle_unlinkat(ctx: &TracePointContext) -> Result<u32, i64> {
 }
 
 #[inline(always)]
-unsafe fn try_handle_unlinkat_exit(ctx: &TracePointContext) -> Result<u32, i64> {
+unsafe fn try_handle_legacy_file_event(ctx: &TracePointContext, kind: u32) -> Result<u32, i64> {
+    let path_ptr = ctx.read_at::<u64>(16)?;
+    queue_file_event_from_args(AT_FDCWD, path_ptr, kind)
+}
+
+#[inline(always)]
+unsafe fn try_handle_file_operation_exit(ctx: &TracePointContext, kind: u32) -> Result<u32, i64> {
     let ret: i64 = ctx.read_at::<i64>(16)?;
-    emit_pending_file_event(
-        FILE_KIND_DELETE,
-        FILE_KIND_DELETE,
-        FILE_KIND_DELETE,
-        ret == 0,
-    )
+    emit_pending_file_event(kind, kind, kind, ret == 0)
 }
 
 #[inline(always)]
@@ -446,14 +583,10 @@ unsafe fn try_handle_renameat(ctx: &TracePointContext) -> Result<u32, i64> {
 }
 
 #[inline(always)]
-unsafe fn try_handle_renameat_exit(ctx: &TracePointContext) -> Result<u32, i64> {
-    let ret: i64 = ctx.read_at::<i64>(16)?;
-    emit_pending_file_event(
-        FILE_KIND_RENAME,
-        FILE_KIND_RENAME,
-        FILE_KIND_RENAME,
-        ret == 0,
-    )
+unsafe fn try_handle_rename(ctx: &TracePointContext) -> Result<u32, i64> {
+    let old_path_ptr = ctx.read_at::<u64>(16)?;
+    let new_path_ptr = ctx.read_at::<u64>(24)?;
+    queue_rename_event_from_args(AT_FDCWD, old_path_ptr, AT_FDCWD, new_path_ptr)
 }
 
 #[inline(always)]
@@ -492,9 +625,14 @@ unsafe fn read_user_path(ptr: u64, dst: &mut [u8; FILE_PATH_LEN]) -> Option<bool
 
 #[inline(always)]
 unsafe fn queue_file_event(ctx: &TracePointContext, kind: u32) -> Result<u32, i64> {
-    // openat and unlinkat share the layout: dfd at 16, pathname at 24.
+    // The tracked *at path syscalls share dfd at 16 and pathname at 24.
     let dfd = ctx.read_at::<i64>(16)? as i32;
     let path_ptr: u64 = ctx.read_at::<u64>(24)?;
+    queue_file_event_from_args(dfd, path_ptr, kind)
+}
+
+#[inline(always)]
+unsafe fn queue_file_event_from_args(dfd: i32, path_ptr: u64, kind: u32) -> Result<u32, i64> {
     if path_ptr == 0 {
         return Ok(0);
     }
@@ -539,6 +677,16 @@ unsafe fn queue_rename_event(ctx: &TracePointContext) -> Result<u32, i64> {
     let old_path_ptr: u64 = ctx.read_at::<u64>(24)?;
     let new_dfd = ctx.read_at::<i64>(32)? as i32;
     let new_path_ptr: u64 = ctx.read_at::<u64>(40)?;
+    queue_rename_event_from_args(old_dfd, old_path_ptr, new_dfd, new_path_ptr)
+}
+
+#[inline(always)]
+unsafe fn queue_rename_event_from_args(
+    old_dfd: i32,
+    old_path_ptr: u64,
+    new_dfd: i32,
+    new_path_ptr: u64,
+) -> Result<u32, i64> {
     if old_path_ptr == 0 || new_path_ptr == 0 {
         return Ok(0);
     }

--- a/ebpf/src/main.rs
+++ b/ebpf/src/main.rs
@@ -14,15 +14,18 @@
 //! | `handle_connect_exit` | `syscalls/sys_exit_connect` | emit Event 3    |
 //! | `handle_socket`       | `syscalls/sys_enter_socket` | capture type    |
 //! | `handle_socket_exit`  | `syscalls/sys_exit_socket`  | index fd type   |
-//! | `handle_openat`       | `syscalls/sys_enter_openat` | queue Event 11  |
-//! | `handle_vfs_create`   | `kprobe/vfs_create`         | confirm create  |
-//! | `handle_openat_exit`  | `syscalls/sys_exit_openat`  | emit Event 11   |
-//! | `handle_unlinkat`     | `syscalls/sys_enter_unlinkat`| queue Event 23 |
-//! | `handle_unlinkat_exit`| `syscalls/sys_exit_unlinkat`| emit Event 23  |
-//! | `handle_renameat`     | `syscalls/sys_enter_renameat` | queue rename |
-//! | `handle_renameat_exit`| `syscalls/sys_exit_renameat`  | emit rename  |
-//! | `handle_renameat2`    | `syscalls/sys_enter_renameat2`| queue rename |
-//! | `handle_renameat2_exit`| `syscalls/sys_exit_renameat2`| emit rename |
+//! | `handle_open*`        | `sys_enter_open/openat/openat2` | queue file event |
+//! | `handle_creat`        | `syscalls/sys_enter_creat`  | queue Event 11 |
+//! | `handle_vfs_create`   | `kprobe/vfs_create`         | confirm create |
+//! | `handle_open*_exit`   | `sys_exit_open/openat/openat2` | emit file event |
+//! | `handle_unlink*`      | `sys_enter_unlink/unlinkat` | queue Event 23 |
+//! | `handle_unlink*_exit` | `sys_exit_unlink/unlinkat`  | emit Event 23 |
+//! | `handle_rename*`      | `sys_enter_rename/renameat/renameat2` | queue rename |
+//! | `handle_rename*_exit` | `sys_exit_rename/renameat/renameat2` | emit rename |
+//! | `handle_mkdir*`       | `sys_enter_mkdir/mkdirat` | queue directory create |
+//! | `handle_mkdir*_exit`  | `sys_exit_mkdir/mkdirat` | emit directory create |
+//! | `handle_rmdir`        | `syscalls/sys_enter_rmdir`  | queue directory delete |
+//! | `handle_rmdir_exit`   | `syscalls/sys_exit_rmdir`   | emit directory delete |
 //! | `handle_sendto`       | `syscalls/sys_enter_sendto`  | emit DNS query |
 //! | `handle_sendmsg`      | `syscalls/sys_enter_sendmsg` | emit DNS query |
 //! | `handle_sendmmsg`     | `syscalls/sys_enter_sendmmsg`| emit DNS query |

--- a/src/sensor/linux/ebpf.rs
+++ b/src/sensor/linux/ebpf.rs
@@ -139,6 +139,17 @@ impl Sensor for EbpfSensor {
             "sys_exit_socket",
         )?;
         attach_tracepoint(&mut bpf, "handle_openat", "syscalls", "sys_enter_openat")?;
+        attach_optional_tracepoint(&mut bpf, "handle_open", "syscalls", "sys_enter_open")?;
+        attach_optional_tracepoint(&mut bpf, "handle_open_exit", "syscalls", "sys_exit_open")?;
+        attach_optional_tracepoint(&mut bpf, "handle_creat", "syscalls", "sys_enter_creat")?;
+        attach_optional_tracepoint(&mut bpf, "handle_creat_exit", "syscalls", "sys_exit_creat")?;
+        attach_tracepoint(&mut bpf, "handle_openat2", "syscalls", "sys_enter_openat2")?;
+        attach_tracepoint(
+            &mut bpf,
+            "handle_openat2_exit",
+            "syscalls",
+            "sys_exit_openat2",
+        )?;
         attach_kprobe(&mut bpf, "handle_vfs_create", "vfs_create")?;
         attach_tracepoint(
             &mut bpf,
@@ -157,6 +168,13 @@ impl Sensor for EbpfSensor {
             "handle_unlinkat_exit",
             "syscalls",
             "sys_exit_unlinkat",
+        )?;
+        attach_optional_tracepoint(&mut bpf, "handle_unlink", "syscalls", "sys_enter_unlink")?;
+        attach_optional_tracepoint(
+            &mut bpf,
+            "handle_unlink_exit",
+            "syscalls",
+            "sys_exit_unlink",
         )?;
         attach_tracepoint(
             &mut bpf,
@@ -182,6 +200,24 @@ impl Sensor for EbpfSensor {
             "syscalls",
             "sys_exit_renameat2",
         )?;
+        attach_optional_tracepoint(&mut bpf, "handle_rename", "syscalls", "sys_enter_rename")?;
+        attach_optional_tracepoint(
+            &mut bpf,
+            "handle_rename_exit",
+            "syscalls",
+            "sys_exit_rename",
+        )?;
+        attach_optional_tracepoint(&mut bpf, "handle_mkdir", "syscalls", "sys_enter_mkdir")?;
+        attach_optional_tracepoint(&mut bpf, "handle_mkdir_exit", "syscalls", "sys_exit_mkdir")?;
+        attach_tracepoint(&mut bpf, "handle_mkdirat", "syscalls", "sys_enter_mkdirat")?;
+        attach_tracepoint(
+            &mut bpf,
+            "handle_mkdirat_exit",
+            "syscalls",
+            "sys_exit_mkdirat",
+        )?;
+        attach_optional_tracepoint(&mut bpf, "handle_rmdir", "syscalls", "sys_enter_rmdir")?;
+        attach_optional_tracepoint(&mut bpf, "handle_rmdir_exit", "syscalls", "sys_exit_rmdir")?;
         attach_tracepoint(&mut bpf, "handle_file_close", "syscalls", "sys_enter_close")?;
         attach_optional_tracepoint(&mut bpf, "handle_file_dup2", "syscalls", "sys_enter_dup2")?;
         attach_tracepoint(&mut bpf, "handle_file_dup3", "syscalls", "sys_enter_dup3")?;


### PR DESCRIPTION
## Summary

- capture `open`, `creat`, `openat2`, `unlink`, `rename`, `mkdir`, `mkdirat`, and `rmdir` through entry and exit tracepoints
- keep every new file event success-gated and represent legacy relative paths with `AT_FDCWD`
- attach legacy-only tracepoints optionally so Linux arm64 remains supported
- update the Linux sensor architecture and limitation documentation

## Validation

- `cargo test --locked`
- `cargo clippy --locked --all-targets -- -D clippy::all`
- `cargo fmt --all -- --check`
- `cargo +nightly-2026-08-11 build --release --bin rustinel-ebpf`
- loaded and attached all programs on the Ubuntu lab kernel 7.0
- verified CPython `os.rename` and `os.unlink`, gcc and collect2 legacy cleanup, directory create and removal, and direct `openat2` capture
- verified a failed legacy `unlink` emits no file event
- measured the file benchmark at 6.368 s baseline versus 6.697 s with the sensor, about 5.2% overhead

Closes #419