### PR TITLE
feat(linux-ebpf): probe capabilities, version the ABI, degrade per feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3201,6 +3201,7 @@ dependencies = [
  "md-5 0.11.0",
  "memmap2",
  "notify",
+ "object",
  "pelite",
  "regex",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ notify = "8.2.0"
 [target.'cfg(target_os = "linux")'.dependencies]
 aya = { version = "0.14", default-features = false }
 libc = "0.2"
+object = { version = "0.39", default-features = false, features = ["elf", "read_core", "std"] }
 
 # YARA-X uses its native JIT outside macOS.
 [target.'cfg(not(target_os = "macos"))'.dependencies]

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -152,6 +152,12 @@ three platforms, but several Sysmon-style fields are unavailable.
 
 The Linux sensor covers process, network, file, and DNS.
 
+Tracepoint layouts and hook availability are discovered from tracefs at
+startup. Kernels that omit a hook retain the other telemetry families; the
+resulting per-feature coverage is reported in `telemetry.json` and by
+`rustinel doctor`. An object whose event ABI does not match the loader is
+rejected before any program attaches.
+
 - **The raw image path is capped at 255 bytes.** `Image`
   comes from the raw `execve()` argument. When its suffix does not fit,
   `ImageTruncated` and `edr.process.image_truncated` mark the path as incomplete

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -102,6 +102,9 @@ mount -t debugfs debugfs /sys/kernel/debug
 
 - some minimal Linux environments, including some WSL 2 distros, may start without these filesystems mounted
 - retry without `RUSTINEL_EBPF_OBJECT` if you were using an override
+- if the error names an ABI mismatch, rebuild the eBPF object and userspace
+  binary together; the loader refuses to decode an object with a different
+  ring-buffer schema
 - if you are iterating on the eBPF program, rebuild the object and retry
 - check the operational log for the exact Aya or loader error
 
@@ -432,6 +435,19 @@ On Linux, also inspect the `linux_ebpf` check. It covers loss before the shared
   [WARN] linux_ebpf: process ring was full 42 times
       detail: process ring: 10042 seen, 10000 submitted, 0 in flight, 42 ring full, 0 map full, 10000 received, 10000 decoded, 10000 emitted, 0 internal, 0 dropped
 ```
+
+The same section reports kernel-dependent coverage by feature. A missing hook
+does not stop the other Linux telemetry families; it produces a named check
+such as `linux_ebpf_dns_capability` instead:
+
+```text
+  [WARN] linux_ebpf_dns_capability: Linux eBPF dns telemetry is degraded
+      detail: handle_sendmmsg: syscalls/sys_enter_sendmmsg: tracepoint is unavailable
+```
+
+The `linux_ebpf.abi_version` and `linux_ebpf.features` fields in
+`telemetry.json` carry the same active/degraded feature set for automated
+inventory.
 
 `in flight` is queue occupancy at snapshot time, not loss. A growing
 `ring full`, `map full`, `short reads`, or userspace drop count is a detection

--- a/ebpf/src/dns.rs
+++ b/ebpf/src/dns.rs
@@ -20,6 +20,38 @@ use crate::events::{event_metadata, DnsEvent};
 use crate::process::current_process_start_time;
 use crate::telemetry::{record_ring_full, record_submitted, DNS_FAMILY};
 
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct DnsTracepointOffsets {
+    pub sendto_fd: u32,
+    pub sendto_buf: u32,
+    pub sendto_len: u32,
+    pub sendto_addr: u32,
+    pub sendmsg_fd: u32,
+    pub sendmsg_msg: u32,
+    pub sendmmsg_fd: u32,
+    pub sendmmsg_msgvec: u32,
+    pub sendmmsg_vlen: u32,
+}
+
+#[no_mangle]
+pub static DNS_TRACEPOINT_OFFSETS: DnsTracepointOffsets = DnsTracepointOffsets {
+    sendto_fd: 0,
+    sendto_buf: 0,
+    sendto_len: 0,
+    sendto_addr: 0,
+    sendmsg_fd: 0,
+    sendmsg_msg: 0,
+    sendmmsg_fd: 0,
+    sendmmsg_msgvec: 0,
+    sendmmsg_vlen: 0,
+};
+
+#[inline(always)]
+unsafe fn tracepoint_offset(value: *const u32) -> usize {
+    core::ptr::read_volatile(value) as usize
+}
+
 const DNS_EVENT_QUERY: u32 = 1;
 const DNS_HEADER_LEN: usize = 12;
 const DNS_PORT: u16 = 53;
@@ -126,10 +158,18 @@ pub fn handle_sendmmsg(ctx: TracePointContext) -> u32 {
 unsafe fn try_handle_sendto(ctx: &TracePointContext) -> Result<u32, i64> {
     let pid = (bpf_get_current_pid_tgid() >> 32) as u32;
     let uid = bpf_get_current_uid_gid() as u32;
-    let fd = ctx.read_at::<i64>(16)? as i32;
-    let buf_ptr = ctx.read_at::<u64>(24)?;
-    let len = ctx.read_at::<u64>(32)? as usize;
-    let addr_ptr = ctx.read_at::<u64>(48)?;
+    let fd = ctx.read_at::<i64>(tracepoint_offset(core::ptr::addr_of!(
+        DNS_TRACEPOINT_OFFSETS.sendto_fd
+    )))? as i32;
+    let buf_ptr = ctx.read_at::<u64>(tracepoint_offset(core::ptr::addr_of!(
+        DNS_TRACEPOINT_OFFSETS.sendto_buf
+    )))?;
+    let len = ctx.read_at::<u64>(tracepoint_offset(core::ptr::addr_of!(
+        DNS_TRACEPOINT_OFFSETS.sendto_len
+    )))? as usize;
+    let addr_ptr = ctx.read_at::<u64>(tracepoint_offset(core::ptr::addr_of!(
+        DNS_TRACEPOINT_OFFSETS.sendto_addr
+    )))?;
 
     if buf_ptr == 0
         || len < DNS_HEADER_LEN
@@ -162,8 +202,12 @@ unsafe fn try_handle_sendto(ctx: &TracePointContext) -> Result<u32, i64> {
 unsafe fn try_handle_sendmsg(ctx: &TracePointContext) -> Result<u32, i64> {
     let pid = (bpf_get_current_pid_tgid() >> 32) as u32;
     let uid = bpf_get_current_uid_gid() as u32;
-    let fd = ctx.read_at::<i64>(16)? as i32;
-    let msg_ptr = ctx.read_at::<u64>(24)?;
+    let fd = ctx.read_at::<i64>(tracepoint_offset(core::ptr::addr_of!(
+        DNS_TRACEPOINT_OFFSETS.sendmsg_fd
+    )))? as i32;
+    let msg_ptr = ctx.read_at::<u64>(tracepoint_offset(core::ptr::addr_of!(
+        DNS_TRACEPOINT_OFFSETS.sendmsg_msg
+    )))?;
 
     if msg_ptr == 0 {
         return Ok(0);
@@ -195,9 +239,15 @@ unsafe fn try_handle_sendmsg(ctx: &TracePointContext) -> Result<u32, i64> {
 unsafe fn try_handle_sendmmsg(ctx: &TracePointContext) -> Result<u32, i64> {
     let pid = (bpf_get_current_pid_tgid() >> 32) as u32;
     let uid = bpf_get_current_uid_gid() as u32;
-    let fd = ctx.read_at::<i64>(16)? as i32;
-    let msgvec_ptr = ctx.read_at::<u64>(24)?;
-    let message_count = ctx.read_at::<u64>(32)? as usize;
+    let fd = ctx.read_at::<i64>(tracepoint_offset(core::ptr::addr_of!(
+        DNS_TRACEPOINT_OFFSETS.sendmmsg_fd
+    )))? as i32;
+    let msgvec_ptr = ctx.read_at::<u64>(tracepoint_offset(core::ptr::addr_of!(
+        DNS_TRACEPOINT_OFFSETS.sendmmsg_msgvec
+    )))?;
+    let message_count = ctx.read_at::<u64>(tracepoint_offset(core::ptr::addr_of!(
+        DNS_TRACEPOINT_OFFSETS.sendmmsg_vlen
+    )))? as usize;
 
     if msgvec_ptr == 0 || message_count == 0 {
         return Ok(0);

--- a/ebpf/src/file.rs
+++ b/ebpf/src/file.rs
@@ -36,7 +36,8 @@
 //! A userspace path is eligible only when the file event captured the same
 //! token, so an untracked reopen cannot consume an older `(pid, fd)` entry.
 //!
-//! sys_enter_openat tracepoint format (x86_64, 64-bit ABI):
+//! Example sys_enter_openat tracepoint format (x86_64, 64-bit ABI). These
+//! offsets are documentation only; the loader supplies this kernel's values:
 //!   offset  0: common_type         (u16)
 //!   offset  2: common_flags        (u8)
 //!   offset  3: common_preempt_count(u8)
@@ -85,6 +86,62 @@ use crate::events::{
 use crate::network::forget_socket_type;
 use crate::process::current_process_start_time;
 use crate::telemetry::{record_map_full, record_ring_full, record_submitted, FILE_FAMILY};
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct FileTracepointOffsets {
+    pub openat_dfd: u32,
+    pub openat_path: u32,
+    pub openat_flags: u32,
+    pub openat_ret: u32,
+    pub open_path: u32,
+    pub open_flags: u32,
+    pub open_ret: u32,
+    pub creat_path: u32,
+    pub creat_ret: u32,
+    pub openat2_dfd: u32,
+    pub openat2_path: u32,
+    pub openat2_how: u32,
+    pub openat2_ret: u32,
+    pub unlinkat_dfd: u32,
+    pub unlinkat_path: u32,
+    pub unlinkat_ret: u32,
+    pub unlink_path: u32,
+    pub unlink_ret: u32,
+    pub renameat_old_dfd: u32,
+    pub renameat_old_path: u32,
+    pub renameat_new_dfd: u32,
+    pub renameat_new_path: u32,
+    pub renameat_ret: u32,
+    pub renameat2_old_dfd: u32,
+    pub renameat2_old_path: u32,
+    pub renameat2_new_dfd: u32,
+    pub renameat2_new_path: u32,
+    pub renameat2_ret: u32,
+    pub rename_old_path: u32,
+    pub rename_new_path: u32,
+    pub rename_ret: u32,
+    pub mkdir_path: u32,
+    pub mkdir_ret: u32,
+    pub mkdirat_dfd: u32,
+    pub mkdirat_path: u32,
+    pub mkdirat_ret: u32,
+    pub rmdir_path: u32,
+    pub rmdir_ret: u32,
+    pub close_fd: u32,
+    pub dup2_old_fd: u32,
+    pub dup2_new_fd: u32,
+    pub dup3_old_fd: u32,
+    pub dup3_new_fd: u32,
+}
+
+#[no_mangle]
+pub static FILE_TRACEPOINT_OFFSETS: FileTracepointOffsets = unsafe { core::mem::zeroed() };
+
+#[inline(always)]
+unsafe fn tracepoint_offset(value: *const u32) -> usize {
+    core::ptr::read_volatile(value) as usize
+}
 
 /// O_CREAT flag — create file if it does not exist.
 const O_CREAT: u64 = 0x40;
@@ -202,25 +259,49 @@ pub fn handle_vfs_create(ctx: ProbeContext) -> u32 {
 /// Emit a file-create event only after `openat` succeeds.
 #[tracepoint]
 pub fn handle_openat_exit(ctx: TracePointContext) -> u32 {
-    unsafe { try_handle_open_exit(&ctx) }.unwrap_or(1)
+    unsafe {
+        try_handle_open_exit(
+            &ctx,
+            tracepoint_offset(core::ptr::addr_of!(FILE_TRACEPOINT_OFFSETS.openat_ret)),
+        )
+    }
+    .unwrap_or(1)
 }
 
 /// Emit a legacy `open` file event only after the syscall succeeds.
 #[tracepoint]
 pub fn handle_open_exit(ctx: TracePointContext) -> u32 {
-    unsafe { try_handle_open_exit(&ctx) }.unwrap_or(1)
+    unsafe {
+        try_handle_open_exit(
+            &ctx,
+            tracepoint_offset(core::ptr::addr_of!(FILE_TRACEPOINT_OFFSETS.open_ret)),
+        )
+    }
+    .unwrap_or(1)
 }
 
 /// Emit a legacy `creat` event only after the syscall succeeds.
 #[tracepoint]
 pub fn handle_creat_exit(ctx: TracePointContext) -> u32 {
-    unsafe { try_handle_open_exit(&ctx) }.unwrap_or(1)
+    unsafe {
+        try_handle_open_exit(
+            &ctx,
+            tracepoint_offset(core::ptr::addr_of!(FILE_TRACEPOINT_OFFSETS.creat_ret)),
+        )
+    }
+    .unwrap_or(1)
 }
 
 /// Emit an `openat2` file event only after the syscall succeeds.
 #[tracepoint]
 pub fn handle_openat2_exit(ctx: TracePointContext) -> u32 {
-    unsafe { try_handle_open_exit(&ctx) }.unwrap_or(1)
+    unsafe {
+        try_handle_open_exit(
+            &ctx,
+            tracepoint_offset(core::ptr::addr_of!(FILE_TRACEPOINT_OFFSETS.openat2_ret)),
+        )
+    }
+    .unwrap_or(1)
 }
 
 /// Queue a potential file-delete event for `unlinkat`.
@@ -232,19 +313,40 @@ pub fn handle_unlinkat(ctx: TracePointContext) -> u32 {
 /// Emit a file-delete event only after `unlinkat` succeeds.
 #[tracepoint]
 pub fn handle_unlinkat_exit(ctx: TracePointContext) -> u32 {
-    unsafe { try_handle_file_operation_exit(&ctx, FILE_KIND_DELETE) }.unwrap_or(1)
+    unsafe {
+        try_handle_file_operation_exit(
+            &ctx,
+            FILE_KIND_DELETE,
+            tracepoint_offset(core::ptr::addr_of!(FILE_TRACEPOINT_OFFSETS.unlinkat_ret)),
+        )
+    }
+    .unwrap_or(1)
 }
 
 /// Queue a potential file-delete event for legacy `unlink`.
 #[tracepoint]
 pub fn handle_unlink(ctx: TracePointContext) -> u32 {
-    unsafe { try_handle_legacy_file_event(&ctx, FILE_KIND_DELETE) }.unwrap_or(1)
+    unsafe {
+        try_handle_legacy_file_event(
+            &ctx,
+            FILE_KIND_DELETE,
+            tracepoint_offset(core::ptr::addr_of!(FILE_TRACEPOINT_OFFSETS.unlink_path)),
+        )
+    }
+    .unwrap_or(1)
 }
 
 /// Emit a file-delete event only after legacy `unlink` succeeds.
 #[tracepoint]
 pub fn handle_unlink_exit(ctx: TracePointContext) -> u32 {
-    unsafe { try_handle_file_operation_exit(&ctx, FILE_KIND_DELETE) }.unwrap_or(1)
+    unsafe {
+        try_handle_file_operation_exit(
+            &ctx,
+            FILE_KIND_DELETE,
+            tracepoint_offset(core::ptr::addr_of!(FILE_TRACEPOINT_OFFSETS.unlink_ret)),
+        )
+    }
+    .unwrap_or(1)
 }
 
 /// Queue a potential file-rename event for `renameat`.
@@ -256,19 +358,33 @@ pub fn handle_renameat(ctx: TracePointContext) -> u32 {
 /// Emit a file-rename event only after `renameat` succeeds.
 #[tracepoint]
 pub fn handle_renameat_exit(ctx: TracePointContext) -> u32 {
-    unsafe { try_handle_file_operation_exit(&ctx, FILE_KIND_RENAME) }.unwrap_or(1)
+    unsafe {
+        try_handle_file_operation_exit(
+            &ctx,
+            FILE_KIND_RENAME,
+            tracepoint_offset(core::ptr::addr_of!(FILE_TRACEPOINT_OFFSETS.renameat_ret)),
+        )
+    }
+    .unwrap_or(1)
 }
 
 /// Queue a potential file-rename event for `renameat2`.
 #[tracepoint]
 pub fn handle_renameat2(ctx: TracePointContext) -> u32 {
-    unsafe { try_handle_renameat(&ctx) }.unwrap_or(1)
+    unsafe { try_handle_renameat2(&ctx) }.unwrap_or(1)
 }
 
 /// Emit a file-rename event only after `renameat2` succeeds.
 #[tracepoint]
 pub fn handle_renameat2_exit(ctx: TracePointContext) -> u32 {
-    unsafe { try_handle_file_operation_exit(&ctx, FILE_KIND_RENAME) }.unwrap_or(1)
+    unsafe {
+        try_handle_file_operation_exit(
+            &ctx,
+            FILE_KIND_RENAME,
+            tracepoint_offset(core::ptr::addr_of!(FILE_TRACEPOINT_OFFSETS.renameat2_ret)),
+        )
+    }
+    .unwrap_or(1)
 }
 
 /// Queue a potential file-rename event for legacy `rename`.
@@ -280,43 +396,85 @@ pub fn handle_rename(ctx: TracePointContext) -> u32 {
 /// Emit a file-rename event only after legacy `rename` succeeds.
 #[tracepoint]
 pub fn handle_rename_exit(ctx: TracePointContext) -> u32 {
-    unsafe { try_handle_file_operation_exit(&ctx, FILE_KIND_RENAME) }.unwrap_or(1)
+    unsafe {
+        try_handle_file_operation_exit(
+            &ctx,
+            FILE_KIND_RENAME,
+            tracepoint_offset(core::ptr::addr_of!(FILE_TRACEPOINT_OFFSETS.rename_ret)),
+        )
+    }
+    .unwrap_or(1)
 }
 
 /// Queue a potential directory-create event for legacy `mkdir`.
 #[tracepoint]
 pub fn handle_mkdir(ctx: TracePointContext) -> u32 {
-    unsafe { try_handle_legacy_file_event(&ctx, FILE_KIND_CREATE) }.unwrap_or(1)
+    unsafe {
+        try_handle_legacy_file_event(
+            &ctx,
+            FILE_KIND_CREATE,
+            tracepoint_offset(core::ptr::addr_of!(FILE_TRACEPOINT_OFFSETS.mkdir_path)),
+        )
+    }
+    .unwrap_or(1)
 }
 
 /// Emit a directory-create event only after legacy `mkdir` succeeds.
 #[tracepoint]
 pub fn handle_mkdir_exit(ctx: TracePointContext) -> u32 {
-    unsafe { try_handle_file_operation_exit(&ctx, FILE_KIND_CREATE) }.unwrap_or(1)
+    unsafe {
+        try_handle_file_operation_exit(
+            &ctx,
+            FILE_KIND_CREATE,
+            tracepoint_offset(core::ptr::addr_of!(FILE_TRACEPOINT_OFFSETS.mkdir_ret)),
+        )
+    }
+    .unwrap_or(1)
 }
 
 /// Queue a potential directory-create event for `mkdirat`.
 #[tracepoint]
 pub fn handle_mkdirat(ctx: TracePointContext) -> u32 {
-    unsafe { queue_file_event(&ctx, FILE_KIND_CREATE) }.unwrap_or(1)
+    unsafe { try_handle_mkdirat(&ctx) }.unwrap_or(1)
 }
 
 /// Emit a directory-create event only after `mkdirat` succeeds.
 #[tracepoint]
 pub fn handle_mkdirat_exit(ctx: TracePointContext) -> u32 {
-    unsafe { try_handle_file_operation_exit(&ctx, FILE_KIND_CREATE) }.unwrap_or(1)
+    unsafe {
+        try_handle_file_operation_exit(
+            &ctx,
+            FILE_KIND_CREATE,
+            tracepoint_offset(core::ptr::addr_of!(FILE_TRACEPOINT_OFFSETS.mkdirat_ret)),
+        )
+    }
+    .unwrap_or(1)
 }
 
 /// Queue a potential directory-delete event for `rmdir`.
 #[tracepoint]
 pub fn handle_rmdir(ctx: TracePointContext) -> u32 {
-    unsafe { try_handle_legacy_file_event(&ctx, FILE_KIND_DELETE) }.unwrap_or(1)
+    unsafe {
+        try_handle_legacy_file_event(
+            &ctx,
+            FILE_KIND_DELETE,
+            tracepoint_offset(core::ptr::addr_of!(FILE_TRACEPOINT_OFFSETS.rmdir_path)),
+        )
+    }
+    .unwrap_or(1)
 }
 
 /// Emit a directory-delete event only after `rmdir` succeeds.
 #[tracepoint]
 pub fn handle_rmdir_exit(ctx: TracePointContext) -> u32 {
-    unsafe { try_handle_file_operation_exit(&ctx, FILE_KIND_DELETE) }.unwrap_or(1)
+    unsafe {
+        try_handle_file_operation_exit(
+            &ctx,
+            FILE_KIND_DELETE,
+            tracepoint_offset(core::ptr::addr_of!(FILE_TRACEPOINT_OFFSETS.rmdir_ret)),
+        )
+    }
+    .unwrap_or(1)
 }
 
 /// Invalidate an indexed descriptor before it can be closed and reused.
@@ -334,7 +492,7 @@ pub fn handle_file_dup2(ctx: TracePointContext) -> u32 {
 /// Invalidate the destination descriptor that `dup3` may replace.
 #[tracepoint]
 pub fn handle_file_dup3(ctx: TracePointContext) -> u32 {
-    unsafe { try_invalidate_dup_target(&ctx) }.unwrap_or(1)
+    unsafe { try_invalidate_dup3_target(&ctx) }.unwrap_or(1)
 }
 
 /// Reset a process index before `close_range` can recycle many descriptors.
@@ -404,7 +562,9 @@ unsafe fn invalidate_fd(pid: u32, fd: i32) {
 
 #[inline(always)]
 unsafe fn try_invalidate_close(ctx: &TracePointContext) -> Result<u32, i64> {
-    let fd = ctx.read_at::<i64>(16)? as i32;
+    let fd = ctx.read_at::<i64>(tracepoint_offset(core::ptr::addr_of!(
+        FILE_TRACEPOINT_OFFSETS.close_fd
+    )))? as i32;
     let pid = (bpf_get_current_pid_tgid() >> 32) as u32;
     invalidate_fd(pid, fd);
     Ok(0)
@@ -427,13 +587,33 @@ unsafe fn invalidate_dir_token(pid: u32, fd: i32) {
 
 #[inline(always)]
 unsafe fn try_invalidate_dup_target(ctx: &TracePointContext) -> Result<u32, i64> {
-    let old_fd = ctx.read_at::<i64>(16)? as i32;
-    let new_fd = ctx.read_at::<i64>(24)? as i32;
+    let old_fd = ctx.read_at::<i64>(tracepoint_offset(core::ptr::addr_of!(
+        FILE_TRACEPOINT_OFFSETS.dup2_old_fd
+    )))? as i32;
+    let new_fd = ctx.read_at::<i64>(tracepoint_offset(core::ptr::addr_of!(
+        FILE_TRACEPOINT_OFFSETS.dup2_new_fd
+    )))? as i32;
     if old_fd == new_fd {
         return Ok(0);
     }
     let pid = (bpf_get_current_pid_tgid() >> 32) as u32;
     // `dup2`/`dup3` close whatever `new_fd` held without a `close` syscall.
+    invalidate_fd(pid, new_fd);
+    Ok(0)
+}
+
+#[inline(always)]
+unsafe fn try_invalidate_dup3_target(ctx: &TracePointContext) -> Result<u32, i64> {
+    let old_fd = ctx.read_at::<i64>(tracepoint_offset(core::ptr::addr_of!(
+        FILE_TRACEPOINT_OFFSETS.dup3_old_fd
+    )))? as i32;
+    let new_fd = ctx.read_at::<i64>(tracepoint_offset(core::ptr::addr_of!(
+        FILE_TRACEPOINT_OFFSETS.dup3_new_fd
+    )))? as i32;
+    if old_fd == new_fd {
+        return Ok(0);
+    }
+    let pid = (bpf_get_current_pid_tgid() >> 32) as u32;
     invalidate_fd(pid, new_fd);
     Ok(0)
 }
@@ -466,22 +646,34 @@ unsafe fn try_reset_dir_index(_ctx: &TracePointContext) -> Result<u32, i64> {
 
 #[inline(always)]
 unsafe fn try_handle_openat(ctx: &TracePointContext) -> Result<u32, i64> {
-    let flags: u64 = ctx.read_at::<u64>(32)?;
-    let dfd = ctx.read_at::<i64>(16)? as i32;
-    let path_ptr = ctx.read_at::<u64>(24)?;
+    let flags: u64 = ctx.read_at::<u64>(tracepoint_offset(core::ptr::addr_of!(
+        FILE_TRACEPOINT_OFFSETS.openat_flags
+    )))?;
+    let dfd = ctx.read_at::<i64>(tracepoint_offset(core::ptr::addr_of!(
+        FILE_TRACEPOINT_OFFSETS.openat_dfd
+    )))? as i32;
+    let path_ptr = ctx.read_at::<u64>(tracepoint_offset(core::ptr::addr_of!(
+        FILE_TRACEPOINT_OFFSETS.openat_path
+    )))?;
     try_queue_open(flags, dfd, path_ptr)
 }
 
 #[inline(always)]
 unsafe fn try_handle_open(ctx: &TracePointContext) -> Result<u32, i64> {
-    let path_ptr = ctx.read_at::<u64>(16)?;
-    let flags = ctx.read_at::<u64>(24)?;
+    let path_ptr = ctx.read_at::<u64>(tracepoint_offset(core::ptr::addr_of!(
+        FILE_TRACEPOINT_OFFSETS.open_path
+    )))?;
+    let flags = ctx.read_at::<u64>(tracepoint_offset(core::ptr::addr_of!(
+        FILE_TRACEPOINT_OFFSETS.open_flags
+    )))?;
     try_queue_open(flags, AT_FDCWD, path_ptr)
 }
 
 #[inline(always)]
 unsafe fn try_handle_creat(ctx: &TracePointContext) -> Result<u32, i64> {
-    let path_ptr = ctx.read_at::<u64>(16)?;
+    let path_ptr = ctx.read_at::<u64>(tracepoint_offset(core::ptr::addr_of!(
+        FILE_TRACEPOINT_OFFSETS.creat_path
+    )))?;
     let tid = bpf_get_current_pid_tgid() as u32;
     let _ = OPENAT_CREATED.remove(&tid);
     queue_file_event_from_args(AT_FDCWD, path_ptr, FILE_KIND_CREATE)
@@ -489,9 +681,15 @@ unsafe fn try_handle_creat(ctx: &TracePointContext) -> Result<u32, i64> {
 
 #[inline(always)]
 unsafe fn try_handle_openat2(ctx: &TracePointContext) -> Result<u32, i64> {
-    let dfd = ctx.read_at::<i64>(16)? as i32;
-    let path_ptr = ctx.read_at::<u64>(24)?;
-    let how_ptr = ctx.read_at::<u64>(32)?;
+    let dfd = ctx.read_at::<i64>(tracepoint_offset(core::ptr::addr_of!(
+        FILE_TRACEPOINT_OFFSETS.openat2_dfd
+    )))? as i32;
+    let path_ptr = ctx.read_at::<u64>(tracepoint_offset(core::ptr::addr_of!(
+        FILE_TRACEPOINT_OFFSETS.openat2_path
+    )))?;
+    let how_ptr = ctx.read_at::<u64>(tracepoint_offset(core::ptr::addr_of!(
+        FILE_TRACEPOINT_OFFSETS.openat2_how
+    )))?;
     if how_ptr == 0 {
         return Ok(0);
     }
@@ -531,8 +729,8 @@ unsafe fn try_queue_open(flags: u64, dfd: i32, path_ptr: u64) -> Result<u32, i64
 }
 
 #[inline(always)]
-unsafe fn try_handle_open_exit(ctx: &TracePointContext) -> Result<u32, i64> {
-    let ret: i64 = ctx.read_at::<i64>(16)?;
+unsafe fn try_handle_open_exit(ctx: &TracePointContext, ret_offset: usize) -> Result<u32, i64> {
+    let ret: i64 = ctx.read_at::<i64>(ret_offset)?;
     let tid = bpf_get_current_pid_tgid() as u32;
     // Clean up the vfs_create marker regardless.
     let _ = OPENAT_CREATED.remove(&tid);
@@ -566,18 +764,31 @@ unsafe fn try_handle_open_exit(ctx: &TracePointContext) -> Result<u32, i64> {
 
 #[inline(always)]
 unsafe fn try_handle_unlinkat(ctx: &TracePointContext) -> Result<u32, i64> {
-    queue_file_event(ctx, FILE_KIND_DELETE)
+    queue_file_event(
+        ctx,
+        FILE_KIND_DELETE,
+        tracepoint_offset(core::ptr::addr_of!(FILE_TRACEPOINT_OFFSETS.unlinkat_dfd)),
+        tracepoint_offset(core::ptr::addr_of!(FILE_TRACEPOINT_OFFSETS.unlinkat_path)),
+    )
 }
 
 #[inline(always)]
-unsafe fn try_handle_legacy_file_event(ctx: &TracePointContext, kind: u32) -> Result<u32, i64> {
-    let path_ptr = ctx.read_at::<u64>(16)?;
+unsafe fn try_handle_legacy_file_event(
+    ctx: &TracePointContext,
+    kind: u32,
+    path_offset: usize,
+) -> Result<u32, i64> {
+    let path_ptr = ctx.read_at::<u64>(path_offset)?;
     queue_file_event_from_args(AT_FDCWD, path_ptr, kind)
 }
 
 #[inline(always)]
-unsafe fn try_handle_file_operation_exit(ctx: &TracePointContext, kind: u32) -> Result<u32, i64> {
-    let ret: i64 = ctx.read_at::<i64>(16)?;
+unsafe fn try_handle_file_operation_exit(
+    ctx: &TracePointContext,
+    kind: u32,
+    ret_offset: usize,
+) -> Result<u32, i64> {
+    let ret: i64 = ctx.read_at::<i64>(ret_offset)?;
     emit_pending_file_event(kind, kind, kind, ret == 0)
 }
 
@@ -588,9 +799,23 @@ unsafe fn try_handle_renameat(ctx: &TracePointContext) -> Result<u32, i64> {
 
 #[inline(always)]
 unsafe fn try_handle_rename(ctx: &TracePointContext) -> Result<u32, i64> {
-    let old_path_ptr = ctx.read_at::<u64>(16)?;
-    let new_path_ptr = ctx.read_at::<u64>(24)?;
+    let old_path_ptr = ctx.read_at::<u64>(tracepoint_offset(core::ptr::addr_of!(
+        FILE_TRACEPOINT_OFFSETS.rename_old_path
+    )))?;
+    let new_path_ptr = ctx.read_at::<u64>(tracepoint_offset(core::ptr::addr_of!(
+        FILE_TRACEPOINT_OFFSETS.rename_new_path
+    )))?;
     queue_rename_event_from_args(AT_FDCWD, old_path_ptr, AT_FDCWD, new_path_ptr)
+}
+
+#[inline(always)]
+unsafe fn try_handle_mkdirat(ctx: &TracePointContext) -> Result<u32, i64> {
+    queue_file_event(
+        ctx,
+        FILE_KIND_CREATE,
+        tracepoint_offset(core::ptr::addr_of!(FILE_TRACEPOINT_OFFSETS.mkdirat_dfd)),
+        tracepoint_offset(core::ptr::addr_of!(FILE_TRACEPOINT_OFFSETS.mkdirat_path)),
+    )
 }
 
 #[inline(always)]
@@ -628,10 +853,14 @@ unsafe fn read_user_path(ptr: u64, dst: &mut [u8; FILE_PATH_LEN]) -> Option<bool
 }
 
 #[inline(always)]
-unsafe fn queue_file_event(ctx: &TracePointContext, kind: u32) -> Result<u32, i64> {
-    // The tracked *at path syscalls share dfd at 16 and pathname at 24.
-    let dfd = ctx.read_at::<i64>(16)? as i32;
-    let path_ptr: u64 = ctx.read_at::<u64>(24)?;
+unsafe fn queue_file_event(
+    ctx: &TracePointContext,
+    kind: u32,
+    dfd_offset: usize,
+    path_offset: usize,
+) -> Result<u32, i64> {
+    let dfd = ctx.read_at::<i64>(dfd_offset)? as i32;
+    let path_ptr: u64 = ctx.read_at::<u64>(path_offset)?;
     queue_file_event_from_args(dfd, path_ptr, kind)
 }
 
@@ -680,10 +909,35 @@ unsafe fn queue_file_event_from_args(dfd: i32, path_ptr: u64, kind: u32) -> Resu
 
 #[inline(always)]
 unsafe fn queue_rename_event(ctx: &TracePointContext) -> Result<u32, i64> {
-    let old_dfd = ctx.read_at::<i64>(16)? as i32;
-    let old_path_ptr: u64 = ctx.read_at::<u64>(24)?;
-    let new_dfd = ctx.read_at::<i64>(32)? as i32;
-    let new_path_ptr: u64 = ctx.read_at::<u64>(40)?;
+    let old_dfd = ctx.read_at::<i64>(tracepoint_offset(core::ptr::addr_of!(
+        FILE_TRACEPOINT_OFFSETS.renameat_old_dfd
+    )))? as i32;
+    let old_path_ptr: u64 = ctx.read_at::<u64>(tracepoint_offset(core::ptr::addr_of!(
+        FILE_TRACEPOINT_OFFSETS.renameat_old_path
+    )))?;
+    let new_dfd = ctx.read_at::<i64>(tracepoint_offset(core::ptr::addr_of!(
+        FILE_TRACEPOINT_OFFSETS.renameat_new_dfd
+    )))? as i32;
+    let new_path_ptr: u64 = ctx.read_at::<u64>(tracepoint_offset(core::ptr::addr_of!(
+        FILE_TRACEPOINT_OFFSETS.renameat_new_path
+    )))?;
+    queue_rename_event_from_args(old_dfd, old_path_ptr, new_dfd, new_path_ptr)
+}
+
+#[inline(always)]
+unsafe fn try_handle_renameat2(ctx: &TracePointContext) -> Result<u32, i64> {
+    let old_dfd = ctx.read_at::<i64>(tracepoint_offset(core::ptr::addr_of!(
+        FILE_TRACEPOINT_OFFSETS.renameat2_old_dfd
+    )))? as i32;
+    let old_path_ptr: u64 = ctx.read_at::<u64>(tracepoint_offset(core::ptr::addr_of!(
+        FILE_TRACEPOINT_OFFSETS.renameat2_old_path
+    )))?;
+    let new_dfd = ctx.read_at::<i64>(tracepoint_offset(core::ptr::addr_of!(
+        FILE_TRACEPOINT_OFFSETS.renameat2_new_dfd
+    )))? as i32;
+    let new_path_ptr: u64 = ctx.read_at::<u64>(tracepoint_offset(core::ptr::addr_of!(
+        FILE_TRACEPOINT_OFFSETS.renameat2_new_path
+    )))?;
     queue_rename_event_from_args(old_dfd, old_path_ptr, new_dfd, new_path_ptr)
 }
 

--- a/ebpf/src/main.rs
+++ b/ebpf/src/main.rs
@@ -47,6 +47,14 @@ pub mod network;
 pub mod process;
 pub mod telemetry;
 
+/// Ring-buffer and loader-global ABI implemented by this object.
+///
+/// Userspace reads this ELF symbol before asking the kernel to load any
+/// program. Keep it in sync with `LINUX_EBPF_ABI_VERSION` in the loader.
+#[used]
+#[no_mangle]
+pub static RUSTINEL_ABI_VERSION: u32 = 1;
+
 #[panic_handler]
 fn panic(_info: &core::panic::PanicInfo) -> ! {
     loop {}

--- a/ebpf/src/network.rs
+++ b/ebpf/src/network.rs
@@ -31,7 +31,8 @@
 //! for the directory index, which calls [`forget_socket_type`] rather than pay
 //! a second tracepoint dispatch on paths as hot as `close`.
 //!
-//! sys_enter_connect tracepoint format (x86_64, 64-bit ABI):
+//! Example sys_enter_connect tracepoint format (x86_64, 64-bit ABI). These
+//! offsets are documentation only; the loader supplies this kernel's values:
 //!   offset  0: common_type         (u16)
 //!   offset  2: common_flags        (u8)
 //!   offset  3: common_preempt_count(u8)
@@ -65,6 +66,32 @@ use crate::events::{
 };
 use crate::process::current_process_start_time;
 use crate::telemetry::{record_map_full, record_ring_full, record_submitted, NETWORK_FAMILY};
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct NetworkTracepointOffsets {
+    pub connect_fd: u32,
+    pub connect_addr: u32,
+    pub connect_ret: u32,
+    pub socket_family: u32,
+    pub socket_type: u32,
+    pub socket_ret: u32,
+}
+
+#[no_mangle]
+pub static NETWORK_TRACEPOINT_OFFSETS: NetworkTracepointOffsets = NetworkTracepointOffsets {
+    connect_fd: 0,
+    connect_addr: 0,
+    connect_ret: 0,
+    socket_family: 0,
+    socket_type: 0,
+    socket_ret: 0,
+};
+
+#[inline(always)]
+unsafe fn tracepoint_offset(value: *const u32) -> usize {
+    core::ptr::read_volatile(value) as usize
+}
 
 /// AF_INET (IPv4).
 const AF_INET: u16 = 2;
@@ -179,7 +206,9 @@ unsafe fn try_handle_socket(ctx: &TracePointContext) -> Result<u32, i64> {
 
     // Only IP sockets can reach the connect hook's address-family filter;
     // indexing AF_UNIX and AF_NETLINK would evict entries that can be used.
-    let family = ctx.read_at::<i64>(16)?;
+    let family = ctx.read_at::<i64>(tracepoint_offset(core::ptr::addr_of!(
+        NETWORK_TRACEPOINT_OFFSETS.socket_family
+    )))?;
     if family != AF_INET as i64 && family != AF_INET6 as i64 {
         // Anything still pending belongs to a thread that was killed inside an
         // earlier `socket()`; drop it so this call's exit cannot claim it.
@@ -187,7 +216,9 @@ unsafe fn try_handle_socket(ctx: &TracePointContext) -> Result<u32, i64> {
         return Ok(0);
     }
 
-    let sock_type = (ctx.read_at::<i64>(24)? & SOCK_TYPE_MASK) as u8;
+    let sock_type = (ctx.read_at::<i64>(tracepoint_offset(core::ptr::addr_of!(
+        NETWORK_TRACEPOINT_OFFSETS.socket_type
+    )))? & SOCK_TYPE_MASK) as u8;
     if SOCKET_PENDING.insert(&tid, &sock_type, 0).is_err() {
         record_map_full(NETWORK_FAMILY);
     }
@@ -203,7 +234,9 @@ unsafe fn try_handle_socket_exit(ctx: &TracePointContext) -> Result<u32, i64> {
     let _ = SOCKET_PENDING.remove(&tid);
 
     // A failed socket(2) returns -errno and owns no descriptor.
-    let ret = ctx.read_at::<i64>(16)?;
+    let ret = ctx.read_at::<i64>(tracepoint_offset(core::ptr::addr_of!(
+        NETWORK_TRACEPOINT_OFFSETS.socket_ret
+    )))?;
     if ret < 0 {
         return Ok(0);
     }
@@ -226,10 +259,14 @@ unsafe fn try_handle_connect(ctx: &TracePointContext) -> Result<u32, i64> {
     let _ = NETWORK_PENDING.remove(&tid);
 
     let uid = bpf_get_current_uid_gid() as u32;
-    let fd = ctx.read_at::<i64>(16)? as i32;
+    let fd = ctx.read_at::<i64>(tracepoint_offset(core::ptr::addr_of!(
+        NETWORK_TRACEPOINT_OFFSETS.connect_fd
+    )))? as i32;
 
     // Read pointer to user-space sockaddr structure.
-    let uservaddr: u64 = ctx.read_at::<u64>(24)?;
+    let uservaddr: u64 = ctx.read_at::<u64>(tracepoint_offset(core::ptr::addr_of!(
+        NETWORK_TRACEPOINT_OFFSETS.connect_addr
+    )))?;
     if uservaddr == 0 {
         return Ok(0);
     }
@@ -294,7 +331,9 @@ unsafe fn try_handle_connect(ctx: &TracePointContext) -> Result<u32, i64> {
 
 #[inline(always)]
 unsafe fn try_handle_connect_exit(ctx: &TracePointContext) -> Result<u32, i64> {
-    let ret = ctx.read_at::<i64>(16)? as i32;
+    let ret = ctx.read_at::<i64>(tracepoint_offset(core::ptr::addr_of!(
+        NETWORK_TRACEPOINT_OFFSETS.connect_ret
+    )))? as i32;
     let tid = bpf_get_current_pid_tgid() as u32;
 
     let Some(pending) = NETWORK_PENDING.get(&tid) else {

--- a/ebpf/src/process.rs
+++ b/ebpf/src/process.rs
@@ -15,7 +15,8 @@
 //! accumulating, and the next `execve` on the same thread overwrites the key
 //! before it can be misattributed.
 //!
-//! sys_enter_execve tracepoint format (x86_64, 64-bit ABI):
+//! Example sys_enter_execve tracepoint format (x86_64, 64-bit ABI). These
+//! offsets are documentation only; the loader supplies this kernel's values:
 //!   offset 16: filename            (u64  — user pointer to path string)
 //!   offset 24: argv                (u64  — user pointer to char *const[])
 //!   offset 32: envp                (u64)
@@ -57,6 +58,8 @@ pub struct ProcessTracepointOffsets {
     pub fork_child_pid: u32,
     pub clone_flags: u32,
     pub clone3_args: u32,
+    pub execve_argv: u32,
+    pub execveat_argv: u32,
 }
 
 #[no_mangle]
@@ -68,6 +71,8 @@ pub static PROCESS_TRACEPOINT_OFFSETS: ProcessTracepointOffsets = ProcessTracepo
     fork_child_pid: 0,
     clone_flags: 0,
     clone3_args: 0,
+    execve_argv: 0,
+    execveat_argv: 0,
 };
 
 /// Read a loader-patched global without letting LLVM fold its zero initializer
@@ -126,12 +131,6 @@ const ARGV_ARG_MAX: usize = 128;
 /// vectors longer than this are captured up to this point and flagged
 /// truncated.
 const ARGV_MAX_ARGS: usize = 32;
-
-/// `argv` offset in the `sys_enter_execve` tracepoint record.
-const EXECVE_ARGV_OFFSET: usize = 24;
-
-/// `argv` offset in the `sys_enter_execveat` tracepoint record.
-const EXECVEAT_ARGV_OFFSET: usize = 32;
 
 /// Kernel-side argv snapshot, staged between `execve` entry and the
 /// `sched_process_exec` that follows it.
@@ -207,13 +206,27 @@ pub fn handle_process_vfork(_ctx: TracePointContext) -> u32 {
 /// it is still mapped in the calling process.
 #[tracepoint]
 pub fn handle_execve(ctx: TracePointContext) -> u32 {
-    unsafe { try_capture_argv(&ctx, EXECVE_ARGV_OFFSET) }.unwrap_or(1)
+    unsafe {
+        try_capture_argv(
+            &ctx,
+            tracepoint_offset(core::ptr::addr_of!(PROCESS_TRACEPOINT_OFFSETS.execve_argv)),
+        )
+    }
+    .unwrap_or(1)
 }
 
 /// Tracepoint handler for `syscalls/sys_enter_execveat`.
 #[tracepoint]
 pub fn handle_execveat(ctx: TracePointContext) -> u32 {
-    unsafe { try_capture_argv(&ctx, EXECVEAT_ARGV_OFFSET) }.unwrap_or(1)
+    unsafe {
+        try_capture_argv(
+            &ctx,
+            tracepoint_offset(core::ptr::addr_of!(
+                PROCESS_TRACEPOINT_OFFSETS.execveat_argv
+            )),
+        )
+    }
+    .unwrap_or(1)
 }
 
 #[inline(always)]

--- a/src/doctor/telemetry.rs
+++ b/src/doctor/telemetry.rs
@@ -95,6 +95,34 @@ fn linux_ebpf_results(snapshot: &TelemetrySnapshot) -> Vec<DiagnosticResult> {
         return Vec::new();
     };
 
+    let mut results = ebpf
+        .features
+        .iter()
+        .map(|feature| {
+            let id = format!("linux_ebpf_{}_capability", feature.feature);
+            if feature.unavailable_hooks.is_empty() {
+                return DiagnosticResult::pass(
+                    id,
+                    format!(
+                        "Linux eBPF {} telemetry is active ({} hooks)",
+                        feature.feature,
+                        feature.attached_hooks.len()
+                    ),
+                );
+            }
+
+            let state = if feature.active { "degraded" } else { "unavailable" };
+            DiagnosticResult::warn(
+                id,
+                format!("Linux eBPF {} telemetry is {state}", feature.feature),
+                feature.unavailable_hooks.join("; "),
+            )
+            .with_fix(
+                "The named hooks are not available on this kernel. Upgrade the kernel or disable rules that require this telemetry category",
+            )
+        })
+        .collect::<Vec<_>>();
+
     let mut findings = Vec::new();
     for family in &ebpf.families {
         if family.kernel_ring_full > 0 {
@@ -181,22 +209,24 @@ fn linux_ebpf_results(snapshot: &TelemetrySnapshot) -> Vec<DiagnosticResult> {
     }
 
     if findings.is_empty() {
-        return vec![DiagnosticResult::pass(
+        results.push(DiagnosticResult::pass(
             "linux_ebpf",
             format!(
                 "Linux eBPF pipeline reconciles across {} submitted events ({} in flight)",
                 submitted, in_flight
             ),
-        )];
+        ));
+        return results;
     }
 
-    vec![
+    results.push(
         DiagnosticResult::warn("linux_ebpf", findings.join("; "), detail).with_fix(
             "Kernel ring or map failures are detection gaps. Reduce event volume or investigate a \
          stalled ring drain. A small non-growing reconciliation mismatch may be a snapshot taken \
          during an update; a growing mismatch should be reported",
         ),
-    ]
+    );
+    results
 }
 
 /// Registry key-path resolution, the one gap a channel counter cannot show.
@@ -389,7 +419,7 @@ mod tests {
     use crate::doctor::inspect::DiagnosticStatus;
     use crate::telemetry::{
         ChannelSnapshot, EtwDecodeFailureSnapshot, EtwDecodeSnapshot, FileAttributionSnapshot,
-        LinuxEbpfFamilySnapshot, LinuxEbpfSnapshot, RegistrySnapshot,
+        LinuxEbpfFamilySnapshot, LinuxEbpfFeatureSnapshot, LinuxEbpfSnapshot, RegistrySnapshot,
     };
 
     fn snapshot(channels: Vec<ChannelSnapshot>) -> TelemetrySnapshot {
@@ -445,6 +475,8 @@ mod tests {
         process.kernel_seen = 12;
         process.kernel_ring_full = 2;
         snap.linux_ebpf = Some(LinuxEbpfSnapshot {
+            abi_version: 1,
+            features: Vec::new(),
             families: vec![process],
         });
 
@@ -459,6 +491,8 @@ mod tests {
     fn clean_quiesced_linux_pipeline_passes() {
         let mut snap = snapshot(vec![channel("sensor_events", 10, 0)]);
         snap.linux_ebpf = Some(LinuxEbpfSnapshot {
+            abi_version: 1,
+            features: Vec::new(),
             families: vec![linux_ring("process")],
         });
 
@@ -467,6 +501,32 @@ mod tests {
         assert_eq!(results[0].status, DiagnosticStatus::Pass);
         assert!(results[0].message.contains("10 submitted events"));
         assert!(results[0].message.contains("0 in flight"));
+    }
+
+    #[test]
+    fn degraded_linux_feature_gets_a_named_warning() {
+        let mut snap = snapshot(vec![]);
+        snap.linux_ebpf = Some(LinuxEbpfSnapshot {
+            abi_version: 1,
+            features: vec![LinuxEbpfFeatureSnapshot {
+                feature: "dns".to_string(),
+                active: true,
+                attached_hooks: vec!["handle_sendto".to_string()],
+                unavailable_hooks: vec![
+                    "handle_sendmmsg: syscalls/sys_enter_sendmmsg is unavailable".to_string(),
+                ],
+            }],
+            families: vec![linux_ring("dns")],
+        });
+
+        let results = linux_ebpf_results(&snap);
+        let capability = results
+            .iter()
+            .find(|result| result.id == "linux_ebpf_dns_capability")
+            .expect("named DNS capability result");
+        assert_eq!(capability.status, DiagnosticStatus::Warn);
+        assert!(capability.message.contains("degraded"));
+        assert!(capability.detail.as_deref().unwrap().contains("sendmmsg"));
     }
 
     #[test]

--- a/src/sensor/linux/abi.rs
+++ b/src/sensor/linux/abi.rs
@@ -1,0 +1,74 @@
+//! Version contract between the userspace decoder and the embedded eBPF object.
+
+use anyhow::{bail, Context, Result};
+use object::{Object, ObjectSection, ObjectSymbol};
+
+/// Bump this whenever a ring-buffer event layout or loader-patched global changes.
+pub(crate) const LINUX_EBPF_ABI_VERSION: u32 = 1;
+
+const ABI_SYMBOL: &str = "RUSTINEL_ABI_VERSION";
+
+/// Read and validate the ABI version embedded in an eBPF ELF object.
+pub(super) fn validate_object_abi(bytes: &[u8]) -> Result<()> {
+    validate_version(object_abi_version(bytes)?)
+}
+
+fn validate_version(actual: u32) -> Result<()> {
+    if actual != LINUX_EBPF_ABI_VERSION {
+        bail!(
+            "Linux eBPF ABI mismatch: loader expects {}, object provides {}; rebuild the eBPF object and userspace binary together",
+            LINUX_EBPF_ABI_VERSION,
+            actual
+        );
+    }
+    Ok(())
+}
+
+fn object_abi_version(bytes: &[u8]) -> Result<u32> {
+    let object = object::File::parse(bytes).context("failed to parse eBPF object ELF")?;
+    let symbol = object
+        .symbols()
+        .find(|symbol| symbol.name() == Ok(ABI_SYMBOL))
+        .with_context(|| format!("eBPF object does not declare {ABI_SYMBOL}"))?;
+    let section_index = symbol
+        .section_index()
+        .with_context(|| format!("{ABI_SYMBOL} has no data section"))?;
+    let section = object
+        .section_by_index(section_index)
+        .context("failed to locate eBPF ABI data section")?;
+    let data = section
+        .data()
+        .context("failed to read eBPF ABI data section")?;
+    let offset = symbol
+        .address()
+        .checked_sub(section.address())
+        .context("eBPF ABI symbol address precedes its section")? as usize;
+    let raw = data
+        .get(offset..offset + std::mem::size_of::<u32>())
+        .context("eBPF ABI symbol is truncated")?;
+    Ok(u32::from_le_bytes(raw.try_into().expect("four-byte slice")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn expected_abi_is_nonzero() {
+        assert_ne!(LINUX_EBPF_ABI_VERSION, 0);
+    }
+
+    #[test]
+    fn embedded_object_declares_expected_abi() {
+        validate_object_abi(super::super::EBPF_BYTES).unwrap();
+    }
+
+    #[test]
+    fn mismatch_fails_with_both_versions() {
+        let err = validate_version(LINUX_EBPF_ABI_VERSION + 1).unwrap_err();
+        let message = err.to_string();
+        assert!(message.contains("ABI mismatch"));
+        assert!(message.contains(&LINUX_EBPF_ABI_VERSION.to_string()));
+        assert!(message.contains(&(LINUX_EBPF_ABI_VERSION + 1).to_string()));
+    }
+}

--- a/src/sensor/linux/abi.rs
+++ b/src/sensor/linux/abi.rs
@@ -3,8 +3,7 @@
 use anyhow::{bail, Context, Result};
 use object::{Object, ObjectSection, ObjectSymbol};
 
-/// Bump this whenever a ring-buffer event layout or loader-patched global changes.
-pub(crate) const LINUX_EBPF_ABI_VERSION: u32 = 1;
+use crate::telemetry::LINUX_EBPF_ABI_VERSION;
 
 const ABI_SYMBOL: &str = "RUSTINEL_ABI_VERSION";
 

--- a/src/sensor/linux/ebpf.rs
+++ b/src/sensor/linux/ebpf.rs
@@ -33,12 +33,13 @@ use crate::sensor::{
 use crate::telemetry::{LinuxEbpfFamily, LinuxEbpfKernelSample, LINUX_EBPF};
 use crate::utils::lookup_username_by_uid;
 
+use super::abi::validate_object_abi;
 use super::events::{
     bytes_to_string, connect_result_is_connection, parse_event, system_time_from_boot_ns, DnsEvent,
     FileEvent, FileEventHeader, FileIndexEvent, NetworkEvent, ProcessEvent,
 };
 use super::paths::{resolve_at_path, resolve_indexable_dir_path, truncation_marker, DirFdIndex};
-use super::tracepoint_format::ProcessTracepointOffsets;
+use super::tracepoint_format::{tracepoint_exists, TracepointLayouts};
 
 /// Sysmon-compatible event IDs emitted for Linux events.
 const EVENT_ID_PROCESS_CREATE: u16 = 1;
@@ -113,10 +114,14 @@ impl Sensor for EbpfSensor {
         };
         let bytes: &[u8] = override_bytes.as_deref().unwrap_or(super::EBPF_BYTES);
 
-        let process_offsets = ProcessTracepointOffsets::load()
-            .context("failed to resolve process tracepoint layouts")?;
+        validate_object_abi(bytes).context("refusing to load incompatible eBPF object")?;
+        let layouts = TracepointLayouts::probe();
         let mut loader = EbpfLoader::new();
-        loader.override_global("PROCESS_TRACEPOINT_OFFSETS", &process_offsets, true);
+        loader
+            .override_global("PROCESS_TRACEPOINT_OFFSETS", &layouts.process, true)
+            .override_global("NETWORK_TRACEPOINT_OFFSETS", &layouts.network, true)
+            .override_global("FILE_TRACEPOINT_OFFSETS", &layouts.file, true)
+            .override_global("DNS_TRACEPOINT_OFFSETS", &layouts.dns, true);
         let mut bpf = loader
             .load(bytes)
             .context("eBPF object load failed — ensure BTF is available and kernel is 5.8+")?;
@@ -870,30 +875,35 @@ fn attach_optional_tracepoint(
     category: &str,
     name: &str,
 ) -> Result<()> {
-    let available = [
-        "/sys/kernel/tracing/events",
-        "/sys/kernel/debug/tracing/events",
-    ]
-    .into_iter()
-    .map(|root| {
-        std::path::Path::new(root)
-            .join(category)
-            .join(name)
-            .join("id")
-    })
-    .any(|path| path.exists());
-    if available {
-        attach_tracepoint(bpf, program, category, name)
-    } else {
-        warn!(
-            program,
-            category, name, "optional tracepoint is unavailable"
-        );
-        Ok(())
-    }
+    attach_tracepoint(bpf, program, category, name)
 }
 
 fn attach_tracepoint(bpf: &mut Ebpf, program: &str, category: &str, name: &str) -> Result<()> {
+    if let Some(reason) = TracepointLayouts::current_unavailable_reason(program) {
+        record_unavailable_hook(program, reason);
+        warn!(program, category, name, reason, "eBPF hook is unavailable");
+        return Ok(());
+    }
+    if !tracepoint_exists(category, name) {
+        let reason = format!("tracepoint {category}/{name} is unavailable");
+        record_unavailable_hook(program, &reason);
+        warn!(program, category, name, "eBPF hook is unavailable");
+        return Ok(());
+    }
+
+    if let Err(err) = try_attach_tracepoint(bpf, program, category, name) {
+        let reason = format!("{err:#}");
+        record_unavailable_hook(program, &reason);
+        warn!(program, category, name, error = %err, "eBPF hook failed to attach");
+        return Ok(());
+    }
+    for feature in features_for_program(program) {
+        LINUX_EBPF.record_hook(feature, program, true, None);
+    }
+    Ok(())
+}
+
+fn try_attach_tracepoint(bpf: &mut Ebpf, program: &str, category: &str, name: &str) -> Result<()> {
     let prog: &mut TracePoint = bpf
         .program_mut(program)
         .with_context(|| format!("program '{}' not found in eBPF object", program))?
@@ -910,6 +920,19 @@ fn attach_tracepoint(bpf: &mut Ebpf, program: &str, category: &str, name: &str) 
 }
 
 fn attach_kprobe(bpf: &mut Ebpf, program: &str, function: &str) -> Result<()> {
+    if let Err(err) = try_attach_kprobe(bpf, program, function) {
+        let reason = format!("{err:#}");
+        record_unavailable_hook(program, &reason);
+        warn!(program, function, error = %err, "eBPF hook failed to attach");
+        return Ok(());
+    }
+    for feature in features_for_program(program) {
+        LINUX_EBPF.record_hook(feature, program, true, None);
+    }
+    Ok(())
+}
+
+fn try_attach_kprobe(bpf: &mut Ebpf, program: &str, function: &str) -> Result<()> {
     let prog: &mut KProbe = bpf
         .program_mut(program)
         .with_context(|| format!("program '{}' not found in eBPF object", program))?
@@ -923,6 +946,32 @@ fn attach_kprobe(bpf: &mut Ebpf, program: &str, function: &str) -> Result<()> {
         .with_context(|| format!("failed to attach '{}' to {}", program, function))?;
 
     Ok(())
+}
+
+fn record_unavailable_hook(program: &str, reason: &str) {
+    for feature in features_for_program(program) {
+        LINUX_EBPF.record_hook(feature, program, false, Some(reason));
+    }
+}
+
+fn features_for_program(program: &str) -> &'static [&'static str] {
+    match program {
+        "handle_exec"
+        | "handle_fork"
+        | "handle_exit"
+        | "handle_execve"
+        | "handle_execveat"
+        | "handle_clone"
+        | "handle_clone3"
+        | "handle_process_fork"
+        | "handle_process_vfork" => &["process"],
+        "handle_connect" | "handle_connect_exit" | "handle_socket" | "handle_socket_exit" => {
+            &["network"]
+        }
+        "handle_sendto" | "handle_sendmsg" | "handle_sendmmsg" => &["dns"],
+        "handle_file_close" | "handle_file_dup2" | "handle_file_dup3" => &["file", "network"],
+        _ => &["file"],
+    }
 }
 
 #[cfg(test)]

--- a/src/sensor/linux/mod.rs
+++ b/src/sensor/linux/mod.rs
@@ -1,5 +1,6 @@
 //! Linux sensor support.
 
+pub(crate) mod abi;
 pub mod ebpf;
 pub mod events;
 pub mod paths;

--- a/src/sensor/linux/tracepoint_format.rs
+++ b/src/sensor/linux/tracepoint_format.rs
@@ -1,5 +1,11 @@
+//! Runtime tracepoint-layout discovery.
+//!
+//! Tracepoint records are not a kernel ABI. Every offset consumed by the eBPF
+//! programs is resolved from tracefs and patched into the object before load.
+
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 
 use anyhow::{bail, Context, Result};
 
@@ -8,8 +14,10 @@ const TRACEFS_ROOTS: [&str; 2] = [
     "/sys/kernel/debug/tracing/events",
 ];
 
+static LAYOUTS: OnceLock<TracepointLayouts> = OnceLock::new();
+
 #[repr(C)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub(super) struct ProcessTracepointOffsets {
     pub exec_filename: u32,
     pub exec_pid: u32,
@@ -18,41 +26,528 @@ pub(super) struct ProcessTracepointOffsets {
     pub fork_child_pid: u32,
     pub clone_flags: u32,
     pub clone3_args: u32,
+    pub execve_argv: u32,
+    pub execveat_argv: u32,
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(super) struct NetworkTracepointOffsets {
+    pub connect_fd: u32,
+    pub connect_addr: u32,
+    pub connect_ret: u32,
+    pub socket_family: u32,
+    pub socket_type: u32,
+    pub socket_ret: u32,
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(super) struct DnsTracepointOffsets {
+    pub sendto_fd: u32,
+    pub sendto_buf: u32,
+    pub sendto_len: u32,
+    pub sendto_addr: u32,
+    pub sendmsg_fd: u32,
+    pub sendmsg_msg: u32,
+    pub sendmmsg_fd: u32,
+    pub sendmmsg_msgvec: u32,
+    pub sendmmsg_vlen: u32,
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(super) struct FileTracepointOffsets {
+    pub openat_dfd: u32,
+    pub openat_path: u32,
+    pub openat_flags: u32,
+    pub openat_ret: u32,
+    pub open_path: u32,
+    pub open_flags: u32,
+    pub open_ret: u32,
+    pub creat_path: u32,
+    pub creat_ret: u32,
+    pub openat2_dfd: u32,
+    pub openat2_path: u32,
+    pub openat2_how: u32,
+    pub openat2_ret: u32,
+    pub unlinkat_dfd: u32,
+    pub unlinkat_path: u32,
+    pub unlinkat_ret: u32,
+    pub unlink_path: u32,
+    pub unlink_ret: u32,
+    pub renameat_old_dfd: u32,
+    pub renameat_old_path: u32,
+    pub renameat_new_dfd: u32,
+    pub renameat_new_path: u32,
+    pub renameat_ret: u32,
+    pub renameat2_old_dfd: u32,
+    pub renameat2_old_path: u32,
+    pub renameat2_new_dfd: u32,
+    pub renameat2_new_path: u32,
+    pub renameat2_ret: u32,
+    pub rename_old_path: u32,
+    pub rename_new_path: u32,
+    pub rename_ret: u32,
+    pub mkdir_path: u32,
+    pub mkdir_ret: u32,
+    pub mkdirat_dfd: u32,
+    pub mkdirat_path: u32,
+    pub mkdirat_ret: u32,
+    pub rmdir_path: u32,
+    pub rmdir_ret: u32,
+    pub close_fd: u32,
+    pub dup2_old_fd: u32,
+    pub dup2_new_fd: u32,
+    pub dup3_old_fd: u32,
+    pub dup3_new_fd: u32,
 }
 
 unsafe impl aya::Pod for ProcessTracepointOffsets {}
+unsafe impl aya::Pod for NetworkTracepointOffsets {}
+unsafe impl aya::Pod for DnsTracepointOffsets {}
+unsafe impl aya::Pod for FileTracepointOffsets {}
 
-impl ProcessTracepointOffsets {
-    pub(super) fn load() -> Result<Self> {
-        let exec = read_format("sched", "sched_process_exec")?;
-        let fork = read_format("sched", "sched_process_fork")?;
-        let clone = read_format("syscalls", "sys_enter_clone")?;
-        let clone3 = find_format("syscalls", "sys_enter_clone3")
-            .map(std::fs::read_to_string)
-            .transpose()
-            .context("failed to read syscalls/sys_enter_clone3 format")?;
+#[derive(Debug, Default)]
+pub(super) struct TracepointLayouts {
+    pub process: ProcessTracepointOffsets,
+    pub network: NetworkTracepointOffsets,
+    pub dns: DnsTracepointOffsets,
+    pub file: FileTracepointOffsets,
+    unavailable: HashMap<&'static str, String>,
+}
 
-        Self::parse(&exec, &fork, &clone, clone3.as_deref())
+impl TracepointLayouts {
+    pub(super) fn probe() -> &'static Self {
+        LAYOUTS.get_or_init(|| {
+            let mut layouts = Self::default();
+            layouts.probe_process();
+            layouts.probe_network();
+            layouts.probe_dns();
+            layouts.probe_file();
+            layouts
+        })
     }
 
-    fn parse(exec: &str, fork: &str, clone: &str, clone3: Option<&str>) -> Result<Self> {
-        let exec = parse_fields(exec)?;
-        let fork = parse_fields(fork)?;
-        let clone = parse_fields(clone)?;
-        let clone3 = clone3.map(parse_fields).transpose()?;
+    pub(super) fn current_unavailable_reason(program: &str) -> Option<&'static str> {
+        LAYOUTS
+            .get()
+            .and_then(|layouts| layouts.unavailable_reason(program))
+    }
 
-        Ok(Self {
-            exec_filename: required_offset(&exec, "filename", 4)?,
-            exec_pid: required_offset(&exec, "pid", 4)?,
-            exec_old_pid: required_offset(&exec, "old_pid", 4)?,
-            fork_parent_pid: required_offset(&fork, "parent_pid", 4)?,
-            fork_child_pid: required_offset(&fork, "child_pid", 4)?,
-            clone_flags: required_one_of(&clone, &["clone_flags", "flags"], 8)?,
-            clone3_args: match clone3 {
-                Some(fields) => required_one_of(&fields, &["uargs", "cl_args"], 8)?,
-                None => 0,
-            },
-        })
+    pub(super) fn unavailable_reason(&self, program: &str) -> Option<&str> {
+        self.unavailable.get(program).map(String::as_str)
+    }
+
+    fn fields(
+        &mut self,
+        program: &'static str,
+        category: &str,
+        name: &str,
+        specs: &[FieldSpec<'_>],
+    ) -> Option<Vec<u32>> {
+        match resolve_fields(category, name, specs) {
+            Ok(offsets) => Some(offsets),
+            Err(err) => {
+                self.unavailable
+                    .insert(program, format!("{category}/{name}: {err:#}"));
+                None
+            }
+        }
+    }
+
+    fn probe_process(&mut self) {
+        if let Some(v) = self.fields(
+            "handle_exec",
+            "sched",
+            "sched_process_exec",
+            &[
+                FieldSpec::one("filename", 4),
+                FieldSpec::one("pid", 4),
+                FieldSpec::one("old_pid", 4),
+            ],
+        ) {
+            self.process.exec_filename = v[0];
+            self.process.exec_pid = v[1];
+            self.process.exec_old_pid = v[2];
+        }
+        if let Some(v) = self.fields(
+            "handle_fork",
+            "sched",
+            "sched_process_fork",
+            &[
+                FieldSpec::one("parent_pid", 4),
+                FieldSpec::one("child_pid", 4),
+            ],
+        ) {
+            self.process.fork_parent_pid = v[0];
+            self.process.fork_child_pid = v[1];
+        }
+        if let Some(v) = self.fields(
+            "handle_clone",
+            "syscalls",
+            "sys_enter_clone",
+            &[FieldSpec::either(&["clone_flags", "flags"], 8)],
+        ) {
+            self.process.clone_flags = v[0];
+        }
+        if let Some(v) = self.fields(
+            "handle_clone3",
+            "syscalls",
+            "sys_enter_clone3",
+            &[FieldSpec::either(&["uargs", "cl_args"], 8)],
+        ) {
+            self.process.clone3_args = v[0];
+        }
+        if let Some(v) = self.fields(
+            "handle_execve",
+            "syscalls",
+            "sys_enter_execve",
+            &[FieldSpec::one("argv", 8)],
+        ) {
+            self.process.execve_argv = v[0];
+        }
+        if let Some(v) = self.fields(
+            "handle_execveat",
+            "syscalls",
+            "sys_enter_execveat",
+            &[FieldSpec::one("argv", 8)],
+        ) {
+            self.process.execveat_argv = v[0];
+        }
+    }
+
+    fn probe_network(&mut self) {
+        if let Some(v) = self.fields(
+            "handle_connect",
+            "syscalls",
+            "sys_enter_connect",
+            &[FieldSpec::one("fd", 8), FieldSpec::one("uservaddr", 8)],
+        ) {
+            self.network.connect_fd = v[0];
+            self.network.connect_addr = v[1];
+        }
+        if let Some(v) = self.fields(
+            "handle_connect_exit",
+            "syscalls",
+            "sys_exit_connect",
+            &[FieldSpec::one("ret", 8)],
+        ) {
+            self.network.connect_ret = v[0];
+        }
+        if let Some(v) = self.fields(
+            "handle_socket",
+            "syscalls",
+            "sys_enter_socket",
+            &[FieldSpec::one("family", 8), FieldSpec::one("type", 8)],
+        ) {
+            self.network.socket_family = v[0];
+            self.network.socket_type = v[1];
+        }
+        if let Some(v) = self.fields(
+            "handle_socket_exit",
+            "syscalls",
+            "sys_exit_socket",
+            &[FieldSpec::one("ret", 8)],
+        ) {
+            self.network.socket_ret = v[0];
+        }
+    }
+
+    fn probe_dns(&mut self) {
+        if let Some(v) = self.fields(
+            "handle_sendto",
+            "syscalls",
+            "sys_enter_sendto",
+            &[
+                FieldSpec::one("fd", 8),
+                FieldSpec::either(&["buff", "buf"], 8),
+                FieldSpec::one("len", 8),
+                FieldSpec::one("addr", 8),
+            ],
+        ) {
+            self.dns.sendto_fd = v[0];
+            self.dns.sendto_buf = v[1];
+            self.dns.sendto_len = v[2];
+            self.dns.sendto_addr = v[3];
+        }
+        if let Some(v) = self.fields(
+            "handle_sendmsg",
+            "syscalls",
+            "sys_enter_sendmsg",
+            &[FieldSpec::one("fd", 8), FieldSpec::one("msg", 8)],
+        ) {
+            self.dns.sendmsg_fd = v[0];
+            self.dns.sendmsg_msg = v[1];
+        }
+        if let Some(v) = self.fields(
+            "handle_sendmmsg",
+            "syscalls",
+            "sys_enter_sendmmsg",
+            &[
+                FieldSpec::one("fd", 8),
+                FieldSpec::either(&["msg", "mmsg"], 8),
+                FieldSpec::one("vlen", 8),
+            ],
+        ) {
+            self.dns.sendmmsg_fd = v[0];
+            self.dns.sendmmsg_msgvec = v[1];
+            self.dns.sendmmsg_vlen = v[2];
+        }
+    }
+
+    #[allow(clippy::too_many_lines)]
+    fn probe_file(&mut self) {
+        macro_rules! fields {
+            ($program:literal, $name:literal, [$($field:expr),+ $(,)?]) => { self.fields($program, "syscalls", $name, &[$($field),+]) };
+        }
+        if let Some(v) = fields!(
+            "handle_openat",
+            "sys_enter_openat",
+            [
+                FieldSpec::one("dfd", 8),
+                FieldSpec::one("filename", 8),
+                FieldSpec::one("flags", 8)
+            ]
+        ) {
+            self.file.openat_dfd = v[0];
+            self.file.openat_path = v[1];
+            self.file.openat_flags = v[2];
+        }
+        if let Some(v) = fields!(
+            "handle_openat_exit",
+            "sys_exit_openat",
+            [FieldSpec::one("ret", 8)]
+        ) {
+            self.file.openat_ret = v[0];
+        }
+        if let Some(v) = fields!(
+            "handle_open",
+            "sys_enter_open",
+            [FieldSpec::one("filename", 8), FieldSpec::one("flags", 8)]
+        ) {
+            self.file.open_path = v[0];
+            self.file.open_flags = v[1];
+        }
+        if let Some(v) = fields!(
+            "handle_open_exit",
+            "sys_exit_open",
+            [FieldSpec::one("ret", 8)]
+        ) {
+            self.file.open_ret = v[0];
+        }
+        if let Some(v) = fields!(
+            "handle_creat",
+            "sys_enter_creat",
+            [FieldSpec::either(&["pathname", "filename"], 8)]
+        ) {
+            self.file.creat_path = v[0];
+        }
+        if let Some(v) = fields!(
+            "handle_creat_exit",
+            "sys_exit_creat",
+            [FieldSpec::one("ret", 8)]
+        ) {
+            self.file.creat_ret = v[0];
+        }
+        if let Some(v) = fields!(
+            "handle_openat2",
+            "sys_enter_openat2",
+            [
+                FieldSpec::one("dfd", 8),
+                FieldSpec::one("filename", 8),
+                FieldSpec::one("how", 8)
+            ]
+        ) {
+            self.file.openat2_dfd = v[0];
+            self.file.openat2_path = v[1];
+            self.file.openat2_how = v[2];
+        }
+        if let Some(v) = fields!(
+            "handle_openat2_exit",
+            "sys_exit_openat2",
+            [FieldSpec::one("ret", 8)]
+        ) {
+            self.file.openat2_ret = v[0];
+        }
+        if let Some(v) = fields!(
+            "handle_unlinkat",
+            "sys_enter_unlinkat",
+            [FieldSpec::one("dfd", 8), FieldSpec::one("pathname", 8)]
+        ) {
+            self.file.unlinkat_dfd = v[0];
+            self.file.unlinkat_path = v[1];
+        }
+        if let Some(v) = fields!(
+            "handle_unlinkat_exit",
+            "sys_exit_unlinkat",
+            [FieldSpec::one("ret", 8)]
+        ) {
+            self.file.unlinkat_ret = v[0];
+        }
+        if let Some(v) = fields!(
+            "handle_unlink",
+            "sys_enter_unlink",
+            [FieldSpec::one("pathname", 8)]
+        ) {
+            self.file.unlink_path = v[0];
+        }
+        if let Some(v) = fields!(
+            "handle_unlink_exit",
+            "sys_exit_unlink",
+            [FieldSpec::one("ret", 8)]
+        ) {
+            self.file.unlink_ret = v[0];
+        }
+        if let Some(v) = fields!(
+            "handle_renameat",
+            "sys_enter_renameat",
+            [
+                FieldSpec::one("olddfd", 8),
+                FieldSpec::one("oldname", 8),
+                FieldSpec::one("newdfd", 8),
+                FieldSpec::one("newname", 8)
+            ]
+        ) {
+            self.file.renameat_old_dfd = v[0];
+            self.file.renameat_old_path = v[1];
+            self.file.renameat_new_dfd = v[2];
+            self.file.renameat_new_path = v[3];
+        }
+        if let Some(v) = fields!(
+            "handle_renameat_exit",
+            "sys_exit_renameat",
+            [FieldSpec::one("ret", 8)]
+        ) {
+            self.file.renameat_ret = v[0];
+        }
+        if let Some(v) = fields!(
+            "handle_renameat2",
+            "sys_enter_renameat2",
+            [
+                FieldSpec::one("olddfd", 8),
+                FieldSpec::one("oldname", 8),
+                FieldSpec::one("newdfd", 8),
+                FieldSpec::one("newname", 8)
+            ]
+        ) {
+            self.file.renameat2_old_dfd = v[0];
+            self.file.renameat2_old_path = v[1];
+            self.file.renameat2_new_dfd = v[2];
+            self.file.renameat2_new_path = v[3];
+        }
+        if let Some(v) = fields!(
+            "handle_renameat2_exit",
+            "sys_exit_renameat2",
+            [FieldSpec::one("ret", 8)]
+        ) {
+            self.file.renameat2_ret = v[0];
+        }
+        if let Some(v) = fields!(
+            "handle_rename",
+            "sys_enter_rename",
+            [FieldSpec::one("oldname", 8), FieldSpec::one("newname", 8)]
+        ) {
+            self.file.rename_old_path = v[0];
+            self.file.rename_new_path = v[1];
+        }
+        if let Some(v) = fields!(
+            "handle_rename_exit",
+            "sys_exit_rename",
+            [FieldSpec::one("ret", 8)]
+        ) {
+            self.file.rename_ret = v[0];
+        }
+        if let Some(v) = fields!(
+            "handle_mkdir",
+            "sys_enter_mkdir",
+            [FieldSpec::one("pathname", 8)]
+        ) {
+            self.file.mkdir_path = v[0];
+        }
+        if let Some(v) = fields!(
+            "handle_mkdir_exit",
+            "sys_exit_mkdir",
+            [FieldSpec::one("ret", 8)]
+        ) {
+            self.file.mkdir_ret = v[0];
+        }
+        if let Some(v) = fields!(
+            "handle_mkdirat",
+            "sys_enter_mkdirat",
+            [FieldSpec::one("dfd", 8), FieldSpec::one("pathname", 8)]
+        ) {
+            self.file.mkdirat_dfd = v[0];
+            self.file.mkdirat_path = v[1];
+        }
+        if let Some(v) = fields!(
+            "handle_mkdirat_exit",
+            "sys_exit_mkdirat",
+            [FieldSpec::one("ret", 8)]
+        ) {
+            self.file.mkdirat_ret = v[0];
+        }
+        if let Some(v) = fields!(
+            "handle_rmdir",
+            "sys_enter_rmdir",
+            [FieldSpec::one("pathname", 8)]
+        ) {
+            self.file.rmdir_path = v[0];
+        }
+        if let Some(v) = fields!(
+            "handle_rmdir_exit",
+            "sys_exit_rmdir",
+            [FieldSpec::one("ret", 8)]
+        ) {
+            self.file.rmdir_ret = v[0];
+        }
+        if let Some(v) = fields!(
+            "handle_file_close",
+            "sys_enter_close",
+            [FieldSpec::one("fd", 8)]
+        ) {
+            self.file.close_fd = v[0];
+        }
+        if let Some(v) = fields!(
+            "handle_file_dup2",
+            "sys_enter_dup2",
+            [FieldSpec::one("oldfd", 8), FieldSpec::one("newfd", 8)]
+        ) {
+            self.file.dup2_old_fd = v[0];
+            self.file.dup2_new_fd = v[1];
+        }
+        if let Some(v) = fields!(
+            "handle_file_dup3",
+            "sys_enter_dup3",
+            [FieldSpec::one("oldfd", 8), FieldSpec::one("newfd", 8)]
+        ) {
+            self.file.dup3_old_fd = v[0];
+            self.file.dup3_new_fd = v[1];
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct FieldSpec<'a> {
+    name: &'a str,
+    alternate: Option<&'a str>,
+    size: u32,
+}
+
+impl<'a> FieldSpec<'a> {
+    const fn one(name: &'a str, size: u32) -> Self {
+        Self {
+            name,
+            alternate: None,
+            size,
+        }
+    }
+    const fn either(names: &'a [&'a str], size: u32) -> Self {
+        Self {
+            name: names[0],
+            alternate: Some(names[1]),
+            size,
+        }
     }
 }
 
@@ -62,24 +557,34 @@ struct TracepointField {
     size: u32,
 }
 
-fn find_format(category: &str, name: &str) -> Option<PathBuf> {
+pub(super) fn tracepoint_exists(category: &str, name: &str) -> bool {
+    find_file(category, name, "id").is_some()
+}
+
+fn find_file(category: &str, name: &str, file: &str) -> Option<PathBuf> {
     TRACEFS_ROOTS
         .iter()
         .map(Path::new)
-        .map(|root| root.join(category).join(name).join("format"))
+        .map(|root| root.join(category).join(name).join(file))
         .find(|path| path.exists())
 }
 
 fn read_format(category: &str, name: &str) -> Result<String> {
-    let path = find_format(category, name)
-        .with_context(|| format!("tracepoint {category}/{name} is unavailable"))?;
+    let path = find_file(category, name, "format").with_context(|| "tracepoint is unavailable")?;
     std::fs::read_to_string(&path)
         .with_context(|| format!("failed to read tracepoint format from {}", path.display()))
 }
 
+fn resolve_fields(category: &str, name: &str, specs: &[FieldSpec<'_>]) -> Result<Vec<u32>> {
+    let fields = parse_fields(&read_format(category, name)?)?;
+    specs
+        .iter()
+        .map(|spec| required_spec(&fields, spec))
+        .collect()
+}
+
 fn parse_fields(format: &str) -> Result<HashMap<String, TracepointField>> {
     let mut fields = HashMap::new();
-
     for line in format.lines().map(str::trim) {
         let Some(rest) = line.strip_prefix("field:") else {
             continue;
@@ -87,7 +592,7 @@ fn parse_fields(format: &str) -> Result<HashMap<String, TracepointField>> {
         let mut parts = rest.split(';');
         let declaration = parts.next().unwrap_or_default().trim();
         let Some(raw_name) = declaration.split_whitespace().last() else {
-            bail!("tracepoint field has no name: {line}");
+            bail!("tracepoint field has no name: {line}")
         };
         let name = raw_name
             .trim_start_matches('*')
@@ -97,7 +602,6 @@ fn parse_fields(format: &str) -> Result<HashMap<String, TracepointField>> {
         if name.is_empty() {
             bail!("tracepoint field has an unsupported declaration: {line}");
         }
-
         let mut offset = None;
         let mut size = None;
         for part in parts {
@@ -118,106 +622,79 @@ fn parse_fields(format: &str) -> Result<HashMap<String, TracepointField>> {
                 );
             }
         }
-
-        let field = TracepointField {
-            offset: offset.with_context(|| format!("field {name} has no offset"))?,
-            size: size.with_context(|| format!("field {name} has no size"))?,
-        };
-        fields.insert(name.to_string(), field);
+        fields.insert(
+            name.to_string(),
+            TracepointField {
+                offset: offset.with_context(|| format!("field {name} has no offset"))?,
+                size: size.with_context(|| format!("field {name} has no size"))?,
+            },
+        );
     }
-
     if fields.is_empty() {
         bail!("tracepoint format contains no fields");
     }
     Ok(fields)
 }
 
-fn required_offset(
-    fields: &HashMap<String, TracepointField>,
-    name: &str,
-    expected_size: u32,
-) -> Result<u32> {
-    let field = fields
-        .get(name)
-        .with_context(|| format!("required tracepoint field {name} is absent"))?;
-    if field.size != expected_size {
-        bail!(
-            "tracepoint field {name} has unsupported size {}, expected {expected_size}",
-            field.size
-        );
-    }
-    Ok(field.offset)
-}
-
 fn required_one_of(
     fields: &HashMap<String, TracepointField>,
     names: &[&str],
-    expected_size: u32,
+    size: u32,
 ) -> Result<u32> {
     for name in names {
-        if fields.contains_key(*name) {
-            return required_offset(fields, name, expected_size);
+        if let Some(field) = fields.get(*name) {
+            if field.size != size {
+                bail!(
+                    "tracepoint field {name} has unsupported size {}, expected {size}",
+                    field.size
+                );
+            }
+            return Ok(field.offset);
         }
     }
     bail!("required tracepoint field {} is absent", names.join(" or "))
+}
+
+fn required_spec(fields: &HashMap<String, TracepointField>, spec: &FieldSpec<'_>) -> Result<u32> {
+    match spec.alternate {
+        Some(alternate) => required_one_of(fields, &[spec.name, alternate], spec.size),
+        None => required_one_of(fields, &[spec.name], spec.size),
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    const EXEC: &str = r#"
-field:unsigned short common_type; offset:0; size:2; signed:0;
-field:__data_loc char[] filename; offset:8; size:4; signed:0;
-field:pid_t pid; offset:12; size:4; signed:1;
-field:pid_t old_pid; offset:16; size:4; signed:1;
-"#;
-
-    const CLONE: &str = r#"
-field:int __syscall_nr; offset:8; size:4; signed:1;
-field:unsigned long clone_flags; offset:16; size:8; signed:0;
-"#;
-
-    const CLONE3: &str = r#"
-field:struct clone_args * uargs; offset:16; size:8; signed:0;
-"#;
-
     #[test]
-    fn parses_data_loc_fork_layout() {
-        let fork = r#"
-field:__data_loc char[] parent_comm; offset:8; size:4; signed:0;
-field:pid_t parent_pid; offset:12; size:4; signed:1;
-field:__data_loc char[] child_comm; offset:16; size:4; signed:0;
-field:pid_t child_pid; offset:20; size:4; signed:1;
+    fn parses_fixed_and_data_loc_fields_by_name() {
+        let format = r#"
+field:char parent_comm[16]; offset:8; size:16; signed:1;
+field:pid_t parent_pid; offset:24; size:4; signed:1;
+field:__data_loc char[] child_comm; offset:28; size:4; signed:0;
+field:pid_t child_pid; offset:32; size:4; signed:1;
 "#;
-        let offsets = ProcessTracepointOffsets::parse(EXEC, fork, CLONE, Some(CLONE3)).unwrap();
-        assert_eq!(offsets.fork_parent_pid, 12);
-        assert_eq!(offsets.fork_child_pid, 20);
+        let fields = parse_fields(format).unwrap();
+        assert_eq!(required_one_of(&fields, &["parent_pid"], 4).unwrap(), 24);
+        assert_eq!(required_one_of(&fields, &["child_pid"], 4).unwrap(), 32);
     }
 
     #[test]
-    fn parses_fixed_array_fork_layout() {
-        let fork = r#"
-field:char parent_comm[16]; offset:8; size:16; signed:1;
-field:pid_t parent_pid; offset:24; size:4; signed:1;
-field:char child_comm[16]; offset:28; size:16; signed:1;
-field:pid_t child_pid; offset:44; size:4; signed:1;
-"#;
-        let offsets = ProcessTracepointOffsets::parse(EXEC, fork, CLONE, None).unwrap();
-        assert_eq!(offsets.fork_parent_pid, 24);
-        assert_eq!(offsets.fork_child_pid, 44);
-        assert_eq!(offsets.clone3_args, 0);
+    fn accepts_field_aliases() {
+        let fields =
+            parse_fields("field:unsigned long flags; offset:16; size:8; signed:0;").unwrap();
+        assert_eq!(
+            required_one_of(&fields, &["clone_flags", "flags"], 8).unwrap(),
+            16
+        );
     }
 
     #[test]
     fn rejects_wrong_field_size() {
-        let fork = r#"
-field:pid_t parent_pid; offset:12; size:8; signed:1;
-field:pid_t child_pid; offset:20; size:4; signed:1;
-"#;
-        let err = ProcessTracepointOffsets::parse(EXEC, fork, CLONE, None).unwrap_err();
-        assert!(err
+        let fields = parse_fields("field:pid_t pid; offset:12; size:8; signed:1;").unwrap();
+        assert!(required_one_of(&fields, &["pid"], 4)
+            .unwrap_err()
             .to_string()
-            .contains("parent_pid has unsupported size 8"));
+            .contains("unsupported size 8"));
     }
 }

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -27,9 +27,9 @@ use crate::utils::LogRateLimiter;
 
 pub use snapshot::{
     snapshot_path, spawn_reporter, write_final_snapshot, ChannelSnapshot, EtwDecodeFailureSnapshot,
-    EtwDecodeSnapshot, FileAttributionSnapshot, LinuxEbpfFamilySnapshot, LinuxEbpfSnapshot,
-    ProcessCommandLineSnapshot, RegistrySnapshot, SensorEventCategorySnapshot, TelemetrySnapshot,
-    SNAPSHOT_FILE_NAME,
+    EtwDecodeSnapshot, FileAttributionSnapshot, LinuxEbpfFamilySnapshot, LinuxEbpfFeatureSnapshot,
+    LinuxEbpfSnapshot, ProcessCommandLineSnapshot, RegistrySnapshot, SensorEventCategorySnapshot,
+    TelemetrySnapshot, SNAPSHOT_FILE_NAME,
 };
 
 use crate::models::EventCategory;
@@ -119,6 +119,7 @@ impl LinuxEbpfFamilyCounters {
 pub struct LinuxEbpfCounters {
     active: AtomicBool,
     families: [LinuxEbpfFamilyCounters; 4],
+    features: Mutex<Vec<LinuxEbpfFeatureSnapshot>>,
 }
 
 pub static LINUX_EBPF: LinuxEbpfCounters = LinuxEbpfCounters::new();
@@ -133,11 +134,52 @@ impl LinuxEbpfCounters {
                 LinuxEbpfFamilyCounters::new(),
                 LinuxEbpfFamilyCounters::new(),
             ],
+            features: Mutex::new(Vec::new()),
         }
     }
 
     pub fn activate(&self) {
+        let mut features = self
+            .features
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        for feature in &mut *features {
+            feature.active = linux_feature_is_active(feature);
+        }
         self.active.store(true, Ordering::Release);
+    }
+
+    /// Record one attempted hook so snapshots expose both active coverage and
+    /// named, family-local degradation.
+    pub fn record_hook(
+        &self,
+        feature: &str,
+        hook: &str,
+        attached: bool,
+        unavailable_reason: Option<&str>,
+    ) {
+        let mut features = self
+            .features
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let state = match features.iter_mut().find(|state| state.feature == feature) {
+            Some(state) => state,
+            None => {
+                features.push(LinuxEbpfFeatureSnapshot {
+                    feature: feature.to_string(),
+                    active: false,
+                    attached_hooks: Vec::new(),
+                    unavailable_hooks: Vec::new(),
+                });
+                features.last_mut().expect("feature was just inserted")
+            }
+        };
+        if attached {
+            state.attached_hooks.push(hook.to_string());
+        } else {
+            let reason = unavailable_reason.unwrap_or("unavailable");
+            state.unavailable_hooks.push(format!("{hook}: {reason}"));
+        }
     }
 
     pub fn set_kernel_sample(&self, family: LinuxEbpfFamily, sample: LinuxEbpfKernelSample) {
@@ -209,6 +251,12 @@ impl LinuxEbpfCounters {
         }
 
         Some(LinuxEbpfSnapshot {
+            abi_version: crate::sensor::linux::abi::LINUX_EBPF_ABI_VERSION,
+            features: self
+                .features
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .clone(),
             families: LinuxEbpfFamily::ALL
                 .into_iter()
                 .map(|family| {
@@ -241,6 +289,10 @@ impl LinuxEbpfCounters {
     #[cfg(test)]
     pub fn reset(&self) {
         self.active.store(false, Ordering::Relaxed);
+        self.features
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clear();
         for counters in &self.families {
             counters.kernel_seen.store(0, Ordering::Relaxed);
             counters.kernel_submitted.store(0, Ordering::Relaxed);
@@ -255,6 +307,34 @@ impl LinuxEbpfCounters {
             counters.userspace_dropped.store(0, Ordering::Relaxed);
             counters.unresolved_file_events.store(0, Ordering::Relaxed);
         }
+    }
+}
+
+fn linux_feature_is_active(feature: &LinuxEbpfFeatureSnapshot) -> bool {
+    let attached = |hook: &str| feature.attached_hooks.iter().any(|value| value == hook);
+    match feature.feature.as_str() {
+        "process" => attached("handle_exec"),
+        "network" => attached("handle_connect") && attached("handle_connect_exit"),
+        "dns" => ["handle_sendto", "handle_sendmsg", "handle_sendmmsg"]
+            .into_iter()
+            .any(attached),
+        "file" => [
+            ("handle_openat", "handle_openat_exit"),
+            ("handle_open", "handle_open_exit"),
+            ("handle_creat", "handle_creat_exit"),
+            ("handle_openat2", "handle_openat2_exit"),
+            ("handle_unlinkat", "handle_unlinkat_exit"),
+            ("handle_unlink", "handle_unlink_exit"),
+            ("handle_renameat", "handle_renameat_exit"),
+            ("handle_renameat2", "handle_renameat2_exit"),
+            ("handle_rename", "handle_rename_exit"),
+            ("handle_mkdir", "handle_mkdir_exit"),
+            ("handle_mkdirat", "handle_mkdirat_exit"),
+            ("handle_rmdir", "handle_rmdir_exit"),
+        ]
+        .into_iter()
+        .any(|(entry, exit)| attached(entry) && attached(exit)),
+        _ => false,
     }
 }
 
@@ -1154,6 +1234,31 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
+
+    fn linux_feature(feature: &str, hooks: &[&str]) -> LinuxEbpfFeatureSnapshot {
+        LinuxEbpfFeatureSnapshot {
+            feature: feature.to_string(),
+            active: false,
+            attached_hooks: hooks.iter().map(|hook| (*hook).to_string()).collect(),
+            unavailable_hooks: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn paired_linux_features_require_both_sides_of_a_hook() {
+        assert!(!linux_feature_is_active(&linux_feature(
+            "network",
+            &["handle_connect_exit"]
+        )));
+        assert!(linux_feature_is_active(&linux_feature(
+            "network",
+            &["handle_connect", "handle_connect_exit"]
+        )));
+        assert!(linux_feature_is_active(&linux_feature(
+            "file",
+            &["handle_unlinkat", "handle_unlinkat_exit"]
+        )));
+    }
 
     #[test]
     fn process_command_line_fidelity_counts_hits_and_misses() {

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -38,6 +38,13 @@ use crate::sensor::SensorEvent;
 /// Tracing target for pipeline telemetry accounting.
 pub const TARGET_TELEMETRY: &str = "telemetry";
 
+/// Version shared by Linux eBPF userspace telemetry and the object loader.
+///
+/// Bump this whenever a ring-buffer event layout or loader-patched global
+/// changes. This lives outside the Linux-only sensor module because telemetry
+/// snapshots are compiled on every supported platform.
+pub(crate) const LINUX_EBPF_ABI_VERSION: u32 = 1;
+
 /// Linux ring-buffer program families, in snapshot order.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LinuxEbpfFamily {
@@ -251,7 +258,7 @@ impl LinuxEbpfCounters {
         }
 
         Some(LinuxEbpfSnapshot {
-            abi_version: crate::sensor::linux::abi::LINUX_EBPF_ABI_VERSION,
+            abi_version: LINUX_EBPF_ABI_VERSION,
             features: self
                 .features
                 .lock()

--- a/src/telemetry/snapshot.rs
+++ b/src/telemetry/snapshot.rs
@@ -370,7 +370,24 @@ impl LinuxEbpfFamilySnapshot {
 /// Linux eBPF pipeline accounting, absent when that sensor did not run.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LinuxEbpfSnapshot {
+    /// ABI version shared by the loader and the object that was loaded.
+    #[serde(default)]
+    pub abi_version: u32,
+    /// Runtime hook availability grouped by telemetry family.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub features: Vec<LinuxEbpfFeatureSnapshot>,
     pub families: Vec<LinuxEbpfFamilySnapshot>,
+}
+
+/// Runtime capability state for one Linux telemetry family.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LinuxEbpfFeatureSnapshot {
+    pub feature: String,
+    pub active: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub attached_hooks: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub unavailable_hooks: Vec<String>,
 }
 
 impl LinuxEbpfSnapshot {
@@ -706,6 +723,29 @@ mod tests {
         };
 
         assert_eq!(fidelity.capture_rate_pct(), 75.0);
+    }
+
+    #[test]
+    fn linux_feature_set_is_serialized_with_the_abi() {
+        let snapshot = LinuxEbpfSnapshot {
+            abi_version: 1,
+            features: vec![LinuxEbpfFeatureSnapshot {
+                feature: "dns".to_string(),
+                active: true,
+                attached_hooks: vec!["handle_sendto".to_string()],
+                unavailable_hooks: vec!["handle_sendmmsg: unavailable".to_string()],
+            }],
+            families: Vec::new(),
+        };
+
+        let json = serde_json::to_value(snapshot).unwrap();
+        assert_eq!(json["abi_version"], 1);
+        assert_eq!(json["features"][0]["feature"], "dns");
+        assert_eq!(json["features"][0]["active"], true);
+        assert_eq!(
+            json["features"][0]["unavailable_hooks"][0],
+            "handle_sendmmsg: unavailable"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #421

## Summary

- resolve every eBPF tracepoint field offset from the running kernel's tracefs format files and patch family-specific offset tables before program load
- embed and validate a versioned eBPF/userspace ABI before any program attaches
- probe and attach hooks independently so unavailable or rejected hooks degrade only process, network, file, or DNS telemetry
- persist the active/degraded hook set and ABI version in `telemetry.json`, with named `rustinel doctor` capability diagnostics
- document ABI mismatch recovery and per-feature degradation

## Validation

- `cargo +nightly build --release --bin rustinel-ebpf` (from `ebpf/`)
- `cargo fmt --all -- --check`
- `cargo +nightly fmt --all --manifest-path ebpf/Cargo.toml -- --check`
- `cargo clippy --locked --all-targets -- -D clippy::all`
- `cargo test --locked -- --skip ioc::hash::tests::file_changed_during_hashing_is_not_cached --skip scanner::tests::test_yara_scan_cache_miss_on_identity_change`
- ABI, tracepoint parser, telemetry JSON, and doctor capability tests run separately and pass

The two skipped tests are unrelated inode/metadata identity tests that fail independently in this local ext filesystem because identities are immediately reused; 413 unit tests and the complete integration/doc-test set pass.

Privileged live-kernel attachment still needs validation on the project's lowest supported kernel and a current kernel.
