### PR TITLE
feat(release): add reviewed highlights and organize changelog

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,11 +4,15 @@
 ## Type of change
 <!-- Add the matching label to this PR before merging -->
 - [ ] `feat` / `enhancement` - new feature
+- [ ] `performance` - performance improvement
 - [ ] `bug` - bug fix
 - [ ] `refactor` - refactoring, no behaviour change
 - [ ] `documentation` - docs only
 - [ ] `ci` - CI and release changes
 - [ ] `dependencies` - dependency update
+- [ ] `chore` - other maintenance
+- [ ] `breaking-change` - breaking change (takes priority over other categories)
+- [ ] `skip-changelog` - release preparation or changes with no release-note value
 
 ## Test plan
 - [ ] Tested on Windows
@@ -19,3 +23,4 @@
 ## Checklist
 - [ ] Label added to this PR
 - [ ] Docs updated (if behaviour changed)
+- [ ] Release highlights and upgrade notes added (release preparation only)

--- a/.github/release-notes/1.6.0.md
+++ b/.github/release-notes/1.6.0.md
@@ -1,0 +1,6 @@
+## Highlights
+
+- Linux eBPF reports more accurate process and connection metadata, including parent identity and socket addresses measured when connect and accept complete.
+- Collection gaps are more visible through capability probing, kernel event-loss accounting, and reporting for rules without a backing collector.
+- Event timestamps and process identity handling improve attribution accuracy, including preservation of authoritative macOS execution metadata.
+- Network processing and IOC matching are faster through batched macOS socket attribution, removal of per-event Linux socket scans, and indexed wildcard domain matching.

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,5 +1,15 @@
 changelog:
+  exclude:
+    labels:
+      - skip-changelog
   categories:
+    - title: Breaking Changes
+      labels:
+        - breaking-change
+    - title: Performance
+      labels:
+        - performance
+        - perf
     - title: Features
       labels:
         - feature
@@ -10,24 +20,20 @@ changelog:
         - bug
         - fix
         - bugfix
-    - title: Refactoring
-      labels:
-        - refactor
-        - refactoring
     - title: Documentation
       labels:
         - documentation
         - docs
-    - title: CI and release
-      labels:
-        - ci
-        - ci-cd
-        - workflow
     - title: Dependencies
       labels:
         - dependencies
     - title: Maintenance
       labels:
+        - refactor
+        - refactoring
+        - ci
+        - ci-cd
+        - workflow
         - chore
         - maintenance
     - title: Other Changes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -436,6 +436,27 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+
+      - name: Read release highlights
+        id: highlights
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          NOTES=".github/release-notes/${VERSION}.md"
+          if [[ ! -s "$NOTES" ]] || ! grep -q '[^[:space:]]' "$NOTES"; then
+            echo "::error::Add release highlights to $NOTES in the release preparation PR."
+            exit 1
+          fi
+          DELIMITER="release_notes_$(openssl rand -hex 16)"
+          {
+            echo "body<<$DELIMITER"
+            cat "$NOTES"
+            printf '\n%s\n' "$DELIMITER"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Download Linux x86_64 binary
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -465,10 +486,6 @@ jobs:
         with:
           name: rustinel-macos-x86_64
           path: dist/macos-x86_64/
-
-      - name: Extract version from tag
-        id: version
-        run: echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
 
       - name: Package Linux x86_64
         run: |
@@ -566,6 +583,8 @@ jobs:
           make_latest: ${{ contains(github.ref_name, '-') && 'false' || 'true' }}
           name: Rustinel ${{ github.ref_name }}
           body: |
+            ${{ steps.highlights.outputs.body }}
+
             ## Downloads
 
             | Platform | Architecture | Package |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,11 +21,36 @@ For Linux eBPF development you need nightly Rust, `rust-src`, and `bpf-linker`. 
 3. Add or update tests if behaviour changed
 4. **Add a label** to your PR before requesting review. This drives release notes:
    - `enhancement`: new feature
+   - `performance`: performance improvement
    - `bug`: bug fix
    - `refactor`: refactoring
    - `documentation`: docs only
    - `ci`: CI/CD changes
+   - `dependencies`: dependency update
+   - `chore`: other maintenance
+   - `breaking-change`: breaking change (takes priority over other categories)
+   - `skip-changelog`: release preparation or changes with no release-note value
 5. Open a PR against `main`
+
+## Preparing a release
+
+In the `chore(release)` preparation PR, add `.github/release-notes/<version>.md`
+using the exact tag version without the leading `v` (for example, `1.6.0.md` or
+`1.7.0-rc.1.md`). Start with `## Highlights` and write 3 to 5 bullets explaining
+user-visible improvements. Add `## Upgrade notes` when users need to change
+configuration, integrations, or deployment steps. Review these notes with the PR.
+See [the 1.6.0 notes](.github/release-notes/1.6.0.md) for an example.
+
+Label the preparation PR `skip-changelog` so the version bump does not appear in
+the generated list. Before tagging, check that the release's PRs have appropriate
+labels, especially `breaking-change` and `performance`. Categories use PR labels,
+not conventional title prefixes. Breaking changes take priority, followed by
+Performance, so a performance PR can also carry a feature or bug label.
+
+The release workflow requires a nonempty notes file matching the tag. It places
+those reviewed notes before downloads and installation instructions, then appends
+GitHub's generated PR list and full comparison link. Refactoring, CI, and chores
+are grouped under Maintenance. Keep notes for previous versions in place.
 
 ## Writing documentation
 


### PR DESCRIPTION
## Summary

Release notes currently begin with installation details and present changes only as a categorized PR list. Add reviewed, versioned highlights before downloads while retaining the generated PR list and comparison link.

- Require a nonempty `.github/release-notes/<version>.md` file before publication, with 1.6.0 notes as an example.
- Add Breaking Changes and Performance categories, group refactoring, CI, and chores under Maintenance, and exclude PRs labeled `skip-changelog`.
- Document release preparation and update the PR checklist and label guidance.

## Validation

- Workflow lint with actionlint passed.
- YAML parsing and `git diff --check` passed.
- Notes-loading checks passed for a stable version and a prerelease, including preservation of multiline content.
- Missing, empty, and whitespace-only notes correctly fail publication.

Future release preparation PRs must include highlights matching the release tag. No application code changed; the release workflow has not been run against a live tag.
