### PR TITLE
feat(linux-ebpf): resolve process identity from runtime BTF

### DIFF
--- a/compatibility/field-availability.json
+++ b/compatibility/field-availability.json
@@ -2621,8 +2621,117 @@
       "action": "start",
       "provider": "ebpf",
       "source": "execve tracepoints",
-      "field": "User",
+      "field": "RealUserId",
       "availability": "always"
+    },
+    {
+      "platform": "linux",
+      "category": "process_creation",
+      "event_id": 1,
+      "action": "start",
+      "provider": "ebpf",
+      "source": "execve tracepoints",
+      "field": "RealGroupId",
+      "availability": "always"
+    },
+    {
+      "platform": "linux",
+      "category": "process_creation",
+      "event_id": 1,
+      "action": "start",
+      "provider": "ebpf",
+      "source": "execve tracepoints",
+      "field": "EffectiveUserId",
+      "availability": "conditional",
+      "reason": "runtime BTF resolves this field and the kernel read succeeds"
+    },
+    {
+      "platform": "linux",
+      "category": "process_creation",
+      "event_id": 1,
+      "action": "start",
+      "provider": "ebpf",
+      "source": "execve tracepoints",
+      "field": "EffectiveGroupId",
+      "availability": "conditional",
+      "reason": "runtime BTF resolves this field and the kernel read succeeds"
+    },
+    {
+      "platform": "linux",
+      "category": "process_creation",
+      "event_id": 1,
+      "action": "start",
+      "provider": "ebpf",
+      "source": "execve tracepoints",
+      "field": "MountNamespace",
+      "availability": "conditional",
+      "reason": "runtime BTF resolves this field and the kernel read succeeds"
+    },
+    {
+      "platform": "linux",
+      "category": "process_creation",
+      "event_id": 1,
+      "action": "start",
+      "provider": "ebpf",
+      "source": "execve tracepoints",
+      "field": "PidNamespace",
+      "availability": "conditional",
+      "reason": "runtime BTF resolves this field and the kernel read succeeds"
+    },
+    {
+      "platform": "linux",
+      "category": "process_creation",
+      "event_id": 1,
+      "action": "start",
+      "provider": "ebpf",
+      "source": "execve tracepoints",
+      "field": "NetworkNamespace",
+      "availability": "conditional",
+      "reason": "runtime BTF resolves this field and the kernel read succeeds"
+    },
+    {
+      "platform": "linux",
+      "category": "process_creation",
+      "event_id": 1,
+      "action": "start",
+      "provider": "ebpf",
+      "source": "execve tracepoints",
+      "field": "SessionId",
+      "availability": "conditional",
+      "reason": "runtime BTF resolves this field and the kernel read succeeds"
+    },
+    {
+      "platform": "linux",
+      "category": "process_creation",
+      "event_id": 1,
+      "action": "start",
+      "provider": "ebpf",
+      "source": "execve tracepoints",
+      "field": "KernelStartBoottime",
+      "availability": "conditional",
+      "reason": "runtime BTF resolves this field and the kernel read succeeds"
+    },
+    {
+      "platform": "linux",
+      "category": "process_creation",
+      "event_id": 1,
+      "action": "start",
+      "provider": "ebpf",
+      "source": "execve tracepoints",
+      "field": "ControllingTty",
+      "availability": "conditional",
+      "reason": "runtime BTF resolves terminal fields and the process has a controlling terminal"
+    },
+    {
+      "platform": "linux",
+      "category": "process_creation",
+      "event_id": 1,
+      "action": "start",
+      "provider": "ebpf",
+      "source": "execve tracepoints",
+      "field": "User",
+      "availability": "conditional",
+      "reason": "runtime BTF resolves effective credentials and the kernel read succeeds"
     },
     {
       "platform": "linux",
@@ -2816,7 +2925,8 @@
       "provider": "ebpf",
       "source": "connect tracepoints",
       "field": "User",
-      "availability": "always"
+      "availability": "conditional",
+      "reason": "runtime BTF resolves effective credentials and the kernel read succeeds"
     },
     {
       "platform": "linux",
@@ -2908,7 +3018,8 @@
       "provider": "ebpf",
       "source": "file syscall tracepoints",
       "field": "User",
-      "availability": "always"
+      "availability": "conditional",
+      "reason": "runtime BTF resolves effective credentials and the kernel read succeeds"
     },
     {
       "platform": "linux",
@@ -2985,7 +3096,8 @@
       "provider": "ebpf",
       "source": "file syscall tracepoints",
       "field": "User",
-      "availability": "always"
+      "availability": "conditional",
+      "reason": "runtime BTF resolves effective credentials and the kernel read succeeds"
     },
     {
       "platform": "linux",
@@ -3062,7 +3174,8 @@
       "provider": "ebpf",
       "source": "file syscall tracepoints",
       "field": "User",
-      "availability": "always"
+      "availability": "conditional",
+      "reason": "runtime BTF resolves effective credentials and the kernel read succeeds"
     },
     {
       "platform": "linux",
@@ -3139,7 +3252,8 @@
       "provider": "ebpf",
       "source": "file syscall tracepoints",
       "field": "User",
-      "availability": "always"
+      "availability": "conditional",
+      "reason": "runtime BTF resolves effective credentials and the kernel read succeeds"
     },
     {
       "platform": "linux",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -133,7 +133,8 @@ The loader attaches a mix of tracepoints and kprobes: `sched_process_exec` and
 `rmdir`, entry hooks on `connect`, `sendto`, `sendmsg`, and `sendmmsg`, and a
 `vfs_create` kprobe. The authoritative list is in `src/sensor/linux/`.
 
-Requirements for the Linux sensor are kernel 5.12+, BTF, and eBPF privileges.
+Requirements for the Linux sensor are kernel 5.8+ and eBPF privileges.
+Runtime BTF enables kernel process identity fields; doctor reports unavailable fields.
 
 ### macOS
 

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -143,7 +143,7 @@ condition must be analysed before deciding whether that rule can fire.
 | Platform | Always | Conditional | Never |
 | --- | ---: | ---: | ---: |
 | windows | 19 | 184 | 40 |
-| linux | 23 | 24 | 19 |
+| linux | 19 | 38 | 19 |
 | macos | 27 | 22 | 28 |
 
 The complete machine-readable baseline is

--- a/docs/development.md
+++ b/docs/development.md
@@ -62,6 +62,25 @@ cd ..
 
 `build.rs` watches `ebpf/src`, `ebpf/Cargo.toml`, and `ebpf/rustinel-ebpf.o`. On Linux builds it embeds either the prebuilt object or a freshly compiled one.
 
+### Linux task identity validation
+
+Build the eBPF object first, then run the ignored live comparison as root on an
+isolated Linux test host with tracefs mounted:
+
+```sh
+RUSTINEL_EBPF_OBJECT=/absolute/path/to/rustinel-ebpf.o \
+  cargo test --test linux_task_identity live_task_identity_matches_proc -- --ignored --nocapture
+```
+
+This exercises real versus effective credentials, active PID namespace versus
+child PID namespace, mount and network namespaces, session/TTY, kernel birth
+time, and startup inventory reconciliation. It also execs from a non-leader
+thread to check that kernel birth time remains separate from execution identity.
+Run the same object on 5.10, 5.15, 6.1, and 6.8 before changing the read plans.
+In a disposable VM, hide `/sys/kernel/btf` and run
+`live_without_btf_keeps_base_telemetry` to check graceful degradation. Never hide
+host BTF on a shared machine.
+
 ## Recommended Dev Runs
 
 ### Windows

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -125,7 +125,7 @@ pack or `--no-start` to register without starting. See
 | Platform | Requirements |
 | --- | --- |
 | Windows | Windows 10/11 or Server 2016+, x64 Visual C++ Redistributable, Administrator |
-| Linux | Kernel 5.8+ with BTF; root, or `CAP_BPF` + `CAP_PERFMON` + `CAP_NET_ADMIN` (or `CAP_SYS_ADMIN`); `tracefs` and `debugfs` mounted |
+| Linux | Kernel 5.8+; BTF for process identity fields; root, or `CAP_BPF` + `CAP_PERFMON` + `CAP_NET_ADMIN` (or `CAP_SYS_ADMIN`); `tracefs` and `debugfs` mounted |
 | macOS | macOS 11+, root, signed Endpoint Security client, Full Disk Access, and `/dev/bpf*` access for network and DNS |
 
 Source builds need Rust 1.92 and platform build tools. See

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -85,7 +85,6 @@ table and run `cargo run --bin generate-field-availability`, not this section.
 | Writes through handles or keys opened before startup are invisible | Windows |
 | Security channel events depend on audit policy Rustinel does not set | Windows |
 | Image paths are truncated, and truncation is unmarked on process events | Linux |
-| `User` is the real UID, not the effective one | Linux |
 
 ## Windows (ETW and Event Log)
 
@@ -238,9 +237,10 @@ rejected before any program attaches.
   provenance. Ordinary fork, vfork, clone, and clone3 process creation records
   the creator TGID at `sched_process_fork`. Thread creation is excluded.
 - **Processes that predate the sensor may have no parent identity.** The fork
-  relationship and sensor-minted execution key do not exist for tasks already
-  running at startup. Missing data stays absent instead of consulting a later,
-  potentially reparented procfs record.
+  relationship does not exist for tasks already running at startup. A bounded
+  startup inventory supplies metadata only after kernel `start_boottime` matches
+  the inventoried `/proc` start ticks. Fork parents remain absent when unobserved;
+  later procfs reparenting is not substituted for the original relationship.
 - **File paths are capped at 511 bytes, and the overflow is marked.** The event
   carries `PathTruncated` naming which side was cut. Since truncation removes
   the end of the path, `|endswith` rules and extension IOCs are what it defeats.
@@ -293,17 +293,17 @@ rejected before any program attaches.
   to be a fixed `tcp`, which matched UDP traffic and never matched
   `Protocol: 'udp'`. Socket types other than `SOCK_STREAM` and `SOCK_DGRAM`
   (a raw or SCTP socket) are also left absent rather than named.
-- **`User` is the real UID, not the effective one (silent risk).**
-  `bpf_get_current_uid_gid()` returns the real UID, so a process running with
-  effective root through a setuid binary is reported as the unprivileged caller
-  and a rule filtering `User: 'root'` does not see it. Measured with a
-  setuid-root binary: userspace `euid=0`, sensor `User=1000`
-  ([#327](https://github.com/Karib0u/rustinel/issues/327)).
+- **Kernel identity fields depend on runtime BTF.** `User` uses the effective
+  UID. Missing BTF or an unsupported member disables only the affected fields,
+  with `linux_task_<field>` doctor warnings; an unknown effective UID stays
+  absent. Rules requiring those fields cannot match while they are unavailable.
+  No build-kernel offsets are used as fallback.
 - **No library-load, module-load, or ptrace events.** Sigma rules in those
   categories never match.
-- **Kernel requirements.** Linux 5.8+ with BTF and `CAP_BPF` + `CAP_PERFMON` +
-  `CAP_NET_ADMIN` (or `CAP_SYS_ADMIN`). Older or BTF-less kernels and many
-  restricted containers are unsupported.
+- **Kernel requirements.** Linux 5.8+ with `CAP_BPF` + `CAP_PERFMON` +
+  `CAP_NET_ADMIN` (or `CAP_SYS_ADMIN`). Older kernels and many
+  restricted containers are unsupported. BTF is needed for kernel process
+  identity fields and startup inventory reconciliation.
 
 ## macOS (ESF, experimental)
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -69,6 +69,11 @@ Format:
 | `edr.process.image_source` | Linux process image provenance. Process exec events use `execve` for the raw invocation string captured by the kernel. |
 | `edr.process.image_truncated` | *(Linux process alerts only)* `true` when `process.executable` is a kernel-captured prefix whose suffix did not fit the 256-byte buffer. Absent when the path is complete. |
 | `edr.process.cgroup_id` | Kernel cgroup identifier measured at Linux process exec. Container and runtime resolution is handled separately. |
+| `edr.process.real_user_id`, `edr.process.real_group_id` | Linux real credentials, distinct from effective credentials. |
+| `edr.process.effective_user_id`, `edr.process.effective_group_id` | Linux effective credentials measured at exec. `User` resolves the effective UID to an account name. |
+| `edr.process.mount_namespace`, `edr.process.pid_namespace`, `edr.process.network_namespace` | Namespace inode numbers. PID namespace is the active namespace, as in `/proc/PID/ns/pid`. |
+| `edr.process.session_id`, `edr.process.controlling_tty` | Host session ID and controlling terminal device as `major:minor`. No terminal leaves the TTY absent. |
+| `edr.process.kernel_start_boottime` | Kernel process birth time in nanoseconds since boot, separate from the sensor's execution identity. |
 | `event.count`       | *(rollup only)* Number of suppressed repeats this rollup represents, i.e. occurrences within the dedup window excluding the first. Absent on the live first emission, which represents a single event. Summing `event.count` across lines (absent = 1) gives the true event volume. |
 
 ### Windows Process Alert Example

--- a/ebpf/src/dns.rs
+++ b/ebpf/src/dns.rs
@@ -7,10 +7,7 @@
 //! should enrich the event with the domain in userspace via the raw payload.
 
 use aya_ebpf::{
-    helpers::{
-        bpf_get_current_pid_tgid, bpf_get_current_uid_gid, bpf_probe_read_user,
-        bpf_probe_read_user_buf,
-    },
+    helpers::{bpf_get_current_pid_tgid, bpf_probe_read_user, bpf_probe_read_user_buf},
     macros::{map, tracepoint},
     maps::{PerCpuArray, RingBuf},
     programs::TracePointContext,
@@ -157,7 +154,7 @@ pub fn handle_sendmmsg(ctx: TracePointContext) -> u32 {
 #[inline(always)]
 unsafe fn try_handle_sendto(ctx: &TracePointContext) -> Result<u32, i64> {
     let pid = (bpf_get_current_pid_tgid() >> 32) as u32;
-    let uid = bpf_get_current_uid_gid() as u32;
+    let uid = crate::task_identity::effective_uid().unwrap_or(u32::MAX);
     let fd = ctx.read_at::<i64>(tracepoint_offset(core::ptr::addr_of!(
         DNS_TRACEPOINT_OFFSETS.sendto_fd
     )))? as i32;
@@ -201,7 +198,7 @@ unsafe fn try_handle_sendto(ctx: &TracePointContext) -> Result<u32, i64> {
 #[inline(always)]
 unsafe fn try_handle_sendmsg(ctx: &TracePointContext) -> Result<u32, i64> {
     let pid = (bpf_get_current_pid_tgid() >> 32) as u32;
-    let uid = bpf_get_current_uid_gid() as u32;
+    let uid = crate::task_identity::effective_uid().unwrap_or(u32::MAX);
     let fd = ctx.read_at::<i64>(tracepoint_offset(core::ptr::addr_of!(
         DNS_TRACEPOINT_OFFSETS.sendmsg_fd
     )))? as i32;
@@ -238,7 +235,7 @@ unsafe fn try_handle_sendmsg(ctx: &TracePointContext) -> Result<u32, i64> {
 #[inline(always)]
 unsafe fn try_handle_sendmmsg(ctx: &TracePointContext) -> Result<u32, i64> {
     let pid = (bpf_get_current_pid_tgid() >> 32) as u32;
-    let uid = bpf_get_current_uid_gid() as u32;
+    let uid = crate::task_identity::effective_uid().unwrap_or(u32::MAX);
     let fd = ctx.read_at::<i64>(tracepoint_offset(core::ptr::addr_of!(
         DNS_TRACEPOINT_OFFSETS.sendmmsg_fd
     )))? as i32;

--- a/ebpf/src/events.rs
+++ b/ebpf/src/events.rs
@@ -49,6 +49,7 @@ pub const PROCESS_IMAGE_CAPACITY: usize = 256;
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct ProcessEvent {
+    pub identity: crate::task_identity_abi::TaskIdentity,
     pub event_time_ns: u64,
     pub source_seq: u64,
     /// Cgroup v2 inode-like identifier measured by the kernel helper.
@@ -61,7 +62,7 @@ pub struct ProcessEvent {
     pub kind: u32,
     /// Thread group ID — the POSIX "process ID".
     pub pid: u32,
-    /// Effective UID of the new process.
+    /// Real UID; effective credentials are carried in `identity`.
     pub uid: u32,
     /// Process parent captured by the fork tracepoint.
     pub parent_pid: u32,
@@ -93,7 +94,7 @@ pub struct ProcessEvent {
     pub args: [u8; ARGV_CAPACITY],
 }
 
-const _: () = assert!(core::mem::size_of::<ProcessEvent>() == 856);
+const _: () = assert!(core::mem::size_of::<ProcessEvent>() == 944);
 
 /// `connect(2)` succeeded — the connection is established.
 pub const CONNECT_RESULT_OK: i32 = 0;

--- a/ebpf/src/file.rs
+++ b/ebpf/src/file.rs
@@ -71,8 +71,8 @@
 
 use aya_ebpf::{
     helpers::{
-        bpf_get_current_comm, bpf_get_current_pid_tgid, bpf_get_current_uid_gid, bpf_ktime_get_ns,
-        bpf_probe_read_user, bpf_probe_read_user_str_bytes,
+        bpf_get_current_comm, bpf_get_current_pid_tgid, bpf_ktime_get_ns, bpf_probe_read_user,
+        bpf_probe_read_user_str_bytes,
     },
     macros::{kprobe, map, tracepoint},
     maps::{HashMap, LruHashMap, PerCpuArray, RingBuf},
@@ -881,7 +881,7 @@ unsafe fn queue_file_event_from_args(dfd: i32, path_ptr: u64, kind: u32) -> Resu
     let pid_tgid = bpf_get_current_pid_tgid();
     (*event).kind = kind;
     (*event).pid = (pid_tgid >> 32) as u32;
-    (*event).uid = bpf_get_current_uid_gid() as u32;
+    (*event).uid = crate::task_identity::effective_uid().unwrap_or(u32::MAX);
     (*event).flags = if truncated {
         FILE_FLAG_PATH_TRUNCATED
     } else {
@@ -977,7 +977,7 @@ unsafe fn queue_rename_event_from_args(
     let pid_tgid = bpf_get_current_pid_tgid();
     (*event).kind = FILE_KIND_RENAME;
     (*event).pid = (pid_tgid >> 32) as u32;
-    (*event).uid = bpf_get_current_uid_gid() as u32;
+    (*event).uid = crate::task_identity::effective_uid().unwrap_or(u32::MAX);
     (*event).flags = flags;
     (*event).dfd = new_dfd;
     (*event).aux_dfd = old_dfd;

--- a/ebpf/src/main.rs
+++ b/ebpf/src/main.rs
@@ -33,7 +33,7 @@
 //! | `handle_sendmsg`      | `syscalls/sys_enter_sendmsg` | emit DNS query |
 //! | `handle_sendmmsg`     | `syscalls/sys_enter_sendmmsg`| emit DNS query |
 //!
-//! Requirements: Linux 5.8+ with BTF enabled (CO-RE / ring-buffer support).
+//! Requirements: Linux 5.8+; runtime BTF enables task identity fields.
 
 #![no_std]
 #![no_main]
@@ -45,6 +45,8 @@ pub mod events;
 pub mod file;
 pub mod network;
 pub mod process;
+pub mod task_identity;
+pub mod task_identity_abi;
 pub mod telemetry;
 
 /// Ring-buffer and loader-global ABI implemented by this object.
@@ -53,7 +55,7 @@ pub mod telemetry;
 /// program. Keep it in sync with `LINUX_EBPF_ABI_VERSION` in the loader.
 #[used]
 #[no_mangle]
-pub static RUSTINEL_ABI_VERSION: u32 = 1;
+pub static RUSTINEL_ABI_VERSION: u32 = 2;
 
 #[panic_handler]
 fn panic(_info: &core::panic::PanicInfo) -> ! {

--- a/ebpf/src/network.rs
+++ b/ebpf/src/network.rs
@@ -55,7 +55,7 @@
 //!   offset 16: ret                 (i64 — the new descriptor, or -errno)
 
 use aya_ebpf::{
-    helpers::{bpf_get_current_pid_tgid, bpf_get_current_uid_gid, bpf_probe_read_user},
+    helpers::{bpf_get_current_pid_tgid, bpf_probe_read_user},
     macros::{map, tracepoint},
     maps::{HashMap, LruHashMap, RingBuf},
     programs::TracePointContext,
@@ -258,7 +258,7 @@ unsafe fn try_handle_connect(ctx: &TracePointContext) -> Result<u32, i64> {
     // mid-syscall. Drop it before this syscall's exit can emit it.
     let _ = NETWORK_PENDING.remove(&tid);
 
-    let uid = bpf_get_current_uid_gid() as u32;
+    let uid = crate::task_identity::effective_uid().unwrap_or(u32::MAX);
     let fd = ctx.read_at::<i64>(tracepoint_offset(core::ptr::addr_of!(
         NETWORK_TRACEPOINT_OFFSETS.connect_fd
     )))? as i32;

--- a/ebpf/src/process.rs
+++ b/ebpf/src/process.rs
@@ -84,7 +84,7 @@ unsafe fn tracepoint_offset(value: *const u32) -> usize {
 
 /// Ring buffer shared with the userspace loader for process events.
 ///
-/// The 856-byte event leaves room for more than 2,400 queued events, including
+/// The 944-byte event leaves room for more than 2,200 queued events, including
 /// the measured 1,600-event burst that motivated the image-path fallback.
 #[map]
 pub static PROCESS_RING: RingBuf = RingBuf::with_byte_size(2 * 1024 * 1024, 0);
@@ -113,6 +113,12 @@ struct ForkRelationship {
     _pad: [u8; 3],
 }
 
+#[map]
+static PROCESS_INVENTORY: aya_ebpf::maps::HashMap<
+    u32,
+    crate::task_identity_abi::InventoryIdentity,
+> = aya_ebpf::maps::HashMap::with_max_entries(crate::task_identity_abi::INVENTORY_CAPACITY, 0);
+
 const CLONE_PARENT: u64 = 0x0000_8000;
 const CLONE_THREAD: u64 = 0x0001_0000;
 
@@ -121,7 +127,25 @@ const PROCESS_EVENT_EXIT: u32 = 2;
 
 #[inline(always)]
 pub unsafe fn current_process_start_time(pid: u32) -> u64 {
-    PROCESS_START_TIMES.get(&pid).copied().unwrap_or(0)
+    if let Some(start) = PROCESS_START_TIMES.get(&pid) {
+        return *start;
+    }
+    let Some(inventory) = PROCESS_INVENTORY.get(&pid) else {
+        return 0;
+    };
+    let Some(start) = crate::task_identity::start_boottime() else {
+        return 0;
+    };
+    let hz = inventory.clock_ticks_per_second;
+    if hz == 0 || hz > 1_000_000 {
+        return 0;
+    }
+    let ticks = (start / 1_000_000_000) * hz + (start % 1_000_000_000) * hz / 1_000_000_000;
+    if ticks == inventory.start_ticks {
+        inventory.identity_time
+    } else {
+        0
+    }
 }
 
 /// Maximum bytes copied for a single argument, including its NUL terminator.
@@ -283,6 +307,7 @@ unsafe fn try_handle_exec(ctx: &TracePointContext) -> Result<u32, i64> {
     (*event).kind = PROCESS_EVENT_EXEC;
     (*event).pid = pid;
     (*event).uid = uid;
+    crate::task_identity::capture(core::ptr::addr_of_mut!((*event).identity));
     attach_fork_relationship(event, pid);
     (*event).comm = comm;
     (*event).image = image;
@@ -541,6 +566,7 @@ unsafe fn try_handle_exit(_ctx: &TracePointContext) -> Result<u32, i64> {
     (*event).kind = PROCESS_EVENT_EXIT;
     (*event).pid = pid;
     (*event).uid = uid;
+    crate::task_identity::capture(core::ptr::addr_of_mut!((*event).identity));
     (*event).parent_pid = 0;
     (*event).creator_tid = 0;
     (*event).creator_tgid = 0;
@@ -556,6 +582,7 @@ unsafe fn try_handle_exit(_ctx: &TracePointContext) -> Result<u32, i64> {
     entry.submit(0);
     let _ = PROCESS_START_TIMES.remove(&pid);
     let _ = PROCESS_PARENTS.remove(&pid);
+    let _ = PROCESS_INVENTORY.remove(&pid);
     record_submitted(PROCESS_FAMILY);
 
     Ok(0)

--- a/ebpf/src/task_identity.rs
+++ b/ebpf/src/task_identity.rs
@@ -1,0 +1,104 @@
+//! Probe reads use only plans resolved from the running kernel's BTF.
+
+use crate::task_identity_abi::*;
+use aya_ebpf::{
+    helpers::{bpf_get_current_task, bpf_get_current_uid_gid, bpf_probe_read_kernel},
+    macros::map,
+    maps::Array,
+};
+
+#[map]
+static TASK_IDENTITY_OFFSETS: Array<ReadPlan> = Array::with_max_entries(FIELD_COUNT as u32, 0);
+
+// Credentials and birth time have one pointer hop. Keep this path straight-line
+// because it also runs inside the bounded DNS batching loops on older verifiers.
+#[inline(always)]
+unsafe fn read_pair(task: u64, plan: &ReadPlan, wide: bool) -> Option<u64> {
+    if plan.len != 2 {
+        return None;
+    }
+    let pointer: u64 =
+        bpf_probe_read_kernel((task + (plan.steps[0].offset & 0xffff) as u64) as *const u64)
+            .ok()?;
+    if pointer == 0 {
+        return None;
+    }
+    let address = pointer + (plan.steps[1].offset & 0xffff) as u64;
+    if wide {
+        bpf_probe_read_kernel(address as *const u64).ok()
+    } else {
+        bpf_probe_read_kernel(address as *const u32)
+            .ok()
+            .map(u64::from)
+    }
+}
+
+#[inline(always)]
+unsafe fn read_field(task: u64, plan: &ReadPlan, wide: bool) -> Option<u64> {
+    if plan.len == 0 || plan.len > MAX_STEPS as u32 {
+        return None;
+    }
+    let mut address = task;
+    let mut i = 0;
+    while i < MAX_STEPS {
+        let step = &plan.steps[i];
+        if address == 0 {
+            return None;
+        }
+        let mut offset = step.offset & 0xffff;
+        if step.stride != 0 {
+            let level: u32 = bpf_probe_read_kernel(
+                (address + (step.level_offset & 0xffff) as u64) as *const u32,
+            )
+            .ok()?;
+            // Linux limits PID namespace nesting to 32 levels.
+            if level > 32 {
+                return None;
+            }
+            offset += level * (step.stride & 0xff);
+        }
+        address += (offset & 0xffff) as u64;
+        if i as u32 + 1 == plan.len {
+            return if wide {
+                bpf_probe_read_kernel(address as *const u64).ok()
+            } else {
+                bpf_probe_read_kernel(address as *const u32)
+                    .ok()
+                    .map(u64::from)
+            };
+        }
+        address = bpf_probe_read_kernel(address as *const u64).ok()?;
+        i += 1;
+    }
+    None
+}
+
+#[inline(always)]
+pub unsafe fn capture(identity: *mut TaskIdentity) {
+    (*identity).valid = 0;
+    (*identity).real_gid = (bpf_get_current_uid_gid() >> 32) as u32;
+    let task = bpf_get_current_task();
+    let mut field = 0;
+    while field < FIELD_COUNT {
+        (*identity).values[field] = 0;
+        if let Some(plan) = TASK_IDENTITY_OFFSETS.get(field as u32) {
+            if let Some(value) = read_field(task, plan, field == START_BOOTTIME) {
+                (*identity).values[field] = value;
+                (*identity).valid |= 1 << field;
+            }
+        }
+        field += 1;
+    }
+}
+
+#[inline(always)]
+pub unsafe fn start_boottime() -> Option<u64> {
+    let plan = TASK_IDENTITY_OFFSETS.get(START_BOOTTIME as u32)?;
+    read_pair(bpf_get_current_task(), plan, true)
+}
+
+#[inline(always)]
+pub unsafe fn effective_uid() -> Option<u32> {
+    let plan = TASK_IDENTITY_OFFSETS.get(EUID as u32)?;
+    read_pair(bpf_get_current_task(), plan, false).map(|value| value as u32)
+}

--- a/ebpf/src/task_identity_abi.rs
+++ b/ebpf/src/task_identity_abi.rs
@@ -1,0 +1,52 @@
+//! Runtime BTF read plans and measured process identity, shared with userspace.
+
+pub const FIELD_COUNT: usize = 10;
+pub const MAX_STEPS: usize = 6;
+pub const START_BOOTTIME: usize = 0;
+pub const EUID: usize = 1;
+pub const EGID: usize = 2;
+pub const MOUNT_NS: usize = 3;
+pub const PID_NS: usize = 4;
+pub const NET_NS: usize = 5;
+pub const SESSION_ID: usize = 6;
+pub const TTY_MAJOR: usize = 7;
+pub const TTY_MINOR: usize = 8;
+pub const TTY_INDEX: usize = 9;
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default)]
+pub struct ReadStep {
+    pub offset: u32,
+    /// Nonzero stride selects pid.numbers[pid.level], for the active namespace.
+    pub stride: u32,
+    pub level_offset: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default)]
+pub struct ReadPlan {
+    /// Zero disables this field. Every other step dereferences a pointer;
+    /// the final step reads a scalar of the field's specified width.
+    pub len: u32,
+    pub steps: [ReadStep; MAX_STEPS],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default)]
+pub struct TaskIdentity {
+    pub values: [u64; FIELD_COUNT],
+    /// A zero value is valid (especially effective root) only with this bit set.
+    pub valid: u32,
+    pub real_gid: u32,
+}
+
+/// Startup inventory identity is accepted only after kernel birth-time matching.
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct InventoryIdentity {
+    pub start_ticks: u64,
+    pub clock_ticks_per_second: u64,
+    pub identity_time: u64,
+}
+
+pub const INVENTORY_CAPACITY: u32 = 8192;

--- a/src/alerts/dedup.rs
+++ b/src/alerts/dedup.rs
@@ -380,6 +380,7 @@ mod tests {
                 event_id_string: "1".to_string(),
                 opcode: 1,
                 fields: EventFields::ProcessCreation(ProcessCreationFields {
+                    linux_identity: Default::default(),
                     cgroup_id: None,
                     exec: Default::default(),
                     parent_process_id_derived: false,

--- a/src/capture/writer.rs
+++ b/src/capture/writer.rs
@@ -417,6 +417,7 @@ mod tests {
             event_id_string: "1".to_string(),
             opcode: 1,
             fields: EventFields::ProcessCreation(ProcessCreationFields {
+                linux_identity: Default::default(),
                 cgroup_id: None,
                 exec: Default::default(),
                 parent_process_id_derived: false,

--- a/src/doctor/prerequisites.rs
+++ b/src/doctor/prerequisites.rs
@@ -31,7 +31,7 @@ pub(crate) fn platform_prerequisite_results() -> Vec<DiagnosticResult> {
 
 #[cfg(target_os = "linux")]
 fn linux_prerequisite_results() -> Vec<DiagnosticResult> {
-    vec![
+    let mut results = vec![
         linux_kernel_result(),
         linux_privilege_result(),
         linux_btf_result(),
@@ -45,7 +45,16 @@ fn linux_prerequisite_results() -> Vec<DiagnosticResult> {
             "telemetry_prerequisites",
             "Linux eBPF telemetry prerequisites were inspected",
         ),
-    ]
+    ];
+    let plans = crate::sensor::linux::task_btf::TaskPlans::load();
+    for (name, reason) in plans.warnings {
+        results.push(DiagnosticResult::warn(
+            name,
+            "Kernel process identity field disabled",
+            reason,
+        ));
+    }
+    results
 }
 
 #[cfg(target_os = "linux")]
@@ -93,9 +102,9 @@ fn linux_btf_result() -> DiagnosticResult {
     if path.is_file() {
         DiagnosticResult::pass("linux_btf", "Kernel BTF is available")
     } else {
-        DiagnosticResult::fail(
+        DiagnosticResult::warn(
             "linux_btf",
-            "Kernel BTF is not available",
+            "Kernel BTF is unavailable; task identity fields are disabled",
             path.display().to_string(),
         )
         .with_fix("Install kernel BTF data or use a kernel with CONFIG_DEBUG_INFO_BTF")

--- a/src/engine/alert.rs
+++ b/src/engine/alert.rs
@@ -203,6 +203,7 @@ level: high
             event_id_string: "1".to_string(),
             opcode: 1,
             fields: EventFields::ProcessCreation(ProcessCreationFields {
+                linux_identity: Default::default(),
                 cgroup_id: None,
                 exec: Default::default(),
                 parent_process_id_derived: false,

--- a/src/engine/event.rs
+++ b/src/engine/event.rs
@@ -257,6 +257,7 @@ mod tests {
     #[test]
     fn typed_process_fields_expose_sigma_names() {
         let fields = ProcessCreationFields {
+            linux_identity: Default::default(),
             cgroup_id: None,
             exec: Default::default(),
             parent_process_id_derived: false,

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -725,6 +725,7 @@ detection:
             event_id_string: "1".to_string(),
             opcode: 1,
             fields: EventFields::ProcessCreation(ProcessCreationFields {
+                linux_identity: Default::default(),
                 cgroup_id: None,
                 exec: Default::default(),
                 parent_process_id_derived: false,

--- a/src/field_availability.rs
+++ b/src/field_availability.rs
@@ -491,7 +491,44 @@ const LINUX_PROCESS: &[FieldContract] = &[
     always("Image"),
     always("ImageSource"),
     always("ProcessId"),
-    always("User"),
+    always("RealUserId"),
+    always("RealGroupId"),
+    conditional(
+        "EffectiveUserId",
+        "runtime BTF resolves this field and the kernel read succeeds",
+    ),
+    conditional(
+        "EffectiveGroupId",
+        "runtime BTF resolves this field and the kernel read succeeds",
+    ),
+    conditional(
+        "MountNamespace",
+        "runtime BTF resolves this field and the kernel read succeeds",
+    ),
+    conditional(
+        "PidNamespace",
+        "runtime BTF resolves this field and the kernel read succeeds",
+    ),
+    conditional(
+        "NetworkNamespace",
+        "runtime BTF resolves this field and the kernel read succeeds",
+    ),
+    conditional(
+        "SessionId",
+        "runtime BTF resolves this field and the kernel read succeeds",
+    ),
+    conditional(
+        "KernelStartBoottime",
+        "runtime BTF resolves this field and the kernel read succeeds",
+    ),
+    conditional(
+        "ControllingTty",
+        "runtime BTF resolves terminal fields and the process has a controlling terminal",
+    ),
+    conditional(
+        "User",
+        "runtime BTF resolves effective credentials and the kernel read succeeds",
+    ),
     conditional(
         "ImageTruncated",
         "the raw exec filename exceeded the kernel capture buffer",
@@ -533,7 +570,10 @@ const LINUX_NETWORK: &[FieldContract] = &[
     always("DestinationIp"),
     always("DestinationPort"),
     always("ProcessId"),
-    always("User"),
+    conditional(
+        "User",
+        "runtime BTF resolves effective credentials and the kernel read succeeds",
+    ),
     always("Initiated"),
     conditional(
         "Protocol",
@@ -560,7 +600,10 @@ const LINUX_NETWORK: &[FieldContract] = &[
 const LINUX_FILE: &[FieldContract] = &[
     always("TargetFilename"),
     always("ProcessId"),
-    always("User"),
+    conditional(
+        "User",
+        "runtime BTF resolves effective credentials and the kernel read succeeds",
+    ),
     conditional(
         "SourceFilename",
         "the action is rename and the old path can be resolved",

--- a/src/ioc/mod.rs
+++ b/src/ioc/mod.rs
@@ -220,6 +220,7 @@ impl IocEngine {
                 event_id_string: "1".to_string(),
                 opcode: 1,
                 fields: EventFields::ProcessCreation(ProcessCreationFields {
+                    linux_identity: Default::default(),
                     cgroup_id: None,
                     exec: Default::default(),
                     parent_process_id_derived: false,

--- a/src/models/ecs/alert.rs
+++ b/src/models/ecs/alert.rs
@@ -130,6 +130,57 @@ pub struct EcsAlert {
     )]
     pub edr_process_cgroup_id: Option<String>,
 
+    #[serde(
+        rename = "edr.process.real_user_id",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub edr_process_real_user_id: Option<String>,
+    #[serde(
+        rename = "edr.process.real_group_id",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub edr_process_real_group_id: Option<String>,
+    #[serde(
+        rename = "edr.process.effective_user_id",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub edr_process_effective_user_id: Option<String>,
+    #[serde(
+        rename = "edr.process.effective_group_id",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub edr_process_effective_group_id: Option<String>,
+    #[serde(
+        rename = "edr.process.mount_namespace",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub edr_process_mount_namespace: Option<String>,
+    #[serde(
+        rename = "edr.process.pid_namespace",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub edr_process_pid_namespace: Option<String>,
+    #[serde(
+        rename = "edr.process.network_namespace",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub edr_process_network_namespace: Option<String>,
+    #[serde(
+        rename = "edr.process.session_id",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub edr_process_session_id: Option<String>,
+    #[serde(
+        rename = "edr.process.controlling_tty",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub edr_process_controlling_tty: Option<String>,
+    #[serde(
+        rename = "edr.process.kernel_start_boottime",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub edr_process_kernel_start_boottime: Option<u64>,
+
     #[serde(rename = "process.name", skip_serializing_if = "Option::is_none")]
     pub process_name: Option<String>,
 

--- a/src/models/ecs/mod.rs
+++ b/src/models/ecs/mod.rs
@@ -67,6 +67,16 @@ impl From<&Alert> for EcsAlert {
             edr_process_image_source: None,
             edr_process_image_truncated: None,
             edr_process_cgroup_id: None,
+            edr_process_real_user_id: None,
+            edr_process_real_group_id: None,
+            edr_process_effective_user_id: None,
+            edr_process_effective_group_id: None,
+            edr_process_mount_namespace: None,
+            edr_process_pid_namespace: None,
+            edr_process_network_namespace: None,
+            edr_process_session_id: None,
+            edr_process_controlling_tty: None,
+            edr_process_kernel_start_boottime: None,
             process_name: None,
             process_command_line: None,
             process_pid: None,
@@ -153,6 +163,17 @@ impl From<&Alert> for EcsAlert {
                 ecs.edr_process_image_source = f.image_source.clone();
                 ecs.edr_process_image_truncated = f.image_truncated;
                 ecs.edr_process_cgroup_id = f.cgroup_id.clone();
+                ecs.edr_process_real_user_id =
+                    f.exec.as_ref().and_then(|exec| exec.real_user_id.clone());
+                ecs.edr_process_real_group_id = f.linux_identity.real_group_id.clone();
+                ecs.edr_process_effective_user_id = f.linux_identity.effective_user_id.clone();
+                ecs.edr_process_effective_group_id = f.linux_identity.effective_group_id.clone();
+                ecs.edr_process_mount_namespace = f.linux_identity.mount_namespace.clone();
+                ecs.edr_process_pid_namespace = f.linux_identity.pid_namespace.clone();
+                ecs.edr_process_network_namespace = f.linux_identity.network_namespace.clone();
+                ecs.edr_process_session_id = f.linux_identity.session_id.clone();
+                ecs.edr_process_controlling_tty = f.linux_identity.controlling_tty.clone();
+                ecs.edr_process_kernel_start_boottime = f.linux_identity.kernel_start_boottime;
                 ecs.process_command_line = f.command_line.clone();
                 ecs.process_pid = parse_u64(&f.process_id);
                 ecs.process_parent_executable = f.parent_image.clone();
@@ -429,6 +450,7 @@ mod tests {
                 event_id_string: "1".to_string(),
                 opcode: 1,
                 fields: EventFields::ProcessCreation(ProcessCreationFields {
+                    linux_identity: Default::default(),
                     cgroup_id: Some("123456".to_string()),
                     exec: Default::default(),
                     parent_process_id_derived: false,

--- a/src/models/event.rs
+++ b/src/models/event.rs
@@ -251,6 +251,14 @@ impl NormalizedEvent {
                 "CommandLine" => f.command_line.as_deref(),
                 "ProcessId" => f.process_id.as_deref(),
                 "CgroupId" => f.cgroup_id.as_deref(),
+                "RealGroupId" => f.linux_identity.real_group_id.as_deref(),
+                "EffectiveUserId" => f.linux_identity.effective_user_id.as_deref(),
+                "EffectiveGroupId" => f.linux_identity.effective_group_id.as_deref(),
+                "MountNamespace" => f.linux_identity.mount_namespace.as_deref(),
+                "PidNamespace" => f.linux_identity.pid_namespace.as_deref(),
+                "NetworkNamespace" => f.linux_identity.network_namespace.as_deref(),
+                "SessionId" => f.linux_identity.session_id.as_deref(),
+                "ControllingTty" => f.linux_identity.controlling_tty.as_deref(),
                 "ParentProcessId" => f.parent_process_id.as_deref(),
                 "ParentImage" => f.parent_image.as_deref(),
                 "ParentCommandLine" => f.parent_command_line.as_deref(),
@@ -522,6 +530,7 @@ mod round_trip_tests {
             event_id_string: "1".to_string(),
             opcode: 1,
             fields: EventFields::ProcessCreation(ProcessCreationFields {
+                linux_identity: Default::default(),
                 cgroup_id: None,
                 exec: Default::default(),
                 parent_process_id_derived: false,
@@ -782,6 +791,7 @@ mod round_trip_tests {
             event_id_string: "1".to_string(),
             opcode: 1,
             fields: EventFields::ProcessCreation(ProcessCreationFields {
+                linux_identity: Default::default(),
                 cgroup_id: None,
                 exec: Default::default(),
                 parent_process_id_derived: false,
@@ -830,6 +840,7 @@ mod round_trip_tests {
         event.event_id_string = "1".to_string();
         event.opcode = 1;
         event.fields = EventFields::ProcessCreation(ProcessCreationFields {
+            linux_identity: Default::default(),
             cgroup_id: None,
             exec: Default::default(),
             parent_process_id_derived: false,

--- a/src/models/fields.rs
+++ b/src/models/fields.rs
@@ -91,11 +91,39 @@ pub struct ExecMetadata {
     pub(crate) file_identity: Option<crate::utils::file_identity::FileIdentity>,
 }
 
+/// Linux kernel process identity measured at the event, when available.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct LinuxProcessIdentity {
+    #[serde(rename = "RealGroupId", skip_serializing_if = "Option::is_none")]
+    pub real_group_id: Option<String>,
+    #[serde(rename = "EffectiveUserId", skip_serializing_if = "Option::is_none")]
+    pub effective_user_id: Option<String>,
+    #[serde(rename = "EffectiveGroupId", skip_serializing_if = "Option::is_none")]
+    pub effective_group_id: Option<String>,
+    #[serde(rename = "MountNamespace", skip_serializing_if = "Option::is_none")]
+    pub mount_namespace: Option<String>,
+    #[serde(rename = "PidNamespace", skip_serializing_if = "Option::is_none")]
+    pub pid_namespace: Option<String>,
+    #[serde(rename = "NetworkNamespace", skip_serializing_if = "Option::is_none")]
+    pub network_namespace: Option<String>,
+    #[serde(rename = "SessionId", skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(rename = "ControllingTty", skip_serializing_if = "Option::is_none")]
+    pub controlling_tty: Option<String>,
+    #[serde(
+        rename = "KernelStartBoottime",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub kernel_start_boottime: Option<u64>,
+}
+
 /// Process creation/access event fields (Sigma: process_creation, process_access)
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProcessCreationFields {
     #[serde(flatten, default)]
     pub exec: Option<Box<ExecMetadata>>,
+    #[serde(flatten, default)]
+    pub linux_identity: Box<LinuxProcessIdentity>,
     #[serde(rename = "Image", skip_serializing_if = "Option::is_none")]
     pub image: Option<String>,
 

--- a/src/normalizer/mod.rs
+++ b/src/normalizer/mod.rs
@@ -120,6 +120,21 @@ impl Normalizer {
 
         let mut fields = fields.clone();
         self.resolve_user_field(&mut fields.user);
+        #[cfg(target_os = "linux")]
+        if event.platform == Platform::Linux {
+            if let Some(uid) = fields
+                .linux_identity
+                .effective_user_id
+                .as_deref()
+                .and_then(|id| id.parse::<u32>().ok())
+            {
+                // Account lookup belongs downstream, outside the ring drain.
+                if let Some(name) = crate::utils::lookup_username_by_uid(uid) {
+                    fields.user = Some(name);
+                    provenance.mark_derived("User");
+                }
+            }
+        }
         if fields.process_start_time.is_none() {
             fields.process_start_time = event.process_start_key.map(|key| key.start_time);
             if fields.process_start_time.is_some()
@@ -534,8 +549,15 @@ mod tests {
             }),
             parent_process_start_key: None,
             payload: SensorPayload::Process(ProcessCreationFields {
+                linux_identity: Box::new(LinuxProcessIdentity {
+                    real_group_id: Some("1000".to_string()),
+                    ..Default::default()
+                }),
                 cgroup_id: None,
-                exec: Default::default(),
+                exec: Some(Box::new(ExecMetadata {
+                    real_user_id: Some("1000".to_string()),
+                    ..Default::default()
+                })),
                 parent_process_id_derived: false,
                 image: Some("/usr/bin/curl".to_string()),
                 image_source: (platform == Platform::Linux).then(|| "proc".to_string()),
@@ -582,6 +604,7 @@ mod tests {
             }),
             parent_process_start_key: None,
             payload: SensorPayload::Process(ProcessCreationFields {
+                linux_identity: Default::default(),
                 cgroup_id: None,
                 exec: Default::default(),
                 parent_process_id_derived: false,
@@ -724,6 +747,7 @@ mod tests {
             }),
             parent_process_start_key: None,
             payload: SensorPayload::Process(ProcessCreationFields {
+                linux_identity: Default::default(),
                 cgroup_id: None,
                 exec: Default::default(),
                 parent_process_id_derived: false,

--- a/src/replay/output.rs
+++ b/src/replay/output.rs
@@ -198,6 +198,7 @@ mod tests {
                 event_id_string: "1".to_string(),
                 opcode: 1,
                 fields: EventFields::ProcessCreation(ProcessCreationFields {
+                    linux_identity: Default::default(),
                     cgroup_id: None,
                     exec: Default::default(),
                     parent_process_id_derived: false,

--- a/src/replay/recording.rs
+++ b/src/replay/recording.rs
@@ -245,6 +245,7 @@ mod tests {
             event_id_string: "1".to_string(),
             opcode: 1,
             fields: EventFields::ProcessCreation(ProcessCreationFields {
+                linux_identity: Default::default(),
                 cgroup_id: None,
                 exec: Default::default(),
                 parent_process_id_derived: false,

--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -667,6 +667,7 @@ mod tests {
                 event_id_string: "1".to_string(),
                 opcode: 1,
                 fields: EventFields::ProcessCreation(ProcessCreationFields {
+                    linux_identity: Default::default(),
                     cgroup_id: None,
                     exec: Default::default(),
                     parent_process_id_derived: false,

--- a/src/runtime/capture.rs
+++ b/src/runtime/capture.rs
@@ -135,8 +135,8 @@ pub(crate) struct CaptureSession {
 
 impl CaptureSession {
     /// Process metadata cache, so platforms that can enumerate running
-    /// processes seed it before the sensors start. Only Windows does today.
-    #[cfg(windows)]
+    /// processes can seed it during startup.
+    #[cfg(any(windows, target_os = "linux"))]
     pub(crate) fn process_cache(&self) -> &Arc<ProcessCache> {
         &self.process_cache
     }

--- a/src/runtime/linux.rs
+++ b/src/runtime/linux.rs
@@ -29,7 +29,9 @@ pub fn run_capture(options: CaptureOptions) -> anyhow::Result<()> {
         let session = context.start_recording(&options, Platform::Linux)?;
         let (sensor_tx, sensor_worker) = session.sensor_channel();
 
-        let sensor = Arc::new(EbpfSensor::new());
+        let sensor = Arc::new(EbpfSensor::with_process_cache(Arc::clone(
+            session.process_cache(),
+        )));
         info!(target: TARGET_CONSOLE, "Starting eBPF sensor...");
         if let Err(e) = sensor.start(sensor_tx) {
             error!("eBPF sensor failed to start: {:#}", e);
@@ -66,6 +68,7 @@ async fn run_linux_edr(
     let response_config = Arc::new(ArcSwap::from(Arc::new(cfg.response.clone())));
     let (response_engine, response_worker_handle) = ResponseEngine::new(response_config.clone());
 
+    let process_cache = Arc::clone(&state.process_cache);
     let pipeline = LivePipeline::new(
         &cfg,
         resolved_config_path,
@@ -77,7 +80,7 @@ async fn run_linux_edr(
     );
 
     // 13. eBPF sensor
-    let sensor = Arc::new(EbpfSensor::new());
+    let sensor = Arc::new(EbpfSensor::with_process_cache(process_cache));
 
     info!(
         target: TARGET_CONSOLE,

--- a/src/runtime/yara.rs
+++ b/src/runtime/yara.rs
@@ -110,6 +110,7 @@ pub fn build_yara_alert(
             event_id_string: "1".to_string(),
             opcode: 1,
             fields: EventFields::ProcessCreation(ProcessCreationFields {
+                linux_identity: Default::default(),
                 cgroup_id: None,
                 exec: Default::default(),
                 parent_process_id_derived: false,
@@ -198,6 +199,7 @@ pub fn build_yara_memory_alert(
             event_id_string: "1".to_string(),
             opcode: 1,
             fields: EventFields::ProcessCreation(ProcessCreationFields {
+                linux_identity: Default::default(),
                 cgroup_id: None,
                 exec: Default::default(),
                 parent_process_id_derived: false,

--- a/src/sensor/linux/ebpf.rs
+++ b/src/sensor/linux/ebpf.rs
@@ -9,7 +9,7 @@
 //! 4. Spawns a tokio task that polls all ring buffers and converts raw events
 //!    into [`SensorEvent`] values for the shared pipeline.
 //!
-//! Requirements: Linux 5.12+ with BTF, `CAP_BPF` (or `CAP_SYS_ADMIN`).
+//! Requirements: Linux 5.8+ and eBPF privileges; runtime BTF enables task identity.
 
 use std::net::{Ipv4Addr, Ipv6Addr};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -76,12 +76,20 @@ unsafe impl aya::Pod for KernelCounterRow {}
 /// Linux eBPF sensor. Implements [`Sensor`]; call `start()` from within a
 /// tokio runtime context.
 pub struct EbpfSensor {
+    process_cache: Option<Arc<crate::state::ProcessCache>>,
     shutdown: Arc<AtomicBool>,
 }
 
 impl EbpfSensor {
+    pub fn with_process_cache(cache: Arc<crate::state::ProcessCache>) -> Self {
+        Self {
+            process_cache: Some(cache),
+            ..Self::new()
+        }
+    }
     pub fn new() -> Self {
         Self {
+            process_cache: None,
             shutdown: Arc::new(AtomicBool::new(false)),
         }
     }
@@ -124,7 +132,20 @@ impl Sensor for EbpfSensor {
             .override_global("DNS_TRACEPOINT_OFFSETS", &layouts.dns, true);
         let mut bpf = loader
             .load(bytes)
-            .context("eBPF object load failed — ensure BTF is available and kernel is 5.8+")?;
+            .context("eBPF object load failed; ensure the kernel is 5.8+")?;
+
+        let task_plans = super::task_btf::TaskPlans::load();
+        for (diagnostic, reason) in &task_plans.warnings {
+            warn!(%diagnostic, %reason, "kernel process identity field disabled");
+        }
+        let mut offsets =
+            aya::maps::Array::<_, super::events::task_identity_abi::ReadPlan>::try_from(
+                bpf.map_mut("TASK_IDENTITY_OFFSETS")
+                    .context("missing task identity offsets map")?,
+            )?;
+        for (index, plan) in task_plans.plans.iter().enumerate() {
+            offsets.set(index as u32, *plan, 0)?;
+        }
 
         // ── Attach programs ──────────────────────────────────────────────────
 
@@ -275,6 +296,14 @@ impl Sensor for EbpfSensor {
         info!("eBPF tracepoints attached");
 
         // ── Take ring-buffer maps ────────────────────────────────────────────
+
+        if let Some(cache) = &self.process_cache {
+            if task_plans.plans[super::events::task_identity_abi::START_BOOTTIME].len != 0 {
+                if let Err(error) = super::inventory::seed(&mut bpf, cache) {
+                    warn!(%error, "linux_process_inventory: startup inventory unavailable");
+                }
+            }
+        }
 
         let process_ring: RingBuf<MapData> = RingBuf::try_from(
             bpf.take_map("PROCESS_RING")
@@ -605,6 +634,7 @@ fn build_process_event(ev: &ProcessEvent) -> Option<SensorEvent> {
                     command_line: ev.kernel_command_line(),
                     process_id: Some(ev.pid.to_string()),
                     process_start_time: None,
+                    linux_identity: ev.linux_identity(),
                     cgroup_id: (ev.cgroup_id != 0).then(|| ev.cgroup_id.to_string()),
                     parent_process_id: (ev.parent_pid != 0).then(|| ev.parent_pid.to_string()),
                     parent_image: None,
@@ -612,8 +642,8 @@ fn build_process_event(ev: &ProcessEvent) -> Option<SensorEvent> {
                     current_directory: None,
                     // Windows-specific; absent on Linux.
                     integrity_level: None,
-                    user: Some(ev.uid.to_string()),
-                    exec: Default::default(),
+                    user: ev.effective_uid(),
+                    exec: ev.exec_metadata(),
                     parent_process_id_derived: ev.parent_pid_derived != 0,
                 }),
             })
@@ -644,14 +674,15 @@ fn build_process_event(ev: &ProcessEvent) -> Option<SensorEvent> {
                 command_line: None,
                 process_id: Some(ev.pid.to_string()),
                 process_start_time: None,
+                linux_identity: ev.linux_identity(),
                 cgroup_id: (ev.cgroup_id != 0).then(|| ev.cgroup_id.to_string()),
                 parent_process_id: None,
                 parent_image: None,
                 parent_command_line: None,
                 current_directory: None,
                 integrity_level: None,
-                user: Some(ev.uid.to_string()),
-                exec: Default::default(),
+                user: ev.effective_uid(),
+                exec: ev.exec_metadata(),
                 parent_process_id_derived: false,
             }),
         }),
@@ -717,7 +748,7 @@ fn build_network_event(ev: &NetworkEvent) -> Option<SensorEvent> {
             process_id: Some(ev.pid.to_string()),
             // Enriched by the normalizer from ProcessCache if PID is known.
             image: None,
-            user: Some(user),
+            user,
             destination_hostname: None,
             // The kernel-side socket type is authoritative: it is recorded
             // when the socket is created rather than guessed after the event.
@@ -798,7 +829,7 @@ fn build_file_event(
             image: None,
             creation_utc_time: None,
             previous_creation_utc_time: None,
-            user: Some(user),
+            user,
             path_truncated,
         }),
     })
@@ -867,8 +898,8 @@ fn try_send(tx: &Sender<SensorEvent>, event: SensorEvent) {
     let _ = crate::telemetry::try_send_sensor_event(tx, event);
 }
 
-fn resolved_linux_user(uid: u32) -> String {
-    lookup_username_by_uid(uid).unwrap_or_else(|| uid.to_string())
+fn resolved_linux_user(uid: u32) -> Option<String> {
+    (uid != u32::MAX).then(|| lookup_username_by_uid(uid).unwrap_or_else(|| uid.to_string()))
 }
 
 fn attach_optional_tracepoint(
@@ -991,10 +1022,43 @@ mod tests {
     use crate::state::{DnsCache, ProcessCache, SidCache};
     use std::sync::Arc;
 
+    #[test]
+    fn effective_root_is_distinct_from_real_uid_and_missing_credentials() {
+        use super::super::events::task_identity_abi::*;
+        let mut raw = raw_process_event(PROCESS_EVENT_EXEC, 424242, "/usr/bin/example");
+        raw.identity.values[EUID] = 0;
+        raw.identity.valid = 1 << EUID;
+        let event = build_process_event(&raw).unwrap();
+        let normalizer = Normalizer::new(
+            Arc::new(ProcessCache::new()),
+            Arc::new(SidCache::new()),
+            Arc::new(DnsCache::new()),
+        );
+        let normalized = normalizer.normalize(&event).unwrap();
+        assert_eq!(normalized.get_field("User"), Some("root"));
+        assert_eq!(normalized.get_field("RealUserId"), Some("1000"));
+        assert_eq!(normalized.get_field("EffectiveUserId"), Some("0"));
+        let recorded = serde_json::to_value(&normalized).unwrap();
+        assert_eq!(recorded["fields"]["EffectiveUserId"], "0");
+        assert!(recorded["fields"].get("MountNamespace").is_none());
+        let replay: crate::models::NormalizedEvent = serde_json::from_value(recorded).unwrap();
+        assert_eq!(replay.get_field("EffectiveUserId"), Some("0"));
+
+        raw.identity.valid = 0;
+        let absent = normalizer
+            .normalize(&build_process_event(&raw).unwrap())
+            .unwrap();
+        assert_eq!(absent.get_field("User"), None);
+        assert_eq!(absent.get_field("EffectiveUserId"), None);
+        assert_eq!(absent.get_field("RealUserId"), Some("1000"));
+        assert_eq!(resolved_linux_user(u32::MAX), None);
+    }
+
     /// Build a `ProcessEvent` the way the kernel would, with no argv capture.
     /// Tests that exercise argv override `args*` explicitly.
     fn raw_process_event(kind: u32, pid: u32, image: &str) -> ProcessEvent {
         ProcessEvent {
+            identity: Default::default(),
             event_time_ns: 0,
             source_seq: 0,
             cgroup_id: 55,
@@ -1157,7 +1221,9 @@ mod tests {
 
     #[test]
     fn build_process_exec_uses_fork_time_parent_identity_and_cgroup() {
-        let raw = raw_process_event(PROCESS_EVENT_EXEC, DEAD_PID, "/usr/bin/bash");
+        let mut raw = raw_process_event(PROCESS_EVENT_EXEC, DEAD_PID, "/usr/bin/bash");
+        raw.identity.valid = 1 << super::super::events::task_identity_abi::EUID;
+        raw.identity.values[super::super::events::task_identity_abi::EUID] = 1000;
 
         let event = build_process_event(&raw).expect("process exec should build");
         assert_eq!(

--- a/src/sensor/linux/events.rs
+++ b/src/sensor/linux/events.rs
@@ -8,6 +8,9 @@
 //! When modifying either side, update both files together and run the
 //! cross-platform golden tests to verify byte-level compatibility.
 
+#[path = "../../../ebpf/src/task_identity_abi.rs"]
+pub mod task_identity_abi;
+
 #[cfg(target_os = "linux")]
 use std::sync::OnceLock;
 #[cfg(target_os = "linux")]
@@ -54,6 +57,7 @@ pub const PROCESS_IMAGE_CAPACITY: usize = 256;
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct ProcessEvent {
+    pub identity: self::task_identity_abi::TaskIdentity,
     pub event_time_ns: u64,
     pub source_seq: u64,
     pub cgroup_id: u64,
@@ -85,6 +89,47 @@ pub struct ProcessEvent {
 }
 
 impl ProcessEvent {
+    pub fn exec_metadata(&self) -> Option<Box<crate::models::ExecMetadata>> {
+        Some(Box::new(crate::models::ExecMetadata {
+            real_user_id: Some(self.uid.to_string()),
+            ..Default::default()
+        }))
+    }
+
+    pub fn effective_uid(&self) -> Option<String> {
+        self.identity_value(task_identity_abi::EUID)
+            .map(|uid| uid.to_string())
+    }
+
+    fn identity_value(&self, field: usize) -> Option<u64> {
+        (self.identity.valid & (1 << field) != 0).then_some(self.identity.values[field])
+    }
+
+    pub fn linux_identity(&self) -> Box<crate::models::LinuxProcessIdentity> {
+        use task_identity_abi::*;
+        let text = |field| self.identity_value(field).map(|value| value.to_string());
+        let controlling_tty = self
+            .identity_value(TTY_MAJOR)
+            .zip(self.identity_value(TTY_MINOR))
+            .zip(self.identity_value(TTY_INDEX))
+            .and_then(|((major, minor), index)| {
+                minor
+                    .checked_add(index)
+                    .map(|minor| format!("{major}:{minor}"))
+            });
+        Box::new(crate::models::LinuxProcessIdentity {
+            real_group_id: Some(self.identity.real_gid.to_string()),
+            effective_user_id: text(EUID),
+            effective_group_id: text(EGID),
+            mount_namespace: text(MOUNT_NS),
+            pid_namespace: text(PID_NS),
+            network_namespace: text(NET_NS),
+            session_id: text(SESSION_ID),
+            controlling_tty,
+            kernel_start_boottime: self.identity_value(START_BOOTTIME),
+        })
+    }
+
     /// Command line reconstructed from the kernel argv capture.
     ///
     /// Returns `None` when the kernel captured nothing, so callers can fall
@@ -287,18 +332,18 @@ pub struct DnsEvent {
 // These catch accidental struct layout divergence at compile time.
 
 const _: () = assert!(
-    core::mem::size_of::<ProcessEvent>() == 856,
+    core::mem::size_of::<ProcessEvent>() == 944,
     "ProcessEvent layout changed — update ebpf/src/events.rs to match"
 );
 // The argv fields were appended after `image`; pin their offsets so a
 // reordering on either side fails the build instead of decoding garbage.
 const _: () = assert!(
-    core::mem::offset_of!(ProcessEvent, args_len) == 336
-        && core::mem::offset_of!(ProcessEvent, args_count) == 338
-        && core::mem::offset_of!(ProcessEvent, args_truncated) == 340
-        && core::mem::offset_of!(ProcessEvent, image_truncated) == 341
-        && core::mem::offset_of!(ProcessEvent, parent_pid_derived) == 342
-        && core::mem::offset_of!(ProcessEvent, args) == 344,
+    core::mem::offset_of!(ProcessEvent, args_len) == 424
+        && core::mem::offset_of!(ProcessEvent, args_count) == 426
+        && core::mem::offset_of!(ProcessEvent, args_truncated) == 428
+        && core::mem::offset_of!(ProcessEvent, image_truncated) == 429
+        && core::mem::offset_of!(ProcessEvent, parent_pid_derived) == 430
+        && core::mem::offset_of!(ProcessEvent, args) == 432,
     "ProcessEvent argv fields moved — update ebpf/src/events.rs to match"
 );
 // `ret` and `sock_type` took over slots that used to be explicit padding, so a
@@ -383,8 +428,9 @@ pub mod mapping {
                 event.parent_process_start_time,
             ),
             payload: SensorPayload::Process(ProcessCreationFields {
+                linux_identity: event.linux_identity(),
                 cgroup_id: (event.cgroup_id != 0).then(|| event.cgroup_id.to_string()),
-                exec: Default::default(),
+                exec: event.exec_metadata(),
                 parent_process_id_derived: event.parent_pid_derived != 0,
                 image: Some(bytes_to_string(&event.image)),
                 image_source: None,
@@ -406,7 +452,7 @@ pub mod mapping {
                 parent_command_line: None,
                 current_directory: None,
                 integrity_level: None,
-                user: Some(event.uid.to_string()),
+                user: event.effective_uid(),
             }),
         }
     }
@@ -434,7 +480,7 @@ pub mod mapping {
                 source_port: None,
                 process_id: Some(event.pid.to_string()),
                 image: None,
-                user: Some(event.uid.to_string()),
+                user: (event.uid != u32::MAX).then(|| event.uid.to_string()),
                 destination_hostname: None,
                 protocol: event.transport().map(str::to_string),
                 // The probe hooks `connect()` only, so every captured
@@ -494,7 +540,7 @@ pub mod mapping {
                 image: None,
                 creation_utc_time: None,
                 previous_creation_utc_time: None,
-                user: Some(event.uid.to_string()),
+                user: (event.uid != u32::MAX).then(|| event.uid.to_string()),
             }),
         })
     }
@@ -562,6 +608,7 @@ mod tests {
     #[test]
     fn process_event_round_trips_kernel_argv_through_raw_bytes() {
         let mut event = ProcessEvent {
+            identity: Default::default(),
             event_time_ns: 0,
             source_seq: 0,
             cgroup_id: 55,

--- a/src/sensor/linux/inventory.rs
+++ b/src/sensor/linux/inventory.rs
@@ -1,0 +1,84 @@
+//! Seed metadata once, then require kernel birth-time reconciliation before use.
+
+use super::events::task_identity_abi::{InventoryIdentity, INVENTORY_CAPACITY};
+use crate::{state::ProcessCache, utils::query_process_details};
+use anyhow::{Context, Result};
+use aya::{maps::HashMap, Ebpf};
+
+unsafe impl aya::Pod for InventoryIdentity {}
+
+pub fn seed(bpf: &mut Ebpf, cache: &ProcessCache) -> Result<()> {
+    let hz = unsafe { libc::sysconf(libc::_SC_CLK_TCK) };
+    anyhow::ensure!(
+        hz > 0 && hz <= 1_000_000,
+        "unsupported proc clock frequency"
+    );
+    let mut now: libc::timespec = unsafe { std::mem::zeroed() };
+    anyhow::ensure!(
+        unsafe { libc::clock_gettime(libc::CLOCK_BOOTTIME, &mut now) } == 0,
+        "reading boot clock"
+    );
+    let identity_time = now.tv_sec as u64 * 1_000_000_000 + now.tv_nsec as u64;
+    let mut inventory = HashMap::<_, u32, InventoryIdentity>::try_from(
+        bpf.map_mut("PROCESS_INVENTORY")
+            .context("missing process inventory map")?,
+    )?;
+    let mut count = 0;
+    for entry in std::fs::read_dir("/proc")? {
+        let Ok(entry) = entry else {
+            continue;
+        };
+        let Some(pid) = entry
+            .file_name()
+            .to_str()
+            .and_then(|name| name.parse::<u32>().ok())
+        else {
+            continue;
+        };
+        let Some(details) = query_process_details(pid) else {
+            continue;
+        };
+        let (Some(start_ticks), Some(image)) = (details.start_time, details.image) else {
+            continue;
+        };
+        // A PID that changed lifetime while reading metadata cannot seed the cache.
+        let current = crate::utils::query_process_identity(pid);
+        if !current.is_some_and(|current| {
+            current.start_time == Some(start_ticks) && current.image == image
+        }) {
+            continue;
+        }
+        let row = InventoryIdentity {
+            start_ticks,
+            clock_ticks_per_second: hz as u64,
+            identity_time,
+        };
+        inventory.insert(pid, row, 0)?;
+        cache.add(
+            pid,
+            identity_time,
+            image,
+            details.command_line,
+            None,
+            details.parent_process_id,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            details.current_directory,
+            None,
+        );
+        count += 1;
+        if count == INVENTORY_CAPACITY {
+            break;
+        }
+    }
+    tracing::info!(
+        count,
+        "startup process inventory awaits kernel birth-time reconciliation"
+    );
+    Ok(())
+}

--- a/src/sensor/linux/mod.rs
+++ b/src/sensor/linux/mod.rs
@@ -3,7 +3,9 @@
 pub(crate) mod abi;
 pub mod ebpf;
 pub mod events;
+mod inventory;
 pub mod paths;
+pub mod task_btf;
 mod tracepoint_format;
 
 pub use ebpf::EbpfSensor;

--- a/src/sensor/linux/task_btf.rs
+++ b/src/sensor/linux/task_btf.rs
@@ -1,0 +1,444 @@
+//! Resolve bounded probe-read plans from runtime BTF, without compiled layouts.
+//! Encoding reference: https://docs.kernel.org/bpf/btf.html
+
+use super::events::task_identity_abi::*;
+use anyhow::{anyhow, bail, ensure, Context, Result};
+
+pub const BTF_PATH: &str = "/sys/kernel/btf/vmlinux";
+pub const FIELD_NAMES: [&str; FIELD_COUNT] = [
+    "start_boottime",
+    "euid",
+    "egid",
+    "mount_namespace",
+    "pid_namespace",
+    "network_namespace",
+    "session_id",
+    "tty_major",
+    "tty_minor",
+    "tty_index",
+];
+
+unsafe impl aya::Pod for ReadPlan {}
+
+pub struct TaskPlans {
+    pub plans: [ReadPlan; FIELD_COUNT],
+    pub warnings: Vec<(String, String)>,
+}
+
+impl TaskPlans {
+    pub fn load() -> Self {
+        Self::resolve(
+            std::fs::read(BTF_PATH)
+                .context("reading kernel BTF")
+                .and_then(|bytes| Btf::parse(&bytes)),
+        )
+    }
+
+    fn resolve(btf: Result<Btf>) -> Self {
+        let mut result = Self {
+            plans: [ReadPlan::default(); FIELD_COUNT],
+            warnings: Vec::new(),
+        };
+        for (index, name) in FIELD_NAMES.iter().enumerate() {
+            let plan = match &btf {
+                Ok(btf) => btf.plan(index),
+                Err(error) => Err(anyhow!("{error:#}")),
+            };
+            match plan {
+                Ok(plan) => result.plans[index] = plan,
+                Err(error) => result
+                    .warnings
+                    .push((format!("linux_task_{name}"), format!("{error:#}"))),
+            }
+        }
+        result
+    }
+}
+
+#[derive(Debug)]
+struct Member {
+    name: String,
+    ty: u32,
+    bits: u32,
+    bitfield: bool,
+}
+
+#[derive(Debug, Default)]
+struct Type {
+    name: String,
+    kind: u32,
+    size_type: u32,
+    members: Vec<Member>,
+    array: Option<(u32, u32)>,
+    int_encoding: u32,
+}
+
+struct Btf {
+    types: Vec<Type>,
+}
+
+fn word(bytes: &[u8], offset: usize) -> Result<u32> {
+    let value = bytes
+        .get(offset..offset + 4)
+        .context("truncated BTF word")?;
+    Ok(u32::from_le_bytes(value.try_into()?))
+}
+
+impl Btf {
+    fn parse(bytes: &[u8]) -> Result<Self> {
+        ensure!(
+            bytes.get(..4) == Some(&[0x9f, 0xeb, 1, 0]),
+            "unsupported BTF header (expected little-endian v1)"
+        );
+        let header = word(bytes, 4)? as usize;
+        ensure!(
+            header >= 24 && header <= bytes.len(),
+            "invalid BTF header length"
+        );
+        let section = |offset, length| -> Result<&[u8]> {
+            let start = header
+                .checked_add(word(bytes, offset)? as usize)
+                .context("BTF offset overflow")?;
+            let end = start
+                .checked_add(word(bytes, length)? as usize)
+                .context("BTF length overflow")?;
+            bytes.get(start..end).context("truncated BTF section")
+        };
+        let data = section(8, 12)?;
+        let strings = section(16, 20)?;
+        ensure!(strings.first() == Some(&0), "invalid BTF string table");
+        let name = |offset: u32| -> Result<String> {
+            let tail = strings
+                .get(offset as usize..)
+                .context("invalid BTF string offset")?;
+            let end = tail
+                .iter()
+                .position(|byte| *byte == 0)
+                .context("unterminated BTF string")?;
+            Ok(std::str::from_utf8(&tail[..end])?.to_owned())
+        };
+        let mut types = vec![Type::default()];
+        let mut cursor = 0;
+        while cursor < data.len() {
+            let info = word(data, cursor + 4)?;
+            let kind = (info >> 24) & 31;
+            let count = (info & 0xffff) as usize;
+            let extra = match kind {
+                1 | 14 | 17 => 4,
+                3 => 12,
+                4 | 5 | 15 | 19 => count * 12,
+                6 | 13 => count * 8,
+                2 | 7..=12 | 16 | 18 => 0,
+                _ => bail!("unsupported BTF kind {kind}"),
+            };
+            let mut ty = Type {
+                name: name(word(data, cursor)?)?,
+                kind,
+                size_type: word(data, cursor + 8)?,
+                ..Type::default()
+            };
+            cursor += 12;
+            let payload = data
+                .get(cursor..cursor + extra)
+                .context("truncated BTF type")?;
+            if kind == 4 || kind == 5 {
+                for member in payload.as_chunks::<12>().0 {
+                    let raw = word(member, 8)?;
+                    let flagged = info >> 31 != 0;
+                    ty.members.push(Member {
+                        name: name(word(member, 0)?)?,
+                        ty: word(member, 4)?,
+                        bits: if flagged { raw & 0xffffff } else { raw },
+                        bitfield: flagged && raw >> 24 != 0,
+                    });
+                }
+            } else if kind == 6 {
+                for entry in payload.as_chunks::<8>().0 {
+                    ty.members.push(Member {
+                        name: name(word(entry, 0)?)?,
+                        ty: 0,
+                        bits: word(entry, 4)?,
+                        bitfield: false,
+                    });
+                }
+            } else if kind == 3 {
+                ty.array = Some((word(payload, 0)?, word(payload, 8)?));
+            } else if kind == 1 {
+                ty.int_encoding = word(payload, 0)?;
+            }
+            types.push(ty);
+            cursor += extra;
+        }
+        Ok(Self { types })
+    }
+
+    fn ty(&self, mut id: u32) -> Result<&Type> {
+        for _ in 0..32 {
+            let ty = self
+                .types
+                .get(id as usize)
+                .context("invalid BTF type reference")?;
+            if matches!(ty.kind, 8..=11 | 18) {
+                id = ty.size_type;
+            } else {
+                return Ok(ty);
+            }
+        }
+        bail!("cyclic BTF type reference")
+    }
+
+    fn member(&self, ty: &Type, name: &str, depth: usize) -> Result<(u32, u32)> {
+        ensure!(
+            depth < 16 && matches!(ty.kind, 4 | 5),
+            "unsupported composite for {name}"
+        );
+        for member in &ty.members {
+            if member.bitfield || member.bits % 8 != 0 {
+                continue;
+            }
+            let offset = member.bits / 8;
+            if member.name == name {
+                let flexible = self
+                    .ty(member.ty)?
+                    .array
+                    .is_some_and(|(_, count)| count == 0);
+                ensure!(
+                    offset < ty.size_type || (flexible && offset == ty.size_type),
+                    "member outside struct: {name}"
+                );
+                return Ok((offset, member.ty));
+            }
+            if member.name.is_empty() {
+                if let Ok((inner, id)) = self.member(self.ty(member.ty)?, name, depth + 1) {
+                    return Ok((
+                        offset
+                            .checked_add(inner)
+                            .context("member offset overflow")?,
+                        id,
+                    ));
+                }
+            }
+        }
+        bail!("missing or unsupported member {}.{name}", ty.name)
+    }
+
+    fn plan(&self, field: usize) -> Result<ReadPlan> {
+        let path: &[&str] = match field {
+            START_BOOTTIME => &["group_leader", "start_boottime"],
+            EUID => &["cred", "euid", "val"],
+            EGID => &["cred", "egid", "val"],
+            MOUNT_NS => &["nsproxy", "mnt_ns", "ns", "inum"],
+            PID_NS => &["thread_pid", "numbers", "@active", "ns", "ns", "inum"],
+            NET_NS => &["nsproxy", "net_ns", "ns", "inum"],
+            SESSION_ID => &["signal", "pids", "@session", "numbers", "@first", "nr"],
+            TTY_MAJOR => &["signal", "tty", "driver", "major"],
+            TTY_MINOR => &["signal", "tty", "driver", "minor_start"],
+            TTY_INDEX => &["signal", "tty", "index"],
+            _ => bail!("unknown task field"),
+        };
+        let mut ty = self
+            .types
+            .iter()
+            .find(|ty| ty.kind == 4 && ty.name == "task_struct")
+            .context("missing task_struct")?;
+        let mut plan = ReadPlan::default();
+        let mut step = ReadStep::default();
+        let mut array_parent = None;
+        for component in path {
+            while ty.kind == 2 {
+                ensure!((plan.len as usize) < MAX_STEPS - 1, "too many pointer hops");
+                plan.steps[plan.len as usize] = step;
+                plan.len += 1;
+                step = ReadStep::default();
+                ty = self.ty(ty.size_type)?;
+            }
+            if component.starts_with('@') {
+                let (element, count) = ty.array.context("expected BTF array")?;
+                ty = self.ty(element)?;
+                let size = if ty.kind == 2 { 8 } else { ty.size_type };
+                match *component {
+                    "@active" => {
+                        let parent = array_parent.context("missing pid array parent")?;
+                        let (offset, level_type) = self.member(parent, "level", 0)?;
+                        self.scalar(self.ty(level_type)?, 4)?;
+                        ensure!(
+                            size > 0 && size <= 255 && offset <= 65535,
+                            "unsupported pid layout"
+                        );
+                        step.stride = size;
+                        step.level_offset = offset;
+                    }
+                    "@session" => {
+                        // PIDTYPE_SID is a kernel enum, resolved rather than assumed.
+                        let sid = self.enum_value("pid_type", "PIDTYPE_SID")?;
+                        ensure!(sid < count, "session PID index outside array");
+                        step.offset = step
+                            .offset
+                            .checked_add(sid.checked_mul(size).context("array overflow")?)
+                            .context("offset overflow")?;
+                    }
+                    "@first" => (),
+                    _ => bail!("unsupported array selector"),
+                }
+            } else {
+                array_parent = Some(ty);
+                let (offset, id) = self.member(ty, component, 0)?;
+                step.offset = step.offset.checked_add(offset).context("offset overflow")?;
+                ty = self.ty(id)?;
+            }
+            ensure!(
+                step.offset <= 65535 && step.offset + 32 * step.stride <= 65535,
+                "BTF offset exceeds verifier bounds"
+            );
+        }
+        self.scalar(ty, if field == START_BOOTTIME { 8 } else { 4 })?;
+        plan.steps[plan.len as usize] = step;
+        plan.len += 1;
+        if matches!(field, START_BOOTTIME | EUID | EGID) {
+            ensure!(
+                plan.len == 2 && plan.steps.iter().all(|step| step.stride == 0),
+                "unsupported credential or birth-time pointer layout"
+            );
+        }
+        Ok(plan)
+    }
+
+    fn scalar(&self, ty: &Type, width: u32) -> Result<()> {
+        ensure!(
+            ty.kind == 1 && ty.size_type == width && ty.int_encoding & 0xffffff == width * 8,
+            "unsupported scalar width or bitfield"
+        );
+        Ok(())
+    }
+
+    fn enum_value(&self, name: &str, member: &str) -> Result<u32> {
+        let ty = self
+            .types
+            .iter()
+            .find(|ty| ty.kind == 6 && ty.name == name)
+            .context("missing BTF enum")?;
+        ty.members
+            .iter()
+            .find(|entry| entry.name == member)
+            .map(|entry| entry.bits)
+            .context("missing BTF enum value")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture(cred_offset: u32, euid_offset: u32, euid_name: &str, width: u32) -> Vec<u8> {
+        let mut strings = vec![0];
+        let mut data = Vec::new();
+        let mut name = |s: &str| {
+            let offset = strings.len() as u32;
+            strings.extend_from_slice(s.as_bytes());
+            strings.push(0);
+            offset
+        };
+        let mut words = |values: &[u32]| {
+            for value in values {
+                data.extend(value.to_le_bytes());
+            }
+        };
+        words(&[name("u32"), 1 << 24, width, width * 8]); // 1
+        words(&[name("kuid_t"), (4 << 24) | 1, width, name("val"), 1, 0]); // 2
+        words(&[
+            name("cred"),
+            (4 << 24) | 2,
+            64,
+            name(euid_name),
+            2,
+            euid_offset * 8,
+            name("egid"),
+            2,
+            40 * 8,
+        ]); // 3
+        words(&[0, 2 << 24, 3]); // 4 pointer
+        words(&[
+            name("task_struct"),
+            (4 << 24) | 1,
+            4096,
+            name("cred"),
+            4,
+            cred_offset * 8,
+        ]); // 5
+        let mut bytes = vec![0x9f, 0xeb, 1, 0];
+        for value in [
+            24,
+            0,
+            data.len() as u32,
+            data.len() as u32,
+            strings.len() as u32,
+        ] {
+            bytes.extend(value.to_le_bytes());
+        }
+        bytes.extend(data);
+        bytes.extend(strings);
+        bytes
+    }
+
+    #[test]
+    fn offsets_follow_running_layout_and_zero_is_valid() {
+        for (cred, euid) in [(2720, 24), (2984, 20), (3328, 0)] {
+            let plans = TaskPlans::resolve(Btf::parse(&fixture(cred, euid, "euid", 4)));
+            assert_eq!(plans.plans[EUID].len, 2);
+            assert_eq!(plans.plans[EUID].steps[0].offset, cred);
+            assert_eq!(plans.plans[EUID].steps[1].offset, euid);
+        }
+    }
+
+    #[test]
+    fn missing_member_disables_only_affected_field() {
+        let plans = TaskPlans::resolve(Btf::parse(&fixture(2720, 24, "renamed_euid", 4)));
+        assert_eq!(plans.plans[EUID].len, 0);
+        assert_eq!(plans.plans[EGID].len, 2);
+        assert!(plans
+            .warnings
+            .iter()
+            .any(|(name, _)| name == "linux_task_euid"));
+        assert!(!plans
+            .warnings
+            .iter()
+            .any(|(name, _)| name == "linux_task_egid"));
+    }
+
+    #[test]
+    fn changed_scalar_width_is_disabled() {
+        let plans = TaskPlans::resolve(Btf::parse(&fixture(2720, 24, "euid", 8)));
+        assert_eq!(plans.plans[EUID].len, 0);
+        assert_eq!(plans.plans[EGID].len, 0);
+    }
+
+    #[test]
+    fn bitfields_and_unbounded_offsets_are_disabled() {
+        let mut bytes = fixture(2720, 24, "euid", 4);
+        // Header (24), int (16), kuid (24), then cred's header and members.
+        let cred = 24 + 16 + 24;
+        bytes[cred + 4..cred + 8].copy_from_slice(&((1u32 << 31) | (4 << 24) | 2).to_le_bytes());
+        bytes[cred + 20..cred + 24].copy_from_slice(&((16u32 << 24) | (24 * 8)).to_le_bytes());
+        let plans = TaskPlans::resolve(Btf::parse(&bytes));
+        assert_eq!(plans.plans[EUID].len, 0);
+        assert_eq!(plans.plans[EGID].len, 2);
+        let plans = TaskPlans::resolve(Btf::parse(&fixture(65536, 24, "euid", 4)));
+        assert_eq!(plans.plans[EUID].len, 0);
+    }
+
+    #[test]
+    fn truncated_and_malformed_btf_never_panics() {
+        let bytes = fixture(2720, 24, "euid", 4);
+        for len in 0..bytes.len() {
+            assert!(Btf::parse(&bytes[..len]).is_err());
+        }
+        for offset in [4, 8, 12, 16, 20] {
+            let mut corrupt = bytes.clone();
+            corrupt[offset..offset + 4].copy_from_slice(&u32::MAX.to_le_bytes());
+            assert!(Btf::parse(&corrupt).is_err());
+        }
+        let plans = TaskPlans::resolve(Btf::parse(&[]));
+        assert_eq!(plans.warnings.len(), FIELD_COUNT);
+        assert!(plans.plans.iter().all(|plan| plan.len == 0));
+    }
+}

--- a/src/sensor/macos/esf.rs
+++ b/src/sensor/macos/esf.rs
@@ -432,6 +432,7 @@ fn process_start_event(raw: RawExec) -> SensorEvent {
         }),
         parent_process_start_key: raw.parent_process_start_key,
         payload: SensorPayload::Process(ProcessCreationFields {
+            linux_identity: Default::default(),
             cgroup_id: None,
             exec: Some(Box::new(raw.metadata)),
             parent_process_id_derived: raw.parent_derived,
@@ -497,6 +498,7 @@ fn process_stop_event(
         process_start_key: start_time.map(|start_time| ProcessStartKey { pid, start_time }),
         parent_process_start_key: None,
         payload: SensorPayload::Process(ProcessCreationFields {
+            linux_identity: Default::default(),
             cgroup_id: None,
             exec: Default::default(),
             parent_process_id_derived: false,

--- a/src/sensor/mod.rs
+++ b/src/sensor/mod.rs
@@ -324,6 +324,7 @@ mod tests {
     #[test]
     fn payload_category_matches_variant() {
         let payload = SensorPayload::Process(ProcessCreationFields {
+            linux_identity: Default::default(),
             cgroup_id: None,
             exec: Default::default(),
             parent_process_id_derived: false,

--- a/src/sensor/windows/enrichment.rs
+++ b/src/sensor/windows/enrichment.rs
@@ -63,6 +63,7 @@ mod tests {
 
     fn process_fields(image: &str) -> ProcessCreationFields {
         ProcessCreationFields {
+            linux_identity: Default::default(),
             cgroup_id: None,
             exec: Default::default(),
             parent_process_id_derived: false,

--- a/src/sensor/windows/etw/decode.rs
+++ b/src/sensor/windows/etw/decode.rs
@@ -298,6 +298,7 @@ pub(super) fn decode_process(
     let parent_image = raw_parent_image.map(|path| convert_nt_to_dos(&path));
 
     let fields = ProcessCreationFields {
+        linux_identity: Default::default(),
         cgroup_id: None,
         exec: Default::default(),
         parent_process_id_derived: false,

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -43,7 +43,7 @@ pub const TARGET_TELEMETRY: &str = "telemetry";
 /// Bump this whenever a ring-buffer event layout or loader-patched global
 /// changes. This lives outside the Linux-only sensor module because telemetry
 /// snapshots are compiled on every supported platform.
-pub(crate) const LINUX_EBPF_ABI_VERSION: u32 = 1;
+pub(crate) const LINUX_EBPF_ABI_VERSION: u32 = 2;
 
 /// Linux ring-buffer program families, in snapshot order.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/tests/active_response.rs
+++ b/tests/active_response.rs
@@ -48,6 +48,7 @@ fn build_yara_alert(pid: u32, image: &str) -> Alert {
             event_id_string: "1".to_string(),
             opcode: 1,
             fields: EventFields::ProcessCreation(ProcessCreationFields {
+                linux_identity: Default::default(),
                 cgroup_id: None,
                 exec: Default::default(),
                 parent_process_id_derived: false,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -129,17 +129,28 @@ pub fn process_start_event(platform: Platform) -> SensorEvent {
         }),
         parent_process_start_key: None,
         payload: SensorPayload::Process(ProcessCreationFields {
-            cgroup_id: None,
-            exec: (platform == Platform::MacOS).then(|| {
-                serde_json::from_value(serde_json::json!({
-                    "RealUserId": "501",
-                    "Signed": "false",
-                    "SignatureStatus": "unsigned",
-                    "CodeSigningFlags": "0",
-                    "IsPlatformBinary": false
-                }))
-                .expect("macOS exec metadata fixture")
+            linux_identity: Box::new(rustinel::models::LinuxProcessIdentity {
+                real_group_id: (platform == Platform::Linux).then(|| "1000".to_string()),
+                ..Default::default()
             }),
+            cgroup_id: None,
+            exec: if platform == Platform::Linux {
+                Some(
+                    serde_json::from_value(serde_json::json!({"RealUserId": "1000"}))
+                        .expect("Linux real UID fixture"),
+                )
+            } else {
+                (platform == Platform::MacOS).then(|| {
+                    serde_json::from_value(serde_json::json!({
+                        "RealUserId": "501",
+                        "Signed": "false",
+                        "SignatureStatus": "unsigned",
+                        "CodeSigningFlags": "0",
+                        "IsPlatformBinary": false
+                    }))
+                    .expect("macOS exec metadata fixture")
+                })
+            },
             parent_process_id_derived: false,
             image: Some(image.to_string()),
             image_source: (platform == Platform::Linux).then(|| "proc".to_string()),

--- a/tests/dedup_integration.rs
+++ b/tests/dedup_integration.rs
@@ -33,6 +33,7 @@ fn make_alert(rule: &str, image: &str) -> Alert {
             event_id_string: "1".to_string(),
             opcode: 1,
             fields: EventFields::ProcessCreation(ProcessCreationFields {
+                linux_identity: Default::default(),
                 cgroup_id: None,
                 exec: Default::default(),
                 parent_process_id_derived: false,

--- a/tests/ecs_contract.rs
+++ b/tests/ecs_contract.rs
@@ -135,6 +135,7 @@ fn ecs_category_coverage_maps_event_contract_fields() {
                 1,
                 1,
                 EventFields::ProcessCreation(ProcessCreationFields {
+                    linux_identity: Default::default(),
                     cgroup_id: None,
                     exec: Default::default(),
                     parent_process_id_derived: false,
@@ -500,6 +501,7 @@ fn ecs_version_field_is_9_4_0() {
         1,
         1,
         EventFields::ProcessCreation(ProcessCreationFields {
+            linux_identity: Default::default(),
             cgroup_id: None,
             exec: Default::default(),
             parent_process_id_derived: false,
@@ -534,6 +536,7 @@ fn ecs_process_image_truncation_marker_is_preserved() {
         1,
         1,
         EventFields::ProcessCreation(ProcessCreationFields {
+            linux_identity: Default::default(),
             cgroup_id: None,
             exec: Default::default(),
             parent_process_id_derived: false,
@@ -581,6 +584,7 @@ fn test_rule_id_mapping_and_omit_behavior() {
             event_id_string: "1".to_string(),
             opcode: 1,
             fields: EventFields::ProcessCreation(ProcessCreationFields {
+                linux_identity: Default::default(),
                 cgroup_id: None,
                 exec: Default::default(),
                 parent_process_id_derived: false,

--- a/tests/field_availability.rs
+++ b/tests/field_availability.rs
@@ -158,6 +158,7 @@ fn missing_always_fields_detect_decoder_contract_drift() {
         1,
         1,
         EventFields::ProcessCreation(ProcessCreationFields {
+            linux_identity: Default::default(),
             image: Some(r"C:\Windows\System32\cmd.exe".to_string()),
             image_source: None,
             image_truncated: None,

--- a/tests/linux_task_identity.rs
+++ b/tests/linux_task_identity.rs
@@ -1,0 +1,276 @@
+#![cfg(target_os = "linux")]
+
+use rustinel::{
+    sensor::{linux::EbpfSensor, Sensor, SensorAction, SensorPayload},
+    state::ProcessCache,
+};
+use std::{
+    io::{Read, Write},
+    os::unix::{fs::MetadataExt, process::CommandExt},
+    process::{Command, Stdio},
+    sync::Arc,
+    time::Duration,
+};
+
+#[test]
+#[ignore = "subprocess for privileged task identity validation"]
+fn identity_child() {
+    assert_eq!(std::env::var("RUSTINEL_IDENTITY_CHILD").as_deref(), Ok("1"));
+    let mut byte = [0];
+    std::io::stdin().read_exact(&mut byte).unwrap();
+    std::fs::write(
+        format!("/tmp/task433-{}", std::process::id()),
+        b"identity probe",
+    )
+    .unwrap();
+    std::io::stdin().read_exact(&mut byte).unwrap();
+    panic!("exec failed: {}", Command::new("/bin/cat").exec());
+}
+
+fn child() -> Command {
+    let mut command = Command::new(std::env::current_exe().unwrap());
+    command
+        .args(["--ignored", "--exact", "identity_child", "--nocapture"])
+        .env("RUSTINEL_IDENTITY_CHILD", "1")
+        .stdin(Stdio::piped());
+    command
+}
+
+struct Child(std::process::Child);
+impl Drop for Child {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+        let _ = std::fs::remove_file(format!("/tmp/task433-{}", self.0.id()));
+    }
+}
+
+fn assert_verifier_acceptance() {
+    let snapshot = rustinel::telemetry::LINUX_EBPF.snapshot().unwrap();
+    for feature in snapshot.features {
+        for reason in feature.unavailable_hooks {
+            assert!(!reason.contains("BPF_PROG_LOAD"), "{reason}");
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires root, tracefs, kernel BTF, and a built eBPF object"]
+async fn live_task_identity_matches_proc() {
+    assert_eq!(unsafe { libc::geteuid() }, 0);
+    let plans = rustinel::sensor::linux::task_btf::TaskPlans::load();
+    assert!(plans.warnings.is_empty(), "{:?}", plans.warnings);
+    // This child predates attachment and must reconcile through the inventory.
+    let mut existing = Child(child().spawn().unwrap());
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let cache = Arc::new(ProcessCache::new());
+    let sensor = EbpfSensor::with_process_cache(Arc::clone(&cache));
+    let (tx, mut rx) = tokio::sync::mpsc::channel(8192);
+    sensor.start(tx).unwrap();
+    assert_verifier_acceptance();
+    existing.0.stdin.as_mut().unwrap().write_all(b"x").unwrap();
+    let mut command = Command::new("/bin/cat");
+    command.stdin(Stdio::piped()).stdout(Stdio::null());
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setsid() < 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            if libc::unshare(libc::CLONE_NEWNS | libc::CLONE_NEWNET | libc::CLONE_NEWPID) != 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            let master = libc::posix_openpt(libc::O_RDWR);
+            if master < 0 || libc::grantpt(master) != 0 || libc::unlockpt(master) != 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            let slave = libc::open(libc::ptsname(master), libc::O_RDWR);
+            if slave < 0 || libc::ioctl(slave, libc::TIOCSCTTY, 0) != 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            // Model the real/effective credentials of a setuid-root exec.
+            if libc::setresgid(1000, 0, 0) != 0 || libc::setresuid(1000, 0, 0) != 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    let target = Child(command.spawn().unwrap());
+    let target_pid = target.0.id();
+    let mut saw_exec = false;
+    let mut saw_inventory = false;
+    let mut inventory_key = None;
+    tokio::time::timeout(Duration::from_secs(15), async {
+        while let Some(event) = rx.recv().await {
+            if event.pid == Some(existing.0.id()) && matches!(event.payload, SensorPayload::File(_))
+            {
+                let key = event
+                    .process_start_key
+                    .expect("inventory must produce an identity");
+                assert!(cache.get_metadata_by_key(key.pid, key.start_time).is_some());
+                saw_inventory = true;
+                inventory_key = Some(key);
+            }
+            if event.pid == Some(target_pid) && event.action == SensorAction::Start {
+                let SensorPayload::Process(fields) = event.payload else {
+                    continue;
+                };
+                let identity = &fields.linux_identity;
+                let status = std::fs::read_to_string(format!("/proc/{target_pid}/status")).unwrap();
+                let ids = |key: &str| -> Vec<String> {
+                    status
+                        .lines()
+                        .find(|line| line.starts_with(key))
+                        .unwrap()
+                        .split_whitespace()
+                        .skip(1)
+                        .map(str::to_owned)
+                        .collect()
+                };
+                let uid = ids("Uid:");
+                let gid = ids("Gid:");
+                assert_eq!(uid[0], "1000");
+                assert_eq!(uid[1], "0");
+                assert_eq!(fields.user.as_deref(), Some(uid[1].as_str()));
+                assert_eq!(
+                    fields
+                        .exec
+                        .as_ref()
+                        .and_then(|exec| exec.real_user_id.as_deref()),
+                    Some(uid[0].as_str())
+                );
+                assert_eq!(identity.real_group_id.as_deref(), Some(gid[0].as_str()));
+                assert_eq!(
+                    identity.effective_group_id.as_deref(),
+                    Some(gid[1].as_str())
+                );
+                for (name, value) in [
+                    ("mnt", &identity.mount_namespace),
+                    ("pid", &identity.pid_namespace),
+                    ("net", &identity.network_namespace),
+                ] {
+                    let inode = std::fs::metadata(format!("/proc/{target_pid}/ns/{name}"))
+                        .unwrap()
+                        .ino();
+                    assert_eq!(value.as_deref(), Some(inode.to_string().as_str()), "{name}");
+                }
+                let active = std::fs::metadata(format!("/proc/{target_pid}/ns/pid"))
+                    .unwrap()
+                    .ino();
+                let children = std::fs::metadata(format!("/proc/{target_pid}/ns/pid_for_children"))
+                    .ok()
+                    .map(|meta| meta.ino());
+                assert_ne!(
+                    Some(active),
+                    children,
+                    "exercise the active PID namespace distinction"
+                );
+                let stat = std::fs::read_to_string(format!("/proc/{target_pid}/stat")).unwrap();
+                let tail: Vec<_> = stat
+                    .rsplit_once(')')
+                    .unwrap()
+                    .1
+                    .split_whitespace()
+                    .collect();
+                assert_eq!(identity.session_id.as_deref(), Some(tail[3]));
+                let tty = tail[4].parse::<u32>().unwrap() as u64;
+                let major = (tty >> 8) & 0xfff;
+                let minor = (tty & 0xff) | ((tty >> 12) & 0xfff00);
+                assert_eq!(
+                    identity.controlling_tty.as_deref(),
+                    Some(format!("{major}:{minor}").as_str())
+                );
+                let start = identity.kernel_start_boottime.unwrap();
+                let hz = unsafe { libc::sysconf(libc::_SC_CLK_TCK) } as u64;
+                assert_eq!(
+                    start / 1_000_000_000 * hz + start % 1_000_000_000 * hz / 1_000_000_000,
+                    tail[19].parse::<u64>().unwrap()
+                );
+                assert_ne!(
+                    event.process_start_key.unwrap().start_time,
+                    start,
+                    "execution identity remains separate from kernel birth time"
+                );
+                saw_exec = true;
+            }
+            if saw_exec && saw_inventory {
+                break;
+            }
+        }
+    })
+    .await
+    .unwrap();
+    assert!(saw_exec && saw_inventory);
+    existing.0.stdin.as_mut().unwrap().write_all(b"x").unwrap();
+    tokio::time::timeout(Duration::from_secs(10), async {
+        while let Some(event) = rx.recv().await {
+            if event.pid == Some(existing.0.id()) && event.action == SensorAction::Start {
+                assert_ne!(
+                    event.process_start_key, inventory_key,
+                    "exec must mint a new execution identity"
+                );
+                let SensorPayload::Process(fields) = event.payload else {
+                    continue;
+                };
+                let start = fields.linux_identity.kernel_start_boottime.unwrap();
+                let ticks = rustinel::utils::query_process_details(existing.0.id())
+                    .unwrap()
+                    .start_time
+                    .unwrap();
+                let hz = unsafe { libc::sysconf(libc::_SC_CLK_TCK) } as u64;
+                assert_eq!(
+                    start / 1_000_000_000 * hz + start % 1_000_000_000 * hz / 1_000_000_000,
+                    ticks
+                );
+                return;
+            }
+        }
+        panic!("no repeated exec event");
+    })
+    .await
+    .unwrap();
+    sensor.shutdown();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires an isolated root VM with /sys/kernel/btf hidden"]
+async fn live_without_btf_keeps_base_telemetry() {
+    let plans = rustinel::sensor::linux::task_btf::TaskPlans::load();
+    assert!(plans.plans.iter().all(|plan| plan.len == 0));
+    assert_eq!(plans.warnings.len(), 10);
+    let sensor = EbpfSensor::new();
+    let (tx, mut rx) = tokio::sync::mpsc::channel(8192);
+    sensor.start(tx).unwrap();
+    assert_verifier_acceptance();
+    let target = Child(
+        Command::new("/bin/cat")
+            .stdin(Stdio::piped())
+            .spawn()
+            .unwrap(),
+    );
+    tokio::time::timeout(Duration::from_secs(10), async {
+        while let Some(event) = rx.recv().await {
+            if event.pid == Some(target.0.id()) && event.action == SensorAction::Start {
+                let SensorPayload::Process(fields) = event.payload else {
+                    continue;
+                };
+                assert!(fields.user.is_none());
+                assert!(fields.linux_identity.effective_user_id.is_none());
+                assert!(fields.linux_identity.mount_namespace.is_none());
+                assert!(fields.linux_identity.kernel_start_boottime.is_none());
+                assert_eq!(
+                    fields
+                        .exec
+                        .as_ref()
+                        .and_then(|exec| exec.real_user_id.as_deref()),
+                    Some("0")
+                );
+                assert!(event.process_start_key.is_some());
+                sensor.shutdown();
+                return;
+            }
+        }
+        panic!("no process event");
+    })
+    .await
+    .unwrap();
+}

--- a/tests/platform_mapping.rs
+++ b/tests/platform_mapping.rs
@@ -30,6 +30,7 @@ fn linux_ebpf_raw_events_map_to_sensor_events() {
     use std::os::fd::AsRawFd;
 
     let mut process = ProcessEvent {
+        identity: Default::default(),
         event_time_ns: 0,
         source_seq: 0,
         cgroup_id: 55,

--- a/tests/reload.rs
+++ b/tests/reload.rs
@@ -698,6 +698,7 @@ fn build_critical_process_alert(pid: u32, image: &str) -> rustinel::models::Aler
             event_id_string: "1".to_string(),
             opcode: 1,
             fields: EventFields::ProcessCreation(ProcessCreationFields {
+                linux_identity: Default::default(),
                 cgroup_id: None,
                 exec: Default::default(),
                 parent_process_id_derived: false,

--- a/tests/sigma_corpus_compatibility.rs
+++ b/tests/sigma_corpus_compatibility.rs
@@ -259,6 +259,7 @@ fn process_event(timestamp: &str) -> NormalizedEvent {
         event_id_string: "1".to_string(),
         opcode: 1,
         fields: EventFields::ProcessCreation(ProcessCreationFields {
+            linux_identity: Default::default(),
             cgroup_id: None,
             exec: Default::default(),
             parent_process_id_derived: false,

--- a/tests/sigma_documents.rs
+++ b/tests/sigma_documents.rs
@@ -29,6 +29,7 @@ fn process_event(timestamp: &str, user: &str) -> NormalizedEvent {
         event_id_string: "1".to_string(),
         opcode: 1,
         fields: EventFields::ProcessCreation(ProcessCreationFields {
+            linux_identity: Default::default(),
             cgroup_id: None,
             exec: Default::default(),
             parent_process_id_derived: false,

--- a/tests/yara_disk.rs
+++ b/tests/yara_disk.rs
@@ -84,6 +84,7 @@ fn build_yara_alert(
             event_id_string: "1".to_string(),
             opcode: 1,
             fields: EventFields::ProcessCreation(ProcessCreationFields {
+                linux_identity: Default::default(),
                 cgroup_id: None,
                 exec: Default::default(),
                 parent_process_id_derived: false,


### PR DESCRIPTION
## Summary

A Linux process with real UID 1000 and effective UID 0 now reports `User: root` and `RealUserId: 1000`. Effective credentials, active mount/PID/network namespace inodes, session ID, controlling terminal, and kernel birth time are measured from the current task using offsets resolved from the running kernel's BTF.

- Pass bounded read plans through an array map and use `bpf_get_current_task()`, including on 5.10. Missing members disable fields individually with `linux_task_<field>` doctor warnings. Validity bits distinguish effective root from a failed read; there are no build-kernel offset fallbacks.
- Seed a bounded startup inventory and accept its metadata only after kernel `start_boottime` matches `/proc` start ticks. Keep sensor execution keys separate, including after non-leader-thread exec.
- Correct effective UID on file and network events too, retain process account-name resolution outside the ring drain, expose identity fields to Sigma/recordings/ECS, and update the field availability contract.
- Bump the eBPF event ABI to 2. Decoder fixtures on other platforms receive default Linux identity metadata.

Closes #433. Addresses the Linux portion of #327.

## Type of change

- [x] `feat` / `enhancement` - new feature
- [x] `bug` - bug fix

## Test plan

- [ ] Tested on Windows
- [x] Tested on Linux
- [x] Tested on macOS
- [x] Existing tests pass (`cargo test --locked -j 2` on Linux and macOS)
- [x] New tests added for BTF layout changes, missing members, invalid widths/bitfields, malformed input, effective-root normalization, and recording round trips
- [x] `cargo clippy --all-targets -- -D clippy::all` on Linux and macOS
- [x] Formatting checks for both workspaces and a release eBPF build

Live tests ran in disposable x86_64 VMs with the same userspace test executable and unmodified ABI v2 eBPF object across all four kernels:

| Kernel | Identity versus `/proc`, startup inventory, non-leader exec | BTF hidden: base telemetry still works |
| --- | --- | --- |
| 5.10.0-32-amd64 | Pass | Pass |
| 5.15.0-198-generic | Pass | Pass |
| 6.1.0-50-amd64 | Pass | Pass |
| 6.8.0-146-generic | Pass | Pass |

The privileged tests check differing real/effective UIDs and GIDs, active PID namespace versus the namespace for future children, mount/network inodes, session/TTY, kernel birth ticks, and execution-key changes. They also reject verifier load failures in hooks that the capability-aware loader could otherwise skip.

Tests: `live_task_identity_matches_proc` and `live_without_btf_keeps_base_telemetry` in `tests/linux_task_identity.rs`. Reproduction guidance is in `docs/development.md`.

Tested eBPF object SHA-256: `59f84708dc7bddaa93acc9a971de08629f824abf96b38b982786c7bf507021a1`.

## Checklist

- [x] Labels added to this PR
- [x] Docs and generated field availability artifacts updated
