### PR TITLE
fix(linux-ebpf): measure parent identity at fork

### DIFF
--- a/docs/detection.md
+++ b/docs/detection.md
@@ -265,15 +265,13 @@ Per-platform process notes:
 
 - **Linux:** `CommandLine` comes from argv snapshotted in eBPF at `execve` entry,
   so it survives processes that exit before enrichment; it is bounded at 512
-  bytes, 32 arguments, and 127 bytes per argument. `Image` resolves from
-  `/proc/<pid>/exe`, which is absolute and symlink-resolved, but short-lived
-  processes fall back to the raw `execve()` argument, which may be relative and
-  is capped at 255 bytes. When that fallback is cut, `ImageTruncated` is `true`
-  and ECS carries `edr.process.image_truncated`; the marker is absent when
-  `/proc` supplies the complete path. `ImageSource` distinguishes the two cases
-  with `proc` or `execve`. `ParentImage`, `ParentProcessId`,
-  `ParentCommandLine`, and `CurrentDirectory` are enriched from `/proc` and may
-  be absent.
+  bytes, 32 arguments, and 127 bytes per argument. `Image` is the raw
+  `execve()` argument, which may be relative and is capped at 255 bytes. When
+  it is cut, `ImageTruncated` is `true` and ECS carries
+  `edr.process.image_truncated`. `ImageSource` is `execve`.
+  `ParentProcessId` is captured at fork before reparenting can occur.
+  `ParentImage` and `ParentCommandLine` are bounded cache enrichment and carry
+  `Derived` provenance. `CurrentDirectory` may be absent.
 - **macOS:** ESF exec events carry `CommandLine`, `ParentImage`,
   `ParentProcessId`, and `CurrentDirectory` natively. `ParentCommandLine` is not
   provided, and `IntegrityLevel` is a Windows field with no macOS equivalent.

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -152,19 +152,26 @@ three platforms, but several Sysmon-style fields are unavailable.
 
 The Linux sensor covers process, network, file, and DNS.
 
-- **The raw image-path fallback is capped at 255 bytes.** `Image` normally
-  comes from `/proc/<pid>/exe` and is absolute and symlink-resolved. Under a
-  burst the sensor may instead use the raw `execve()` argument; when its suffix
-  does not fit, `ImageTruncated` and `edr.process.image_truncated` mark the path
-  as incomplete ([#307](https://github.com/Karib0u/rustinel/issues/307)). The
-  raw argument may also be relative
+- **The raw image path is capped at 255 bytes.** `Image`
+  comes from the raw `execve()` argument. When its suffix does not fit,
+  `ImageTruncated` and `edr.process.image_truncated` mark the path as incomplete
+  ([#307](https://github.com/Karib0u/rustinel/issues/307)). The raw argument may
+  also be relative
   ([#308](https://github.com/Karib0u/rustinel/issues/308)).
 - **Kernel-captured argv is bounded.** Argv is snapshotted at `execve` entry, so
   a process that exits before the ring is drained still reports its command
   line. Caps are 512 bytes total, 32 arguments, and 127 bytes per argument; past
-  any of those the event is flagged truncated and the loader prefers
-  `/proc/<pid>/cmdline` while the process lives. A process that rewrites its own
+  any of those the event is flagged truncated. A process that rewrites its own
   argv (`setproctitle`) reports what it was launched with.
+- **`CLONE_PARENT` parent attribution is derived.** Stable eBPF helpers expose
+  the creating task but not its real parent. For `CLONE_PARENT`,
+  `ParentProcessId` therefore names the creator TGID and carries `Derived`
+  provenance. Ordinary fork, vfork, clone, and clone3 process creation records
+  the creator TGID at `sched_process_fork`. Thread creation is excluded.
+- **Processes that predate the sensor may have no parent identity.** The fork
+  relationship and sensor-minted execution key do not exist for tasks already
+  running at startup. Missing data stays absent instead of consulting a later,
+  potentially reparented procfs record.
 - **File paths are capped at 511 bytes, and the overflow is marked.** The event
   carries `PathTruncated` naming which side was cut. Since truncation removes
   the end of the path, `|endswith` rules and extension IOCs are what it defeats.

--- a/docs/output.md
+++ b/docs/output.md
@@ -66,8 +66,9 @@ Format:
 | `rule.id`           | Optional detection rule identifier, unique amongs the rustinel rules. Formatted as: `sigma::<uuid>` for Sigma, `yara::<id>` for YARA (if metadata ID is defined), or `ioc::<type>::<value>` for IOCs. |
 | `edr.rule.severity` | Low, Medium, High, or Critical                                                                                                                                                                        |
 | `edr.rule.engine`   | `Sigma`, `Yara`, or `Ioc`                                                                                                                                                                             |
-| `edr.process.image_source` | Linux process image provenance: `proc` when resolved from `/proc/<pid>/exe`, or `execve` when the raw invocation string was used after that lookup lost the process lifetime race. |
-| `edr.process.image_truncated` | *(Linux process alerts only)* `true` when `process.executable` is a kernel-captured prefix whose suffix did not fit the 256-byte buffer. Absent when the path is complete or `/proc` supplied it. |
+| `edr.process.image_source` | Linux process image provenance. Process exec events use `execve` for the raw invocation string captured by the kernel. |
+| `edr.process.image_truncated` | *(Linux process alerts only)* `true` when `process.executable` is a kernel-captured prefix whose suffix did not fit the 256-byte buffer. Absent when the path is complete. |
+| `edr.process.cgroup_id` | Kernel cgroup identifier measured at Linux process exec. Container and runtime resolution is handled separately. |
 | `event.count`       | *(rollup only)* Number of suppressed repeats this rollup represents, i.e. occurrences within the dedup window excluding the first. Absent on the live first emission, which represents a single event. Summing `event.count` across lines (absent = 1) gives the true event volume. |
 
 ### Windows Process Alert Example
@@ -116,7 +117,7 @@ Format:
   "host.os.type": "linux",
   "host.os.family": "linux",
   "process.executable": "/usr/bin/whoami",
-  "edr.process.image_source": "proc",
+  "edr.process.image_source": "execve",
   "process.name": "whoami",
   "user.name": "root"
 }

--- a/ebpf/src/events.rs
+++ b/ebpf/src/events.rs
@@ -51,13 +51,24 @@ pub const PROCESS_IMAGE_CAPACITY: usize = 256;
 pub struct ProcessEvent {
     pub event_time_ns: u64,
     pub source_seq: u64,
+    /// Cgroup v2 inode-like identifier measured by the kernel helper.
+    pub cgroup_id: u64,
+    /// Sensor-minted identity for this execution of `pid`.
+    pub process_start_time: u64,
+    /// Sensor-minted execution identity of `parent_pid`, when observed.
+    pub parent_process_start_time: u64,
     /// Event kind: 1 = exec, 2 = exit.
     pub kind: u32,
     /// Thread group ID — the POSIX "process ID".
     pub pid: u32,
     /// Effective UID of the new process.
     pub uid: u32,
-    pub _pad: u32,
+    /// Process parent captured by the fork tracepoint.
+    pub parent_pid: u32,
+    /// Task that invoked the creation syscall.
+    pub creator_tid: u32,
+    /// Thread group containing `creator_tid`.
+    pub creator_tgid: u32,
     /// Null-terminated process name (`comm`, up to 15 chars).
     pub comm: [u8; 16],
     /// Null-terminated executable path (up to 255 bytes).
@@ -72,15 +83,17 @@ pub struct ProcessEvent {
     pub args_truncated: u8,
     /// 1 when `image` did not fit its capture buffer, 0 when complete.
     pub image_truncated: u8,
-    pub _pad1: [u8; 2],
+    /// 1 when `CLONE_PARENT` made `parent_pid` a creator approximation.
+    pub parent_pid_derived: u8,
+    pub _pad1: u8,
     /// Argv captured at `execve` entry, NUL-separated (no trailing NUL
     /// guaranteed). Only the first `args_len` bytes are meaningful.
     ///
     /// Empty for exit events.
     pub args: [u8; ARGV_CAPACITY],
-    /// Sensor-minted identity for this execution of `pid`.
-    pub process_start_time: u64,
 }
+
+const _: () = assert!(core::mem::size_of::<ProcessEvent>() == 856);
 
 /// `connect(2)` succeeded — the connection is established.
 pub const CONNECT_RESULT_OK: i32 = 0;

--- a/ebpf/src/main.rs
+++ b/ebpf/src/main.rs
@@ -7,9 +7,12 @@
 //! | Program               | Hook                        | Purpose         |
 //! |-----------------------|-----------------------------|-----------------|
 //! | `handle_exec`         | `sched/sched_process_exec`  | Event 1         |
+//! | `handle_fork`         | `sched/sched_process_fork`  | record parent   |
 //! | `handle_exit`         | `sched/sched_process_exit`  | cache cleanup   |
 //! | `handle_execve`       | `syscalls/sys_enter_execve` | capture argv    |
 //! | `handle_execveat`     | `syscalls/sys_enter_execveat`| capture argv   |
+//! | `handle_clone*`       | `syscalls/sys_enter_clone*` | capture flags   |
+//! | `handle_process_*fork`| `syscalls/sys_enter_*fork`  | capture flags   |
 //! | `handle_connect`      | `syscalls/sys_enter_connect`| queue Event 3   |
 //! | `handle_connect_exit` | `syscalls/sys_exit_connect` | emit Event 3    |
 //! | `handle_socket`       | `syscalls/sys_enter_socket` | capture type    |

--- a/ebpf/src/process.rs
+++ b/ebpf/src/process.rs
@@ -1,9 +1,9 @@
-//! Process exec eBPF program.
+//! Process lifecycle eBPF programs.
 //!
 //! Attaches to `sched/sched_process_exec`. Fires after `execve` succeeds —
 //! the process image has been replaced and the new binary is about to run.
-//! Also attaches to `sched/sched_process_exit` to emit cache-maintenance
-//! stop events from the same ring buffer.
+//! `sched_process_fork` records parentage before reparenting can occur, and
+//! `sched_process_exit` emits cache-maintenance stop events from the same ring.
 //!
 //! Command lines are captured in the kernel rather than read from
 //! `/proc/<pid>/cmdline`, which a short-lived process can outrun. The argv
@@ -14,16 +14,6 @@
 //! pending entry behind; the map is LRU so those are evicted rather than
 //! accumulating, and the next `execve` on the same thread overwrites the key
 //! before it can be misattributed.
-//!
-//! sched_process_exec tracepoint format (from kernel trace event headers):
-//!   offset  0: common_type         (u16)
-//!   offset  2: common_flags        (u8)
-//!   offset  3: common_preempt_count(u8)
-//!   offset  4: common_pid          (i32)  — scheduling PID (may be a thread)
-//!   offset  8: __data_loc filename (u32)  — encoded: low16 = str offset, high16 = len
-//!   offset 12: pid                 (i32)  — TGID of the new process
-//!   offset 16: old_pid             (i32)  — previous TGID (thread that called exec)
-//!   offset 20+: variable string data
 //!
 //! sys_enter_execve tracepoint format (x86_64, 64-bit ABI):
 //!   offset 16: filename            (u64  — user pointer to path string)
@@ -39,8 +29,9 @@
 
 use aya_ebpf::{
     helpers::{
-        bpf_get_current_comm, bpf_get_current_pid_tgid, bpf_get_current_uid_gid,
-        bpf_probe_read_kernel_str_bytes, bpf_probe_read_user, bpf_probe_read_user_str_bytes,
+        bpf_get_current_cgroup_id, bpf_get_current_comm, bpf_get_current_pid_tgid,
+        bpf_get_current_uid_gid, bpf_probe_read_kernel_str_bytes, bpf_probe_read_user,
+        bpf_probe_read_user_str_bytes,
     },
     macros::{map, tracepoint},
     maps::{LruHashMap, PerCpuArray, RingBuf},
@@ -51,9 +42,44 @@ use aya_ebpf::{
 use crate::events::{event_metadata, ProcessEvent, ARGV_CAPACITY, PROCESS_IMAGE_CAPACITY};
 use crate::telemetry::{record_map_full, record_ring_full, record_submitted, PROCESS_FAMILY};
 
+/// Loader-populated offsets for the process tracepoints used below.
+///
+/// Tracepoint layouts are not a stable ABI. Userspace parses each kernel's
+/// format files, validates the required fields, and overrides this global
+/// before any program is loaded.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct ProcessTracepointOffsets {
+    pub exec_filename: u32,
+    pub exec_pid: u32,
+    pub exec_old_pid: u32,
+    pub fork_parent_pid: u32,
+    pub fork_child_pid: u32,
+    pub clone_flags: u32,
+    pub clone3_args: u32,
+}
+
+#[no_mangle]
+pub static PROCESS_TRACEPOINT_OFFSETS: ProcessTracepointOffsets = ProcessTracepointOffsets {
+    exec_filename: 0,
+    exec_pid: 0,
+    exec_old_pid: 0,
+    fork_parent_pid: 0,
+    fork_child_pid: 0,
+    clone_flags: 0,
+    clone3_args: 0,
+};
+
+/// Read a loader-patched global without letting LLVM fold its zero initializer
+/// into the program instructions.
+#[inline(always)]
+unsafe fn tracepoint_offset(value: *const u32) -> usize {
+    core::ptr::read_volatile(value) as usize
+}
+
 /// Ring buffer shared with the userspace loader for process events.
 ///
-/// The 832-byte event leaves room for more than 2,500 queued events, including
+/// The 856-byte event leaves room for more than 2,400 queued events, including
 /// the measured 1,600-event burst that motivated the image-path fallback.
 #[map]
 pub static PROCESS_RING: RingBuf = RingBuf::with_byte_size(2 * 1024 * 1024, 0);
@@ -61,6 +87,29 @@ pub static PROCESS_RING: RingBuf = RingBuf::with_byte_size(2 * 1024 * 1024, 0);
 /// Current execution identity by thread-group ID.
 #[map]
 static PROCESS_START_TIMES: LruHashMap<u32, u64> = LruHashMap::with_max_entries(65_536, 0);
+
+/// Fork-time relationship retained until process exit. The map is keyed by
+/// child TGID for process creations. Thread creations are explicitly removed.
+#[map]
+static PROCESS_PARENTS: LruHashMap<u32, ForkRelationship> = LruHashMap::with_max_entries(65_536, 0);
+
+/// Creation flags staged from the syscall entry until `sched_process_fork`.
+#[map]
+static CREATION_FLAGS: LruHashMap<u32, u64> = LruHashMap::with_max_entries(4096, 0);
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct ForkRelationship {
+    parent_start_time: u64,
+    parent_pid: u32,
+    creator_tid: u32,
+    creator_tgid: u32,
+    parent_pid_derived: u8,
+    _pad: [u8; 3],
+}
+
+const CLONE_PARENT: u64 = 0x0000_8000;
+const CLONE_THREAD: u64 = 0x0001_0000;
 
 const PROCESS_EVENT_EXEC: u32 = 1;
 const PROCESS_EVENT_EXIT: u32 = 2;
@@ -122,6 +171,38 @@ pub fn handle_exit(ctx: TracePointContext) -> u32 {
     unsafe { try_handle_exit(&ctx) }.unwrap_or(1)
 }
 
+/// Tracepoint handler for `sched/sched_process_fork`.
+#[tracepoint]
+pub fn handle_fork(ctx: TracePointContext) -> u32 {
+    unsafe { try_handle_fork(&ctx) }.unwrap_or(1)
+}
+
+/// Stage the flags for legacy `clone(2)`.
+#[tracepoint]
+pub fn handle_clone(ctx: TracePointContext) -> u32 {
+    unsafe { try_capture_clone_flags(&ctx) }.unwrap_or(1)
+}
+
+/// Stage the flags for `clone3(2)`.
+#[tracepoint]
+pub fn handle_clone3(ctx: TracePointContext) -> u32 {
+    unsafe { try_capture_clone3_flags(&ctx) }.unwrap_or(1)
+}
+
+/// `fork(2)` always creates a new process with ordinary parent semantics.
+#[tracepoint]
+pub fn handle_process_fork(_ctx: TracePointContext) -> u32 {
+    unsafe { stage_creation_flags(0) };
+    0
+}
+
+/// `vfork(2)` uses ordinary parent semantics for attribution.
+#[tracepoint]
+pub fn handle_process_vfork(_ctx: TracePointContext) -> u32 {
+    unsafe { stage_creation_flags(0) };
+    0
+}
+
 /// Tracepoint handler for `syscalls/sys_enter_execve` — snapshots argv while
 /// it is still mapped in the calling process.
 #[tracepoint]
@@ -138,16 +219,22 @@ pub fn handle_execveat(ctx: TracePointContext) -> u32 {
 #[inline(always)]
 unsafe fn try_handle_exec(ctx: &TracePointContext) -> Result<u32, i64> {
     // Read the new-process TGID from the tracepoint format.
-    let pid: u32 = ctx.read_at::<u32>(12)?;
+    let pid: u32 = ctx.read_at::<u32>(tracepoint_offset(core::ptr::addr_of!(
+        PROCESS_TRACEPOINT_OFFSETS.exec_pid
+    )))?;
     // PID of the thread that called `execve`, before `de_thread` renamed it.
-    let old_pid: u32 = ctx.read_at::<u32>(16)?;
+    let old_pid: u32 = ctx.read_at::<u32>(tracepoint_offset(core::ptr::addr_of!(
+        PROCESS_TRACEPOINT_OFFSETS.exec_old_pid
+    )))?;
 
     let uid = bpf_get_current_uid_gid() as u32;
 
     // Read the __data_loc encoded value for `filename`.
     // Low 16 bits = byte offset of the string from ctx.as_ptr().
     // High 16 bits = string length (including null terminator).
-    let data_loc: u32 = ctx.read_at::<u32>(8)?;
+    let data_loc: u32 = ctx.read_at::<u32>(tracepoint_offset(core::ptr::addr_of!(
+        PROCESS_TRACEPOINT_OFFSETS.exec_filename
+    )))?;
     let str_offset = (data_loc & 0xFFFF) as usize;
     let str_len = (data_loc >> 16) as usize;
     let fname_ptr = (ctx.as_ptr() as usize + str_offset) as *const u8;
@@ -163,10 +250,7 @@ unsafe fn try_handle_exec(ctx: &TracePointContext) -> Result<u32, i64> {
     let _ = bpf_probe_read_kernel_str_bytes(fname_ptr, &mut image);
 
     let (event_time_ns, source_seq) = event_metadata();
-    let process_start_time = if PROCESS_START_TIMES
-        .insert(&pid, &event_time_ns, 0)
-        .is_ok()
-    {
+    let process_start_time = if PROCESS_START_TIMES.insert(&pid, &event_time_ns, 0).is_ok() {
         event_time_ns
     } else {
         let _ = PROCESS_START_TIMES.remove(&pid);
@@ -181,15 +265,16 @@ unsafe fn try_handle_exec(ctx: &TracePointContext) -> Result<u32, i64> {
 
     (*event).event_time_ns = event_time_ns;
     (*event).source_seq = source_seq;
+    (*event).cgroup_id = bpf_get_current_cgroup_id();
+    (*event).process_start_time = process_start_time;
     (*event).kind = PROCESS_EVENT_EXEC;
     (*event).pid = pid;
     (*event).uid = uid;
-    (*event)._pad = 0;
+    attach_fork_relationship(event, pid);
     (*event).comm = comm;
     (*event).image = image;
     (*event).image_truncated = (str_len > image.len()) as u8;
-    (*event)._pad1 = [0u8; 2];
-    (*event).process_start_time = process_start_time;
+    (*event)._pad1 = 0;
 
     attach_pending_argv(event, old_pid);
 
@@ -197,6 +282,102 @@ unsafe fn try_handle_exec(ctx: &TracePointContext) -> Result<u32, i64> {
     record_submitted(PROCESS_FAMILY);
 
     Ok(0)
+}
+
+#[inline(always)]
+unsafe fn attach_fork_relationship(event: *mut ProcessEvent, pid: u32) {
+    let Some(relationship) = PROCESS_PARENTS.get(&pid) else {
+        (*event).parent_process_start_time = 0;
+        (*event).parent_pid = 0;
+        (*event).creator_tid = 0;
+        (*event).creator_tgid = 0;
+        (*event).parent_pid_derived = 0;
+        return;
+    };
+
+    (*event).parent_process_start_time = relationship.parent_start_time;
+    (*event).parent_pid = relationship.parent_pid;
+    (*event).creator_tid = relationship.creator_tid;
+    (*event).creator_tgid = relationship.creator_tgid;
+    (*event).parent_pid_derived = relationship.parent_pid_derived;
+}
+
+#[inline(always)]
+unsafe fn try_handle_fork(ctx: &TracePointContext) -> Result<u32, i64> {
+    let trace_parent_tid = ctx.read_at::<u32>(tracepoint_offset(core::ptr::addr_of!(
+        PROCESS_TRACEPOINT_OFFSETS.fork_parent_pid
+    )))?;
+    let child_tid = ctx.read_at::<u32>(tracepoint_offset(core::ptr::addr_of!(
+        PROCESS_TRACEPOINT_OFFSETS.fork_child_pid
+    )))?;
+    let pid_tgid = bpf_get_current_pid_tgid();
+    let creator_tgid = (pid_tgid >> 32) as u32;
+    let creator_tid = pid_tgid as u32;
+
+    if child_tid == 0 || creator_tgid == 0 || trace_parent_tid != creator_tid {
+        return Ok(0);
+    }
+
+    let flags = CREATION_FLAGS.get(&creator_tid).copied().unwrap_or(0);
+    let _ = CREATION_FLAGS.remove(&creator_tid);
+
+    if flags & CLONE_THREAD != 0 {
+        // A new task in the same thread group is not a process parent edge.
+        // Remove a stale PID-reuse entry instead of letting it reach exec.
+        let _ = PROCESS_PARENTS.remove(&child_tid);
+        return Ok(0);
+    }
+
+    let relationship = ForkRelationship {
+        parent_start_time: current_process_start_time(creator_tgid),
+        // `parent_pid` in the tracepoint is the creator TID. The helper gives
+        // us both identities, so process parentage uses the creator TGID.
+        // CLONE_PARENT cannot be resolved with stable helpers. In that case
+        // this is explicitly an approximation and userspace marks it Derived.
+        parent_pid: creator_tgid,
+        creator_tid,
+        creator_tgid,
+        parent_pid_derived: ((flags & CLONE_PARENT) != 0) as u8,
+        _pad: [0u8; 3],
+    };
+    if PROCESS_PARENTS
+        .insert(&child_tid, &relationship, 0)
+        .is_err()
+    {
+        record_map_full(PROCESS_FAMILY);
+    }
+    Ok(0)
+}
+
+#[inline(always)]
+unsafe fn try_capture_clone_flags(ctx: &TracePointContext) -> Result<u32, i64> {
+    let flags = ctx.read_at::<u64>(tracepoint_offset(core::ptr::addr_of!(
+        PROCESS_TRACEPOINT_OFFSETS.clone_flags
+    )))?;
+    stage_creation_flags(flags);
+    Ok(0)
+}
+
+#[inline(always)]
+unsafe fn try_capture_clone3_flags(ctx: &TracePointContext) -> Result<u32, i64> {
+    let args = ctx.read_at::<u64>(tracepoint_offset(core::ptr::addr_of!(
+        PROCESS_TRACEPOINT_OFFSETS.clone3_args
+    )))?;
+    let flags = if args == 0 {
+        0
+    } else {
+        bpf_probe_read_user::<u64>(args as *const u64)?
+    };
+    stage_creation_flags(flags);
+    Ok(0)
+}
+
+#[inline(always)]
+unsafe fn stage_creation_flags(flags: u64) {
+    let creator_tid = bpf_get_current_pid_tgid() as u32;
+    if CREATION_FLAGS.insert(&creator_tid, &flags, 0).is_err() {
+        record_map_full(PROCESS_FAMILY);
+    }
 }
 
 /// Move the argv captured at `execve` entry into the outgoing event.
@@ -218,7 +399,7 @@ unsafe fn attach_pending_argv(event: *mut ProcessEvent, old_pid: u32) {
     }
 
     let Some(snapshot) = pending else {
-        // No kernel capture — userspace falls back to `/proc/<pid>/cmdline`.
+        // No kernel capture. Userspace leaves CommandLine absent.
         (*event).args_len = 0;
         (*event).args_count = 0;
         (*event).args_truncated = 0;
@@ -298,8 +479,7 @@ unsafe fn read_argv(scratch: *mut ArgvSnapshot, argv: *const *const u8) {
 
         // `bpf_probe_read_user_str` silently truncates an over-long argument
         // to the buffer size, NUL included, so a full buffer means the
-        // argument was cut. Flag it — userspace prefers `/proc` over an
-        // incomplete kernel capture.
+        // argument was cut. Preserve that fidelity signal on the event.
         if written.len() >= ARGV_ARG_MAX - 1 {
             (*scratch).truncated = 1;
         }
@@ -333,6 +513,7 @@ unsafe fn try_handle_exit(_ctx: &TracePointContext) -> Result<u32, i64> {
 
     let Some(mut entry) = PROCESS_RING.reserve::<ProcessEvent>(0) else {
         let _ = PROCESS_START_TIMES.remove(&pid);
+        let _ = PROCESS_PARENTS.remove(&pid);
         record_ring_full(PROCESS_FAMILY);
         return Ok(0);
     };
@@ -341,21 +522,27 @@ unsafe fn try_handle_exit(_ctx: &TracePointContext) -> Result<u32, i64> {
 
     (*event).event_time_ns = event_time_ns;
     (*event).source_seq = source_seq;
+    (*event).cgroup_id = bpf_get_current_cgroup_id();
+    (*event).process_start_time = process_start_time;
+    (*event).parent_process_start_time = 0;
     (*event).kind = PROCESS_EVENT_EXIT;
     (*event).pid = pid;
     (*event).uid = uid;
-    (*event)._pad = 0;
+    (*event).parent_pid = 0;
+    (*event).creator_tid = 0;
+    (*event).creator_tgid = 0;
     (*event).comm = comm;
     (*event).image = [0u8; PROCESS_IMAGE_CAPACITY];
     (*event).args_len = 0;
     (*event).args_count = 0;
     (*event).args_truncated = 0;
     (*event).image_truncated = 0;
-    (*event)._pad1 = [0u8; 2];
-    (*event).process_start_time = process_start_time;
+    (*event).parent_pid_derived = 0;
+    (*event)._pad1 = 0;
 
     entry.submit(0);
     let _ = PROCESS_START_TIMES.remove(&pid);
+    let _ = PROCESS_PARENTS.remove(&pid);
     record_submitted(PROCESS_FAMILY);
 
     Ok(0)

--- a/src/alerts/dedup.rs
+++ b/src/alerts/dedup.rs
@@ -390,6 +390,8 @@ mod tests {
                 event_id_string: "1".to_string(),
                 opcode: 1,
                 fields: EventFields::ProcessCreation(ProcessCreationFields {
+                    cgroup_id: None,
+                    parent_process_id_derived: false,
                     image: Some(image.to_string()),
                     image_source: None,
                     image_truncated: None,

--- a/src/capture/writer.rs
+++ b/src/capture/writer.rs
@@ -417,6 +417,8 @@ mod tests {
             event_id_string: "1".to_string(),
             opcode: 1,
             fields: EventFields::ProcessCreation(ProcessCreationFields {
+                cgroup_id: None,
+                parent_process_id_derived: false,
                 image: Some(r"C:\Windows\System32\cmd.exe".to_string()),
                 image_source: None,
                 image_truncated: None,

--- a/src/engine/alert.rs
+++ b/src/engine/alert.rs
@@ -203,6 +203,8 @@ level: high
             event_id_string: "1".to_string(),
             opcode: 1,
             fields: EventFields::ProcessCreation(ProcessCreationFields {
+                cgroup_id: None,
+                parent_process_id_derived: false,
                 image: Some(image.to_string()),
                 image_source: None,
                 image_truncated: None,

--- a/src/engine/event.rs
+++ b/src/engine/event.rs
@@ -204,6 +204,8 @@ mod tests {
     #[test]
     fn typed_process_fields_expose_sigma_names() {
         let fields = ProcessCreationFields {
+            cgroup_id: None,
+            parent_process_id_derived: false,
             image: Some("/usr/bin/curl".to_string()),
             image_source: None,
             image_truncated: Some(true),

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -725,6 +725,8 @@ detection:
             event_id_string: "1".to_string(),
             opcode: 1,
             fields: EventFields::ProcessCreation(ProcessCreationFields {
+                cgroup_id: None,
+                parent_process_id_derived: false,
                 image: Some(image.to_string()),
                 image_source: None,
                 image_truncated: None,

--- a/src/ioc/mod.rs
+++ b/src/ioc/mod.rs
@@ -220,6 +220,8 @@ impl IocEngine {
                 event_id_string: "1".to_string(),
                 opcode: 1,
                 fields: EventFields::ProcessCreation(ProcessCreationFields {
+                    cgroup_id: None,
+                    parent_process_id_derived: false,
                     image: Some(path.to_string()),
                     image_source: None,
                     image_truncated: None,

--- a/src/models/ecs/alert.rs
+++ b/src/models/ecs/alert.rs
@@ -110,8 +110,7 @@ pub struct EcsAlert {
     #[serde(rename = "process.executable", skip_serializing_if = "Option::is_none")]
     pub process_executable: Option<String>,
 
-    /// Linux source used to populate `process.executable`: `proc` for the
-    /// resolved `/proc/<pid>/exe` path, or `execve` for the raw filename.
+    /// Linux source used to populate `process.executable`.
     #[serde(
         rename = "edr.process.image_source",
         skip_serializing_if = "Option::is_none"
@@ -123,6 +122,13 @@ pub struct EcsAlert {
         skip_serializing_if = "Option::is_none"
     )]
     pub edr_process_image_truncated: Option<bool>,
+
+    /// Kernel cgroup identifier measured for a Linux process exec.
+    #[serde(
+        rename = "edr.process.cgroup_id",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub edr_process_cgroup_id: Option<String>,
 
     #[serde(rename = "process.name", skip_serializing_if = "Option::is_none")]
     pub process_name: Option<String>,

--- a/src/models/ecs/mod.rs
+++ b/src/models/ecs/mod.rs
@@ -66,6 +66,7 @@ impl From<&Alert> for EcsAlert {
             process_executable: None,
             edr_process_image_source: None,
             edr_process_image_truncated: None,
+            edr_process_cgroup_id: None,
             process_name: None,
             process_command_line: None,
             process_pid: None,
@@ -156,6 +157,7 @@ impl From<&Alert> for EcsAlert {
                 ecs.process_executable = f.image.clone();
                 ecs.edr_process_image_source = f.image_source.clone();
                 ecs.edr_process_image_truncated = f.image_truncated;
+                ecs.edr_process_cgroup_id = f.cgroup_id.clone();
                 ecs.process_command_line = f.command_line.clone();
                 ecs.process_pid = parse_u64(&f.process_id);
                 ecs.process_parent_executable = f.parent_image.clone();
@@ -442,6 +444,8 @@ mod tests {
                 event_id_string: "1".to_string(),
                 opcode: 1,
                 fields: EventFields::ProcessCreation(ProcessCreationFields {
+                    cgroup_id: Some("123456".to_string()),
+                    parent_process_id_derived: false,
                     image: Some(r"C:\Windows\System32\cmd.exe".to_string()),
                     image_source: None,
                     image_truncated: None,
@@ -494,6 +498,7 @@ mod tests {
             Some(r"C:\Windows\System32\cmd.exe")
         );
         assert_eq!(ecs.process_pid, Some(1234));
+        assert_eq!(ecs.edr_process_cgroup_id.as_deref(), Some("123456"));
         assert_eq!(ecs.process_name.as_deref(), Some("cmd.exe"));
         assert_eq!(ecs.user_name.as_deref(), Some("SYSTEM"));
         assert!(ecs.edr_process_target_image.is_none());

--- a/src/models/event.rs
+++ b/src/models/event.rs
@@ -206,6 +206,7 @@ impl NormalizedEvent {
                 "FileVersion" => f.file_version.as_deref(),
                 "CommandLine" => f.command_line.as_deref(),
                 "ProcessId" => f.process_id.as_deref(),
+                "CgroupId" => f.cgroup_id.as_deref(),
                 "ParentProcessId" => f.parent_process_id.as_deref(),
                 "ParentImage" => f.parent_image.as_deref(),
                 "ParentCommandLine" => f.parent_command_line.as_deref(),
@@ -488,6 +489,8 @@ mod round_trip_tests {
             event_id_string: "1".to_string(),
             opcode: 1,
             fields: EventFields::ProcessCreation(ProcessCreationFields {
+                cgroup_id: None,
+                parent_process_id_derived: false,
                 image: Some("/bin/zsh".to_string()),
                 image_source: None,
                 image_truncated: None,
@@ -745,6 +748,8 @@ mod round_trip_tests {
             event_id_string: "1".to_string(),
             opcode: 1,
             fields: EventFields::ProcessCreation(ProcessCreationFields {
+                cgroup_id: None,
+                parent_process_id_derived: false,
                 image: Some(r"C:\Windows\System32\cmd.exe".to_string()),
                 image_source: None,
                 image_truncated: None,
@@ -788,6 +793,8 @@ mod round_trip_tests {
         event.event_id_string = "1".to_string();
         event.opcode = 1;
         event.fields = EventFields::ProcessCreation(ProcessCreationFields {
+            cgroup_id: None,
+            parent_process_id_derived: false,
             image: Some(image.to_string()),
             image_source: None,
             image_truncated: None,

--- a/src/models/fields.rs
+++ b/src/models/fields.rs
@@ -106,6 +106,10 @@ pub struct ProcessCreationFields {
     #[serde(rename = "ProcessStartTime", skip_serializing_if = "Option::is_none")]
     pub process_start_time: Option<u64>,
 
+    /// Kernel cgroup identifier measured at exec time on Linux.
+    #[serde(rename = "CgroupId", skip_serializing_if = "Option::is_none")]
+    pub cgroup_id: Option<String>,
+
     #[serde(rename = "ParentProcessId", skip_serializing_if = "Option::is_none")]
     pub parent_process_id: Option<String>,
 
@@ -123,6 +127,10 @@ pub struct ProcessCreationFields {
 
     #[serde(rename = "User", skip_serializing_if = "Option::is_none")]
     pub user: Option<String>,
+
+    /// Internal fidelity marker consumed by normalization.
+    #[serde(skip)]
+    pub parent_process_id_derived: bool,
 }
 
 /// File event fields (Sigma: file_access, file_delete, file_event)

--- a/src/normalizer/mod.rs
+++ b/src/normalizer/mod.rs
@@ -108,11 +108,21 @@ impl Normalizer {
         self.resolve_user_field(&mut fields.user);
         if fields.process_start_time.is_none() {
             fields.process_start_time = event.process_start_key.map(|key| key.start_time);
+            if fields.process_start_time.is_some()
+                && event.platform == Platform::Linux
+                && event.provider == "ebpf"
+            {
+                provenance.mark_derived("ProcessStartTime");
+            }
+        }
+        if fields.parent_process_id_derived && fields.parent_process_id.is_some() {
+            provenance.mark_derived("ParentProcessId");
         }
 
         if event.action == SensorAction::Start && fields.command_line.is_none() && pid != 0 {
             if let Some(command_line) = query_process_command_line(pid) {
                 fields.command_line = Some(command_line);
+                provenance.mark_derived("CommandLine");
             }
         }
 
@@ -510,6 +520,8 @@ mod tests {
             }),
             parent_process_start_key: None,
             payload: SensorPayload::Process(ProcessCreationFields {
+                cgroup_id: None,
+                parent_process_id_derived: false,
                 image: Some("/usr/bin/curl".to_string()),
                 image_source: None,
                 image_truncated: None,
@@ -555,6 +567,8 @@ mod tests {
             }),
             parent_process_start_key: None,
             payload: SensorPayload::Process(ProcessCreationFields {
+                cgroup_id: None,
+                parent_process_id_derived: false,
                 image: None,
                 image_source: None,
                 image_truncated: None,
@@ -694,6 +708,8 @@ mod tests {
             }),
             parent_process_start_key: None,
             payload: SensorPayload::Process(ProcessCreationFields {
+                cgroup_id: None,
+                parent_process_id_derived: false,
                 image: None,
                 image_source: None,
                 image_truncated: None,
@@ -1025,6 +1041,10 @@ mod tests {
         assert_eq!(
             normalized.provenance.entries(),
             &[
+                FieldProvenance {
+                    field: "ProcessStartTime".to_string(),
+                    fidelity: Fidelity::Derived,
+                },
                 FieldProvenance {
                     field: "ParentImage".to_string(),
                     fidelity: Fidelity::Derived,

--- a/src/replay/output.rs
+++ b/src/replay/output.rs
@@ -198,6 +198,8 @@ mod tests {
                 event_id_string: "1".to_string(),
                 opcode: 1,
                 fields: EventFields::ProcessCreation(ProcessCreationFields {
+                    cgroup_id: None,
+                    parent_process_id_derived: false,
                     image: Some(r"C:\Windows\System32\powershell.exe".to_string()),
                     image_source: None,
                     image_truncated: None,

--- a/src/replay/recording.rs
+++ b/src/replay/recording.rs
@@ -245,6 +245,8 @@ mod tests {
             event_id_string: "1".to_string(),
             opcode: 1,
             fields: EventFields::ProcessCreation(ProcessCreationFields {
+                cgroup_id: None,
+                parent_process_id_derived: false,
                 image: Some(r"C:\Windows\System32\cmd.exe".to_string()),
                 image_source: None,
                 image_truncated: None,

--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -676,6 +676,8 @@ mod tests {
                 event_id_string: "1".to_string(),
                 opcode: 1,
                 fields: EventFields::ProcessCreation(ProcessCreationFields {
+                    cgroup_id: None,
+                    parent_process_id_derived: false,
                     image: image.map(str::to_string),
                     image_source: None,
                     image_truncated: None,

--- a/src/runtime/yara.rs
+++ b/src/runtime/yara.rs
@@ -110,6 +110,8 @@ pub fn build_yara_alert(
             event_id_string: "1".to_string(),
             opcode: 1,
             fields: EventFields::ProcessCreation(ProcessCreationFields {
+                cgroup_id: None,
+                parent_process_id_derived: false,
                 image: Some(path.to_string()),
                 image_source: None,
                 image_truncated: None,
@@ -195,6 +197,8 @@ pub fn build_yara_memory_alert(
             event_id_string: "1".to_string(),
             opcode: 1,
             fields: EventFields::ProcessCreation(ProcessCreationFields {
+                cgroup_id: None,
+                parent_process_id_derived: false,
                 image: Some(image.to_string()),
                 image_source: None,
                 image_truncated: None,

--- a/src/sensor/linux/ebpf.rs
+++ b/src/sensor/linux/ebpf.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use aya::maps::{MapData, PerCpuArray, RingBuf};
 use aya::programs::{KProbe, TracePoint};
-use aya::Ebpf;
+use aya::{Ebpf, EbpfLoader};
 use tokio::io::unix::AsyncFd;
 use tokio::sync::mpsc::Sender;
 use tracing::{debug, error, info, warn};
@@ -31,13 +31,14 @@ use crate::sensor::{
     SensorPayload,
 };
 use crate::telemetry::{LinuxEbpfFamily, LinuxEbpfKernelSample, LINUX_EBPF};
-use crate::utils::{lookup_username_by_uid, query_process_details};
+use crate::utils::lookup_username_by_uid;
 
 use super::events::{
     bytes_to_string, connect_result_is_connection, parse_event, system_time_from_boot_ns, DnsEvent,
     FileEvent, FileEventHeader, FileIndexEvent, NetworkEvent, ProcessEvent,
 };
 use super::paths::{resolve_at_path, resolve_indexable_dir_path, truncation_marker, DirFdIndex};
+use super::tracepoint_format::ProcessTracepointOffsets;
 
 /// Sysmon-compatible event IDs emitted for Linux events.
 const EVENT_ID_PROCESS_CREATE: u16 = 1;
@@ -112,12 +113,18 @@ impl Sensor for EbpfSensor {
         };
         let bytes: &[u8] = override_bytes.as_deref().unwrap_or(super::EBPF_BYTES);
 
-        let mut bpf = Ebpf::load(bytes)
+        let process_offsets = ProcessTracepointOffsets::load()
+            .context("failed to resolve process tracepoint layouts")?;
+        let mut loader = EbpfLoader::new();
+        loader.override_global("PROCESS_TRACEPOINT_OFFSETS", &process_offsets, true);
+        let mut bpf = loader
+            .load(bytes)
             .context("eBPF object load failed — ensure BTF is available and kernel is 5.8+")?;
 
         // ── Attach programs ──────────────────────────────────────────────────
 
         attach_tracepoint(&mut bpf, "handle_exec", "sched", "sched_process_exec")?;
+        attach_tracepoint(&mut bpf, "handle_fork", "sched", "sched_process_fork")?;
         attach_tracepoint(&mut bpf, "handle_exit", "sched", "sched_process_exit")?;
         attach_tracepoint(&mut bpf, "handle_file_exec", "sched", "sched_process_exec")?;
         attach_tracepoint(&mut bpf, "handle_file_exit", "sched", "sched_process_exit")?;
@@ -129,6 +136,20 @@ impl Sensor for EbpfSensor {
             "handle_execveat",
             "syscalls",
             "sys_enter_execveat",
+        )?;
+        attach_tracepoint(&mut bpf, "handle_clone", "syscalls", "sys_enter_clone")?;
+        attach_optional_tracepoint(&mut bpf, "handle_clone3", "syscalls", "sys_enter_clone3")?;
+        attach_optional_tracepoint(
+            &mut bpf,
+            "handle_process_fork",
+            "syscalls",
+            "sys_enter_fork",
+        )?;
+        attach_optional_tracepoint(
+            &mut bpf,
+            "handle_process_vfork",
+            "syscalls",
+            "sys_enter_vfork",
         )?;
         // Entry captures the destination while the sockaddr is still readable;
         // exit is what decides whether the attempt became a connection.
@@ -537,56 +558,17 @@ fn drain_dns_ring(rb: &mut RingBuf<MapData>, tx: &Sender<SensorEvent>) {
 
 // ── Event builders ───────────────────────────────────────────────────────────
 
-/// Pick the image path for an exec event.
-///
-/// The tracepoint carries `bprm->filename`, i.e. the literal string userspace
-/// passed to `execve()` — `./malware` stays `./malware`. Downstream consumers
-/// (YARA queueing, the allowlist, Sigma `Image` rules, IOC path regexes) all
-/// need a real path, so prefer `/proc/<pid>/exe`, which is absolute,
-/// symlink-resolved, and immune to the caller's `chdir`. The raw kernel string
-/// stays as a fallback for short-lived processes that exit before the userspace
-/// ring drain gets to `/proc`.
-fn resolve_exec_image(
-    proc_exe: Option<&str>,
-    raw_filename: &str,
-    raw_truncated: bool,
-) -> Option<(String, &'static str, bool)> {
-    if let Some(image) = proc_exe.filter(|value| !value.is_empty()) {
-        return Some((image.to_string(), "proc", false));
-    }
-
-    (!raw_filename.is_empty()).then(|| (raw_filename.to_string(), "execve", raw_truncated))
-}
-
-/// Pick the command line for an exec event.
-///
-/// The kernel capture is authoritative when it is complete: it is the argv
-/// this exec was called with, taken before the process could exit or exec
-/// again. `/proc/<pid>/cmdline` is only consulted when the kernel capture is
-/// missing or hit its bounds — and the truncated kernel value is still better
-/// than nothing when `/proc` has already gone away.
-fn resolve_command_line(
-    kernel: Option<String>,
-    truncated: bool,
-    proc_cmdline: Option<String>,
-) -> Option<String> {
-    match kernel {
-        Some(value) if !truncated => Some(value),
-        Some(value) => proc_cmdline.or(Some(value)),
-        None => proc_cmdline,
-    }
+/// Use only the filename carried by the exec tracepoint in the ring drain.
+/// Any path canonicalization belongs in bounded downstream enrichment.
+fn resolve_exec_image(raw_filename: &str, raw_truncated: bool) -> Option<(String, bool)> {
+    (!raw_filename.is_empty()).then(|| (raw_filename.to_string(), raw_truncated))
 }
 
 fn build_process_event(ev: &ProcessEvent) -> Option<SensorEvent> {
-    let user = resolved_linux_user(ev.uid);
     match ev.kind {
         PROCESS_EVENT_EXEC => {
-            let details = query_process_details(ev.pid);
-            let (image, image_source, image_truncated) = resolve_exec_image(
-                details.as_ref().and_then(|value| value.image.as_deref()),
-                &bytes_to_string(&ev.image),
-                ev.image_truncated != 0,
-            )?;
+            let (image, image_truncated) =
+                resolve_exec_image(&bytes_to_string(&ev.image), ev.image_truncated != 0)?;
 
             let event_time = system_time_from_boot_ns(ev.event_time_ns);
             Some(SensorEvent {
@@ -601,10 +583,13 @@ fn build_process_event(ev: &ProcessEvent) -> Option<SensorEvent> {
                 timestamp: event_time,
                 source_seq: Some(ev.source_seq),
                 process_start_key: process_start_key(ev.pid, ev.process_start_time),
-                parent_process_start_key: None,
+                parent_process_start_key: process_start_key(
+                    ev.parent_pid,
+                    ev.parent_process_start_time,
+                ),
                 payload: SensorPayload::Process(ProcessCreationFields {
                     image: Some(image),
-                    image_source: Some(image_source.to_string()),
+                    image_source: Some("execve".to_string()),
                     image_truncated: image_truncated.then_some(true),
                     original_file_name: None,
                     product: None,
@@ -612,30 +597,18 @@ fn build_process_event(ev: &ProcessEvent) -> Option<SensorEvent> {
                     company: None,
                     file_version: None,
                     target_image: None,
-                    command_line: resolve_command_line(
-                        ev.kernel_command_line(),
-                        ev.args_truncated != 0,
-                        details
-                            .as_ref()
-                            .and_then(|value| value.command_line.clone()),
-                    ),
+                    command_line: ev.kernel_command_line(),
                     process_id: Some(ev.pid.to_string()),
                     process_start_time: None,
-                    parent_process_id: details
-                        .as_ref()
-                        .and_then(|value| value.parent_process_id.map(|pid| pid.to_string())),
-                    parent_image: details
-                        .as_ref()
-                        .and_then(|value| value.parent_image.clone()),
-                    parent_command_line: details
-                        .as_ref()
-                        .and_then(|value| value.parent_command_line.clone()),
-                    current_directory: details
-                        .as_ref()
-                        .and_then(|value| value.current_directory.clone()),
+                    cgroup_id: (ev.cgroup_id != 0).then(|| ev.cgroup_id.to_string()),
+                    parent_process_id: (ev.parent_pid != 0).then(|| ev.parent_pid.to_string()),
+                    parent_image: None,
+                    parent_command_line: None,
+                    current_directory: None,
                     // Windows-specific; absent on Linux.
                     integrity_level: None,
-                    user: Some(user),
+                    user: Some(ev.uid.to_string()),
+                    parent_process_id_derived: ev.parent_pid_derived != 0,
                 }),
             })
         }
@@ -665,12 +638,14 @@ fn build_process_event(ev: &ProcessEvent) -> Option<SensorEvent> {
                 command_line: None,
                 process_id: Some(ev.pid.to_string()),
                 process_start_time: None,
+                cgroup_id: (ev.cgroup_id != 0).then(|| ev.cgroup_id.to_string()),
                 parent_process_id: None,
                 parent_image: None,
                 parent_command_line: None,
                 current_directory: None,
                 integrity_level: None,
-                user: Some(user),
+                user: Some(ev.uid.to_string()),
+                parent_process_id_derived: false,
             }),
         }),
         _ => None,
@@ -971,19 +946,24 @@ mod tests {
         ProcessEvent {
             event_time_ns: 0,
             source_seq: 0,
+            cgroup_id: 55,
+            process_start_time: 123_456,
+            parent_process_start_time: 111_222,
             kind,
             pid,
             uid: 1000,
-            _pad: 0,
+            parent_pid: 41,
+            creator_tid: 43,
+            creator_tgid: 41,
             comm: fixed("bash"),
             image: fixed(image),
             args_len: 0,
             args_count: 0,
             args_truncated: 0,
             image_truncated: 0,
-            _pad1: [0u8; 2],
+            parent_pid_derived: 0,
+            _pad1: 0,
             args: [0u8; ARGV_CAPACITY],
-            process_start_time: 123_456,
         }
     }
 
@@ -1093,9 +1073,7 @@ mod tests {
             .expect("raw dns event should normalize")
     }
 
-    /// Never a live pid: above every possible `/proc/sys/kernel/pid_max`, so
-    /// `query_process_details` is guaranteed to come back empty and the builder
-    /// falls back to the raw tracepoint filename.
+    /// Never a live pid: above every possible `/proc/sys/kernel/pid_max`.
     const DEAD_PID: u32 = u32::MAX;
 
     #[test]
@@ -1127,18 +1105,99 @@ mod tests {
     }
 
     #[test]
-    fn build_process_exec_event_resolves_relative_image_from_proc() {
-        let expected = std::fs::read_link("/proc/self/exe")
-            .expect("current process should expose /proc/self/exe");
-        // `./rustinel` is what the kernel records when a binary is run
-        // relatively.
+    fn build_process_exec_uses_fork_time_parent_identity_and_cgroup() {
+        let raw = raw_process_event(PROCESS_EVENT_EXEC, DEAD_PID, "/usr/bin/bash");
+
+        let event = build_process_event(&raw).expect("process exec should build");
+        assert_eq!(
+            event.parent_process_start_key,
+            Some(ProcessStartKey {
+                pid: 41,
+                start_time: 111_222,
+            })
+        );
+        match event.payload {
+            SensorPayload::Process(fields) => {
+                assert_eq!(fields.parent_process_id.as_deref(), Some("41"));
+                assert_eq!(fields.cgroup_id.as_deref(), Some("55"));
+                assert_eq!(fields.user.as_deref(), Some("1000"));
+                assert!(!fields.parent_process_id_derived);
+            }
+            other => panic!("unexpected payload: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn process_that_predates_sensor_does_not_invent_a_parent() {
+        let mut raw = raw_process_event(PROCESS_EVENT_EXEC, DEAD_PID, "/usr/bin/bash");
+        raw.parent_pid = 0;
+        raw.parent_process_start_time = 0;
+        raw.creator_tid = 0;
+        raw.creator_tgid = 0;
+
+        let event = build_process_event(&raw).expect("process exec should build");
+        assert!(event.parent_process_start_key.is_none());
+        match event.payload {
+            SensorPayload::Process(fields) => assert!(fields.parent_process_id.is_none()),
+            other => panic!("unexpected payload: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn fork_map_eviction_leaves_parent_unattributed() {
+        // An LRU miss is encoded as a zeroed relationship in the kernel event.
+        let mut raw = raw_process_event(PROCESS_EVENT_EXEC, DEAD_PID, "/usr/bin/bash");
+        raw.parent_pid = 0;
+        raw.parent_process_start_time = 0;
+        raw.creator_tid = 0;
+        raw.creator_tgid = 0;
+
+        let event = build_process_event(&raw).expect("process exec should build");
+        assert!(event.parent_process_start_key.is_none());
+        match event.payload {
+            SensorPayload::Process(fields) => assert!(fields.parent_process_id.is_none()),
+            other => panic!("unexpected payload: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn clone_parent_approximation_is_marked_derived() {
+        let mut raw = raw_process_event(PROCESS_EVENT_EXEC, DEAD_PID, "/usr/bin/bash");
+        raw.parent_pid_derived = 1;
+
+        let event = build_process_event(&raw).expect("process exec should build");
+        let normalized = test_normalizer()
+            .normalize(&event)
+            .expect("process exec should normalize");
+        assert!(normalized.provenance.entries().iter().any(|entry| {
+            entry.field == "ParentProcessId" && entry.fidelity == crate::models::Fidelity::Derived
+        }));
+    }
+
+    #[test]
+    fn repeated_exec_keeps_parent_but_mints_a_new_identity() {
+        let first = raw_process_event(PROCESS_EVENT_EXEC, 42, "/usr/bin/first");
+        let mut second = raw_process_event(PROCESS_EVENT_EXEC, 42, "/usr/bin/second");
+        second.process_start_time = 654_321;
+
+        let first = build_process_event(&first).expect("first exec should build");
+        let second = build_process_event(&second).expect("second exec should build");
+        assert_ne!(first.process_start_key, second.process_start_key);
+        assert_eq!(
+            first.parent_process_start_key,
+            second.parent_process_start_key
+        );
+    }
+
+    #[test]
+    fn build_process_exec_event_keeps_relative_kernel_image() {
         let raw = raw_process_event(PROCESS_EVENT_EXEC, std::process::id(), "./rustinel");
 
         let event = build_process_event(&raw).expect("process exec should build");
         match event.payload {
             SensorPayload::Process(fields) => {
-                assert_eq!(fields.image.as_deref(), expected.to_str());
-                assert_eq!(fields.image_source.as_deref(), Some("proc"));
+                assert_eq!(fields.image.as_deref(), Some("./rustinel"));
+                assert_eq!(fields.image_source.as_deref(), Some("execve"));
             }
             other => panic!("unexpected payload: {:?}", other),
         }
@@ -1146,8 +1205,7 @@ mod tests {
 
     #[test]
     fn build_process_exec_event_uses_kernel_argv_for_a_dead_process() {
-        // DEAD_PID has no `/proc` entry — exactly the short-lived case where
-        // userspace enrichment loses the command line.
+        // The command line comes entirely from the kernel snapshot.
         let mut raw = raw_process_event(PROCESS_EVENT_EXEC, DEAD_PID, "/bin/true");
         let (args, args_len, args_count) = packed_argv(&["/bin/true", "--quiet"]);
         raw.args = args;
@@ -1185,74 +1243,23 @@ mod tests {
     }
 
     #[test]
-    fn resolve_command_line_prefers_a_complete_kernel_capture() {
+    fn resolve_exec_image_uses_only_the_kernel_filename() {
         assert_eq!(
-            resolve_command_line(
-                Some("/bin/true --quiet".to_string()),
-                false,
-                Some("/bin/true".to_string()),
-            )
-            .as_deref(),
-            Some("/bin/true --quiet")
+            resolve_exec_image("./malware", false),
+            Some(("./malware".to_string(), false))
         );
+        assert_eq!(
+            resolve_exec_image("/usr/bin/bash", false),
+            Some(("/usr/bin/bash".to_string(), false))
+        );
+        assert_eq!(resolve_exec_image("", false), None);
     }
 
     #[test]
-    fn resolve_command_line_prefers_proc_when_the_kernel_capture_is_truncated() {
+    fn resolve_exec_image_marks_a_truncated_kernel_filename() {
         assert_eq!(
-            resolve_command_line(
-                Some("/bin/sh -c long".to_string()),
-                true,
-                Some("/bin/sh -c long and complete".to_string()),
-            )
-            .as_deref(),
-            Some("/bin/sh -c long and complete")
-        );
-    }
-
-    #[test]
-    fn resolve_command_line_keeps_a_truncated_capture_when_proc_is_gone() {
-        assert_eq!(
-            resolve_command_line(Some("/bin/sh -c long".to_string()), true, None).as_deref(),
-            Some("/bin/sh -c long")
-        );
-        assert_eq!(
-            resolve_command_line(None, false, Some("/bin/sh".to_string())).as_deref(),
-            Some("/bin/sh")
-        );
-        assert_eq!(resolve_command_line(None, false, None), None);
-    }
-
-    #[test]
-    fn resolve_exec_image_prefers_proc_exe_over_raw_filename() {
-        assert_eq!(
-            resolve_exec_image(Some("/tmp/malware"), "./malware", true),
-            Some(("/tmp/malware".to_string(), "proc", false))
-        );
-    }
-
-    #[test]
-    fn resolve_exec_image_falls_back_to_raw_filename() {
-        assert_eq!(
-            resolve_exec_image(None, "./malware", false),
-            Some(("./malware".to_string(), "execve", false))
-        );
-        assert_eq!(
-            resolve_exec_image(Some(""), "/usr/bin/bash", false),
-            Some(("/usr/bin/bash".to_string(), "execve", false))
-        );
-        assert_eq!(resolve_exec_image(None, "", false), None);
-    }
-
-    #[test]
-    fn resolve_exec_image_marks_only_a_truncated_raw_fallback() {
-        assert_eq!(
-            resolve_exec_image(None, "/very/long/prefix", true),
-            Some(("/very/long/prefix".to_string(), "execve", true))
-        );
-        assert_eq!(
-            resolve_exec_image(Some("/complete/path"), "/very/long/prefix", true),
-            Some(("/complete/path".to_string(), "proc", false))
+            resolve_exec_image("/very/long/prefix", true),
+            Some(("/very/long/prefix".to_string(), true))
         );
     }
 

--- a/src/sensor/linux/events.rs
+++ b/src/sensor/linux/events.rs
@@ -56,10 +56,17 @@ pub const PROCESS_IMAGE_CAPACITY: usize = 256;
 pub struct ProcessEvent {
     pub event_time_ns: u64,
     pub source_seq: u64,
+    pub cgroup_id: u64,
+    /// Sensor-minted identity for this execution of `pid`.
+    pub process_start_time: u64,
+    /// Sensor-minted execution identity of `parent_pid`, when observed.
+    pub parent_process_start_time: u64,
     pub kind: u32,
     pub pid: u32,
     pub uid: u32,
-    pub _pad: u32,
+    pub parent_pid: u32,
+    pub creator_tid: u32,
+    pub creator_tgid: u32,
     pub comm: [u8; 16],
     pub image: [u8; PROCESS_IMAGE_CAPACITY],
     /// Valid bytes in `args`; 0 when the kernel captured no argv.
@@ -70,11 +77,11 @@ pub struct ProcessEvent {
     pub args_truncated: u8,
     /// 1 when `image` exceeded its kernel capture buffer.
     pub image_truncated: u8,
-    pub _pad1: [u8; 2],
+    /// 1 when `CLONE_PARENT` made `parent_pid` a creator approximation.
+    pub parent_pid_derived: u8,
+    pub _pad1: u8,
     /// NUL-separated argv captured at `execve` entry.
     pub args: [u8; ARGV_CAPACITY],
-    /// Sensor-minted identity for this execution of `pid`.
-    pub process_start_time: u64,
 }
 
 impl ProcessEvent {
@@ -280,17 +287,18 @@ pub struct DnsEvent {
 // These catch accidental struct layout divergence at compile time.
 
 const _: () = assert!(
-    core::mem::size_of::<ProcessEvent>() == 832,
+    core::mem::size_of::<ProcessEvent>() == 856,
     "ProcessEvent layout changed — update ebpf/src/events.rs to match"
 );
 // The argv fields were appended after `image`; pin their offsets so a
 // reordering on either side fails the build instead of decoding garbage.
 const _: () = assert!(
-    core::mem::offset_of!(ProcessEvent, args_len) == 304
-        && core::mem::offset_of!(ProcessEvent, args_count) == 306
-        && core::mem::offset_of!(ProcessEvent, args_truncated) == 308
-        && core::mem::offset_of!(ProcessEvent, image_truncated) == 309
-        && core::mem::offset_of!(ProcessEvent, args) == 312,
+    core::mem::offset_of!(ProcessEvent, args_len) == 336
+        && core::mem::offset_of!(ProcessEvent, args_count) == 338
+        && core::mem::offset_of!(ProcessEvent, args_truncated) == 340
+        && core::mem::offset_of!(ProcessEvent, image_truncated) == 341
+        && core::mem::offset_of!(ProcessEvent, parent_pid_derived) == 342
+        && core::mem::offset_of!(ProcessEvent, args) == 344,
     "ProcessEvent argv fields moved — update ebpf/src/events.rs to match"
 );
 // `ret` and `sock_type` took over slots that used to be explicit padding, so a
@@ -370,8 +378,13 @@ pub mod mapping {
             timestamp: system_time_from_boot_ns(event.event_time_ns),
             source_seq: Some(event.source_seq),
             process_start_key: process_start_key(event.pid, event.process_start_time),
-            parent_process_start_key: None,
+            parent_process_start_key: process_start_key(
+                event.parent_pid,
+                event.parent_process_start_time,
+            ),
             payload: SensorPayload::Process(ProcessCreationFields {
+                cgroup_id: (event.cgroup_id != 0).then(|| event.cgroup_id.to_string()),
+                parent_process_id_derived: event.parent_pid_derived != 0,
                 image: Some(bytes_to_string(&event.image)),
                 image_source: None,
                 image_truncated: (event.image_truncated != 0).then_some(true),
@@ -387,7 +400,7 @@ pub mod mapping {
                     .flatten(),
                 process_id: Some(event.pid.to_string()),
                 process_start_time: None,
-                parent_process_id: None,
+                parent_process_id: (event.parent_pid != 0).then(|| event.parent_pid.to_string()),
                 parent_image: None,
                 parent_command_line: None,
                 current_directory: None,
@@ -550,19 +563,24 @@ mod tests {
         let mut event = ProcessEvent {
             event_time_ns: 0,
             source_seq: 0,
+            cgroup_id: 55,
+            process_start_time: 123_456,
+            parent_process_start_time: 111_222,
             kind: 1,
             pid: 4242,
             uid: 1000,
-            _pad: 0,
+            parent_pid: 4000,
+            creator_tid: 4001,
+            creator_tgid: 4000,
             comm: [0u8; 16],
             image: [0u8; PROCESS_IMAGE_CAPACITY],
             args_len: 0,
             args_count: 0,
             args_truncated: 0,
             image_truncated: 0,
-            _pad1: [0u8; 2],
+            parent_pid_derived: 0,
+            _pad1: 0,
             args: [0u8; ARGV_CAPACITY],
-            process_start_time: 123_456,
         };
         let argv = b"/bin/true\0--quiet\0";
         event.args[..argv.len()].copy_from_slice(argv);

--- a/src/sensor/linux/mod.rs
+++ b/src/sensor/linux/mod.rs
@@ -3,6 +3,7 @@
 pub mod ebpf;
 pub mod events;
 pub mod paths;
+mod tracepoint_format;
 
 pub use ebpf::EbpfSensor;
 

--- a/src/sensor/linux/tracepoint_format.rs
+++ b/src/sensor/linux/tracepoint_format.rs
@@ -1,0 +1,223 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context, Result};
+
+const TRACEFS_ROOTS: [&str; 2] = [
+    "/sys/kernel/tracing/events",
+    "/sys/kernel/debug/tracing/events",
+];
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct ProcessTracepointOffsets {
+    pub exec_filename: u32,
+    pub exec_pid: u32,
+    pub exec_old_pid: u32,
+    pub fork_parent_pid: u32,
+    pub fork_child_pid: u32,
+    pub clone_flags: u32,
+    pub clone3_args: u32,
+}
+
+unsafe impl aya::Pod for ProcessTracepointOffsets {}
+
+impl ProcessTracepointOffsets {
+    pub(super) fn load() -> Result<Self> {
+        let exec = read_format("sched", "sched_process_exec")?;
+        let fork = read_format("sched", "sched_process_fork")?;
+        let clone = read_format("syscalls", "sys_enter_clone")?;
+        let clone3 = find_format("syscalls", "sys_enter_clone3")
+            .map(std::fs::read_to_string)
+            .transpose()
+            .context("failed to read syscalls/sys_enter_clone3 format")?;
+
+        Self::parse(&exec, &fork, &clone, clone3.as_deref())
+    }
+
+    fn parse(exec: &str, fork: &str, clone: &str, clone3: Option<&str>) -> Result<Self> {
+        let exec = parse_fields(exec)?;
+        let fork = parse_fields(fork)?;
+        let clone = parse_fields(clone)?;
+        let clone3 = clone3.map(parse_fields).transpose()?;
+
+        Ok(Self {
+            exec_filename: required_offset(&exec, "filename", 4)?,
+            exec_pid: required_offset(&exec, "pid", 4)?,
+            exec_old_pid: required_offset(&exec, "old_pid", 4)?,
+            fork_parent_pid: required_offset(&fork, "parent_pid", 4)?,
+            fork_child_pid: required_offset(&fork, "child_pid", 4)?,
+            clone_flags: required_one_of(&clone, &["clone_flags", "flags"], 8)?,
+            clone3_args: match clone3 {
+                Some(fields) => required_one_of(&fields, &["uargs", "cl_args"], 8)?,
+                None => 0,
+            },
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct TracepointField {
+    offset: u32,
+    size: u32,
+}
+
+fn find_format(category: &str, name: &str) -> Option<PathBuf> {
+    TRACEFS_ROOTS
+        .iter()
+        .map(Path::new)
+        .map(|root| root.join(category).join(name).join("format"))
+        .find(|path| path.exists())
+}
+
+fn read_format(category: &str, name: &str) -> Result<String> {
+    let path = find_format(category, name)
+        .with_context(|| format!("tracepoint {category}/{name} is unavailable"))?;
+    std::fs::read_to_string(&path)
+        .with_context(|| format!("failed to read tracepoint format from {}", path.display()))
+}
+
+fn parse_fields(format: &str) -> Result<HashMap<String, TracepointField>> {
+    let mut fields = HashMap::new();
+
+    for line in format.lines().map(str::trim) {
+        let Some(rest) = line.strip_prefix("field:") else {
+            continue;
+        };
+        let mut parts = rest.split(';');
+        let declaration = parts.next().unwrap_or_default().trim();
+        let Some(raw_name) = declaration.split_whitespace().last() else {
+            bail!("tracepoint field has no name: {line}");
+        };
+        let name = raw_name
+            .trim_start_matches('*')
+            .split('[')
+            .next()
+            .unwrap_or_default();
+        if name.is_empty() {
+            bail!("tracepoint field has an unsupported declaration: {line}");
+        }
+
+        let mut offset = None;
+        let mut size = None;
+        for part in parts {
+            let part = part.trim();
+            if let Some(value) = part.strip_prefix("offset:") {
+                offset = Some(
+                    value
+                        .trim()
+                        .parse::<u32>()
+                        .with_context(|| format!("invalid offset for tracepoint field {name}"))?,
+                );
+            } else if let Some(value) = part.strip_prefix("size:") {
+                size = Some(
+                    value
+                        .trim()
+                        .parse::<u32>()
+                        .with_context(|| format!("invalid size for tracepoint field {name}"))?,
+                );
+            }
+        }
+
+        let field = TracepointField {
+            offset: offset.with_context(|| format!("field {name} has no offset"))?,
+            size: size.with_context(|| format!("field {name} has no size"))?,
+        };
+        fields.insert(name.to_string(), field);
+    }
+
+    if fields.is_empty() {
+        bail!("tracepoint format contains no fields");
+    }
+    Ok(fields)
+}
+
+fn required_offset(
+    fields: &HashMap<String, TracepointField>,
+    name: &str,
+    expected_size: u32,
+) -> Result<u32> {
+    let field = fields
+        .get(name)
+        .with_context(|| format!("required tracepoint field {name} is absent"))?;
+    if field.size != expected_size {
+        bail!(
+            "tracepoint field {name} has unsupported size {}, expected {expected_size}",
+            field.size
+        );
+    }
+    Ok(field.offset)
+}
+
+fn required_one_of(
+    fields: &HashMap<String, TracepointField>,
+    names: &[&str],
+    expected_size: u32,
+) -> Result<u32> {
+    for name in names {
+        if fields.contains_key(*name) {
+            return required_offset(fields, name, expected_size);
+        }
+    }
+    bail!("required tracepoint field {} is absent", names.join(" or "))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const EXEC: &str = r#"
+field:unsigned short common_type; offset:0; size:2; signed:0;
+field:__data_loc char[] filename; offset:8; size:4; signed:0;
+field:pid_t pid; offset:12; size:4; signed:1;
+field:pid_t old_pid; offset:16; size:4; signed:1;
+"#;
+
+    const CLONE: &str = r#"
+field:int __syscall_nr; offset:8; size:4; signed:1;
+field:unsigned long clone_flags; offset:16; size:8; signed:0;
+"#;
+
+    const CLONE3: &str = r#"
+field:struct clone_args * uargs; offset:16; size:8; signed:0;
+"#;
+
+    #[test]
+    fn parses_data_loc_fork_layout() {
+        let fork = r#"
+field:__data_loc char[] parent_comm; offset:8; size:4; signed:0;
+field:pid_t parent_pid; offset:12; size:4; signed:1;
+field:__data_loc char[] child_comm; offset:16; size:4; signed:0;
+field:pid_t child_pid; offset:20; size:4; signed:1;
+"#;
+        let offsets = ProcessTracepointOffsets::parse(EXEC, fork, CLONE, Some(CLONE3)).unwrap();
+        assert_eq!(offsets.fork_parent_pid, 12);
+        assert_eq!(offsets.fork_child_pid, 20);
+    }
+
+    #[test]
+    fn parses_fixed_array_fork_layout() {
+        let fork = r#"
+field:char parent_comm[16]; offset:8; size:16; signed:1;
+field:pid_t parent_pid; offset:24; size:4; signed:1;
+field:char child_comm[16]; offset:28; size:16; signed:1;
+field:pid_t child_pid; offset:44; size:4; signed:1;
+"#;
+        let offsets = ProcessTracepointOffsets::parse(EXEC, fork, CLONE, None).unwrap();
+        assert_eq!(offsets.fork_parent_pid, 24);
+        assert_eq!(offsets.fork_child_pid, 44);
+        assert_eq!(offsets.clone3_args, 0);
+    }
+
+    #[test]
+    fn rejects_wrong_field_size() {
+        let fork = r#"
+field:pid_t parent_pid; offset:12; size:8; signed:1;
+field:pid_t child_pid; offset:20; size:4; signed:1;
+"#;
+        let err = ProcessTracepointOffsets::parse(EXEC, fork, CLONE, None).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("parent_pid has unsupported size 8"));
+    }
+}

--- a/src/sensor/macos/esf.rs
+++ b/src/sensor/macos/esf.rs
@@ -317,6 +317,8 @@ fn process_start_event(raw: RawExec) -> SensorEvent {
         }),
         parent_process_start_key: None,
         payload: SensorPayload::Process(ProcessCreationFields {
+            cgroup_id: None,
+            parent_process_id_derived: false,
             image: Some(raw.image),
             image_source: None,
             image_truncated: None,
@@ -379,6 +381,8 @@ fn process_stop_event(
         process_start_key: start_time.map(|start_time| ProcessStartKey { pid, start_time }),
         parent_process_start_key: None,
         payload: SensorPayload::Process(ProcessCreationFields {
+            cgroup_id: None,
+            parent_process_id_derived: false,
             image: None,
             image_source: None,
             image_truncated: None,

--- a/src/sensor/mod.rs
+++ b/src/sensor/mod.rs
@@ -324,6 +324,8 @@ mod tests {
     #[test]
     fn payload_category_matches_variant() {
         let payload = SensorPayload::Process(ProcessCreationFields {
+            cgroup_id: None,
+            parent_process_id_derived: false,
             image: Some("/usr/bin/bash".to_string()),
             image_source: None,
             image_truncated: None,

--- a/src/sensor/windows/enrichment.rs
+++ b/src/sensor/windows/enrichment.rs
@@ -63,6 +63,8 @@ mod tests {
 
     fn process_fields(image: &str) -> ProcessCreationFields {
         ProcessCreationFields {
+            cgroup_id: None,
+            parent_process_id_derived: false,
             image: Some(image.to_string()),
             image_source: None,
             image_truncated: None,

--- a/src/sensor/windows/etw/decode.rs
+++ b/src/sensor/windows/etw/decode.rs
@@ -301,6 +301,8 @@ pub(super) fn decode_process(
     let current_directory = raw_current_directory.map(|path| convert_nt_to_dos(&path));
 
     let fields = ProcessCreationFields {
+        cgroup_id: None,
+        parent_process_id_derived: false,
         image: image.clone(),
         image_source: None,
         image_truncated: None,

--- a/tests/active_response.rs
+++ b/tests/active_response.rs
@@ -48,6 +48,8 @@ fn build_yara_alert(pid: u32, image: &str) -> Alert {
             event_id_string: "1".to_string(),
             opcode: 1,
             fields: EventFields::ProcessCreation(ProcessCreationFields {
+                cgroup_id: None,
+                parent_process_id_derived: false,
                 image: Some(image.to_string()),
                 image_source: None,
                 image_truncated: None,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -129,6 +129,8 @@ pub fn process_start_event(platform: Platform) -> SensorEvent {
         }),
         parent_process_start_key: None,
         payload: SensorPayload::Process(ProcessCreationFields {
+            cgroup_id: None,
+            parent_process_id_derived: false,
             image: Some(image.to_string()),
             image_source: None,
             image_truncated: None,

--- a/tests/dedup_integration.rs
+++ b/tests/dedup_integration.rs
@@ -33,6 +33,8 @@ fn make_alert(rule: &str, image: &str) -> Alert {
             event_id_string: "1".to_string(),
             opcode: 1,
             fields: EventFields::ProcessCreation(ProcessCreationFields {
+                cgroup_id: None,
+                parent_process_id_derived: false,
                 image: Some(image.to_string()),
                 image_source: None,
                 image_truncated: None,

--- a/tests/ecs_contract.rs
+++ b/tests/ecs_contract.rs
@@ -135,6 +135,8 @@ fn ecs_category_coverage_maps_event_contract_fields() {
                 1,
                 1,
                 EventFields::ProcessCreation(ProcessCreationFields {
+                    cgroup_id: None,
+                    parent_process_id_derived: false,
                     image: Some(r"C:\Windows\System32\cmd.exe".to_string()),
                     image_source: None,
                     image_truncated: None,
@@ -497,6 +499,8 @@ fn ecs_version_field_is_9_4_0() {
         1,
         1,
         EventFields::ProcessCreation(ProcessCreationFields {
+            cgroup_id: None,
+            parent_process_id_derived: false,
             image: Some(r"C:\Windows\System32\cmd.exe".to_string()),
             image_source: None,
             image_truncated: None,
@@ -528,6 +532,8 @@ fn ecs_process_image_truncation_marker_is_preserved() {
         1,
         1,
         EventFields::ProcessCreation(ProcessCreationFields {
+            cgroup_id: None,
+            parent_process_id_derived: false,
             image: Some(long_prefix),
             image_source: None,
             image_truncated: Some(true),
@@ -572,6 +578,8 @@ fn test_rule_id_mapping_and_omit_behavior() {
             event_id_string: "1".to_string(),
             opcode: 1,
             fields: EventFields::ProcessCreation(ProcessCreationFields {
+                cgroup_id: None,
+                parent_process_id_derived: false,
                 image: Some(r"C:\Windows\System32\cmd.exe".to_string()),
                 image_source: None,
                 image_truncated: None,

--- a/tests/platform_mapping.rs
+++ b/tests/platform_mapping.rs
@@ -32,19 +32,24 @@ fn linux_ebpf_raw_events_map_to_sensor_events() {
     let mut process = ProcessEvent {
         event_time_ns: 0,
         source_seq: 0,
+        cgroup_id: 55,
+        process_start_time: 123_456,
+        parent_process_start_time: 111_222,
         kind: 1,
         pid: 42,
         uid: 1000,
-        _pad: 0,
+        parent_pid: 41,
+        creator_tid: 43,
+        creator_tgid: 41,
         comm: [0; 16],
         image: [0; PROCESS_IMAGE_CAPACITY],
         args_len: 0,
         args_count: 0,
         args_truncated: 0,
         image_truncated: 0,
-        _pad1: [0; 2],
+        parent_pid_derived: 0,
+        _pad1: 0,
         args: [0; ARGV_CAPACITY],
-        process_start_time: 123_456,
     };
     write_cstr(&mut process.image, "/usr/bin/curl");
     // Kernel-captured argv: NUL-separated, `args_len` bytes long.

--- a/tests/reload.rs
+++ b/tests/reload.rs
@@ -698,6 +698,8 @@ fn build_critical_process_alert(pid: u32, image: &str) -> rustinel::models::Aler
             event_id_string: "1".to_string(),
             opcode: 1,
             fields: EventFields::ProcessCreation(ProcessCreationFields {
+                cgroup_id: None,
+                parent_process_id_derived: false,
                 image: Some(image.to_string()),
                 image_source: None,
                 image_truncated: None,

--- a/tests/sigma_corpus_compatibility.rs
+++ b/tests/sigma_corpus_compatibility.rs
@@ -259,6 +259,8 @@ fn process_event(timestamp: &str) -> NormalizedEvent {
         event_id_string: "1".to_string(),
         opcode: 1,
         fields: EventFields::ProcessCreation(ProcessCreationFields {
+            cgroup_id: None,
+            parent_process_id_derived: false,
             image: Some("/usr/bin/curl".to_string()),
             image_source: None,
             image_truncated: None,

--- a/tests/sigma_documents.rs
+++ b/tests/sigma_documents.rs
@@ -29,6 +29,8 @@ fn process_event(timestamp: &str, user: &str) -> NormalizedEvent {
         event_id_string: "1".to_string(),
         opcode: 1,
         fields: EventFields::ProcessCreation(ProcessCreationFields {
+            cgroup_id: None,
+            parent_process_id_derived: false,
             image: Some("/usr/bin/curl".to_string()),
             image_source: None,
             image_truncated: None,

--- a/tests/yara_disk.rs
+++ b/tests/yara_disk.rs
@@ -84,6 +84,8 @@ fn build_yara_alert(
             event_id_string: "1".to_string(),
             opcode: 1,
             fields: EventFields::ProcessCreation(ProcessCreationFields {
+                cgroup_id: None,
+                parent_process_id_derived: false,
                 image: Some(path.to_string()),
                 image_source: None,
                 image_truncated: None,


### PR DESCRIPTION
## Summary

- measure parent PID and execution identity at fork time with bounded eBPF maps
- distinguish creator TID and TGID, ignore thread creation, and mark CLONE_PARENT approximation as derived
- parse process tracepoint layouts dynamically and fail clearly on unsupported formats
- add cgroup ID and sensor-minted process identity to the process event contract
- remove synchronous procfs and account lookups from the process ring drain
- document raw exec filename behavior and parent attribution limitations

## Validation

- full Rust test suite: 369 library tests plus integration tests
- cargo clippy --all-targets -- -D warnings
- Ubuntu Linux sensor tests: 72 passed
- Ubuntu platform mapping tests: 5 passed
- Ubuntu release eBPF build and live program attachment
- orphan test retained the fork-time parent PID after the parent exited
- mixed 2,938-event burst completed with zero source and writer loss

Closes #418