### PR TITLE
fix(ioc): share source paths and intern feed comments

### DIFF
--- a/examples/ioc_load.rs
+++ b/examples/ioc_load.rs
@@ -1,0 +1,39 @@
+//! Measure IOC load time and retain the engine for external RSS measurement.
+//! Run `cargo run --release --example ioc_load -- /path/to/domains.txt`.
+//! The process exits when a line is read from stdin.
+
+use rustinel::config::IocConfig;
+use rustinel::ioc::IocEngine;
+use std::io::{self, Write};
+use std::path::PathBuf;
+use std::time::Instant;
+
+fn main() {
+    let domains_path = PathBuf::from(std::env::args_os().nth(1).expect("domain feed path"));
+    let empty = tempfile::tempdir().expect("empty IOC directory");
+    let config = IocConfig {
+        enabled: true,
+        hashes_path: empty.path().join("hashes.txt"),
+        ips_path: empty.path().join("ips.txt"),
+        domains_path,
+        paths_regex_path: empty.path().join("paths.txt"),
+        default_severity: "high".to_string(),
+        max_file_size_mb: 0,
+        hash_allowlist_paths: Vec::new(),
+    };
+    let start = Instant::now();
+    let engine = IocEngine::load(&config);
+    let elapsed = start.elapsed();
+    println!(
+        "pid={} exact={} suffix={} load_ms={:.3}",
+        std::process::id(),
+        engine.stats().domain_exact,
+        engine.stats().domain_suffix,
+        elapsed.as_secs_f64() * 1000.0
+    );
+    io::stdout().flush().expect("flush measurement");
+    io::stdin()
+        .read_line(&mut String::new())
+        .expect("wait for input");
+    std::hint::black_box(&engine);
+}

--- a/scripts/bench/ioc-load.md
+++ b/scripts/bench/ioc-load.md
@@ -1,0 +1,75 @@
+# IOC metadata sharing measurement
+
+Local measurements for [issue #410](https://github.com/Karib0u/rustinel/issues/410),
+comparing base `2cf83757751acfd09fe74c5c3c9ad2bdc01c6157` with the local
+`Arc<str>` source and per-file comment interning change. Both builds use the
+same `examples/ioc_load.rs` harness and lockfile.
+
+## Method
+
+Measured on 2026-09-10, Apple M1 Max, 64 GiB RAM, macOS 26.6.2 arm64,
+Rust 1.96.0, with `cargo build --locked --release --example ioc_load`.
+The harness times `IocEngine::load`, prints counts and elapsed milliseconds,
+then keeps the engine alive until stdin receives a newline. RSS is read with
+`ps -o rss= -p PID` after the ready line. This is resident process memory after
+loading, including allocator-retained pages, not peak RSS or live heap size.
+
+The synthetic feed contains 2,121,596 distinct wildcard domains and four
+repeated comments, totaling 65,769,476 bytes. It is not the Radegast corpus
+from the issue. Generate it outside the measurement process:
+
+```python
+from pathlib import Path
+path = Path('/tmp/rustinel-ioc-410-benchmark-feeds-malware/domains.txt')
+path.parent.mkdir(parents=True, exist_ok=True)
+with path.open('w') as feed:
+    for i in range(2_121_596):
+        feed.write(f'*.feed{i:07d}.invalid; threat{i % 4}\n')
+```
+
+Save the baseline and updated example executables as `/tmp/rustinel-410-before`
+and `/tmp/rustinel-410-after`. After builds finish, run five fresh processes
+per version, alternating order each round, against the same cached feed:
+
+```python
+import subprocess
+for run in range(5):
+    order = ['before', 'after'] if run % 2 == 0 else ['after', 'before']
+    for version in order:
+        process = subprocess.Popen(
+            ['/tmp/rustinel-410-' + version,
+             '/tmp/rustinel-ioc-410-benchmark-feeds-malware/domains.txt'],
+            stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True)
+        ready = process.stdout.readline().strip()
+        rss = subprocess.check_output(
+            ['ps', '-o', 'rss=', '-p', str(process.pid)], text=True).strip()
+        process.communicate('\n')
+        assert process.returncode == 0
+        print(run + 1, version, ready, 'rss_kib=' + rss)
+```
+
+The public engine reports exactly 2,121,596 suffix entries and zero exact
+entries for every measured process. Feed generation, compilation, and engine
+destruction are excluded from load time. This is a shared development machine;
+load times remain sensitive to unrelated host activity.
+
+## Results
+
+| Run | Before load (ms) | After load (ms) | Before RSS (MiB) | After RSS (MiB) |
+| --- | ---: | ---: | ---: | ---: |
+| 1 | 1386.131 | 1231.219 | 585.05 | 406.33 |
+| 2 | 1367.485 | 1206.723 | 630.98 | 406.36 |
+| 3 | 1363.969 | 1221.076 | 585.88 | 406.78 |
+| 4 | 1353.136 | 1229.880 | 633.00 | 406.80 |
+| 5 | 1350.276 | 1217.531 | 630.50 | 406.91 |
+| Median | 1363.969 | 1221.076 | 630.50 | 406.78 |
+
+Median RSS decreased by 223.72 MiB (35.5%). Median load
+time decreased by 142.893 ms (10.5%). The baseline RSS
+varied more across runs, so the individual samples are retained above.
+
+Validation: `cargo test --locked --release` passed 514 tests with 8 ignored;
+`cargo clippy --locked --all-targets -- -D clippy::all` and
+`cargo fmt --all -- --check` passed. Allocation identity tests cover all four
+loaders; integration tests verify public match metadata, including duplicate
+wildcards, absent comments, and comments containing semicolons.

--- a/src/ioc/alert.rs
+++ b/src/ioc/alert.rs
@@ -27,8 +27,8 @@ pub(crate) fn build_match(
         kind,
         indicator: indicator.to_string(),
         observed: observed.to_string(),
-        comment: meta.comment.clone(),
-        source: meta.source.clone(),
+        comment: meta.comment.as_deref().map(str::to_owned),
+        source: meta.source.to_string(),
         line: meta.line,
     }
 }

--- a/src/ioc/load.rs
+++ b/src/ioc/load.rs
@@ -2,9 +2,11 @@ use super::types::{DomainIocs, HashIocs, IocMeta, IpIocs, PathIocs};
 use crate::models::AlertSeverity;
 use ipnetwork::IpNetwork;
 use regex::{Regex, RegexSetBuilder};
+use std::collections::HashSet;
 use std::fs;
 use std::net::IpAddr;
 use std::path::Path;
+use std::sync::Arc;
 use tracing::{info, warn};
 
 pub(crate) fn parse_severity(value: &str) -> AlertSeverity {
@@ -24,14 +26,24 @@ pub(crate) fn parse_severity(value: &str) -> AlertSeverity {
     }
 }
 
-fn split_value_and_comment(line: &str) -> (String, Option<String>) {
+fn split_value_and_comment(line: &str) -> (&str, Option<&str>) {
     let mut parts = line.splitn(2, ';');
-    let value = parts.next().unwrap_or("").trim().to_string();
-    let comment = parts
-        .next()
-        .map(|v| v.trim().to_string())
-        .filter(|v| !v.is_empty());
+    let value = parts.next().unwrap_or("").trim();
+    let comment = parts.next().map(str::trim).filter(|v| !v.is_empty());
     (value, comment)
+}
+
+// Scoped to one file load: the temporary index is dropped after loading, while
+// metadata retains the shared strings. Reloads do not retain obsolete comments.
+fn intern_comment(comment: Option<&str>, comments: &mut HashSet<Arc<str>>) -> Option<Arc<str>> {
+    comment.map(|text| {
+        if let Some(shared) = comments.get(text) {
+            return Arc::clone(shared);
+        }
+        let shared: Arc<str> = Arc::from(text);
+        comments.insert(Arc::clone(&shared));
+        shared
+    })
 }
 
 fn should_skip_line(line: &str) -> bool {
@@ -61,7 +73,8 @@ fn read_lines(path: &Path) -> Vec<(usize, String)> {
 
 pub(crate) fn load_hashes(path: &Path) -> HashIocs {
     let mut iocs = HashIocs::default();
-    let source = path.display().to_string();
+    let source: Arc<str> = Arc::from(path.display().to_string());
+    let mut comments = HashSet::new();
 
     for (line_no, line) in read_lines(path) {
         let line = line.trim();
@@ -77,8 +90,8 @@ pub(crate) fn load_hashes(path: &Path) -> HashIocs {
 
         let normalized = value.to_ascii_lowercase();
         let meta = IocMeta {
-            comment,
-            source: source.clone(),
+            comment: intern_comment(comment, &mut comments),
+            source: Arc::clone(&source),
             line: line_no,
         };
 
@@ -128,7 +141,8 @@ pub(crate) fn load_hashes(path: &Path) -> HashIocs {
 
 pub(crate) fn load_ips(path: &Path) -> IpIocs {
     let mut iocs = IpIocs::default();
-    let source = path.display().to_string();
+    let source: Arc<str> = Arc::from(path.display().to_string());
+    let mut comments = HashSet::new();
 
     for (line_no, line) in read_lines(path) {
         let line = line.trim();
@@ -143,8 +157,8 @@ pub(crate) fn load_ips(path: &Path) -> IpIocs {
         }
 
         let meta = IocMeta {
-            comment,
-            source: source.clone(),
+            comment: intern_comment(comment, &mut comments),
+            source: Arc::clone(&source),
             line: line_no,
         };
 
@@ -193,7 +207,8 @@ fn is_hex(value: &str) -> bool {
 
 pub(crate) fn load_domains(path: &Path) -> DomainIocs {
     let mut iocs = DomainIocs::default();
-    let source = path.display().to_string();
+    let source: Arc<str> = Arc::from(path.display().to_string());
+    let mut comments = HashSet::new();
 
     for (line_no, line) in read_lines(path) {
         let line = line.trim();
@@ -208,8 +223,8 @@ pub(crate) fn load_domains(path: &Path) -> DomainIocs {
         }
 
         let meta = IocMeta {
-            comment,
-            source: source.clone(),
+            comment: intern_comment(comment, &mut comments),
+            source: Arc::clone(&source),
             line: line_no,
         };
 
@@ -248,7 +263,8 @@ pub(crate) fn load_domains(path: &Path) -> DomainIocs {
 
 pub(crate) fn load_path_regexes(path: &Path) -> PathIocs {
     let mut iocs = PathIocs::default();
-    let source = path.display().to_string();
+    let source: Arc<str> = Arc::from(path.display().to_string());
+    let mut comments = HashSet::new();
     let mut patterns = Vec::new();
 
     for (line_no, line) in read_lines(path) {
@@ -278,8 +294,8 @@ pub(crate) fn load_path_regexes(path: &Path) -> PathIocs {
         iocs.patterns.push((
             value.to_string(),
             IocMeta {
-                comment,
-                source: source.clone(),
+                comment: intern_comment(comment, &mut comments),
+                source: Arc::clone(&source),
                 line: line_no,
             },
         ));
@@ -308,4 +324,66 @@ pub(crate) fn load_path_regexes(path: &Path) -> PathIocs {
     );
 
     iocs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_shared(first: &IocMeta, second: &IocMeta) {
+        assert!(Arc::ptr_eq(&first.source, &second.source));
+        assert!(Arc::ptr_eq(
+            first.comment.as_ref().expect("first comment"),
+            second.comment.as_ref().expect("second comment"),
+        ));
+        assert_eq!(first.comment.as_deref(), Some("repeated; detail"));
+        assert_ne!(first.line, second.line);
+    }
+
+    #[test]
+    fn loaders_share_source_and_repeated_comments() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("feed.txt");
+        fs::write(&path, "# header\nexact.test; repeated; detail\n*.wild.test; repeated; detail\n.wild.test; other\nempty.test; \nnone.test\n").unwrap();
+        let domains = load_domains(&path);
+        let exact = &domains.exact["exact.test"];
+        let suffixes: Vec<_> = domains.suffix.lookup("wild.test").collect();
+        assert_shared(exact, suffixes[0].1);
+        assert_eq!(exact.source.as_ref(), path.display().to_string());
+        assert_eq!(exact.line, 2);
+        assert_eq!(suffixes[0].1.line, 3);
+        assert_eq!(suffixes[1].1.line, 4);
+        assert_eq!(suffixes[1].1.comment.as_deref(), Some("other"));
+        assert!(Arc::ptr_eq(&exact.source, &suffixes[1].1.source));
+        for name in ["empty.test", "none.test"] {
+            assert!(domains.exact[name].comment.is_none());
+            assert!(Arc::ptr_eq(&exact.source, &domains.exact[name].source));
+        }
+
+        fs::write(
+            &path,
+            "192.0.2.1; repeated; detail\n192.0.2.0/24; repeated; detail\n",
+        )
+        .unwrap();
+        let ips = load_ips(&path);
+        assert_shared(&ips.exact[&"192.0.2.1".parse().unwrap()], &ips.cidr[0].1);
+
+        fs::write(&path, "a{2}; repeated; detail\nb{2}; repeated; detail\n").unwrap();
+        let paths = load_path_regexes(&path);
+        assert_shared(&paths.patterns[0].1, &paths.patterns[1].1);
+
+        let md5 = "a".repeat(32);
+        let sha1 = "b".repeat(40);
+        let sha256 = "c".repeat(64);
+        fs::write(
+            &path,
+            format!(
+                "{md5}; repeated; detail\n{sha1}; repeated; detail\n{sha256}; repeated; detail\n"
+            ),
+        )
+        .unwrap();
+        let hashes = load_hashes(&path);
+        assert_shared(&hashes.md5[&md5], &hashes.sha1[&sha1]);
+        assert_shared(&hashes.md5[&md5], &hashes.sha256[&sha256]);
+    }
 }

--- a/src/ioc/mod.rs
+++ b/src/ioc/mod.rs
@@ -265,7 +265,7 @@ mod tests {
             "example.com",
             IocMeta {
                 comment: None,
-                source: "test".to_string(),
+                source: "test".into(),
                 line: 1,
             },
         );
@@ -315,7 +315,7 @@ mod tests {
                 suffix,
                 IocMeta {
                     comment: None,
-                    source: "test".to_string(),
+                    source: "test".into(),
                     line: *line,
                 },
             );
@@ -408,7 +408,7 @@ mod tests {
             "0c2674c3a97c53082187d930efb645c2".to_string(),
             IocMeta {
                 comment: None,
-                source: "test".to_string(),
+                source: "test".into(),
                 line: 1,
             },
         );

--- a/src/ioc/types.rs
+++ b/src/ioc/types.rs
@@ -2,6 +2,7 @@ use ipnetwork::IpNetwork;
 use regex::RegexSet;
 use std::collections::HashMap;
 use std::net::IpAddr;
+use std::sync::Arc;
 
 #[derive(Debug, Clone)]
 pub struct IocMatch {
@@ -38,8 +39,8 @@ impl IocKind {
 
 #[derive(Debug, Clone)]
 pub(crate) struct IocMeta {
-    pub(crate) comment: Option<String>,
-    pub(crate) source: String,
+    pub(crate) comment: Option<Arc<str>>,
+    pub(crate) source: Arc<str>,
     pub(crate) line: usize,
 }
 

--- a/tests/pipeline_ioc.rs
+++ b/tests/pipeline_ioc.rs
@@ -24,6 +24,14 @@ fn domain_ioc_matches_exact_and_suffix_dns_events() {
         .expect("dns event should normalize");
     let matches = engine.check_event(&event);
     assert_eq!(matches.len(), 2);
+    for (m, comment, line) in [(&matches[0], "exact", 1), (&matches[1], "suffix", 2)] {
+        assert_eq!(m.comment.as_deref(), Some(comment));
+        assert_eq!(
+            m.source,
+            fixture.config().domains_path.display().to_string()
+        );
+        assert_eq!(m.line, line);
+    }
 
     let alert = engine.build_alert_for_match(&matches[0], &event);
     let json = ecs_json(&alert);
@@ -86,6 +94,11 @@ fn ip_ioc_matches_network_and_dns_response_ips() {
         .expect("dns event should normalize");
     let matches = engine.check_event(&dns);
     assert_eq!(matches.len(), 2);
+    for (m, comment, line) in [(&matches[0], "exact", 1), (&matches[1], "cidr", 2)] {
+        assert_eq!(m.comment.as_deref(), Some(comment));
+        assert_eq!(m.source, fixture.config().ips_path.display().to_string());
+        assert_eq!(m.line, line);
+    }
 
     let alert = engine.build_alert_for_match(&matches[0], &dns);
     let json = ecs_json(&alert);
@@ -131,6 +144,15 @@ fn path_regex_ioc_matches_process_and_file_paths() {
         .expect("process event should normalize");
     let process_matches = engine.check_event(&process);
     assert_eq!(process_matches.len(), 1);
+    assert_eq!(
+        process_matches[0].comment.as_deref(),
+        Some("suspicious path")
+    );
+    assert_eq!(
+        process_matches[0].source,
+        fixture.config().paths_regex_path.display().to_string()
+    );
+    assert_eq!(process_matches[0].line, 1);
     let alert = engine.build_alert_for_match(&process_matches[0], &process);
     assert!(alert
         .rule_description
@@ -187,6 +209,15 @@ fn hash_ioc_pipeline_detects_required_hashes_and_respects_limits_and_allowlist()
 
     let matches = engine.match_hashes(&hashes);
     assert_eq!(matches.len(), 3);
+    for (m, comment, line) in [
+        (&matches[0], "md5", 1),
+        (&matches[1], "sha1", 2),
+        (&matches[2], "sha256", 3),
+    ] {
+        assert_eq!(m.comment.as_deref(), Some(comment));
+        assert_eq!(m.source, fixture.config().hashes_path.display().to_string());
+        assert_eq!(m.line, line);
+    }
     let alert = engine.build_alert_for_hash_match(
         &matches[0],
         sample.to_str().unwrap(),
@@ -195,4 +226,35 @@ fn hash_ioc_pipeline_detects_required_hashes_and_respects_limits_and_allowlist()
         "ebpf",
     );
     assert_ecs_field_eq(&ecs_json(&alert), "edr.rule.engine", "Ioc");
+}
+
+#[test]
+fn domain_metadata_preserves_duplicate_lines_and_optional_comments() {
+    let fixture = IocFixture::new();
+    fixture.write_domains(&format!(
+        "# header\n{TEST_DOMAIN}; repeated; detail\n*.example.test; repeated; detail\n.example.test; \n*.example.test\n"
+    ));
+    let engine = IocEngine::load(&fixture.config());
+    let harness = TestNormalizer::new();
+    let event = harness
+        .normalizer
+        .normalize(&dns_query_event(Platform::Linux))
+        .expect("DNS event");
+    let matches = engine.check_event(&event);
+    assert_eq!(matches.len(), 4);
+    for (index, m) in matches.iter().enumerate() {
+        assert_eq!(
+            m.source,
+            fixture.config().domains_path.display().to_string()
+        );
+        assert_eq!(m.line, index + 2);
+        assert_eq!(
+            m.comment.as_deref(),
+            if index < 2 {
+                Some("repeated; detail")
+            } else {
+                None
+            }
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Large IOC feeds previously allocated a source path and repeated comment text for every indicator. Share each file's source path through `Arc<str>` and intern comments within each file load. Public `IocMatch` strings and line numbers remain unchanged across hashes, exact and wildcard domains, IPs, CIDRs, and path regexes.

Add allocation-sharing tests, public metadata regression assertions, and a reproducible load benchmark with recorded results. On 2,121,596 synthetic wildcard domains, five alternating runs measured median RSS decreasing from 630.50 to 406.78 MiB (35.5%) and median load time from 1363.969 to 1221.076 ms (10.5%). These macOS measurements use a synthetic feed, not the Radegast corpus; methodology and all samples are in `scripts/bench/ioc-load.md`.

Closes #410.

## Type of change
- [ ] `feat` / `enhancement` - new feature
- [x] `bug` - bug fix
- [ ] `refactor` - refactoring, no behaviour change
- [ ] `documentation` - docs only
- [ ] `ci` - CI and release changes
- [ ] `dependencies` - dependency update

## Test plan
- [ ] Tested on Windows
- [ ] Tested on Linux
- [x] Existing tests pass: `cargo test --locked --release` (514 passed, 8 ignored on macOS)
- [x] New tests added for shared allocations and preserved match metadata
- [x] `cargo clippy --locked --all-targets -- -D clippy::all`
- [x] `cargo fmt --all -- --check`
- [x] Five alternating benchmark runs per version on a 2.12-million-entry feed

## Checklist
- [x] Label added to this PR
- [x] Benchmark methodology and results recorded; public behavior unchanged
