### PR TITLE
fix(yara): bound and stream process memory scans

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -145,13 +145,13 @@ directory = "C:\\Rustinel\\logs"
 | `yara_enabled` | `true` | Enable YARA scanning |
 | `yara_rules_path` | `rules/current/yara` | YARA rules directory, loaded recursively |
 | `yara_allowlist_paths` | inherits `allowlist.paths` | Prefix paths skipped by YARA queueing and scanning |
-| `yara_scan_timeout_ms` | `10000` | Per-scan timeout for file and memory scans; `0` disables |
+| `yara_scan_timeout_ms` | `10000` | Timeout per file or across memory reads and scans of one process; `0` disables |
 | `yara_max_file_mb` | `64` | Files larger than this are reported oversized instead of scanned; `0` disables |
 | `yara_memory_enabled` | `false` | Enable YARA memory scanning (requires `yara_enabled`) |
 | `yara_memory_queue_capacity` | `64` | Maximum pending memory scan jobs before new ones drop |
-| `yara_memory_delay_ms` | `750` | Delay after process start before reading memory |
+| `yara_memory_delay_ms` | `750` | Delay from enqueue to memory access; time waiting in the queue counts |
 | `yara_memory_max_process_mb` | `64` | Stop reading a process after this many MB |
-| `yara_memory_max_region_mb` | `8` | Clamp each region read to this many MB |
+| `yara_memory_max_region_mb` | `8` | Clamp each region read and the reusable payload buffer to this many MB |
 | `yara_memory_include_private` | `true` | Scan private (anonymous) regions |
 | `yara_memory_include_image` | `false` | Scan image-backed regions (loaded executables/DLLs) |
 | `yara_memory_include_mapped` | `false` | Scan file-mapped regions |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -456,7 +456,12 @@ could not be rebuilt safely, so those events reached no rule.
 
 A backed-up YARA queue is usually event volume rather than one stuck scan:
 `scanner.yara_scan_timeout_ms` already bounds how long a single scan can hold
-its worker.
+its worker. Memory reads and scans share one process budget after the enqueue
+delay and identity validation. Regions are scanned one at a time using a buffer
+bounded by `yara_memory_max_region_mb`. A `process_deadline` outcome means the
+budget expired; earlier detections are still emitted. OS reads cannot be
+interrupted and YARA-X checks timeouts periodically, so the active region can
+overrun the budget, but no further region starts after expiry.
 
 ### A registry rule did not fire on Windows
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -310,7 +310,7 @@ pub struct ScannerConfig {
     pub yara_enabled: bool,
     pub yara_rules_path: PathBuf,
     pub yara_allowlist_paths: Vec<String>,
-    /// Per-scan timeout for file and memory scans. 0 disables the timeout.
+    /// Timeout per file or across one process's memory regions. 0 disables it.
     pub yara_scan_timeout_ms: u64,
     /// Maximum size of a file accepted by an on-disk scan. 0 disables the guard.
     pub yara_max_file_mb: u64,

--- a/src/memory/linux.rs
+++ b/src/memory/linux.rs
@@ -1,7 +1,9 @@
-use super::{MemoryChunk, MemoryRegion, MemoryRegionKind, MemoryScanConfig};
+use super::{MemoryChunk, MemoryRegion, MemoryRegionKind, MemoryScanConfig, RegionReader};
 use anyhow::Result;
 use std::fs::File;
 use std::io::{Read, Seek, SeekFrom};
+use std::ops::ControlFlow;
+use std::time::Instant;
 
 struct MapsEntry {
     start: u64,
@@ -53,7 +55,12 @@ fn classify_region(path: Option<&str>) -> MemoryRegionKind {
     }
 }
 
-pub fn read_process_memory_chunks(pid: u32, cfg: &MemoryScanConfig) -> Result<Vec<MemoryChunk>> {
+pub fn visit_process_memory_chunks(
+    pid: u32,
+    cfg: &MemoryScanConfig,
+    deadline: Option<Instant>,
+    mut visitor: impl FnMut(&MemoryChunk) -> ControlFlow<()>,
+) -> Result<()> {
     let maps_path = format!("/proc/{}/maps", pid);
     let mem_path = format!("/proc/{}/mem", pid);
 
@@ -66,7 +73,7 @@ pub fn read_process_memory_chunks(pid: u32, cfg: &MemoryScanConfig) -> Result<Ve
                 error = %err,
                 "YARA memory: cannot read /proc/<pid>/maps"
             );
-            return Ok(Vec::new());
+            return Ok(());
         }
     };
 
@@ -79,15 +86,14 @@ pub fn read_process_memory_chunks(pid: u32, cfg: &MemoryScanConfig) -> Result<Ve
                 error = %err,
                 "YARA memory: cannot open /proc/<pid>/mem"
             );
-            return Ok(Vec::new());
+            return Ok(());
         }
     };
 
-    let mut chunks = Vec::new();
-    let mut total_bytes: usize = 0;
+    let mut reader = RegionReader::new(cfg, deadline);
 
     for line in maps_content.lines() {
-        if total_bytes >= cfg.max_process_bytes {
+        if reader.is_done() {
             break;
         }
 
@@ -125,40 +131,6 @@ pub fn read_process_memory_chunks(pid: u32, cfg: &MemoryScanConfig) -> Result<Ve
         }
 
         let region_size = (entry.end - entry.start) as usize;
-        let read_size = region_size
-            .min(cfg.max_region_bytes)
-            .min(cfg.max_process_bytes - total_bytes);
-
-        if read_size == 0 {
-            break;
-        }
-
-        if mem_file.seek(SeekFrom::Start(entry.start)).is_err() {
-            continue;
-        }
-
-        let mut buf = vec![0u8; read_size];
-        let bytes_read = match mem_file.read(&mut buf) {
-            Ok(n) => n,
-            Err(err) => {
-                tracing::trace!(
-                    target: "scanner",
-                    pid = pid,
-                    base = format_args!("0x{:x}", entry.start),
-                    error = %err,
-                    "Unable to read memory region"
-                );
-                continue;
-            }
-        };
-
-        if bytes_read == 0 {
-            continue;
-        }
-
-        buf.truncate(bytes_read);
-        total_bytes += bytes_read;
-
         let region = MemoryRegion {
             base: entry.start,
             size: region_size,
@@ -168,12 +140,32 @@ pub fn read_process_memory_chunks(pid: u32, cfg: &MemoryScanConfig) -> Result<Ve
             kind,
         };
 
-        chunks.push(MemoryChunk {
-            base: entry.start,
-            bytes: buf,
-            region,
-        });
+        if reader
+            .read_region(
+                region,
+                |buf| {
+                    mem_file.seek(SeekFrom::Start(entry.start)).ok()?;
+                    match mem_file.read(buf) {
+                        Ok(bytes_read) => Some(bytes_read),
+                        Err(err) => {
+                            tracing::trace!(
+                                target: "scanner",
+                                pid = pid,
+                                base = format_args!("0x{:x}", entry.start),
+                                error = %err,
+                                "Unable to read memory region"
+                            );
+                            None
+                        }
+                    }
+                },
+                &mut visitor,
+            )
+            .is_break()
+        {
+            break;
+        }
     }
 
-    Ok(chunks)
+    Ok(())
 }

--- a/src/memory/macos.rs
+++ b/src/memory/macos.rs
@@ -10,7 +10,7 @@
 //! returns an empty result, exactly like the Linux reader does on permission
 //! errors, so memory scanning simply yields nothing rather than failing.
 
-use super::{MemoryChunk, MemoryRegion, MemoryRegionKind, MemoryScanConfig};
+use super::{MemoryChunk, MemoryRegion, MemoryRegionKind, MemoryScanConfig, RegionReader};
 use anyhow::Result;
 use mach2::kern_return::KERN_SUCCESS;
 use mach2::mach_port::mach_port_deallocate;
@@ -20,6 +20,8 @@ use mach2::vm::{mach_vm_read_overwrite, mach_vm_region};
 use mach2::vm_prot::{VM_PROT_EXECUTE, VM_PROT_READ, VM_PROT_WRITE};
 use mach2::vm_region::{vm_region_basic_info_data_64_t, vm_region_info_t, VM_REGION_BASIC_INFO_64};
 use mach2::vm_types::{mach_vm_address_t, mach_vm_size_t};
+use std::ops::ControlFlow;
+use std::time::Instant;
 
 /// Number of 32-bit words in `vm_region_basic_info_data_64_t`, as required by
 /// `mach_vm_region`'s `info_count` argument.
@@ -36,7 +38,12 @@ fn classify(filename: Option<&str>, executable: bool) -> MemoryRegionKind {
     }
 }
 
-pub fn read_process_memory_chunks(pid: u32, cfg: &MemoryScanConfig) -> Result<Vec<MemoryChunk>> {
+pub fn visit_process_memory_chunks(
+    pid: u32,
+    cfg: &MemoryScanConfig,
+    deadline: Option<Instant>,
+    mut visitor: impl FnMut(&MemoryChunk) -> ControlFlow<()>,
+) -> Result<()> {
     let mut task: mach_port_t = MACH_PORT_NULL;
     let kr = unsafe { task_for_pid(mach_task_self(), pid as i32, &mut task) };
     if kr != KERN_SUCCESS {
@@ -46,14 +53,13 @@ pub fn read_process_memory_chunks(pid: u32, cfg: &MemoryScanConfig) -> Result<Ve
             kr = kr,
             "YARA memory: task_for_pid denied (needs root and SIP/entitlement)"
         );
-        return Ok(Vec::new());
+        return Ok(());
     }
 
-    let mut chunks = Vec::new();
-    let mut total_bytes: usize = 0;
+    let mut reader = RegionReader::new(cfg, deadline);
     let mut address: mach_vm_address_t = 0;
 
-    while total_bytes < cfg.max_process_bytes {
+    while !reader.is_done() {
         let mut size: mach_vm_size_t = 0;
         let mut info = vm_region_basic_info_data_64_t::default();
         let mut info_count = basic_info_count();
@@ -104,27 +110,19 @@ pub fn read_process_memory_chunks(pid: u32, cfg: &MemoryScanConfig) -> Result<Ve
 
             if include {
                 let region_size = size as usize;
-                let read_size = region_size
-                    .min(cfg.max_region_bytes)
-                    .min(cfg.max_process_bytes - total_bytes);
-
-                if read_size > 0 {
-                    if let Some(bytes) = read_region(task, address, read_size) {
-                        total_bytes += bytes.len();
-                        let region = MemoryRegion {
-                            base: address,
-                            size: region_size,
-                            readable: true,
-                            writable,
-                            executable,
-                            kind,
-                        };
-                        chunks.push(MemoryChunk {
-                            base: address,
-                            bytes,
-                            region,
-                        });
-                    }
+                let region = MemoryRegion {
+                    base: address,
+                    size: region_size,
+                    readable: true,
+                    writable,
+                    executable,
+                    kind,
+                };
+                if reader
+                    .read_region(region, |buf| read_region(task, address, buf), &mut visitor)
+                    .is_break()
+                {
+                    break;
                 }
             }
         }
@@ -140,18 +138,17 @@ pub fn read_process_memory_chunks(pid: u32, cfg: &MemoryScanConfig) -> Result<Ve
         let _ = mach_port_deallocate(mach_task_self(), task);
     }
 
-    Ok(chunks)
+    Ok(())
 }
 
-/// Read up to `len` bytes at `address` from `task`. Returns `None` on failure.
-fn read_region(task: mach_port_t, address: mach_vm_address_t, len: usize) -> Option<Vec<u8>> {
-    let mut buf = vec![0u8; len];
+/// Read into the region buffer at `address`. Returns `None` on failure.
+fn read_region(task: mach_port_t, address: mach_vm_address_t, buf: &mut [u8]) -> Option<usize> {
     let mut out_size: mach_vm_size_t = 0;
     let kr = unsafe {
         mach_vm_read_overwrite(
             task,
             address,
-            len as mach_vm_size_t,
+            buf.len() as mach_vm_size_t,
             buf.as_mut_ptr() as mach_vm_address_t,
             &mut out_size,
         )
@@ -159,8 +156,7 @@ fn read_region(task: mach_port_t, address: mach_vm_address_t, len: usize) -> Opt
     if kr != KERN_SUCCESS || out_size == 0 {
         return None;
     }
-    buf.truncate(out_size as usize);
-    Some(buf)
+    Some(out_size as usize)
 }
 
 #[cfg(test)]
@@ -191,7 +187,7 @@ mod tests {
             include_mapped: true,
             delay_ms: 0,
         };
-        let result = read_process_memory_chunks(99_999_999, &cfg);
+        let result = super::super::read_process_memory_chunks(99_999_999, &cfg);
         assert!(result.is_ok());
         assert!(result.unwrap().is_empty());
     }

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -1,8 +1,7 @@
 //! Process memory reader for YARA memory scanning.
 //!
-//! Reads selected memory regions from a live process into byte chunks that
-//! can then be passed to `Scanner::scan_bytes`. All I/O failures are treated
-//! as non-fatal: callers receive whatever chunks were successfully read.
+//! Visits selected regions one at a time using a reusable buffer. Individual
+//! region read failures are non-fatal and are skipped.
 
 mod types;
 
@@ -18,6 +17,8 @@ mod windows;
 pub use types::{MemoryChunk, MemoryRegion, MemoryRegionKind, MemoryScanConfig};
 
 use anyhow::Result;
+use std::ops::ControlFlow;
+use std::time::Instant;
 
 #[cfg(target_os = "linux")]
 use linux as platform;
@@ -31,12 +32,229 @@ use windows as platform;
 /// Read selected memory regions from `pid` according to `cfg`.
 /// Returns whatever chunks could be read; individual region failures are silently skipped.
 pub fn read_process_memory_chunks(pid: u32, cfg: &MemoryScanConfig) -> Result<Vec<MemoryChunk>> {
-    platform::read_process_memory_chunks(pid, cfg)
+    let mut chunks = Vec::new();
+    visit_process_memory_chunks(pid, cfg, None, |chunk| {
+        chunks.push(chunk.clone());
+        ControlFlow::Continue(())
+    })?;
+    Ok(chunks)
+}
+
+/// Visit each readable region before reading the next, retaining only one buffer.
+/// The borrowed chunk is valid only during the callback. Return `Break` to stop.
+/// No further region is read after `deadline`; an active OS read cannot be interrupted.
+pub fn visit_process_memory_chunks(
+    pid: u32,
+    cfg: &MemoryScanConfig,
+    deadline: Option<Instant>,
+    visitor: impl FnMut(&MemoryChunk) -> ControlFlow<()>,
+) -> Result<()> {
+    platform::visit_process_memory_chunks(pid, cfg, deadline, visitor)
+}
+
+/// Shared byte limits and buffer lifecycle for all platform readers.
+#[cfg(any(windows, target_os = "linux", target_os = "macos", test))]
+struct RegionReader<'a> {
+    cfg: &'a MemoryScanConfig,
+    deadline: Option<Instant>,
+    total_bytes: usize,
+    buffer: Vec<u8>,
+}
+
+#[cfg(any(windows, target_os = "linux", target_os = "macos", test))]
+impl<'a> RegionReader<'a> {
+    fn new(cfg: &'a MemoryScanConfig, deadline: Option<Instant>) -> Self {
+        Self {
+            cfg,
+            deadline,
+            total_bytes: 0,
+            buffer: Vec::new(),
+        }
+    }
+
+    fn is_done(&self) -> bool {
+        self.total_bytes >= self.cfg.max_process_bytes
+            || self.cfg.max_region_bytes == 0
+            || self
+                .deadline
+                .is_some_and(|deadline| Instant::now() >= deadline)
+    }
+
+    fn read_region(
+        &mut self,
+        region: MemoryRegion,
+        read: impl FnOnce(&mut [u8]) -> Option<usize>,
+        visitor: &mut impl FnMut(&MemoryChunk) -> ControlFlow<()>,
+    ) -> ControlFlow<()> {
+        if self.is_done() {
+            return ControlFlow::Break(());
+        }
+        let size = region
+            .size
+            .min(self.cfg.max_region_bytes)
+            .min(self.cfg.max_process_bytes - self.total_bytes);
+        if size == 0 {
+            return ControlFlow::Continue(());
+        }
+        // Reserve exactly so capacity stays within the region byte limit.
+        if self.buffer.capacity() < size {
+            self.buffer.reserve_exact(size - self.buffer.len());
+        }
+        self.buffer.resize(size, 0);
+        if self.is_done() {
+            return ControlFlow::Break(());
+        }
+        let Some(bytes_read) = read(&mut self.buffer) else {
+            return ControlFlow::Continue(());
+        };
+        let bytes_read = bytes_read.min(size);
+        if bytes_read == 0 {
+            return ControlFlow::Continue(());
+        }
+        self.total_bytes += bytes_read;
+        self.buffer.truncate(bytes_read);
+        let chunk = MemoryChunk {
+            base: region.base,
+            bytes: std::mem::take(&mut self.buffer),
+            region,
+        };
+        let result = visitor(&chunk);
+        // Reclaim this region's payload before any later read.
+        self.buffer = chunk.bytes;
+        result
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn small_config() -> MemoryScanConfig {
+        MemoryScanConfig {
+            max_process_bytes: 10,
+            max_region_bytes: 4,
+            include_private: true,
+            include_image: false,
+            include_mapped: false,
+            delay_ms: 0,
+        }
+    }
+
+    fn region(base: u64) -> MemoryRegion {
+        MemoryRegion {
+            base,
+            size: 20,
+            readable: true,
+            writable: true,
+            executable: false,
+            kind: MemoryRegionKind::Private,
+        }
+    }
+
+    #[test]
+    fn streaming_reclaims_previous_payload_before_later_reads() {
+        use std::cell::Cell;
+        let cfg = small_config();
+        let mut reader = RegionReader::new(&cfg, None);
+        let visited = Cell::new(0);
+        let mut buffer_ptr = None;
+        let mut lengths = Vec::new();
+        for index in 0..3 {
+            assert!(reader
+                .read_region(
+                    region(0x1000 + index),
+                    |buffer| {
+                        // Every previous scan finished before this read. The exact
+                        // same allocation is available again, so no earlier payload
+                        // can remain buffered alongside the current region.
+                        assert_eq!(visited.get(), index);
+                        if let Some(ptr) = buffer_ptr {
+                            assert_eq!(buffer.as_ptr(), ptr);
+                        } else {
+                            buffer_ptr = Some(buffer.as_ptr());
+                        }
+                        buffer.fill(index as u8);
+                        Some(buffer.len())
+                    },
+                    &mut |chunk| {
+                        assert_eq!(chunk.base, 0x1000 + index);
+                        assert_eq!(chunk.region.base, chunk.base);
+                        assert_eq!(chunk.region.size, 20);
+                        assert_eq!(chunk.region.kind, MemoryRegionKind::Private);
+                        assert!(chunk.bytes.iter().all(|byte| *byte == index as u8));
+                        assert!(chunk.bytes.capacity() <= cfg.max_region_bytes);
+                        lengths.push(chunk.bytes.len());
+                        visited.set(index + 1);
+                        ControlFlow::Continue(())
+                    },
+                )
+                .is_continue());
+        }
+        assert_eq!(lengths, [4, 4, 2]);
+        assert!(reader.is_done());
+        assert!(reader
+            .read_region(
+                region(0x2000),
+                |_| panic!("process byte budget exhausted"),
+                &mut |_| panic!("no further chunks"),
+            )
+            .is_break());
+    }
+
+    #[test]
+    fn streaming_partial_and_failed_reads_preserve_byte_budget() {
+        let cfg = small_config();
+        let mut reader = RegionReader::new(&cfg, None);
+        let mut lengths = Vec::new();
+        for count in [None, Some(0), Some(2), Some(4), Some(4)] {
+            assert!(reader
+                .read_region(
+                    region(0x1000),
+                    |buffer| {
+                        assert_eq!(buffer.len(), 4);
+                        count
+                    },
+                    &mut |chunk| {
+                        lengths.push(chunk.bytes.len());
+                        ControlFlow::Continue(())
+                    },
+                )
+                .is_continue());
+        }
+        assert_eq!(lengths, [2, 4, 4]);
+        assert!(reader.is_done());
+    }
+
+    #[test]
+    fn streaming_honors_deadline_and_zero_byte_limits() {
+        for (process_limit, region_limit, deadline) in
+            [(10, 4, Some(Instant::now())), (0, 4, None), (10, 0, None)]
+        {
+            let mut cfg = small_config();
+            cfg.max_process_bytes = process_limit;
+            cfg.max_region_bytes = region_limit;
+            let mut reader = RegionReader::new(&cfg, deadline);
+            assert!(reader
+                .read_region(
+                    region(0x1000),
+                    |_| panic!("stopped reader must not read"),
+                    &mut |_| panic!("stopped reader must not visit"),
+                )
+                .is_break());
+        }
+    }
+
+    #[test]
+    fn streaming_propagates_visitor_stop() {
+        let cfg = small_config();
+        let mut reader = RegionReader::new(&cfg, None);
+        assert!(reader
+            .read_region(region(0x1000), |buffer| Some(buffer.len()), &mut |_| {
+                ControlFlow::Break(())
+            },)
+            .is_break());
+        assert_eq!(reader.buffer.len(), 4);
+    }
 
     #[test]
     fn test_memory_scan_config_fields() {

--- a/src/memory/types.rs
+++ b/src/memory/types.rs
@@ -8,7 +8,7 @@ pub struct MemoryScanConfig {
     pub include_private: bool,
     pub include_image: bool,
     pub include_mapped: bool,
-    /// Milliseconds to wait before scanning (gives packers time to unpack).
+    /// Milliseconds from enqueue before scanning (gives packers time to unpack).
     pub delay_ms: u64,
 }
 
@@ -32,7 +32,7 @@ pub struct MemoryRegion {
     pub kind: MemoryRegionKind,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct MemoryChunk {
     pub base: u64,
     pub bytes: Vec<u8>,

--- a/src/memory/unsupported.rs
+++ b/src/memory/unsupported.rs
@@ -1,6 +1,13 @@
 use super::{MemoryChunk, MemoryScanConfig};
 use anyhow::Result;
+use std::ops::ControlFlow;
+use std::time::Instant;
 
-pub fn read_process_memory_chunks(_pid: u32, _cfg: &MemoryScanConfig) -> Result<Vec<MemoryChunk>> {
-    Ok(Vec::new())
+pub fn visit_process_memory_chunks(
+    _pid: u32,
+    _cfg: &MemoryScanConfig,
+    _deadline: Option<Instant>,
+    _visitor: impl FnMut(&MemoryChunk) -> ControlFlow<()>,
+) -> Result<()> {
+    Ok(())
 }

--- a/src/memory/windows.rs
+++ b/src/memory/windows.rs
@@ -1,5 +1,7 @@
-use super::{MemoryChunk, MemoryRegion, MemoryRegionKind, MemoryScanConfig};
+use super::{MemoryChunk, MemoryRegion, MemoryRegionKind, MemoryScanConfig, RegionReader};
 use anyhow::Result;
+use std::ops::ControlFlow;
+use std::time::Instant;
 use windows::Win32::Foundation::CloseHandle;
 use windows::Win32::System::Diagnostics::Debug::ReadProcessMemory;
 use windows::Win32::System::Memory::{
@@ -37,7 +39,12 @@ fn is_executable(protect: PAGE_PROTECTION_FLAGS) -> bool {
     )
 }
 
-pub fn read_process_memory_chunks(pid: u32, cfg: &MemoryScanConfig) -> Result<Vec<MemoryChunk>> {
+pub fn visit_process_memory_chunks(
+    pid: u32,
+    cfg: &MemoryScanConfig,
+    deadline: Option<Instant>,
+    mut visitor: impl FnMut(&MemoryChunk) -> ControlFlow<()>,
+) -> Result<()> {
     let handle = unsafe {
         OpenProcess(
             PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_VM_READ,
@@ -54,16 +61,15 @@ pub fn read_process_memory_chunks(pid: u32, cfg: &MemoryScanConfig) -> Result<Ve
                 pid = pid,
                 "YARA memory: OpenProcess failed (process may have exited)"
             );
-            return Ok(Vec::new());
+            return Ok(());
         }
     };
 
-    let mut chunks = Vec::new();
+    let mut reader = RegionReader::new(cfg, deadline);
     let mut address: usize = 0;
-    let mut total_bytes: usize = 0;
 
     loop {
-        if total_bytes >= cfg.max_process_bytes {
+        if reader.is_done() {
             break;
         }
 
@@ -119,36 +125,6 @@ pub fn read_process_memory_chunks(pid: u32, cfg: &MemoryScanConfig) -> Result<Ve
             continue;
         }
 
-        let read_size = region_size
-            .min(cfg.max_region_bytes)
-            .min(cfg.max_process_bytes - total_bytes);
-
-        let mut buf = vec![0u8; read_size];
-        let mut bytes_read: usize = 0;
-
-        let ok = unsafe {
-            ReadProcessMemory(
-                handle,
-                region_base as *const _,
-                buf.as_mut_ptr() as *mut _,
-                read_size,
-                Some(&mut bytes_read),
-            )
-        };
-
-        if ok.is_err() || bytes_read == 0 {
-            tracing::trace!(
-                target: "scanner",
-                pid = pid,
-                base = format_args!("0x{:x}", region_base),
-                "YARA memory: ReadProcessMemory failed (normal for guard/exited process)"
-            );
-            continue;
-        }
-
-        buf.truncate(bytes_read);
-        total_bytes += bytes_read;
-
         let region = MemoryRegion {
             base: region_base as u64,
             size: region_size,
@@ -158,16 +134,43 @@ pub fn read_process_memory_chunks(pid: u32, cfg: &MemoryScanConfig) -> Result<Ve
             kind,
         };
 
-        chunks.push(MemoryChunk {
-            base: region_base as u64,
-            bytes: buf,
-            region,
-        });
+        if reader
+            .read_region(
+                region,
+                |buf| {
+                    let mut bytes_read = 0;
+                    let result = unsafe {
+                        ReadProcessMemory(
+                            handle,
+                            region_base as *const _,
+                            buf.as_mut_ptr() as *mut _,
+                            buf.len(),
+                            Some(&mut bytes_read),
+                        )
+                    };
+                    if result.is_err() || bytes_read == 0 {
+                        tracing::trace!(
+                            target: "scanner",
+                            pid = pid,
+                            base = format_args!("0x{:x}", region_base),
+                            "YARA memory: ReadProcessMemory failed (normal for guard/exited process)"
+                        );
+                        None
+                    } else {
+                        Some(bytes_read)
+                    }
+                },
+                &mut visitor,
+            )
+            .is_break()
+        {
+            break;
+        }
     }
 
     unsafe {
         let _ = CloseHandle(handle);
     }
 
-    Ok(chunks)
+    Ok(())
 }

--- a/src/runtime/yara.rs
+++ b/src/runtime/yara.rs
@@ -9,8 +9,9 @@ use crate::response::ResponseEngine;
 use crate::scanner::{self, ScanError, ScanResult, YaraMemoryJob};
 use crate::sensor::Platform;
 use crate::utils::{self, validate_process_identity, LogRateLimiter};
+use std::ops::ControlFlow;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
 
@@ -31,7 +32,9 @@ impl YaraScanCounters {
         match result {
             Ok(matches) if matches.is_empty() => self.clean += 1,
             Ok(_) => self.matched += 1,
-            Err(ScanError::TimedOut { .. }) => self.timed_out += 1,
+            Err(ScanError::TimedOut { .. } | ScanError::ProcessDeadline { .. }) => {
+                self.timed_out += 1
+            }
             Err(ScanError::TooLarge { .. }) => self.oversized += 1,
             Err(ScanError::Failed(_)) => self.failed += 1,
         }
@@ -332,6 +335,75 @@ pub fn spawn_yara_file_worker(
     })
 }
 
+fn wait_for_memory_scan(
+    enqueued_at: Instant,
+    delay: Duration,
+    now: Instant,
+    sleep: impl FnOnce(Duration),
+) {
+    let remaining = delay.saturating_sub(now.saturating_duration_since(enqueued_at));
+    if !remaining.is_zero() {
+        sleep(remaining);
+    }
+}
+
+/// Share one budget across streaming reads and scans. Successful detections
+/// are emitted before the reader reuses the region buffer.
+fn scan_memory_regions<T>(
+    timeout: Duration,
+    mut now: impl FnMut() -> Instant,
+    read: impl FnOnce(Option<Instant>, &mut dyn FnMut(&T) -> ControlFlow<()>) -> anyhow::Result<()>,
+    mut scan: impl FnMut(&T, Duration) -> ScanResult,
+    mut on_matches: impl FnMut(&T, &[YaraRuleMatch]),
+) -> ScanResult {
+    let started = now();
+    let deadline = if timeout.is_zero() {
+        None
+    } else {
+        started.checked_add(timeout)
+    };
+    let mut matches = Vec::new();
+    let mut failure = None;
+    let read_result = read(deadline, &mut |region| {
+        let remaining = if timeout.is_zero() {
+            Duration::ZERO
+        } else {
+            let remaining = timeout.saturating_sub(now().duration_since(started));
+            if remaining.is_zero() {
+                failure = Some(ScanError::ProcessDeadline { timeout });
+                return ControlFlow::Break(());
+            }
+            remaining
+        };
+        match scan(region, remaining) {
+            Ok(mut found) => {
+                on_matches(region, &found);
+                matches.append(&mut found);
+            }
+            Err(ScanError::TimedOut { .. }) if !timeout.is_zero() => {
+                failure = Some(ScanError::ProcessDeadline { timeout });
+                return ControlFlow::Break(());
+            }
+            Err(err) => {
+                failure.get_or_insert(err);
+            }
+        }
+        if !timeout.is_zero() && now().duration_since(started) >= timeout {
+            failure = Some(ScanError::ProcessDeadline { timeout });
+            return ControlFlow::Break(());
+        }
+        ControlFlow::Continue(())
+    });
+    // The reader may stop at the deadline before yielding a region.
+    if !timeout.is_zero() && now().duration_since(started) >= timeout {
+        return Err(ScanError::ProcessDeadline { timeout });
+    }
+    if let Err(err) = read_result {
+        failure.get_or_insert(ScanError::Failed(err));
+    }
+    failure.map_or(Ok(matches), Err)
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn spawn_yara_memory_worker(
     detectors: Arc<DetectorStore>,
@@ -349,7 +421,12 @@ pub fn spawn_yara_memory_worker(
             LogRateLimiter::new(Duration::from_secs(WORKER_LOG_WINDOW_SECS));
         let mut counters = YaraScanCounters::default();
         while let Some(job) = rx.blocking_recv() {
-            std::thread::sleep(Duration::from_millis(cfg.delay_ms));
+            wait_for_memory_scan(
+                job.enqueued_at,
+                Duration::from_millis(cfg.delay_ms),
+                Instant::now(),
+                std::thread::sleep,
+            );
             if let Err(reason) = validate_process_identity(&job.expected_identity) {
                 counters.record_skip();
                 debug!(
@@ -362,67 +439,55 @@ pub fn spawn_yara_memory_worker(
                 continue;
             }
 
-            let chunks = match memory::read_process_memory_chunks(job.expected_identity.pid, &cfg) {
-                Ok(chunks) => chunks,
-                Err(err) => {
-                    counters.failed += 1;
-                    let decision = scan_error_limiter.should_emit("memory_read_error");
-                    if decision.should_emit {
-                        warn!(
-                            target: "scanner",
-                            pid = job.expected_identity.pid,
-                            image = %job.expected_identity.image,
-                            error = %err,
-                            suppressed = decision.suppressed_since_last_emit,
-                            failed_scans_total = counters.failed,
-                            "YARA memory read failure"
-                        );
-                    }
-                    continue;
-                }
-            };
-
             let scanner = detectors.yara();
-            for chunk in &chunks {
-                let scan_result = scanner.scan_bytes(&chunk.bytes, match_debug);
-                counters.record_result(&scan_result);
-                let matches = match scan_result {
-                    Ok(matches) => matches,
-                    Err(err) => {
-                        let decision =
-                            scan_error_limiter.should_emit(&format!("memory_{}", err.kind()));
-                        if decision.should_emit {
-                            warn!(
-                                target: "scanner",
-                                pid = job.expected_identity.pid,
-                                outcome = err.kind(),
-                                error = %err,
-                                suppressed = decision.suppressed_since_last_emit,
-                                failed_scans_total = counters.failed,
-                                timed_out_scans_total = counters.timed_out,
-                                "YARA memory chunk scan not completed"
+            let scan_result = scan_memory_regions(
+                scanner.limits().timeout,
+                Instant::now,
+                |deadline, visitor| {
+                    memory::visit_process_memory_chunks(
+                        job.expected_identity.pid,
+                        &cfg,
+                        deadline,
+                        visitor,
+                    )
+                },
+                |chunk, timeout| {
+                    scanner.scan_bytes_with_timeout(&chunk.bytes, match_debug, timeout)
+                },
+                |chunk, matches| {
+                    if !matches.is_empty() {
+                        for rule_match in matches {
+                            let details =
+                                build_yara_memory_match_details(match_debug, rule_match, chunk);
+                            let alert = build_yara_memory_alert(
+                                &rule_match.rule,
+                                rule_match.metadata_id.clone(),
+                                &job.expected_identity.image,
+                                job.expected_identity.pid,
+                                details,
+                                platform,
+                                provider,
                             );
+                            alert_sink.write_alert(&alert);
+                            response_engine.handle_alert(&alert);
                         }
-                        continue;
                     }
-                };
-
-                if !matches.is_empty() {
-                    for rule_match in &matches {
-                        let details =
-                            build_yara_memory_match_details(match_debug, rule_match, chunk);
-                        let alert = build_yara_memory_alert(
-                            &rule_match.rule,
-                            rule_match.metadata_id.clone(),
-                            &job.expected_identity.image,
-                            job.expected_identity.pid,
-                            details,
-                            platform,
-                            provider,
-                        );
-                        alert_sink.write_alert(&alert);
-                        response_engine.handle_alert(&alert);
-                    }
+                },
+            );
+            counters.record_result(&scan_result);
+            if let Err(err) = scan_result {
+                let decision = scan_error_limiter.should_emit(err.kind());
+                if decision.should_emit {
+                    warn!(
+                        target: "scanner",
+                        pid = job.expected_identity.pid,
+                        outcome = err.kind(),
+                        error = %err,
+                        suppressed = decision.suppressed_since_last_emit,
+                        failed_scans_total = counters.failed,
+                        timed_out_scans_total = counters.timed_out,
+                        "YARA memory process scan not completed"
+                    );
                 }
             }
         }
@@ -453,6 +518,232 @@ mod tests {
             tags: Vec::new(),
             namespace: None,
             strings: Vec::new(),
+        }
+    }
+
+    fn read_test_regions(
+        _deadline: Option<std::time::Instant>,
+        visitor: &mut dyn FnMut(&i32) -> std::ops::ControlFlow<()>,
+    ) -> anyhow::Result<()> {
+        for region in 0..3 {
+            if visitor(&region).is_break() {
+                break;
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn memory_read_time_counts_toward_process_deadline() {
+        use std::cell::Cell;
+        let started = std::time::Instant::now();
+        for yield_region in [false, true] {
+            let elapsed = Cell::new(Duration::ZERO);
+            let result = super::scan_memory_regions(
+                Duration::from_secs(10),
+                || started + elapsed.get(),
+                |deadline, visitor| {
+                    assert_eq!(deadline, Some(started + Duration::from_secs(10)));
+                    elapsed.set(Duration::from_secs(10));
+                    if yield_region {
+                        assert!(visitor(&0).is_break());
+                    }
+                    Ok(())
+                },
+                |_: &i32, _| panic!("read exhausted the budget before scanning"),
+                |_, _| panic!("no matches"),
+            );
+            assert!(matches!(result, Err(ScanError::ProcessDeadline { .. })));
+        }
+    }
+
+    #[test]
+    fn streaming_matches_keep_region_metadata_after_later_read_failure() {
+        use crate::memory::{MemoryChunk, MemoryRegion, MemoryRegionKind};
+        use crate::models::MatchDebugLevel;
+        let mut summaries = Vec::new();
+        let result = super::scan_memory_regions(
+            Duration::ZERO,
+            std::time::Instant::now,
+            |deadline, visitor| {
+                assert!(deadline.is_none());
+                for base in [0x1000, 0x2000] {
+                    let chunk = MemoryChunk {
+                        base,
+                        bytes: vec![1; 4],
+                        region: MemoryRegion {
+                            base,
+                            size: 20,
+                            readable: true,
+                            writable: true,
+                            executable: false,
+                            kind: MemoryRegionKind::Private,
+                        },
+                    };
+                    assert!(visitor(&chunk).is_continue());
+                }
+                Err(anyhow::anyhow!("reader failure"))
+            },
+            |_: &MemoryChunk, _| Ok(vec![rule_match()]),
+            |chunk, matches| {
+                summaries.push(
+                    super::build_yara_memory_match_details(
+                        MatchDebugLevel::Full,
+                        &matches[0],
+                        chunk,
+                    )
+                    .unwrap()
+                    .summary,
+                );
+            },
+        );
+        assert!(matches!(result, Err(ScanError::Failed(_))));
+        assert_eq!(
+            summaries,
+            [
+                "matched YARA rule TestRule in process memory at 0x1000 Private rw-",
+                "matched YARA rule TestRule in process memory at 0x2000 Private rw-",
+            ]
+        );
+    }
+
+    #[test]
+    fn memory_scan_burst_shares_enqueue_delay() {
+        let enqueued_at = std::time::Instant::now();
+        let delay = Duration::from_millis(750);
+        let mut now = enqueued_at;
+        let mut sleeps = Vec::new();
+        for _ in 0..64 {
+            super::wait_for_memory_scan(enqueued_at, delay, now, |remaining| {
+                sleeps.push(remaining);
+                now += remaining;
+            });
+        }
+        assert_eq!(sleeps, [delay]);
+        assert_eq!(now.duration_since(enqueued_at), delay);
+    }
+
+    #[test]
+    fn memory_scan_waits_only_for_remaining_delay() {
+        let enqueued_at = std::time::Instant::now();
+        super::wait_for_memory_scan(
+            enqueued_at,
+            Duration::from_millis(750),
+            enqueued_at + Duration::from_millis(500),
+            |remaining| assert_eq!(remaining, Duration::from_millis(250)),
+        );
+        for (delay, elapsed) in [(750, 750), (750, 1000), (0, 0)] {
+            super::wait_for_memory_scan(
+                enqueued_at,
+                Duration::from_millis(delay),
+                enqueued_at + Duration::from_millis(elapsed),
+                |_| panic!("due jobs must not sleep"),
+            );
+        }
+    }
+
+    #[test]
+    fn memory_regions_share_deadline_and_preserve_earlier_matches() {
+        use std::cell::Cell;
+        use std::time::Instant;
+
+        for engine_timeout in [false, true] {
+            let elapsed = Cell::new(Duration::ZERO);
+            let start = Instant::now();
+            let mut budgets = Vec::new();
+            let mut detected = Vec::new();
+            let result = super::scan_memory_regions(
+                Duration::from_secs(10),
+                || start + elapsed.get(),
+                read_test_regions,
+                |region, remaining| {
+                    budgets.push(remaining);
+                    if *region == 0 {
+                        elapsed.set(Duration::from_secs(4));
+                        Ok(vec![rule_match()])
+                    } else if engine_timeout {
+                        Err(ScanError::TimedOut { timeout: remaining })
+                    } else {
+                        elapsed.set(Duration::from_secs(10));
+                        Ok(Vec::new())
+                    }
+                },
+                |region, matches| {
+                    detected.extend(matches.iter().map(|m| (*region, m.rule.clone())));
+                },
+            );
+            assert_eq!(budgets, [Duration::from_secs(10), Duration::from_secs(6)]);
+            assert_eq!(detected, [(0, "TestRule".to_string())]);
+            assert!(matches!(result, Err(ScanError::ProcessDeadline { .. })));
+            assert_eq!(result.as_ref().unwrap_err().kind(), "process_deadline");
+            let mut counters = YaraScanCounters::default();
+            counters.record_result(&result);
+            assert_eq!(counters.timed_out, 1);
+            assert_eq!(counters.clean + counters.matched + counters.failed, 0);
+        }
+    }
+
+    #[test]
+    fn memory_regions_do_not_start_after_deadline() {
+        let start = std::time::Instant::now();
+        let mut calls = 0;
+        let result = super::scan_memory_regions(
+            Duration::from_secs(1),
+            || {
+                calls += 1;
+                start + Duration::from_secs(calls - 1)
+            },
+            read_test_regions,
+            |_, _| panic!("expired region must not start"),
+            |_, _| {},
+        );
+        assert!(matches!(result, Err(ScanError::ProcessDeadline { .. })));
+    }
+
+    #[test]
+    fn memory_regions_without_timeout_continue_after_failure() {
+        let mut scanned = Vec::new();
+        let mut detected = Vec::new();
+        let result = super::scan_memory_regions(
+            Duration::ZERO,
+            std::time::Instant::now,
+            read_test_regions,
+            |region, remaining| {
+                assert!(remaining.is_zero());
+                scanned.push(*region);
+                if *region == 1 {
+                    Err(ScanError::Failed(anyhow::anyhow!("engine failure")))
+                } else {
+                    Ok(vec![rule_match()])
+                }
+            },
+            |region, _| detected.push(*region),
+        );
+        assert_eq!(scanned, [0, 1, 2]);
+        assert_eq!(detected, [0, 2]);
+        assert!(matches!(result, Err(ScanError::Failed(_))));
+    }
+
+    #[test]
+    fn memory_regions_report_one_successful_process_outcome() {
+        for matched in [false, true] {
+            let result = super::scan_memory_regions(
+                Duration::from_secs(10),
+                std::time::Instant::now,
+                read_test_regions,
+                |_, _| {
+                    Ok(if matched {
+                        vec![rule_match()]
+                    } else {
+                        Vec::new()
+                    })
+                },
+                |_, _| {},
+            );
+            let mut counters = YaraScanCounters::default();
+            counters.record_result(&result);
+            assert_eq!(counters.matched, u64::from(matched));
+            assert_eq!(counters.clean, u64::from(!matched));
         }
     }
 

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -7,7 +7,7 @@ use std::collections::{HashMap, VecDeque};
 use std::fs;
 use std::path::Path;
 use std::sync::Mutex;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::sync::mpsc::Sender;
 use tracing::{debug, info, warn};
 use yara_x::{Compiler, Rules, Scanner as XScanner};
@@ -42,7 +42,7 @@ pub fn is_path_allowlisted(path: &str, allowlist_paths: &[String]) -> bool {
         .is_match(path, allowlist_paths)
 }
 
-/// Default per-scan timeout applied to file and memory scans.
+/// Default timeout per file or across one process's memory reads and scans.
 pub const DEFAULT_SCAN_TIMEOUT_MS: u64 = 10_000;
 /// Default maximum size of a file accepted by [`Scanner::scan_file`].
 pub const DEFAULT_MAX_FILE_MB: u64 = 64;
@@ -52,7 +52,7 @@ pub const DEFAULT_MAX_FILE_MB: u64 = 64;
 /// A zero value disables the corresponding guard.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ScanLimits {
-    /// Per-scan timeout handed to `yara_x::Scanner::set_timeout`.
+    /// Timeout per file or shared across one process's memory regions.
     pub timeout: Duration,
     /// Maximum size of a file accepted by [`Scanner::scan_file`].
     pub max_file_bytes: u64,
@@ -76,6 +76,9 @@ pub enum ScanError {
     /// The scan hit the configured per-scan timeout.
     #[error("YARA scan timed out after {} ms", timeout.as_millis())]
     TimedOut { timeout: Duration },
+    /// The shared budget for all regions of a process was exhausted.
+    #[error("YARA process deadline exceeded after {} ms", timeout.as_millis())]
+    ProcessDeadline { timeout: Duration },
     /// The target was larger than the configured maximum and was not scanned.
     #[error("target of {size} bytes exceeds the maximum scan size of {limit} bytes")]
     TooLarge { size: u64, limit: u64 },
@@ -89,6 +92,7 @@ impl ScanError {
     pub fn kind(&self) -> &'static str {
         match self {
             ScanError::TimedOut { .. } => "timeout",
+            ScanError::ProcessDeadline { .. } => "process_deadline",
             ScanError::TooLarge { .. } => "oversized",
             ScanError::Failed(_) => "failed",
         }
@@ -199,6 +203,8 @@ fn truncate_str(s: &str, max_len: usize) -> String {
 #[derive(Debug, Clone)]
 pub struct YaraMemoryJob {
     pub expected_identity: ProcessIdentity,
+    /// Monotonic enqueue time so queue waiting counts toward the scan delay.
+    pub enqueued_at: Instant,
 }
 
 /// Main Scanner struct holding compiled rules
@@ -479,15 +485,31 @@ impl Scanner {
     /// caller's job here: memory scans are already bounded by
     /// `MemoryScanConfig::max_region_bytes`.
     pub fn scan_bytes(&self, data: &[u8], match_debug: MatchDebugLevel) -> ScanResult {
+        self.scan_bytes_with_timeout(data, match_debug, self.limits.timeout)
+    }
+
+    /// Scan one region with the remaining process budget. Zero disables the timeout.
+    pub(crate) fn scan_bytes_with_timeout(
+        &self,
+        data: &[u8],
+        match_debug: MatchDebugLevel,
+        timeout: Duration,
+    ) -> ScanResult {
         if self.compiled_files == 0 {
             return Ok(Vec::new());
         }
 
         let mut scanner = XScanner::new(&self.rules);
-        self.apply_timeout(&mut scanner);
-        let scan_results = scanner
-            .scan(data)
-            .map_err(|err| self.map_scan_error(err, || "YARA memory scan failed".to_string()))?;
+        if !timeout.is_zero() {
+            scanner.set_timeout(timeout);
+        }
+        let scan_results = scanner.scan(data).map_err(|err| {
+            if matches!(err, yara_x::ScanError::Timeout) {
+                ScanError::TimedOut { timeout }
+            } else {
+                ScanError::Failed(anyhow::Error::new(err).context("YARA memory scan failed"))
+            }
+        })?;
         Ok(collect_yara_matches(scan_results, match_debug))
     }
 }
@@ -652,7 +674,10 @@ impl SensorEventHandler for YaraEventHandler {
             match crate::telemetry::try_send(
                 crate::telemetry::ChannelId::YaraMemoryScan,
                 memory_tx,
-                YaraMemoryJob { expected_identity },
+                YaraMemoryJob {
+                    expected_identity,
+                    enqueued_at: Instant::now(),
+                },
             ) {
                 Ok(_) => tracing::trace!(
                     target: "scanner",

--- a/tests/router_and_handlers.rs
+++ b/tests/router_and_handlers.rs
@@ -81,12 +81,15 @@ async fn yara_event_handler_queues_disk_and_memory_only_for_non_allowlisted_star
         allowlist_paths: Vec::new(),
     };
 
+    let before_enqueue = std::time::Instant::now();
     handler.handle_event(&process_start_event(Platform::Linux));
     let target = file_rx.try_recv().expect("disk job queued");
     let (path, pid) = (target.path, target.pid);
     assert_eq!(path, common::image_for(Platform::Linux));
     assert_eq!(pid, TEST_PID);
     let memory = memory_rx.try_recv().expect("memory job queued");
+    assert!(memory.enqueued_at >= before_enqueue);
+    assert!(memory.enqueued_at <= std::time::Instant::now());
     assert_eq!(memory.expected_identity.pid, TEST_PID);
     assert_eq!(
         memory.expected_identity.image,


### PR DESCRIPTION
## Summary

Process memory jobs previously waited the full delay after dequeue, retained all selected region bytes, and restarted the full scan timeout for each region. This change counts queue time toward the delay and streams regions through one reusable buffer, with one deadline shared across process memory reads and scans.

- Stop starting new regions when the process deadline expires and report one `process_deadline` outcome, preserving earlier detections.
- Keep process identity validation immediately before memory access and retain existing delay configuration.
- Enforce process and region byte limits across Linux, macOS, and Windows while preserving originating region metadata.
- Keep the collected-reader API for compatibility; the worker uses the streaming callback.

Active OS reads cannot be interrupted, and YARA-X checks timeouts periodically, so an active region can still overrun the deadline.

Closes #381
Closes #379
Closes #384

## Type of change

- [x] `bug` - bug fix

## Test plan

- [ ] Tested on Windows
- [ ] Tested on Linux
- [x] Existing tests pass (`cargo test --locked`): 524 passed, 8 ignored on macOS
- [x] New deterministic tests cover a 64-job burst, shared deadlines, buffer reuse before later reads, byte limits, and preserved detections and region metadata
- [x] `cargo clippy --locked --all-targets -- -D clippy::all`
- [x] `cargo fmt --check` and `git diff --check`
- [x] Linux and Windows reader modules cross-compiled in an isolated check crate; live memory tests on those platforms were not run

## Checklist

- [x] Bug label added to this PR
- [x] Docs updated for scheduling, streaming, and process timeout behavior
