### PR TITLE
chore(release): prepare 1.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3180,7 +3180,7 @@ dependencies = [
 
 [[package]]
 name = "rustinel"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustinel"
-version = "1.5.1"
+version = "1.6.0"
 edition = "2021"
 authors = []
 description = "Open-source EDR for Windows, Linux, and macOS with Sigma, YARA, and IOC detection"


### PR DESCRIPTION
## Summary

- bump the package version to 1.6.0
- prepare the stable release after the Linux eBPF fidelity and performance work

## Validation

- `cargo fmt --all -- --check`
- `cargo check --locked --all-targets`