### PR TITLE
docs(limitations): record the Linux real-UID gap and schedule the Windows file rundown

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -19,6 +19,7 @@ full rather than hide them.
 | Writes through handles or keys opened before startup are invisible | Windows |
 | Security channel events depend on audit policy Rustinel does not set | Windows |
 | Image paths are truncated, and truncation is unmarked on process events | Linux |
+| `User` is the real UID, not the effective one | Linux, macOS |
 
 ## Windows (ETW and Event Log)
 
@@ -75,6 +76,10 @@ three platforms, but several Sysmon-style fields are unavailable.
   lab desktop over 45 seconds: 399 of 33,029 file events resolved (1.2%), with
   no index evictions - so on a freshly started agent the gap is wide, and it is
   handles older than the session rather than index pressure that causes it.
+  This is scheduled rather than accepted: a classic `FileIo` rundown, which
+  enumerates the handles already open when the session starts, is lab-validated
+  as a fix costing roughly 100 ms at startup
+  ([#428](https://github.com/Karib0u/rustinel/issues/428)).
 - **A small share of registry writes is still unattributed (silent risk).**
   Registry keys open before the trace session are named from the kernel handle
   table at startup, which covered 5,908 of 6,644 open keys (88.9%) in 32 ms on a
@@ -212,6 +217,12 @@ The Linux sensor covers process, network, file, and DNS.
   to be a fixed `tcp`, which matched UDP traffic and never matched
   `Protocol: 'udp'`. Socket types other than `SOCK_STREAM` and `SOCK_DGRAM`
   (a raw or SCTP socket) are also left absent rather than named.
+- **`User` is the real UID, not the effective one (silent risk).**
+  `bpf_get_current_uid_gid()` returns the real UID, so a process running with
+  effective root through a setuid binary is reported as the unprivileged caller
+  and a rule filtering `User: 'root'` does not see it. Measured with a
+  setuid-root binary: userspace `euid=0`, sensor `User=1000`. Same defect as
+  macOS ([#327](https://github.com/Karib0u/rustinel/issues/327)).
 - **No library-load, module-load, or ptrace events.** Sigma rules in those
   categories never match.
 - **Kernel requirements.** Linux 5.8+ with BTF and `CAP_BPF` + `CAP_PERFMON` +


### PR DESCRIPTION
Closes #422.

## What

- Adds the **Linux `User` is the real UID** entry to the Linux (eBPF) section, labelled a silent risk with its measured evidence (setuid-root binary: userspace `euid=0`, sensor `User=1000`) and pointing at #327, which closes it.
- Reclassifies the Windows file-path attribution entry (1.2% resolution on a freshly started agent) from accepted to **scheduled**, naming the lab-validated classic `FileIo` rundown (~100 ms at startup) and referencing #428.
- Adds the real-UID gap to the "Start with these" table, marked Linux + macOS since it is the same defect on both.

## Not included

The issue also asked for an entry on Python's invisible deletes/renames (legacy `unlink`/`rename`, plus uncollected `mkdir`/`rmdir`). That gap was closed on main by #445, which hooks the legacy variants and adds directory create/delete, so documenting it now would be documenting a limitation that no longer exists. The generic `*at` wording in the file-drop entry was already updated by that PR.