### PR TITLE
chore(deps): replace unmaintained serde_yaml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3211,7 +3211,6 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "serde_yaml",
  "sha1 0.11.0",
  "sha2 0.11.0",
  "tempfile",
@@ -3223,6 +3222,7 @@ dependencies = [
  "url",
  "windows 0.62.2",
  "windows-service",
+ "yaml_serde",
  "yara-x",
  "zip",
 ]
@@ -3460,19 +3460,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
 ]
 
 [[package]]
@@ -4179,12 +4166,6 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,8 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signa
 # Serialization
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_yaml = "0.9"
+# Use the same maintained YAML parser as RSigma, including document streams.
+yaml_serde = "0.10.4"
 chrono = { version = "0.4", features = ["clock"] }
 semver = "1.0"
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -22,6 +22,24 @@ This test only parses, compiles, and routes rules. Live atomic firing tests and
 curated detection packs belong in `rustinel-rules` and are not run by this
 gate.
 
+## YAML parser
+
+Rule document inspection and pack manifest loading use `yaml_serde`, the
+[YAML organization's maintained fork](https://github.com/yaml/yaml-serde),
+under MIT OR Apache-2.0. RSigma already uses this crate, so sharing it avoids
+adding a second parser implementation. Its `Value`, `from_slice`, and streaming
+`Deserializer` APIs preserve the existing loading code, including inspection
+of every document for omitted temporal correlation conditions.
+
+Other alternatives include `serde-saphyr` (a different deserialization API)
+and `yaml-rust2` (a lower-level parser requiring a Serde integration). Neither
+provides a benefit here over reusing RSigma's existing dependency.
+
+When changing parsers, run `cargo test --locked` for detection, document,
+manifest, and pipeline coverage, then run the pinned corpus gate above without
+changing its baseline. Run `cargo deny --locked check` to verify advisory,
+license, dependency, and source policies.
+
 ## Build Matrix
 
 | Target | Tooling |

--- a/src/doctor/rules.rs
+++ b/src/doctor/rules.rs
@@ -107,7 +107,7 @@ fn validate_pack_manifest(
         }
     };
 
-    let manifest: DoctorPackManifest = match serde_yaml::from_slice(&bytes) {
+    let manifest: DoctorPackManifest = match yaml_serde::from_slice(&bytes) {
         Ok(manifest) => manifest,
         Err(err) => {
             results.push(

--- a/src/engine/loader.rs
+++ b/src/engine/loader.rs
@@ -68,8 +68,8 @@ impl DocumentSources {
 
         // Preserve whether the source omitted the temporal condition before
         // the parser replaces that omission with its current default.
-        for document in serde_yaml::Deserializer::from_str(content) {
-            let value = serde_yaml::Value::deserialize(document)
+        for document in yaml_serde::Deserializer::from_str(content) {
+            let value = yaml_serde::Value::deserialize(document)
                 .context("Failed to inspect parsed Sigma document")?;
             let Some(correlation) = value.get("correlation") else {
                 continue;

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -502,7 +502,7 @@ fn validate_extracted_pack(extracted_dir: &Path, pack: &CatalogPack) -> Result<(
     let manifest_bytes = fs::read(&manifest_path)
         .with_context(|| format!("read manifest {}", manifest_path.display()))?;
     let manifest: PackManifest =
-        serde_yaml::from_slice(&manifest_bytes).context("parse pack manifest")?;
+        yaml_serde::from_slice(&manifest_bytes).context("parse pack manifest")?;
     validate_manifest(&manifest, pack)?;
 
     let rules_root = locate_pack_rules_root(extracted_dir)?;


### PR DESCRIPTION
## Summary

Replace unmaintained `serde_yaml` with `yaml_serde`, the maintained MIT/Apache-2.0 parser already used by RSigma. Migrate Sigma document inspection and both pack manifest readers while preserving multi-document iteration and omitted temporal condition handling. Remove `serde_yaml` and `unsafe-libyaml` from the lockfile and document the parser selection.

Closes #138. The prerequisite #135 is complete; the pinned corpus baseline is unchanged.

## Type of change

- [x] `dependencies` - dependency update

## Test plan

- [ ] Tested on Windows
- [ ] Tested on Linux
- [x] Existing tests pass (`cargo test --locked`): 512 passed, 8 ignored on macOS
- [x] Pinned SigmaHQ corpus test: 2 passed, matching the unchanged Windows, Linux, and macOS routing baseline
- [x] Existing multi-document, temporal correlation, detection, and pipeline tests pass; this checkout has one Sigma backend and no separate backend-parity target
- [x] `cargo clippy --locked --all-targets -- -D clippy::all`
- [x] `cargo fmt --all -- --check` and `git diff --check`
- [x] Root and eBPF cargo-deny advisory, license, dependency, and source checks pass

## Checklist

- [x] Dependency label added
- [x] Parser choice and validation workflow documented
