### PR TITLE
feat(linux-ebpf): measure socket tuples at connect and accept exit

### DIFF
--- a/compatibility/field-availability.json
+++ b/compatibility/field-availability.json
@@ -2893,7 +2893,7 @@
       "event_id": 3,
       "action": "connect",
       "provider": "ebpf",
-      "source": "connect tracepoints",
+      "source": "socket fexit or connect tracepoints",
       "field": "DestinationIp",
       "availability": "always"
     },
@@ -2903,7 +2903,7 @@
       "event_id": 3,
       "action": "connect",
       "provider": "ebpf",
-      "source": "connect tracepoints",
+      "source": "socket fexit or connect tracepoints",
       "field": "DestinationPort",
       "availability": "always"
     },
@@ -2913,7 +2913,7 @@
       "event_id": 3,
       "action": "connect",
       "provider": "ebpf",
-      "source": "connect tracepoints",
+      "source": "socket fexit or connect tracepoints",
       "field": "ProcessId",
       "availability": "always"
     },
@@ -2923,7 +2923,7 @@
       "event_id": 3,
       "action": "connect",
       "provider": "ebpf",
-      "source": "connect tracepoints",
+      "source": "socket fexit or connect tracepoints",
       "field": "User",
       "availability": "conditional",
       "reason": "runtime BTF resolves effective credentials and the kernel read succeeds"
@@ -2934,7 +2934,7 @@
       "event_id": 3,
       "action": "connect",
       "provider": "ebpf",
-      "source": "connect tracepoints",
+      "source": "socket fexit or connect tracepoints",
       "field": "Initiated",
       "availability": "always"
     },
@@ -2944,10 +2944,10 @@
       "event_id": 3,
       "action": "connect",
       "provider": "ebpf",
-      "source": "connect tracepoints",
+      "source": "socket fexit or connect tracepoints",
       "field": "Protocol",
       "availability": "conditional",
-      "reason": "the socket was observed being created and is TCP or UDP"
+      "reason": "the socket fexit tier is active and sk_protocol names TCP or UDP"
     },
     {
       "platform": "linux",
@@ -2955,7 +2955,7 @@
       "event_id": 3,
       "action": "connect",
       "provider": "ebpf",
-      "source": "connect tracepoints",
+      "source": "socket fexit or connect tracepoints",
       "field": "Image",
       "availability": "conditional",
       "reason": "the process identity is still present in the process cache"
@@ -2966,7 +2966,7 @@
       "event_id": 3,
       "action": "connect",
       "provider": "ebpf",
-      "source": "connect tracepoints",
+      "source": "socket fexit or connect tracepoints",
       "field": "DestinationHostname",
       "availability": "conditional",
       "reason": "a preceding observed DNS answer resolves the destination"
@@ -2977,10 +2977,10 @@
       "event_id": 3,
       "action": "connect",
       "provider": "ebpf",
-      "source": "connect tracepoints",
+      "source": "socket fexit or connect tracepoints",
       "field": "SourceIp",
-      "availability": "never",
-      "reason": "connect syscall arguments do not carry the kernel-assigned source address"
+      "availability": "conditional",
+      "reason": "the socket fexit tier measures the bound source address"
     },
     {
       "platform": "linux",
@@ -2988,10 +2988,10 @@
       "event_id": 3,
       "action": "connect",
       "provider": "ebpf",
-      "source": "connect tracepoints",
+      "source": "socket fexit or connect tracepoints",
       "field": "SourcePort",
-      "availability": "never",
-      "reason": "connect syscall arguments do not carry the kernel-assigned source port"
+      "availability": "conditional",
+      "reason": "the socket fexit tier measures the bound source port"
     },
     {
       "platform": "linux",

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -143,7 +143,7 @@ condition must be analysed before deciding whether that rule can fire.
 | Platform | Always | Conditional | Never |
 | --- | ---: | ---: | ---: |
 | windows | 19 | 184 | 40 |
-| linux | 19 | 38 | 19 |
+| linux | 19 | 40 | 17 |
 | macos | 27 | 22 | 28 |
 
 The complete machine-readable baseline is

--- a/docs/development.md
+++ b/docs/development.md
@@ -81,6 +81,27 @@ In a disposable VM, hide `/sys/kernel/btf` and run
 `live_without_btf_keeps_base_telemetry` to check graceful degradation. Never hide
 host BTF on a shared machine.
 
+### Linux socket tuple validation
+
+Build the object above, then run on an isolated Linux host with eBPF privileges,
+tracefs, kernel BTF, and a non-loopback IPv4 interface:
+
+```sh
+cargo test --test linux_socket_tuple running_kernel_socket_layout -- --ignored --nocapture
+sudo env RUSTINEL_EBPF_OBJECT=/absolute/path/to/rustinel-ebpf.o \
+  cargo test --test linux_socket_tuple live_tuple_and_connection_churn -- --ignored --nocapture
+```
+
+The live test checks TCP connect and accept direction, UDP sockets created before
+attachment, kernel loopback filtering, and 2,000 connections while the ring drain
+runs. It prints received event counts and maximum delivery delay. Run the same
+object on a kernel with the four-argument accept prototype and one with the
+two-argument prototype. Run `live_without_socket_btf_uses_syscall_fallback` with an empty file bind-mounted
+over `/sys/kernel/btf/vmlinux` inside a private mount namespace to verify the
+syscall fallback. Never hide BTF in the host mount namespace. Fixture tests also
+cover layout rejection and capability state. The sensor's minimum remains Linux 5.8 due
+to ring buffers; a kernel version alone is never used to select the tuple tier.
+
 ## Recommended Dev Runs
 
 ### Windows

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -20,8 +20,6 @@ table and run `cargo run --bin generate-field-availability`, not this section.
 | linux | `dns_query` | `22 / query` | `socket send tracepoints` | `QueryStatus` | the eBPF DNS probe does not parse response status |
 | linux | `file_event` | `create, delete, modify, rename` | `file syscall tracepoints` | `CreationUtcTime` | the eBPF file probes do not read file timestamps |
 | linux | `file_event` | `create, delete, modify, rename` | `file syscall tracepoints` | `PreviousCreationUtcTime` | the eBPF file probes do not read file timestamps |
-| linux | `network_connection` | `3 / connect` | `connect tracepoints` | `SourceIp` | connect syscall arguments do not carry the kernel-assigned source address |
-| linux | `network_connection` | `3 / connect` | `connect tracepoints` | `SourcePort` | connect syscall arguments do not carry the kernel-assigned source port |
 | linux | `process_creation` | `1 / start` | `execve tracepoints` | `Company` | PE version resources are Windows-only |
 | linux | `process_creation` | `1 / start` | `execve tracepoints` | `Description` | PE version resources are Windows-only |
 | linux | `process_creation` | `1 / start` | `execve tracepoints` | `FileVersion` | PE version resources are Windows-only |
@@ -269,30 +267,24 @@ rejected before any program attaches.
   is decoded only for A, NS, CNAME, PTR, TXT, and AAAA. Every other type is
   reported as the literal string `OTHER`, so a rule selecting on any other
   record type cannot match.
-- **Network is outbound `connect()` only.** No inbound or `accept()` visibility,
-  so every event carries `Initiated: true` and a rule selecting
-  `Initiated: 'false'` has nothing to match on Linux — inbound connections are
-  absent rather than misreported. Capture is split across syscall entry and
-  exit, so a `connect()` that is refused, unreachable, or times out is dropped
-  instead of being reported as a connection. A non-blocking connect is the
-  exception: it returns `EINPROGRESS` immediately and its outcome is delivered
-  on the socket long after the syscall returns, so it is reported when the
-  attempt starts and a later asynchronous failure is not retracted.
-  `SourceIp`/`SourcePort` are **reported as absent**, never as `0.0.0.0`/`0`:
-  the syscall never carries them and the probe does not read the bound address
-  back out of the socket. The sensor does not try to reconstruct them later
-  from `/proc/net`: by then the descriptor may name a different socket, and
-  scanning the system-wide socket tables for every event stalls the ring drain
-  under connection churn. Only AF_INET and AF_INET6.
-- **`Protocol` is absent for sockets created before the sensor started.** The
-  transport comes from the type the socket was created with, so `socket(2)` is
-  watched and the type indexed by descriptor. A descriptor the sensor never
-  watched being created — opened before startup, inherited across `fork`, or
-  received over `SCM_RIGHTS` — reports no `Protocol` at all, and a rule
-  selecting either value does not match it. That is deliberate: the field used
-  to be a fixed `tcp`, which matched UDP traffic and never matched
-  `Protocol: 'udp'`. Socket types other than `SOCK_STREAM` and `SOCK_DGRAM`
-  (a raw or SCTP socket) are also left absent rather than named.
+- **Network fidelity depends on the socket fexit capability.** With runtime BTF
+  and all three probes attached, connect and accept events carry the bound
+  source address, source port, and TCP/UDP protocol as measured fields. Accepted
+  connections carry `Initiated: false`, with the peer as source and the local
+  listener as destination. Offsets and the accept prototype come
+  from the running kernel, including `sk_protocol`; no compiled layout is used.
+  If BTF, a required member, or an attachment is unavailable, the entire network
+  tier falls back to outbound connect syscalls. `SourceIp`, `SourcePort`, and
+  `Protocol` are absent in that tier, and inbound connections are invisible.
+  `linux_ebpf_network_tuple_capability` reports the degradation in doctor.
+  **Silent risk:** rules requiring those fields or inbound visibility cannot
+  match while the fallback is active. The sensor still requires Linux 5.8+
+  because its event transport uses ring buffers, even though fexit was added
+  in 5.5. Only AF_INET and AF_INET6 are captured; IPv4 loopback and IPv6 `::1`
+  are filtered in the kernel. Unknown IP protocols remain unnamed.
+  Refused, unreachable, and timed-out connects are dropped. `EINPROGRESS` and
+  `EINTR` are reported as attempts underway; later failures are not retracted.
+  No per-event `/proc/net` scan or descriptor-to-socket cache is used.
 - **Kernel identity fields depend on runtime BTF.** `User` uses the effective
   UID. Missing BTF or an unsupported member disables only the affected fields,
   with `linux_task_<field>` doctor warnings; an unknown effective UID stays

--- a/ebpf/src/events.rs
+++ b/ebpf/src/events.rs
@@ -126,19 +126,7 @@ pub fn connect_result_is_connection(result: i32) -> bool {
     )
 }
 
-/// The sensor did not watch this socket being created, so its type is not
-/// known. Userspace reports no `Protocol` rather than guessing one.
-pub const SOCK_TYPE_UNKNOWN: u8 = 0;
-
-/// `SOCK_STREAM` — TCP for AF_INET and AF_INET6.
-pub const SOCK_STREAM: u8 = 1;
-
-/// `SOCK_DGRAM` — UDP for AF_INET and AF_INET6.
-pub const SOCK_DGRAM: u8 = 2;
-
-/// Outbound connection event. Queued by `handle_connect` on
-/// `syscalls/sys_enter_connect` and emitted by `handle_connect_exit` on
-/// `syscalls/sys_exit_connect`, which drops attempts that never connected.
+/// Connection event from a kernel socket or the syscall fallback.
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NetworkEvent {
@@ -148,7 +136,7 @@ pub struct NetworkEvent {
     pub pid: u32,
     /// Effective UID.
     pub uid: u32,
-    /// Socket file descriptor supplied to `connect(2)`.
+    /// Socket descriptor in the syscall fallback; -1 in the fexit tier.
     pub fd: i32,
     /// `connect(2)` return value: 0, or the negative errno of a connect that
     /// is still under way. Failed attempts are never emitted, so this is
@@ -160,11 +148,10 @@ pub struct NetworkEvent {
     pub sport: u16,
     /// Address family: 2 = AF_INET, 10 = AF_INET6.
     pub af: u16,
-    /// Socket type the descriptor was created with, masked to
-    /// `SOCK_TYPE_MASK`: [`SOCK_STREAM`], [`SOCK_DGRAM`], another `SOCK_*`
-    /// value, or [`SOCK_TYPE_UNKNOWN`] when the creation was not observed.
-    pub sock_type: u8,
-    pub _pad1: u8,
+    /// IP protocol number read from sk_protocol; zero in the syscall fallback.
+    pub protocol: u8,
+    /// TUPLE_MEASURED and INBOUND from socket_tuple_abi.
+    pub tuple_flags: u8,
     /// Destination address. For AF_INET: first 4 bytes hold the IPv4 address
     /// (network byte order); remaining bytes are zero. For AF_INET6: all 16
     /// bytes hold the address.

--- a/ebpf/src/file.rs
+++ b/ebpf/src/file.rs
@@ -83,7 +83,6 @@ use crate::events::{
     event_metadata, FileEvent, FileIndexEvent, FILE_FLAG_AUX_PATH_TRUNCATED,
     FILE_FLAG_PATH_TRUNCATED, FILE_PATH_LEN,
 };
-use crate::network::forget_socket_type;
 use crate::process::current_process_start_time;
 use crate::telemetry::{record_map_full, record_ring_full, record_submitted, FILE_FAMILY};
 
@@ -550,14 +549,9 @@ unsafe fn current_dir_token(pid: u32, fd: i32) -> u64 {
 /// Invalidate every per-descriptor index entry `fd` owns before the number can
 /// be recycled.
 ///
-/// The directory index and the socket-type index are keyed the same way and
-/// invalidated at the same moments, so they share this one program rather than
-/// each attaching to `sys_enter_close`, which is among the hottest tracepoints
-/// on the machine.
 #[inline(always)]
 unsafe fn invalidate_fd(pid: u32, fd: i32) {
     invalidate_dir_token(pid, fd);
-    forget_socket_type(pid, fd);
 }
 
 #[inline(always)]

--- a/ebpf/src/main.rs
+++ b/ebpf/src/main.rs
@@ -15,8 +15,6 @@
 //! | `handle_process_*fork`| `syscalls/sys_enter_*fork`  | capture flags   |
 //! | `handle_connect`      | `syscalls/sys_enter_connect`| queue Event 3   |
 //! | `handle_connect_exit` | `syscalls/sys_exit_connect` | emit Event 3    |
-//! | `handle_socket`       | `syscalls/sys_enter_socket` | capture type    |
-//! | `handle_socket_exit`  | `syscalls/sys_exit_socket`  | index fd type   |
 //! | `handle_open*`        | `sys_enter_open/openat/openat2` | queue file event |
 //! | `handle_creat`        | `syscalls/sys_enter_creat`  | queue Event 11 |
 //! | `handle_vfs_create`   | `kprobe/vfs_create`         | confirm create |
@@ -45,6 +43,8 @@ pub mod events;
 pub mod file;
 pub mod network;
 pub mod process;
+pub mod socket_tuple;
+pub mod socket_tuple_abi;
 pub mod task_identity;
 pub mod task_identity_abi;
 pub mod telemetry;
@@ -55,7 +55,7 @@ pub mod telemetry;
 /// program. Keep it in sync with `LINUX_EBPF_ABI_VERSION` in the loader.
 #[used]
 #[no_mangle]
-pub static RUSTINEL_ABI_VERSION: u32 = 2;
+pub static RUSTINEL_ABI_VERSION: u32 = 3;
 
 #[panic_handler]
 fn panic(_info: &core::panic::PanicInfo) -> ! {

--- a/ebpf/src/network.rs
+++ b/ebpf/src/network.rs
@@ -1,69 +1,13 @@
-//! Network connection eBPF programs.
-//!
-//! A `connect(2)` is captured across `syscalls/sys_enter_connect` and
-//! `syscalls/sys_exit_connect`, because neither point alone can describe the
-//! event. The destination sockaddr lives in user memory that is only
-//! guaranteed readable while the syscall is on its way in, so entry is where
-//! it has to be read; entry also runs in full task context, so
-//! `bpf_get_current_pid_tgid()` is valid. Whether a connection was made is
-//! only known at exit — hooking entry alone reports `ECONNREFUSED`,
-//! `EHOSTUNREACH`, and `ETIMEDOUT` as connections.
-//!
-//! `handle_connect` therefore stashes the candidate in a per-thread map and
-//! `handle_connect_exit` emits it only when the return value says a connection
-//! was established or is under way. Everything else is dropped in the kernel,
-//! so a failed attempt never reaches the ring buffer, let alone a rule.
-//!
-//! `connect(2)` itself never says which transport it speaks — that was decided
-//! when the socket was created. So `socket(2)` is watched as well and the type
-//! it returns is indexed by `(pid, fd)` for the connect hook to read back. The
-//! type argument is only known at syscall entry and the descriptor only at
-//! syscall exit, so the two are joined through a per-thread slot.
-//!
-//! A descriptor the sensor never watched being created reports
-//! [`SOCK_TYPE_UNKNOWN`], and userspace leaves `Protocol` absent rather than
-//! guessing. That covers sockets opened before the agent started, inherited
-//! across `fork` (the key is per-process), or received over `SCM_RIGHTS`.
-//!
-//! Descriptor numbers are recycled, so an index entry is dropped as soon as its
-//! descriptor can name a different socket: on `close`, and on the `dup2`/`dup3`
-//! target that is closed implicitly. Those tracepoints already carry a program
-//! for the directory index, which calls [`forget_socket_type`] rather than pay
-//! a second tracepoint dispatch on paths as hot as `close`.
-//!
-//! Example sys_enter_connect tracepoint format (x86_64, 64-bit ABI). These
-//! offsets are documentation only; the loader supplies this kernel's values:
-//!   offset  0: common_type         (u16)
-//!   offset  2: common_flags        (u8)
-//!   offset  3: common_preempt_count(u8)
-//!   offset  4: common_pid          (i32)
-//!   offset  8: __syscall_nr        (i32)
-//!   offset 12: _padding            (4 bytes)
-//!   offset 16: fd                  (i64)
-//!   offset 24: uservaddr           (u64 — pointer to user-space sockaddr)
-//!   offset 32: addrlen             (i32)
-//!
-//! sys_exit_connect tracepoint format (same header):
-//!   offset 16: ret                 (i64)
-//!
-//! sys_enter_socket tracepoint format (same header):
-//!   offset 16: family              (i64)
-//!   offset 24: type                (i64 — socket type OR'd with SOCK_* flags)
-//!   offset 32: protocol            (i64)
-//!
-//! sys_exit_socket tracepoint format (same header):
-//!   offset 16: ret                 (i64 — the new descriptor, or -errno)
+//! Connection syscall fallback. The fexit tier reads the bound kernel socket.
 
 use aya_ebpf::{
     helpers::{bpf_get_current_pid_tgid, bpf_probe_read_user},
     macros::{map, tracepoint},
-    maps::{HashMap, LruHashMap, RingBuf},
+    maps::{HashMap, RingBuf},
     programs::TracePointContext,
 };
 
-use crate::events::{
-    connect_result_is_connection, event_metadata, NetworkEvent, SOCK_TYPE_UNKNOWN,
-};
+use crate::events::{connect_result_is_connection, event_metadata, NetworkEvent};
 use crate::process::current_process_start_time;
 use crate::telemetry::{record_map_full, record_ring_full, record_submitted, NETWORK_FAMILY};
 
@@ -73,9 +17,6 @@ pub struct NetworkTracepointOffsets {
     pub connect_fd: u32,
     pub connect_addr: u32,
     pub connect_ret: u32,
-    pub socket_family: u32,
-    pub socket_type: u32,
-    pub socket_ret: u32,
 }
 
 #[no_mangle]
@@ -83,9 +24,6 @@ pub static NETWORK_TRACEPOINT_OFFSETS: NetworkTracepointOffsets = NetworkTracepo
     connect_fd: 0,
     connect_addr: 0,
     connect_ret: 0,
-    socket_family: 0,
-    socket_type: 0,
-    socket_ret: 0,
 };
 
 #[inline(always)]
@@ -97,10 +35,6 @@ unsafe fn tracepoint_offset(value: *const u32) -> usize {
 const AF_INET: u16 = 2;
 /// AF_INET6 (IPv6).
 const AF_INET6: u16 = 10;
-
-/// Bits of the `socket(2)` type argument that name the type. The rest carry
-/// `SOCK_NONBLOCK` and `SOCK_CLOEXEC`, which say nothing about the transport.
-const SOCK_TYPE_MASK: i64 = 0xf;
 
 /// IPv4 socket address as laid out by the C ABI.
 #[repr(C)]
@@ -127,22 +61,6 @@ struct SockAddrIn6 {
 #[map]
 pub static NETWORK_RING: RingBuf = RingBuf::with_byte_size(256 * 1024, 0);
 
-/// Socket type of the `socket(2)` call a thread is currently inside, keyed by
-/// TID. A thread is inside at most one syscall at a time, so one slot per
-/// thread is enough to carry the type from entry to exit.
-#[map]
-static SOCKET_PENDING: HashMap<u32, u8> = HashMap::with_max_entries(16_384, 0);
-
-/// Socket type of every IP socket the sensor watched being created, keyed by
-/// `(pid, fd)`.
-///
-/// LRU rather than plain hash: entries are dropped when their descriptor is
-/// closed, but a process killed with sockets open leaves its entries behind,
-/// and eviction bounds that. An evicted entry costs a `Protocol` value, never
-/// a wrong one.
-#[map]
-static SOCKET_TYPES: LruHashMap<u64, u8> = LruHashMap::with_max_entries(16_384, 0);
-
 /// Connect candidate a thread is currently inside, keyed by TID.
 ///
 /// A thread is inside exactly one `connect(2)` at a time, so one slot per
@@ -163,87 +81,6 @@ pub fn handle_connect(ctx: TracePointContext) -> u32 {
 #[tracepoint]
 pub fn handle_connect_exit(ctx: TracePointContext) -> u32 {
     unsafe { try_handle_connect_exit(&ctx) }.unwrap_or(1)
-}
-
-/// Tracepoint handler for `syscalls/sys_enter_socket`, where the socket type
-/// is still visible.
-#[tracepoint]
-pub fn handle_socket(ctx: TracePointContext) -> u32 {
-    unsafe { try_handle_socket(&ctx) }.unwrap_or(1)
-}
-
-/// Tracepoint handler for `syscalls/sys_exit_socket`, where the descriptor the
-/// pending type belongs to is finally known.
-#[tracepoint]
-pub fn handle_socket_exit(ctx: TracePointContext) -> u32 {
-    unsafe { try_handle_socket_exit(&ctx) }.unwrap_or(1)
-}
-
-#[inline(always)]
-fn socket_key(pid: u32, fd: i32) -> u64 {
-    ((pid as u64) << 32) | (fd as u32 as u64)
-}
-
-/// Drop the indexed socket type for `(pid, fd)`.
-///
-/// Called from the descriptor-lifetime hooks in [`crate::file`] — see this
-/// module's documentation for why they are shared.
-///
-/// # Safety
-///
-/// Must be called from a BPF program context.
-#[inline(always)]
-pub unsafe fn forget_socket_type(pid: u32, fd: i32) {
-    if fd < 0 {
-        return;
-    }
-    let _ = SOCKET_TYPES.remove(&socket_key(pid, fd));
-}
-
-#[inline(always)]
-unsafe fn try_handle_socket(ctx: &TracePointContext) -> Result<u32, i64> {
-    let tid = bpf_get_current_pid_tgid() as u32;
-
-    // Only IP sockets can reach the connect hook's address-family filter;
-    // indexing AF_UNIX and AF_NETLINK would evict entries that can be used.
-    let family = ctx.read_at::<i64>(tracepoint_offset(core::ptr::addr_of!(
-        NETWORK_TRACEPOINT_OFFSETS.socket_family
-    )))?;
-    if family != AF_INET as i64 && family != AF_INET6 as i64 {
-        // Anything still pending belongs to a thread that was killed inside an
-        // earlier `socket()`; drop it so this call's exit cannot claim it.
-        let _ = SOCKET_PENDING.remove(&tid);
-        return Ok(0);
-    }
-
-    let sock_type = (ctx.read_at::<i64>(tracepoint_offset(core::ptr::addr_of!(
-        NETWORK_TRACEPOINT_OFFSETS.socket_type
-    )))? & SOCK_TYPE_MASK) as u8;
-    if SOCKET_PENDING.insert(&tid, &sock_type, 0).is_err() {
-        record_map_full(NETWORK_FAMILY);
-    }
-    Ok(0)
-}
-
-#[inline(always)]
-unsafe fn try_handle_socket_exit(ctx: &TracePointContext) -> Result<u32, i64> {
-    let tid = bpf_get_current_pid_tgid() as u32;
-    let Some(sock_type) = SOCKET_PENDING.get(&tid).copied() else {
-        return Ok(0);
-    };
-    let _ = SOCKET_PENDING.remove(&tid);
-
-    // A failed socket(2) returns -errno and owns no descriptor.
-    let ret = ctx.read_at::<i64>(tracepoint_offset(core::ptr::addr_of!(
-        NETWORK_TRACEPOINT_OFFSETS.socket_ret
-    )))?;
-    if ret < 0 {
-        return Ok(0);
-    }
-
-    let pid = (bpf_get_current_pid_tgid() >> 32) as u32;
-    let _ = SOCKET_TYPES.insert(&socket_key(pid, ret as i32), &sock_type, 0);
-    Ok(0)
 }
 
 #[inline(always)]
@@ -292,15 +129,10 @@ unsafe fn try_handle_connect(ctx: &TracePointContext) -> Result<u32, i64> {
         _ => return Ok(0),
     }
 
-    // Skip loopback-only connects to reduce noise (127.0.0.0/8).
-    if family == AF_INET && daddr[0] == 127 {
+    // Skip loopback-only connects (127.0.0.0/8 and ::1).
+    if crate::socket_tuple_abi::loopback(family, &daddr) {
         return Ok(0);
     }
-
-    let sock_type = match SOCKET_TYPES.get(&socket_key(pid, fd)) {
-        Some(value) => *value,
-        None => SOCK_TYPE_UNKNOWN,
-    };
 
     let event = NetworkEvent {
         event_time_ns: 0,
@@ -313,11 +145,11 @@ unsafe fn try_handle_connect(ctx: &TracePointContext) -> Result<u32, i64> {
         ret: 0,
         dport,
         // Source address and port are still unassigned here and are not read
-        // back at exit either; userspace fills them from the socket.
+        // back at exit; the syscall fallback leaves source fields absent.
         sport: 0,
         af: family,
-        sock_type,
-        _pad1: 0,
+        protocol: 0,
+        tuple_flags: 0,
         daddr,
         saddr: [0u8; 16],
         process_start_time: current_process_start_time(pid),

--- a/ebpf/src/socket_tuple.rs
+++ b/ebpf/src/socket_tuple.rs
@@ -1,0 +1,127 @@
+//! Read the connection tuple using offsets resolved from the running kernel.
+
+use crate::{
+    events::{connect_result_is_connection, event_metadata, NetworkEvent},
+    network::NETWORK_RING,
+    process::current_process_start_time,
+    socket_tuple_abi::{loopback, SocketOffsets, INBOUND, TUPLE_MEASURED},
+    telemetry::{record_ring_full, record_submitted, NETWORK_FAMILY},
+};
+use aya_ebpf::{
+    helpers::{bpf_get_current_pid_tgid, bpf_probe_read_kernel},
+    macros::{fexit, map},
+    maps::Array,
+    programs::FExitContext,
+};
+
+#[map]
+pub static SOCKET_OFFSETS: Array<SocketOffsets> = Array::with_max_entries(1, 0);
+
+// Only the BTF-selected accept variant is loaded. Each context access must
+// have a constant index so the verifier can check it against the prototype.
+#[fexit]
+pub fn handle_accept2(ctx: FExitContext) -> u32 {
+    unsafe { emit(ctx.arg::<u64>(2), 0, true) }.unwrap_or(1)
+}
+
+#[fexit]
+pub fn handle_accept4(ctx: FExitContext) -> u32 {
+    unsafe { emit(ctx.arg::<u64>(4), 0, true) }.unwrap_or(1)
+}
+
+#[fexit]
+pub fn handle_stream_connect(ctx: FExitContext) -> u32 {
+    unsafe { connect(&ctx) }.unwrap_or(1)
+}
+
+#[fexit]
+pub fn handle_dgram_connect(ctx: FExitContext) -> u32 {
+    unsafe { connect(&ctx) }.unwrap_or(1)
+}
+
+#[inline(always)]
+unsafe fn read<T: Copy>(ptr: u64, offset: u32) -> Result<T, i64> {
+    Ok(bpf_probe_read_kernel(
+        (ptr + (offset & 65535) as u64) as *const T,
+    )?)
+}
+
+#[inline(always)]
+unsafe fn connect(ctx: &FExitContext) -> Result<u32, i64> {
+    let ret = ctx.arg::<i32>(4);
+    if !connect_result_is_connection(ret) {
+        return Ok(0);
+    }
+    let Some(offsets) = SOCKET_OFFSETS.get(0) else {
+        return Ok(0);
+    };
+    let sk = read::<u64>(ctx.arg::<u64>(0), offsets.socket_sk)?;
+    emit(sk, ret, false)
+}
+
+#[inline(always)]
+unsafe fn emit(sk: u64, ret: i32, inbound: bool) -> Result<u32, i64> {
+    // accept returns NULL on failure. Reject ERR_PTR values as well.
+    if sk == 0 || sk >= u64::MAX - 4095 {
+        return Ok(0);
+    }
+    let Some(o) = SOCKET_OFFSETS.get(0) else {
+        return Ok(0);
+    };
+    let af = read::<u16>(sk, o.family)?;
+    let mut saddr = [0; 16];
+    let mut daddr = [0; 16];
+    match af {
+        2 => {
+            saddr[..4].copy_from_slice(&read::<[u8; 4]>(sk, o.saddr)?);
+            daddr[..4].copy_from_slice(&read::<[u8; 4]>(sk, o.daddr)?);
+        }
+        10 => {
+            saddr = read(sk, o.saddr6)?;
+            daddr = read(sk, o.daddr6)?;
+        }
+        _ => return Ok(0),
+    }
+    if loopback(af, &daddr) {
+        return Ok(0);
+    }
+    let protocol = if o.protocol_width == 1 {
+        read::<u8>(sk, o.protocol)?
+    } else {
+        let value = read::<u16>(sk, o.protocol)?;
+        if value > 255 {
+            return Ok(0);
+        }
+        value as u8
+    };
+    let pid = (bpf_get_current_pid_tgid() >> 32) as u32;
+    let mut event = NetworkEvent {
+        event_time_ns: 0,
+        source_seq: 0,
+        pid,
+        uid: crate::task_identity::effective_uid().unwrap_or(u32::MAX),
+        fd: -1,
+        ret,
+        af,
+        protocol,
+        tuple_flags: TUPLE_MEASURED | if inbound { INBOUND } else { 0 },
+        sport: read(sk, o.sport)?,
+        dport: u16::from_be(read(sk, o.dport)?),
+        saddr,
+        daddr,
+        process_start_time: current_process_start_time(pid),
+    };
+    if inbound {
+        core::mem::swap(&mut event.saddr, &mut event.daddr);
+        core::mem::swap(&mut event.sport, &mut event.dport);
+    }
+    let Some(mut entry) = NETWORK_RING.reserve::<NetworkEvent>(0) else {
+        record_ring_full(NETWORK_FAMILY);
+        return Ok(0);
+    };
+    (event.event_time_ns, event.source_seq) = event_metadata();
+    entry.write(event);
+    entry.submit(0);
+    record_submitted(NETWORK_FAMILY);
+    Ok(0)
+}

--- a/ebpf/src/socket_tuple_abi.rs
+++ b/ebpf/src/socket_tuple_abi.rs
@@ -1,0 +1,45 @@
+//! Runtime socket layout shared by the loader and kernel programs.
+
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct SocketOffsets {
+    pub socket_sk: u32,
+    pub family: u32,
+    pub saddr: u32,
+    pub daddr: u32,
+    pub sport: u32,
+    pub dport: u32,
+    pub saddr6: u32,
+    pub daddr6: u32,
+    pub protocol: u32,
+    pub protocol_width: u32,
+}
+
+pub const TUPLE_MEASURED: u8 = 1;
+pub const INBOUND: u8 = 2;
+
+#[inline(always)]
+pub fn loopback(family: u16, addr: &[u8; 16]) -> bool {
+    (family == 2 && addr[0] == 127)
+        || (family == 10 && *addr == [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn loopback_filter_covers_v4_subnet_and_v6_localhost() {
+        let mut addr = [0; 16];
+        addr[0] = 127;
+        addr[3] = 42;
+        assert!(loopback(2, &addr));
+        addr[0] = 10;
+        assert!(!loopback(2, &addr));
+        addr = [0; 16];
+        addr[15] = 1;
+        assert!(loopback(10, &addr));
+        addr[15] = 2;
+        assert!(!loopback(10, &addr));
+    }
+}

--- a/src/field_availability.rs
+++ b/src/field_availability.rs
@@ -577,7 +577,7 @@ const LINUX_NETWORK: &[FieldContract] = &[
     always("Initiated"),
     conditional(
         "Protocol",
-        "the socket was observed being created and is TCP or UDP",
+        "the socket fexit tier is active and sk_protocol names TCP or UDP",
     ),
     conditional(
         "Image",
@@ -587,13 +587,13 @@ const LINUX_NETWORK: &[FieldContract] = &[
         "DestinationHostname",
         "a preceding observed DNS answer resolves the destination",
     ),
-    never(
+    conditional(
         "SourceIp",
-        "connect syscall arguments do not carry the kernel-assigned source address",
+        "the socket fexit tier measures the bound source address",
     ),
-    never(
+    conditional(
         "SourcePort",
-        "connect syscall arguments do not carry the kernel-assigned source port",
+        "the socket fexit tier measures the bound source port",
     ),
 ];
 
@@ -1044,7 +1044,7 @@ pub const FIELD_AVAILABILITY: &[EventFieldContract] = &[
         Some(3),
         Connect,
         "ebpf",
-        "connect tracepoints",
+        "socket fexit or connect tracepoints",
         LINUX_NETWORK
     ),
     contract!(

--- a/src/sensor/linux/ebpf.rs
+++ b/src/sensor/linux/ebpf.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use aya::maps::{MapData, PerCpuArray, RingBuf};
-use aya::programs::{KProbe, TracePoint};
+use aya::programs::{FExit, KProbe, TracePoint};
 use aya::{Ebpf, EbpfLoader};
 use tokio::io::unix::AsyncFd;
 use tokio::sync::mpsc::Sender;
@@ -177,24 +177,15 @@ impl Sensor for EbpfSensor {
             "syscalls",
             "sys_enter_vfork",
         )?;
-        // Entry captures the destination while the sockaddr is still readable;
-        // exit is what decides whether the attempt became a connection.
-        attach_tracepoint(&mut bpf, "handle_connect", "syscalls", "sys_enter_connect")?;
-        attach_tracepoint(
-            &mut bpf,
-            "handle_connect_exit",
-            "syscalls",
-            "sys_exit_connect",
-        )?;
-        // `connect()` does not name its transport; the socket type is only
-        // visible while `socket()` runs, and its descriptor only on return.
-        attach_tracepoint(&mut bpf, "handle_socket", "syscalls", "sys_enter_socket")?;
-        attach_tracepoint(
-            &mut bpf,
-            "handle_socket_exit",
-            "syscalls",
-            "sys_exit_socket",
-        )?;
+        if !attach_socket_tuple(&mut bpf)? {
+            attach_tracepoint(&mut bpf, "handle_connect", "syscalls", "sys_enter_connect")?;
+            attach_tracepoint(
+                &mut bpf,
+                "handle_connect_exit",
+                "syscalls",
+                "sys_exit_connect",
+            )?;
+        }
         attach_tracepoint(&mut bpf, "handle_openat", "syscalls", "sys_enter_openat")?;
         attach_optional_tracepoint(&mut bpf, "handle_open", "syscalls", "sys_enter_open")?;
         attach_optional_tracepoint(&mut bpf, "handle_open_exit", "syscalls", "sys_exit_open")?;
@@ -739,24 +730,23 @@ fn build_network_event(ev: &NetworkEvent) -> Option<SensorEvent> {
         parent_process_start_key: None,
         payload: SensorPayload::Network(NetworkConnectionFields {
             destination_ip: Some(destination_ip),
-            // The syscall tracepoint does not measure the kernel-assigned
-            // source tuple. A later procfs lookup is both racy and unbounded,
-            // so source fields stay absent until the kernel probe supplies it.
-            source_ip: None,
+            source_ip: (ev.tuple_flags & super::socket_tuple_abi::TUPLE_MEASURED != 0).then(|| {
+                if ev.af == 2 {
+                    Ipv4Addr::new(ev.saddr[0], ev.saddr[1], ev.saddr[2], ev.saddr[3]).to_string()
+                } else {
+                    Ipv6Addr::from(ev.saddr).to_string()
+                }
+            }),
             destination_port: Some(ev.dport.to_string()),
-            source_port: None,
+            source_port: (ev.tuple_flags & super::socket_tuple_abi::TUPLE_MEASURED != 0)
+                .then(|| ev.sport.to_string()),
             process_id: Some(ev.pid.to_string()),
             // Enriched by the normalizer from ProcessCache if PID is known.
             image: None,
             user,
             destination_hostname: None,
-            // The kernel-side socket type is authoritative: it is recorded
-            // when the socket is created rather than guessed after the event.
             protocol: ev.transport().map(str::to_string),
-            // The probe hooks `connect()` only, so every captured connection
-            // is one this host opened. `accept()` is not hooked, so no inbound
-            // connection can reach here and be mislabelled.
-            initiated: Some(true),
+            initiated: Some(ev.tuple_flags & super::socket_tuple_abi::INBOUND == 0),
         }),
     })
 }
@@ -902,6 +892,61 @@ fn resolved_linux_user(uid: u32) -> Option<String> {
     (uid != u32::MAX).then(|| lookup_username_by_uid(uid).unwrap_or_else(|| uid.to_string()))
 }
 
+/// Try the complete tuple tier before enabling the syscall fallback. Failure
+/// detaches every partial attachment so the fallback cannot duplicate events.
+fn attach_socket_tuple(bpf: &mut Ebpf) -> Result<bool> {
+    let mut loaded = Vec::new();
+    let result = (|| -> Result<()> {
+        let layout = super::task_btf::SocketLayout::load()?;
+        let btf = aya::Btf::from_sys_fs()?;
+        aya::maps::Array::<_, super::socket_tuple_abi::SocketOffsets>::try_from(
+            bpf.map_mut("SOCKET_OFFSETS")
+                .context("missing socket offsets map")?,
+        )?
+        .set(0, layout.offsets, 0)?;
+        for (name, target) in [
+            ("handle_stream_connect", "inet_stream_connect"),
+            ("handle_dgram_connect", "inet_dgram_connect"),
+            (layout.accept_program, "inet_csk_accept"),
+        ] {
+            let program: &mut FExit = bpf
+                .program_mut(name)
+                .context("missing socket program")?
+                .try_into()?;
+            program
+                .load(target, &btf)
+                .with_context(|| format!("load {target}"))?;
+            loaded.push(name);
+            program
+                .attach()
+                .with_context(|| format!("attach {target}"))?;
+        }
+        Ok(())
+    })();
+    if let Err(error) = result {
+        for name in loaded {
+            // Unloading closes every link owned by the program.
+            let program: &mut FExit = bpf
+                .program_mut(name)
+                .expect("loaded socket program")
+                .try_into()
+                .expect("socket fexit program");
+            program
+                .unload()
+                .context("cannot roll back socket tier; refusing duplicate capture")?;
+        }
+        let reason = format!("{error:#}");
+        LINUX_EBPF.record_hook("network_tuple", "socket_fexit", false, Some(&reason));
+        warn!(%reason, "kernel socket tuple unavailable; using connect syscalls");
+        return Ok(false);
+    }
+    for name in loaded {
+        LINUX_EBPF.record_hook("network_tuple", name, true, None);
+        LINUX_EBPF.record_hook("network", name, true, None);
+    }
+    Ok(true)
+}
+
 fn attach_optional_tracepoint(
     bpf: &mut Ebpf,
     program: &str,
@@ -998,11 +1043,8 @@ fn features_for_program(program: &str) -> &'static [&'static str] {
         | "handle_clone3"
         | "handle_process_fork"
         | "handle_process_vfork" => &["process"],
-        "handle_connect" | "handle_connect_exit" | "handle_socket" | "handle_socket_exit" => {
-            &["network"]
-        }
+        "handle_connect" | "handle_connect_exit" => &["network"],
         "handle_sendto" | "handle_sendmsg" | "handle_sendmmsg" => &["dns"],
-        "handle_file_close" | "handle_file_dup2" | "handle_file_dup3" => &["file", "network"],
         _ => &["file"],
     }
 }
@@ -1435,8 +1477,8 @@ mod tests {
             dport: 443,
             sport: 51324,
             af: 2,
-            sock_type: 0,
-            _pad1: 0,
+            protocol: 0,
+            tuple_flags: 0,
             daddr,
             saddr: {
                 let mut source = [0u8; 16];
@@ -1445,6 +1487,20 @@ mod tests {
             },
             process_start_time: 123_456,
         };
+
+        let mut measured = raw;
+        measured.protocol = 6;
+        measured.tuple_flags = super::super::socket_tuple_abi::TUPLE_MEASURED
+            | super::super::socket_tuple_abi::INBOUND;
+        match build_network_event(&measured).unwrap().payload {
+            SensorPayload::Network(fields) => {
+                assert_eq!(fields.source_ip.as_deref(), Some("10.0.0.5"));
+                assert_eq!(fields.source_port.as_deref(), Some("51324"));
+                assert_eq!(fields.protocol.as_deref(), Some("tcp"));
+                assert_eq!(fields.initiated, Some(false));
+            }
+            _ => panic!("expected network fields"),
+        }
 
         let event = build_network_event(&raw).expect("network event should build");
         assert_eq!(
@@ -1466,7 +1522,7 @@ mod tests {
     }
 
     #[test]
-    fn build_network_event_reports_the_kernel_socket_type() {
+    fn build_network_event_reports_the_kernel_ip_protocol() {
         let mut daddr = [0u8; 16];
         daddr[..4].copy_from_slice(&[198, 51, 100, 10]);
 
@@ -1480,8 +1536,8 @@ mod tests {
             dport: 53,
             sport: 0,
             af: 2,
-            sock_type: 2, // SOCK_DGRAM
-            _pad1: 0,
+            protocol: 17, // UDP
+            tuple_flags: 0,
             daddr,
             saddr: [0u8; 16],
             process_start_time: 123_456,
@@ -1493,7 +1549,7 @@ mod tests {
             other => panic!("unexpected payload: {:?}", other),
         }
 
-        raw.sock_type = 1; // SOCK_STREAM
+        raw.protocol = 6; // TCP
         let event = build_network_event(&raw).expect("tcp connect should build");
         match event.payload {
             SensorPayload::Network(fields) => assert_eq!(fields.protocol.as_deref(), Some("tcp")),
@@ -1513,13 +1569,23 @@ mod tests {
             dport: 8443,
             sport: 5353,
             af: 10,
-            sock_type: 0,
-            _pad1: 0,
+            protocol: 0,
+            tuple_flags: 0,
             daddr: Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0x10).octets(),
             saddr: Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 0x20).octets(),
             process_start_time: 123_456,
         };
 
+        let mut measured = raw;
+        measured.tuple_flags = super::super::socket_tuple_abi::TUPLE_MEASURED;
+        match build_network_event(&measured).unwrap().payload {
+            SensorPayload::Network(fields) => {
+                assert_eq!(fields.source_ip.as_deref(), Some("fe80::20"));
+                assert_eq!(fields.source_port.as_deref(), Some("5353"));
+                assert_eq!(fields.initiated, Some(true));
+            }
+            _ => panic!("expected IPv6 network fields"),
+        }
         let event = build_network_event(&raw).expect("ipv6 network event should build");
         match event.payload {
             SensorPayload::Network(fields) => {
@@ -1550,8 +1616,8 @@ mod tests {
                 dport: 443,
                 sport: 0,
                 af: 2,
-                sock_type: 0,
-                _pad1: 0,
+                protocol: 0,
+                tuple_flags: 0,
                 daddr,
                 saddr: [0u8; 16],
                 process_start_time: 123_456,
@@ -1582,8 +1648,8 @@ mod tests {
                 dport: 443,
                 sport: 0,
                 af: 2,
-                sock_type: 0,
-                _pad1: 0,
+                protocol: 0,
+                tuple_flags: 0,
                 daddr,
                 saddr: [0u8; 16],
                 process_start_time: 123_456,
@@ -1613,8 +1679,8 @@ mod tests {
             dport: 443,
             sport: 0,
             af: 2,
-            sock_type: 0,
-            _pad1: 0,
+            protocol: 0,
+            tuple_flags: 0,
             daddr: [0u8; 16],
             saddr: [0u8; 16],
             process_start_time: 123_456,

--- a/src/sensor/linux/events.rs
+++ b/src/sensor/linux/events.rs
@@ -181,19 +181,7 @@ pub fn connect_result_is_connection(result: i32) -> bool {
     )
 }
 
-/// The kernel did not watch this socket being created, so its type is not
-/// known. Mirrors `SOCK_TYPE_UNKNOWN` in `ebpf/src/events.rs`.
-pub const SOCK_TYPE_UNKNOWN: u8 = 0;
-
-/// `SOCK_STREAM` — TCP for AF_INET and AF_INET6.
-pub const SOCK_STREAM: u8 = 1;
-
-/// `SOCK_DGRAM` — UDP for AF_INET and AF_INET6.
-pub const SOCK_DGRAM: u8 = 2;
-
-/// Outbound connection event. Produced by `handle_connect_exit`
-/// (`syscalls/sys_exit_connect`), which emits only the attempts that
-/// connected.
+/// Connection event from a kernel socket or the syscall fallback.
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NetworkEvent {
@@ -201,7 +189,7 @@ pub struct NetworkEvent {
     pub source_seq: u64,
     pub pid: u32,
     pub uid: u32,
-    /// Connected socket file descriptor.
+    /// Socket descriptor in the syscall fallback; -1 in the fexit tier.
     pub fd: i32,
     /// `connect(2)` return value — always one of the values
     /// [`connect_result_is_connection`] accepts.
@@ -213,10 +201,10 @@ pub struct NetworkEvent {
     pub sport: u16,
     /// Address family: 2 = IPv4, 10 = IPv6.
     pub af: u16,
-    /// Socket type the descriptor was created with: [`SOCK_STREAM`],
-    /// [`SOCK_DGRAM`], another `SOCK_*` value, or [`SOCK_TYPE_UNKNOWN`].
-    pub sock_type: u8,
-    pub _pad1: u8,
+    /// IP protocol number read from sk_protocol; zero in the syscall fallback.
+    pub protocol: u8,
+    /// TUPLE_MEASURED and INBOUND from socket_tuple_abi.
+    pub tuple_flags: u8,
     pub daddr: [u8; 16],
     /// Source address. Unspecified (all zero) until the socket is bound; see
     /// [`sport`](Self::sport).
@@ -226,17 +214,12 @@ pub struct NetworkEvent {
 }
 
 impl NetworkEvent {
-    /// Transport name for the Sigma `Protocol` field and ECS
-    /// `network.transport`.
-    ///
-    /// `None` when the socket type was not captured, or names a transport
-    /// this maps no name for. `connect(2)` carries no protocol of its own, so
-    /// the alternative to an absent value is a guess: before the socket type
-    /// was tracked every event was labelled `tcp`, including UDP connects.
+    /// IP transport name measured from sk_protocol. Unknown protocols and the
+    /// syscall fallback remain absent.
     pub fn transport(&self) -> Option<&'static str> {
-        match self.sock_type {
-            SOCK_STREAM => Some("tcp"),
-            SOCK_DGRAM => Some("udp"),
+        match self.protocol {
+            6 => Some("tcp"),
+            17 => Some("udp"),
             _ => None,
         }
     }
@@ -346,14 +329,14 @@ const _: () = assert!(
         && core::mem::offset_of!(ProcessEvent, args) == 432,
     "ProcessEvent argv fields moved — update ebpf/src/events.rs to match"
 );
-// `ret` and `sock_type` took over slots that used to be explicit padding, so a
+// `ret` and `protocol` took over slots that used to be explicit padding, so a
 // stale copy of either side would decode zeros there and pass every event off
 // as a successful connect of unknown transport. Pin both offsets so that fails
 // the build instead.
 const _: () = assert!(
     core::mem::size_of::<NetworkEvent>() == 80
         && core::mem::offset_of!(NetworkEvent, ret) == 28
-        && core::mem::offset_of!(NetworkEvent, sock_type) == 38,
+        && core::mem::offset_of!(NetworkEvent, protocol) == 38,
     "NetworkEvent layout changed — update ebpf/src/events.rs to match"
 );
 const _: () = assert!(
@@ -473,19 +456,19 @@ pub mod mapping {
             parent_process_start_key: None,
             payload: SensorPayload::Network(NetworkConnectionFields {
                 destination_ip: Some(ip_to_string(event.af, &event.daddr)),
-                // The syscall tracepoint does not measure the kernel-assigned
-                // source tuple, so the source fields are consistently absent.
-                source_ip: None,
+                source_ip: (event.tuple_flags & super::super::socket_tuple_abi::TUPLE_MEASURED
+                    != 0)
+                    .then(|| ip_to_string(event.af, &event.saddr)),
                 destination_port: Some(event.dport.to_string()),
-                source_port: None,
+                source_port: (event.tuple_flags & super::super::socket_tuple_abi::TUPLE_MEASURED
+                    != 0)
+                    .then(|| event.sport.to_string()),
                 process_id: Some(event.pid.to_string()),
                 image: None,
                 user: (event.uid != u32::MAX).then(|| event.uid.to_string()),
                 destination_hostname: None,
                 protocol: event.transport().map(str::to_string),
-                // The probe hooks `connect()` only, so every captured
-                // connection is one this host opened.
-                initiated: Some(true),
+                initiated: Some(event.tuple_flags & super::super::socket_tuple_abi::INBOUND == 0),
             }),
         }
     }
@@ -651,7 +634,7 @@ mod tests {
     }
 
     #[test]
-    fn transport_names_only_the_socket_types_it_knows() {
+    fn transport_names_only_known_ip_protocols() {
         let mut event = NetworkEvent {
             event_time_ns: 0,
             source_seq: 0,
@@ -662,22 +645,22 @@ mod tests {
             dport: 53,
             sport: 0,
             af: 2,
-            sock_type: SOCK_DGRAM,
-            _pad1: 0,
+            protocol: 17,
+            tuple_flags: 0,
             daddr: [0u8; 16],
             saddr: [0u8; 16],
             process_start_time: 123_456,
         };
         assert_eq!(event.transport(), Some("udp"));
 
-        event.sock_type = SOCK_STREAM;
+        event.protocol = 6;
         assert_eq!(event.transport(), Some("tcp"));
 
-        // A socket the sensor never saw created, and a type with no name here,
+        // An unmeasured protocol, and a protocol with no name here,
         // are both absent rather than guessed as `tcp`.
-        event.sock_type = SOCK_TYPE_UNKNOWN;
+        event.protocol = 0;
         assert_eq!(event.transport(), None);
-        event.sock_type = 3; // SOCK_RAW
+        event.protocol = 132; // SCTP
         assert_eq!(event.transport(), None);
     }
 

--- a/src/sensor/linux/mod.rs
+++ b/src/sensor/linux/mod.rs
@@ -5,6 +5,8 @@ pub mod ebpf;
 pub mod events;
 mod inventory;
 pub mod paths;
+#[path = "../../../ebpf/src/socket_tuple_abi.rs"]
+pub mod socket_tuple_abi;
 pub mod task_btf;
 mod tracepoint_format;
 

--- a/src/sensor/linux/task_btf.rs
+++ b/src/sensor/linux/task_btf.rs
@@ -152,6 +152,15 @@ impl Btf {
                         bitfield: flagged && raw >> 24 != 0,
                     });
                 }
+            } else if kind == 13 {
+                for param in payload.as_chunks::<8>().0 {
+                    ty.members.push(Member {
+                        name: name(word(param, 0)?)?,
+                        ty: word(param, 4)?,
+                        bits: 0,
+                        bitfield: false,
+                    });
+                }
             } else if kind == 6 {
                 for entry in payload.as_chunks::<8>().0 {
                     ty.members.push(Member {
@@ -303,6 +312,110 @@ impl Btf {
         Ok(plan)
     }
 
+    fn socket_field(&self, root: &str, path: &[&str], width: u32) -> Result<u32> {
+        let mut ty = self
+            .types
+            .iter()
+            .find(|ty| ty.kind == 4 && ty.name == root)
+            .with_context(|| format!("missing {root}"))?;
+        let mut offset = 0u32;
+        for component in path {
+            let (delta, id) = self.member(ty, component, 0)?;
+            offset = offset
+                .checked_add(delta)
+                .context("socket offset overflow")?;
+            ty = self.ty(id)?;
+        }
+        ensure!(offset <= 65535, "socket offset exceeds verifier bounds");
+        match width {
+            16 => ensure!(
+                ty.kind == 4 && ty.size_type == 16,
+                "unsupported IPv6 address layout"
+            ),
+            8 => {
+                ensure!(ty.kind == 2, "expected socket pointer");
+                let pointee = self.ty(ty.size_type)?;
+                ensure!(
+                    pointee.kind == 4 && pointee.name == "sock",
+                    "expected pointer to sock"
+                );
+            }
+            _ => self.scalar(ty, width)?,
+        }
+        Ok(offset)
+    }
+
+    fn function(&self, name: &str, returns_sock: bool) -> Result<usize> {
+        let func = self
+            .types
+            .iter()
+            .find(|ty| ty.kind == 12 && ty.name == name)
+            .with_context(|| format!("missing function {name}"))?;
+        let proto = self.ty(func.size_type)?;
+        ensure!(proto.kind == 13, "missing function prototype");
+        let ret = self.ty(proto.size_type)?;
+        if returns_sock {
+            ensure!(
+                ret.kind == 2 && self.ty(ret.size_type)?.name == "sock",
+                "unexpected accept return type"
+            );
+        } else {
+            self.scalar(ret, 4)?;
+        }
+        let first = self.ty(proto
+            .members
+            .first()
+            .context("missing socket parameter")?
+            .ty)?;
+        ensure!(first.kind == 2, "expected socket argument pointer");
+        ensure!(
+            self.ty(first.size_type)?.name == if returns_sock { "sock" } else { "socket" },
+            "unexpected socket argument"
+        );
+        Ok(proto.members.len())
+    }
+
+    fn socket_layout(&self) -> Result<SocketLayout> {
+        use super::socket_tuple_abi::SocketOffsets;
+        ensure!(
+            self.function("inet_stream_connect", false)? == 4,
+            "unsupported stream connect prototype"
+        );
+        ensure!(
+            self.function("inet_dgram_connect", false)? == 4,
+            "unsupported datagram connect prototype"
+        );
+        let accept_args = self.function("inet_csk_accept", true)?;
+        ensure!(
+            matches!(accept_args, 2 | 4),
+            "unsupported accept prototype: {accept_args} arguments"
+        );
+        let field = |name, width| self.socket_field("sock", &["__sk_common", name], width);
+        let (protocol, protocol_width) = match self.socket_field("sock", &["sk_protocol"], 1) {
+            Ok(offset) => (offset, 1),
+            Err(_) => (self.socket_field("sock", &["sk_protocol"], 2)?, 2),
+        };
+        Ok(SocketLayout {
+            offsets: SocketOffsets {
+                socket_sk: self.socket_field("socket", &["sk"], 8)?,
+                family: field("skc_family", 2)?,
+                saddr: field("skc_rcv_saddr", 4)?,
+                daddr: field("skc_daddr", 4)?,
+                sport: field("skc_num", 2)?,
+                dport: field("skc_dport", 2)?,
+                saddr6: field("skc_v6_rcv_saddr", 16)?,
+                daddr6: field("skc_v6_daddr", 16)?,
+                protocol,
+                protocol_width,
+            },
+            accept_program: if accept_args == 2 {
+                "handle_accept2"
+            } else {
+                "handle_accept4"
+            },
+        })
+    }
+
     fn scalar(&self, ty: &Type, width: u32) -> Result<()> {
         ensure!(
             ty.kind == 1 && ty.size_type == width && ty.int_encoding & 0xffffff == width * 8,
@@ -440,5 +553,154 @@ mod tests {
         let plans = TaskPlans::resolve(Btf::parse(&[]));
         assert_eq!(plans.warnings.len(), FIELD_COUNT);
         assert!(plans.plans.iter().all(|plan| plan.len == 0));
+    }
+}
+
+unsafe impl aya::Pod for super::socket_tuple_abi::SocketOffsets {}
+
+pub struct SocketLayout {
+    pub offsets: super::socket_tuple_abi::SocketOffsets,
+    pub accept_program: &'static str,
+}
+
+impl SocketLayout {
+    pub fn load() -> Result<Self> {
+        Self::from_bytes(&std::fs::read(BTF_PATH).context("reading kernel BTF")?)
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
+        Btf::parse(bytes)?.socket_layout()
+    }
+}
+
+#[cfg(test)]
+mod socket_tests {
+    use super::*;
+
+    fn fixture(protocol_offset: u32, accept_args: usize) -> Btf {
+        let scalar = |size| Type {
+            kind: 1,
+            size_type: size,
+            int_encoding: size * 8,
+            ..Type::default()
+        };
+        let member = |name: &str, ty, offset| Member {
+            name: name.into(),
+            ty,
+            bits: offset * 8,
+            bitfield: false,
+        };
+        let composite = |name: &str, size, members| Type {
+            name: name.into(),
+            kind: 4,
+            size_type: size,
+            members,
+            ..Type::default()
+        };
+        let proto = |first, count, ret| Type {
+            kind: 13,
+            size_type: ret,
+            members: (0..count)
+                .map(|i| member("", if i == 0 { first } else { 3 }, 0))
+                .collect(),
+            ..Type::default()
+        };
+        let func = |name: &str, proto| Type {
+            name: name.into(),
+            kind: 12,
+            size_type: proto,
+            ..Type::default()
+        };
+        Btf {
+            types: vec![
+                Type::default(),
+                scalar(1),
+                scalar(2),
+                scalar(4),                         // 0..3
+                composite("in6_addr", 16, vec![]), // 4
+                composite(
+                    "sock_common",
+                    128,
+                    vec![
+                        // 5
+                        member("skc_daddr", 3, 0),
+                        member("skc_rcv_saddr", 3, 4),
+                        member("skc_dport", 2, 12),
+                        member("skc_num", 2, 14),
+                        member("skc_family", 2, 16),
+                        member("skc_v6_daddr", 4, 56),
+                        member("skc_v6_rcv_saddr", 4, 72),
+                    ],
+                ),
+                composite(
+                    "sock",
+                    1024,
+                    vec![
+                        member("__sk_common", 5, 0),
+                        member("sk_protocol", 2, protocol_offset),
+                    ],
+                ), // 6
+                Type {
+                    kind: 2,
+                    size_type: 6,
+                    ..Type::default()
+                }, // 7
+                composite("socket", 128, vec![member("sk", 7, 24)]), // 8
+                Type {
+                    kind: 2,
+                    size_type: 8,
+                    ..Type::default()
+                }, // 9
+                proto(9, 4, 3),                                      // 10
+                func("inet_stream_connect", 10),
+                func("inet_dgram_connect", 10), // 11,12
+                proto(7, accept_args, 7),
+                func("inet_csk_accept", 13), // 13,14
+            ],
+        }
+    }
+
+    #[test]
+    fn socket_offsets_and_accept_index_follow_kernel_btf() {
+        for (offset, args) in [(540, 4), (548, 4), (516, 4), (548, 2)] {
+            let layout = fixture(offset, args).socket_layout().unwrap();
+            assert_eq!(layout.offsets.protocol, offset);
+            assert_eq!(layout.offsets.protocol_width, 2);
+            assert_eq!(layout.offsets.daddr, 0);
+            assert_eq!(layout.offsets.socket_sk, 24);
+            assert_eq!(
+                layout.accept_program,
+                if args == 2 {
+                    "handle_accept2"
+                } else {
+                    "handle_accept4"
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn unsupported_layouts_select_fallback_without_guessed_offsets() {
+        assert!(SocketLayout::from_bytes(&[]).is_err());
+        assert!(fixture(548, 3).socket_layout().is_err());
+        assert!(fixture(65536, 4).socket_layout().is_err());
+        let mut btf = fixture(548, 4);
+        btf.types[6].members[1].name = "renamed_protocol".into();
+        assert!(btf.socket_layout().is_err());
+        btf.types[6].members[1].name = "sk_protocol".into();
+        btf.types[6].members[1].bitfield = true;
+        assert!(btf.socket_layout().is_err());
+        btf.types[6].members[1].bitfield = false;
+        btf.types[10].members.pop();
+        assert!(btf.socket_layout().is_err());
+    }
+
+    #[test]
+    fn protocol_width_is_resolved_and_unknown_width_is_rejected() {
+        let mut btf = fixture(516, 4);
+        btf.types[6].members[1].ty = 1;
+        assert_eq!(btf.socket_layout().unwrap().offsets.protocol_width, 1);
+        btf.types[6].members[1].ty = 3;
+        assert!(btf.socket_layout().is_err());
     }
 }

--- a/src/sensor/linux/tracepoint_format.rs
+++ b/src/sensor/linux/tracepoint_format.rs
@@ -36,9 +36,6 @@ pub(super) struct NetworkTracepointOffsets {
     pub connect_fd: u32,
     pub connect_addr: u32,
     pub connect_ret: u32,
-    pub socket_family: u32,
-    pub socket_type: u32,
-    pub socket_ret: u32,
 }
 
 #[repr(C)]
@@ -234,23 +231,6 @@ impl TracepointLayouts {
             &[FieldSpec::one("ret", 8)],
         ) {
             self.network.connect_ret = v[0];
-        }
-        if let Some(v) = self.fields(
-            "handle_socket",
-            "syscalls",
-            "sys_enter_socket",
-            &[FieldSpec::one("family", 8), FieldSpec::one("type", 8)],
-        ) {
-            self.network.socket_family = v[0];
-            self.network.socket_type = v[1];
-        }
-        if let Some(v) = self.fields(
-            "handle_socket_exit",
-            "syscalls",
-            "sys_exit_socket",
-            &[FieldSpec::one("ret", 8)],
-        ) {
-            self.network.socket_ret = v[0];
         }
     }
 

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -43,7 +43,7 @@ pub const TARGET_TELEMETRY: &str = "telemetry";
 /// Bump this whenever a ring-buffer event layout or loader-patched global
 /// changes. This lives outside the Linux-only sensor module because telemetry
 /// snapshots are compiled on every supported platform.
-pub(crate) const LINUX_EBPF_ABI_VERSION: u32 = 2;
+pub(crate) const LINUX_EBPF_ABI_VERSION: u32 = 3;
 
 /// Linux ring-buffer program families, in snapshot order.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -321,7 +321,15 @@ fn linux_feature_is_active(feature: &LinuxEbpfFeatureSnapshot) -> bool {
     let attached = |hook: &str| feature.attached_hooks.iter().any(|value| value == hook);
     match feature.feature.as_str() {
         "process" => attached("handle_exec"),
-        "network" => attached("handle_connect") && attached("handle_connect_exit"),
+        "network" => {
+            (attached("handle_connect") && attached("handle_connect_exit"))
+                || (attached("handle_stream_connect") && attached("handle_dgram_connect"))
+        }
+        "network_tuple" => {
+            attached("handle_stream_connect")
+                && attached("handle_dgram_connect")
+                && (attached("handle_accept2") || attached("handle_accept4"))
+        }
         "dns" => ["handle_sendto", "handle_sendmsg", "handle_sendmmsg"]
             .into_iter()
             .any(attached),
@@ -1264,6 +1272,31 @@ mod tests {
         assert!(linux_feature_is_active(&linux_feature(
             "file",
             &["handle_unlinkat", "handle_unlinkat_exit"]
+        )));
+    }
+
+    #[test]
+    fn socket_tier_requires_connect_pair_and_btf_selected_accept() {
+        let connect = ["handle_stream_connect", "handle_dgram_connect"];
+        assert!(linux_feature_is_active(&linux_feature("network", &connect)));
+        assert!(!linux_feature_is_active(&linux_feature(
+            "network_tuple",
+            &connect
+        )));
+        for accept in ["handle_accept2", "handle_accept4"] {
+            assert!(linux_feature_is_active(&linux_feature(
+                "network_tuple",
+                &[connect[0], connect[1], accept]
+            )));
+        }
+        // Missing trampoline support leaves the syscall tier active.
+        let fallback = ["handle_connect", "handle_connect_exit"];
+        assert!(linux_feature_is_active(&linux_feature(
+            "network", &fallback
+        )));
+        assert!(!linux_feature_is_active(&linux_feature(
+            "network_tuple",
+            &fallback
         )));
     }
 

--- a/tests/linux_socket_tuple.rs
+++ b/tests/linux_socket_tuple.rs
@@ -1,0 +1,181 @@
+#![cfg(target_os = "linux")]
+
+use rustinel::sensor::{linux::EbpfSensor, Sensor, SensorPayload};
+use std::{
+    net::{TcpListener, TcpStream, UdpSocket},
+    time::{Duration, Instant},
+};
+
+#[test]
+#[ignore = "requires runtime kernel BTF"]
+fn running_kernel_socket_layout() {
+    let layout = rustinel::sensor::linux::task_btf::SocketLayout::load().unwrap();
+    println!(
+        "sk_protocol offset={}, width={}, accept={}",
+        layout.offsets.protocol, layout.offsets.protocol_width, layout.accept_program
+    );
+}
+
+/// Use a local interface address so both connect and accept can be checked
+/// without an external server. The UDP route lookup sends no packets.
+fn local_ip() -> std::net::IpAddr {
+    let route = UdpSocket::bind("0.0.0.0:0").unwrap();
+    route.connect("192.0.2.1:9").unwrap();
+    route.local_addr().unwrap().ip()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "requires eBPF privileges, tracefs, BTF, and a built object"]
+async fn live_tuple_and_connection_churn() {
+    let ip = local_ip();
+    let listener = TcpListener::bind((ip, 0)).unwrap();
+    let server = listener.local_addr().unwrap();
+    // A socket created before attachment must still report measured UDP.
+    let udp = UdpSocket::bind((ip, 0)).unwrap();
+    let udp_source = udp.local_addr().unwrap();
+    let sensor = EbpfSensor::new();
+    let (tx, mut rx) = tokio::sync::mpsc::channel(32768);
+    sensor.start(tx).unwrap();
+    let snapshot = rustinel::telemetry::LINUX_EBPF.snapshot().unwrap();
+    assert!(
+        snapshot
+            .features
+            .iter()
+            .any(|f| f.feature == "network_tuple" && f.active),
+        "{snapshot:?}"
+    );
+
+    udp.connect(server).unwrap();
+    let count = 2000;
+    let start = Instant::now();
+    let churn = tokio::task::spawn_blocking(move || {
+        let accepter = std::thread::spawn(move || {
+            for _ in 0..count {
+                drop(listener.accept().unwrap());
+            }
+        });
+        for _ in 0..count {
+            drop(TcpStream::connect(server).unwrap());
+        }
+        accepter.join().unwrap();
+    });
+    let mut outbound = 0;
+    let mut inbound = 0;
+    let mut saw_udp = false;
+    let mut max_delay = Duration::ZERO;
+    let pid = std::process::id();
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
+    while outbound + inbound < count * 2 || !saw_udp {
+        let event = tokio::time::timeout_at(deadline, rx.recv())
+            .await
+            .expect("drain stalled or lost connection events")
+            .unwrap();
+        if event.pid != Some(pid) {
+            continue;
+        }
+        let SensorPayload::Network(fields) = event.payload else {
+            continue;
+        };
+        max_delay = max_delay.max(event.timestamp.elapsed().unwrap_or_default());
+        assert_eq!(fields.source_ip.as_deref(), Some(ip.to_string().as_str()));
+        assert_eq!(
+            fields.destination_ip.as_deref(),
+            Some(ip.to_string().as_str())
+        );
+        if fields.protocol.as_deref() == Some("udp") {
+            assert_eq!(
+                fields.source_port.as_deref(),
+                Some(udp_source.port().to_string().as_str())
+            );
+            saw_udp = true;
+        } else {
+            assert_eq!(fields.protocol.as_deref(), Some("tcp"));
+            assert!(fields.source_port.is_some());
+            if fields.initiated == Some(true) {
+                assert_eq!(
+                    fields.destination_port.as_deref(),
+                    Some(server.port().to_string().as_str())
+                );
+                outbound += 1;
+            } else {
+                // Incoming source is the peer, destination is the listener.
+                assert_eq!(
+                    fields.destination_port.as_deref(),
+                    Some(server.port().to_string().as_str())
+                );
+                inbound += 1;
+            }
+        }
+    }
+    churn.await.unwrap();
+    println!("{count} TCP connections: outbound={outbound}, inbound={inbound}, elapsed={:?}, max_drain_delay={max_delay:?}", start.elapsed());
+    assert!(
+        max_delay < Duration::from_secs(2),
+        "ring drain stalled: {max_delay:?}"
+    );
+
+    // Both IPv4 and IPv6 loopback must disappear before the ring buffer.
+    for address in ["127.0.0.1:0", "[::1]:0"] {
+        let listener = TcpListener::bind(address).unwrap();
+        let stream = TcpStream::connect(listener.local_addr().unwrap()).unwrap();
+        drop(listener.accept().unwrap());
+        drop(stream);
+    }
+    let until = tokio::time::Instant::now() + Duration::from_millis(250);
+    while let Ok(Some(event)) = tokio::time::timeout_at(until, rx.recv()).await {
+        if event.pid == Some(pid) {
+            assert!(
+                !matches!(event.payload, SensorPayload::Network(_)),
+                "loopback leaked to ring"
+            );
+        }
+    }
+    sensor.shutdown();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires eBPF privileges and BTF hidden inside a private mount namespace"]
+async fn live_without_socket_btf_uses_syscall_fallback() {
+    assert!(rustinel::sensor::linux::task_btf::SocketLayout::load().is_err());
+    let ip = local_ip();
+    let listener = TcpListener::bind((ip, 0)).unwrap();
+    let server = listener.local_addr().unwrap();
+    let sensor = EbpfSensor::new();
+    let (tx, mut rx) = tokio::sync::mpsc::channel(8192);
+    sensor.start(tx).unwrap();
+    let snapshot = rustinel::telemetry::LINUX_EBPF.snapshot().unwrap();
+    assert!(snapshot
+        .features
+        .iter()
+        .any(|f| f.feature == "network" && f.active));
+    assert!(snapshot
+        .features
+        .iter()
+        .any(|f| f.feature == "network_tuple" && !f.active));
+    let stream = TcpStream::connect(server).unwrap();
+    let accepted = listener.accept().unwrap();
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        let event = tokio::time::timeout_at(deadline, rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        if event.pid != Some(std::process::id()) {
+            continue;
+        }
+        let SensorPayload::Network(fields) = event.payload else {
+            continue;
+        };
+        assert_eq!(
+            fields.destination_port.as_deref(),
+            Some(server.port().to_string().as_str())
+        );
+        assert_eq!(fields.initiated, Some(true));
+        assert!(fields.source_ip.is_none());
+        assert!(fields.source_port.is_none());
+        assert!(fields.protocol.is_none());
+        break;
+    }
+    drop((stream, accepted));
+    sensor.shutdown();
+}

--- a/tests/pipeline_sigma.rs
+++ b/tests/pipeline_sigma.rs
@@ -226,11 +226,7 @@ fn sigma_network_detection_pipeline_enriches_repeats_and_maps_to_ecs() {
             "DestinationPort",
             &TEST_DESTINATION_PORT.to_string(),
         );
-        if platform == Platform::Linux {
-            assert_eq!(first.get_field("SourceIp"), None);
-        } else {
-            assert_normalized_field_eq(&first, "SourceIp", TEST_SOURCE_IP);
-        }
+        assert_normalized_field_eq(&first, "SourceIp", TEST_SOURCE_IP);
         assert_normalized_field_eq(&first, "Protocol", "tcp");
 
         let repeated = harness

--- a/tests/platform_mapping.rs
+++ b/tests/platform_mapping.rs
@@ -100,8 +100,8 @@ fn linux_ebpf_raw_events_map_to_sensor_events() {
         dport: 443,
         sport: 51324,
         af: 2,
-        sock_type: 2,
-        _pad1: 0,
+        protocol: 17,
+        tuple_flags: 0,
         daddr: [0; 16],
         saddr: [0; 16],
         process_start_time: 123_456,
@@ -115,7 +115,7 @@ fn linux_ebpf_raw_events_map_to_sensor_events() {
             assert!(fields.source_ip.is_none());
             assert!(fields.source_port.is_none());
             // The hook covers UDP connects too, so the transport comes from
-            // the socket type rather than a fixed `tcp`.
+            // the measured IP protocol rather than a fixed `tcp`.
             assert_eq!(fields.protocol.as_deref(), Some("udp"));
             // The probe hooks `connect()` only, so a captured connection is
             // outbound by construction.
@@ -123,6 +123,28 @@ fn linux_ebpf_raw_events_map_to_sensor_events() {
         }
         _ => panic!("expected network payload"),
     }
+
+    network.tuple_flags = rustinel::sensor::linux::socket_tuple_abi::TUPLE_MEASURED
+        | rustinel::sensor::linux::socket_tuple_abi::INBOUND;
+    let measured = mapping::network_event_to_sensor(&network);
+    let normalizer = TestNormalizer::new();
+    let normalized = normalizer.normalizer.normalize(&measured).unwrap();
+    assert!(normalized.provenance.entries().iter().all(|entry| ![
+        "SourceIp",
+        "SourcePort",
+        "Protocol"
+    ]
+    .contains(&entry.field.as_str())));
+    match normalized.fields {
+        EventFields::NetworkConnection(fields) => {
+            assert_eq!(fields.source_ip.as_deref(), Some("10.0.0.5"));
+            assert_eq!(fields.source_port.as_deref(), Some("51324"));
+            assert_eq!(fields.protocol.as_deref(), Some("udp"));
+            assert_eq!(fields.initiated, Some(false));
+        }
+        _ => panic!("expected measured network payload"),
+    }
+    network.tuple_flags = 0;
 
     // Zero placeholders are absent too, never `0.0.0.0` and `0`.
     network.sport = 0;


### PR DESCRIPTION
Linux network events now read the bound IPv4/IPv6 tuple and IP protocol from the kernel socket at connect exit, and report accepted connections with `Initiated: false`. Runtime BTF resolves socket offsets, including `sk_protocol`, and selects the two- or four-argument accept program. The parser is shared with task identity resolution.

If the tuple tier cannot load or attach, partial attachments are rolled back and outbound syscall capture remains active with source fields and protocol absent. This removes the socket type cache, socket syscall hooks, and their descriptor invalidation work, filters IPv6 loopback in the kernel, bumps the eBPF ABI, and updates field contracts and generated documentation.

Validation:
- Linux test suite, Clippy across all targets, formatting checks, and release eBPF object build.
- Live Linux 6.8: 2,000 TCP connections produced all 2,000 outbound and 2,000 inbound events in 1.09 seconds, with maximum delivery delay of 9.1 ms. UDP from a socket created before attachment and both loopback filters passed.
- Live fallback with BTF hidden only inside a private mount namespace passed.
- Runtime BTF checks on 6.8 and 7.0 selected the four- and two-argument accept programs respectively. Live attachment was tested on 6.8; 7.0 validation covered BTF resolution.

The existing Linux 5.8 minimum remains because the sensor uses ring buffers. The sub-5.5 requirement in #434 cannot be met by changing the network attachment alone; fallback selection is capability-based and tested on a supported kernel.

Refs #434.
