### PR TITLE
feat(rules): add safe atomic rules pack updates

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -212,11 +212,12 @@ Exit codes are intended for automation:
 
 ### `rules`
 
-Discover and install released rules packs.
+Discover, install, and update released rules packs.
 
 ```text
 rustinel rules list [--catalog-url <URL>] [--rules-dir <PATH>]
 rustinel rules install <PACK> [--catalog-url <URL>] [--rules-dir <PATH>]
+rustinel rules update [--catalog-url <URL>] [--rules-dir <PATH>]
 ```
 
 Examples:
@@ -231,6 +232,26 @@ The default catalog is the latest released `index.json` from
 marks the active pack from `rules/state.json`. `rules install` downloads the pack
 artifact into `rules/staging`, verifies its SHA-256 checksum, rejects unsafe ZIP
 paths, validates `pack.yml`, then atomically replaces `rules/current`.
+
+`rules update` reads the active pack ID and version from `state.json` and checks
+that same pack in the catalog. It installs only a strictly newer semantic version
+compatible with this platform and Rustinel version. An equal or older catalog
+version is a no-op with no download or restart. Missing or invalid state, a missing
+catalog entry, or an incompatible newer pack produces an error without replacing
+the active pack. Updates use the same mandatory checksum, safe extraction,
+manifest validation, and staged activation as installation. Download, validation,
+and activation failures preserve the previous pack and state. Concurrent install
+and update operations on the same rules directory are rejected by a file lock.
+
+After a successful update, run `rustinel service restart` (with the privileges
+required by your service manager), or restart a foreground `rustinel run` process.
+The command prints this requirement and does not restart the service itself.
+A whole-pack replacement requires a restart even with hot reload enabled:
+directory replacement can invalidate filesystem watches, and Sigma, YARA, and
+IOC reloads happen independently. Hot reload remains suitable for individual
+file edits. For a coordinated production change, stop the service, update the
+pack, then start the service; if the update fails, start it with the previous pack.
+Updates replace local edits under `current`, so keep custom rules separately.
 
 Managed active rules layout:
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -96,7 +96,11 @@ empty `logs/` directory.
 
 Install a released pack with `rustinel rules install <PACK>`; packs activate
 atomically under the managed rules directory. Local edits to active Sigma, YARA,
-and IOC files are picked up by hot reload. See
+and IOC files are picked up by hot reload. Use `rustinel rules update` to update
+the active pack, then `rustinel service restart` to load the complete replacement.
+For a coordinated change, stop the service before updating and start it afterward,
+even if the update fails and the previous pack is retained. Whole-pack directory
+replacement requires a restart even when hot reload is enabled. See
 [Configuration](configuration.md#reload) for what reloads and what does not.
 
 After editing a rule, check the operational log for a successful reload and

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -126,6 +126,15 @@ pub enum RulesAction {
         #[arg(long, value_name = "PATH")]
         rules_dir: Option<std::path::PathBuf>,
     },
+    /// Update the active pack; restart the service after a successful update
+    Update {
+        /// Rules catalog index URL
+        #[arg(long, default_value = crate::rules::DEFAULT_CATALOG_URL)]
+        catalog_url: String,
+        /// Rules root directory, containing current, staging, and state.json
+        #[arg(long, value_name = "PATH")]
+        rules_dir: Option<std::path::PathBuf>,
+    },
     /// Install a rules pack and make it active
     Install {
         /// Pack ID from `rustinel rules list`
@@ -143,6 +152,33 @@ pub enum RulesAction {
 mod tests {
     use super::*;
     use clap::Parser;
+
+    #[test]
+    fn rules_update_parses_options() {
+        let cli = Cli::try_parse_from([
+            "rustinel",
+            "rules",
+            "update",
+            "--rules-dir",
+            "custom-rules",
+            "--catalog-url",
+            "https://github.com/example/rules/releases/download/v1/index.json",
+        ])
+        .expect("rules update should parse");
+        match cli.command {
+            Some(Commands::Rules {
+                action:
+                    RulesAction::Update {
+                        rules_dir,
+                        catalog_url,
+                    },
+            }) => {
+                assert_eq!(rules_dir, Some(std::path::PathBuf::from("custom-rules")));
+                assert!(catalog_url.ends_with("/v1/index.json"));
+            }
+            _ => panic!("expected rules update command"),
+        }
+    }
 
     #[test]
     fn run_defaults_to_console_output() {

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -708,7 +708,12 @@ fn atomic_replace_active(
     }
     if state.exists() {
         if let Err(err) = fs::rename(&state, &previous_state) {
-            restore_previous(&current, &state, &previous_current, &previous_state);
+            // State never moved, so only restore the rules directory. The backup
+            // state path may be a stale entry that caused the rename to fail.
+            if previous_current.exists() {
+                fs::rename(&previous_current, &current)
+                    .context("restore current rules after state backup failure")?;
+            }
             return Err(err).context("move current rules state");
         }
     }

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -137,6 +137,23 @@ pub fn run_cli(command: crate::cli::RulesAction, config_path: Option<PathBuf>) -
             print_pack_list(&catalog, &rules_dir);
             Ok(())
         }
+        crate::cli::RulesAction::Update {
+            catalog_url,
+            rules_dir,
+        } => {
+            let rules_dir = resolve_rules_dir(config_path, rules_dir)?;
+            let state = load_update_state(&rules_dir)?;
+            let catalog_url = parse_release_url(&catalog_url)?;
+            let catalog = fetch_catalog(&catalog_url)?;
+            let outcome = update_active_pack(&catalog, &state, &rules_dir, |pack| {
+                let url = resolve_artifact_url(&catalog_url, pack)?;
+                validate_release_url(&url)?;
+                fetch_url_bytes(&url, MAX_ARTIFACT_BYTES)
+                    .with_context(|| format!("download {}", pack.artifact))
+            })?;
+            println!("{}", update_message(&state, outcome.as_ref()));
+            Ok(())
+        }
         crate::cli::RulesAction::Install {
             pack,
             catalog_url,
@@ -144,16 +161,8 @@ pub fn run_cli(command: crate::cli::RulesAction, config_path: Option<PathBuf>) -
         } => {
             let catalog_url = parse_release_url(&catalog_url)?;
             let catalog = fetch_catalog(&catalog_url)?;
-            let selected = catalog
-                .find_pack(&pack)
-                .with_context(|| format!("pack {pack} was not found in the catalog"))?;
-            validate_pack_installable(selected)?;
-            let artifact_url = resolve_artifact_url(&catalog_url, selected)?;
-            validate_release_url(&artifact_url)?;
-            let archive = fetch_url_bytes(&artifact_url, MAX_ARTIFACT_BYTES)
-                .with_context(|| format!("download {}", selected.artifact))?;
             let rules_dir = resolve_rules_dir(config_path, rules_dir)?;
-            let outcome = install_pack_archive_bytes(&catalog, &pack, &rules_dir, &archive)?;
+            let outcome = download_and_install_pack(&catalog_url, &catalog, &pack, &rules_dir)?;
             println!(
                 "Installed {} {} into {}",
                 outcome.pack_id,
@@ -166,6 +175,39 @@ pub fn run_cli(command: crate::cli::RulesAction, config_path: Option<PathBuf>) -
 }
 
 pub fn install_pack_archive_bytes(
+    catalog: &Catalog,
+    pack_id: &str,
+    rules_dir: &Path,
+    archive: &[u8],
+) -> Result<InstallOutcome> {
+    let _lock = lock_rules_dir(rules_dir)?;
+    install_pack_archive_bytes_locked(catalog, pack_id, rules_dir, archive)
+}
+
+struct RulesLock(fs::File);
+
+impl Drop for RulesLock {
+    fn drop(&mut self) {
+        // Release explicitly: a concurrently spawned child may inherit the open file.
+        let _ = self.0.unlock();
+    }
+}
+
+fn lock_rules_dir(rules_dir: &Path) -> Result<RulesLock> {
+    fs::create_dir_all(rules_dir).context("create rules directory")?;
+    let file = fs::OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(rules_dir.join(".install.lock"))
+        .context("open rules installation lock")?;
+    file.try_lock()
+        .context("lock rules directory; another rules operation may be running")?;
+    Ok(RulesLock(file))
+}
+
+fn install_pack_archive_bytes_locked(
     catalog: &Catalog,
     pack_id: &str,
     rules_dir: &Path,
@@ -241,6 +283,55 @@ pub fn download_and_install_pack(
     let archive = fetch_url_bytes(&artifact_url, MAX_ARTIFACT_BYTES)
         .with_context(|| format!("download {}", selected.artifact))?;
     install_pack_archive_bytes(catalog, pack_id, rules_dir, &archive)
+}
+
+fn load_update_state(rules_dir: &Path) -> Result<RulesState> {
+    let bytes = fs::read(rules_dir.join("state.json")).context(
+        "read active rules state; install a pack with rustinel rules install <PACK> first",
+    )?;
+    let state = serde_json::from_slice(&bytes).context("parse active rules state")?;
+    if !rules_dir.join("current/pack.yml").is_file() {
+        bail!("active rules pack is missing; reinstall it before updating");
+    }
+    Ok(state)
+}
+
+fn update_active_pack(
+    catalog: &Catalog,
+    state: &RulesState,
+    rules_dir: &Path,
+    download: impl FnOnce(&CatalogPack) -> Result<Vec<u8>>,
+) -> Result<Option<InstallOutcome>> {
+    let _lock = lock_rules_dir(rules_dir)?;
+    if load_update_state(rules_dir)? != *state {
+        bail!("active rules state changed while checking for updates; retry the update");
+    }
+    let pack = catalog
+        .find_pack(&state.pack_id)
+        .with_context(|| format!("active pack {} was not found in the catalog", state.pack_id))?;
+    let installed = Version::parse(state.version.trim_start_matches('v'))
+        .context("parse active pack version")?;
+    let available = Version::parse(pack.version.trim_start_matches('v'))
+        .context("parse catalog pack version")?;
+    if available.cmp_precedence(&installed).is_le() {
+        return Ok(None);
+    }
+    validate_pack_installable(pack)?;
+    let archive = download(pack)?;
+    install_pack_archive_bytes_locked(catalog, &state.pack_id, rules_dir, &archive).map(Some)
+}
+
+fn update_message(state: &RulesState, outcome: Option<&InstallOutcome>) -> String {
+    match outcome {
+        Some(outcome) => format!(
+            "Updated {} from {} to {} in {}. Restart the service with rustinel service restart to load the complete pack; directory replacement requires a restart even when hot reload is enabled.",
+            outcome.pack_id, state.version, outcome.version, outcome.current_dir.display()
+        ),
+        None => format!(
+            "Rules pack {} {} is up to date; no newer version is available. No restart required.",
+            state.pack_id, state.version
+        ),
+    }
 }
 
 pub fn read_state(rules_dir: &Path) -> Option<RulesState> {
@@ -616,8 +707,10 @@ fn atomic_replace_active(
             .with_context(|| format!("move current rules {}", current.display()))?;
     }
     if state.exists() {
-        fs::rename(&state, &previous_state)
-            .with_context(|| format!("move current state {}", state.display()))?;
+        if let Err(err) = fs::rename(&state, &previous_state) {
+            restore_previous(&current, &state, &previous_current, &previous_state);
+            return Err(err).context("move current rules state");
+        }
     }
 
     if let Err(err) = fs::rename(next_current, &current) {

--- a/src/rules/tests.rs
+++ b/src/rules/tests.rs
@@ -373,8 +373,12 @@ fn state_backup_failure_restores_current_directory() {
     let blocked = temp.path().join("staging/previous-state.json");
     fs::create_dir(&blocked).unwrap();
     fs::write(blocked.join("blocker"), b"blocker").unwrap();
-    assert!(install_pack_archive_bytes(&catalog, "demo-pack", temp.path(), &archive).is_err());
+    let error = install_pack_archive_bytes(&catalog, "demo-pack", temp.path(), &archive)
+        .expect_err("state backup must fail");
+    assert!(error.to_string().contains("move current rules state"));
     assert!(temp.path().join("current/sigma/demo.yml").is_file());
+    assert!(temp.path().join("state.json").is_file());
+    assert_eq!(fs::read(blocked.join("blocker")).unwrap(), b"blocker");
     assert_eq!(
         fs::read(temp.path().join("state.json")).unwrap(),
         previous_state

--- a/src/rules/tests.rs
+++ b/src/rules/tests.rs
@@ -213,3 +213,187 @@ extends: []
 fn sha256_hex(bytes: &[u8]) -> String {
     hex::encode(Sha256::digest(bytes))
 }
+
+#[test]
+fn update_current_or_older_catalog_skips_download_and_restart() {
+    let temp = tempfile::tempdir().unwrap();
+    let archive = pack_zip(current_os(), "demo-pack");
+    let mut catalog = catalog_for("demo-pack", current_os(), &archive);
+    install_pack_archive_bytes(&catalog, "demo-pack", temp.path(), &archive).unwrap();
+    let state = load_update_state(temp.path()).unwrap();
+    let before = fs::read(temp.path().join("state.json")).unwrap();
+    for version in ["0.1.0", "0.0.9", "0.1.0+build.2"] {
+        catalog.packs[0].version = version.into();
+        let result = update_active_pack(&catalog, &state, temp.path(), |_| {
+            panic!("no-op must not download")
+        })
+        .unwrap();
+        assert_eq!(result, None);
+        let message = update_message(&state, result.as_ref());
+        assert!(message.contains("up to date"));
+        assert!(message.contains("No restart required"));
+        assert_eq!(fs::read(temp.path().join("state.json")).unwrap(), before);
+    }
+}
+
+#[test]
+fn update_installs_active_pack_and_requires_restart() {
+    let temp = tempfile::tempdir().unwrap();
+    let archive = pack_zip(current_os(), "demo-pack");
+    let mut catalog = catalog_for("demo-pack", current_os(), &archive);
+    install_pack_archive_bytes(&catalog, "demo-pack", temp.path(), &archive).unwrap();
+    let state = load_update_state(temp.path()).unwrap();
+    fs::write(temp.path().join("current/obsolete.yml"), b"old").unwrap();
+    catalog.packs[0].version = "v0.2.0".into();
+    let outcome = update_active_pack(&catalog, &state, temp.path(), |pack| {
+        assert_eq!(pack.id, state.pack_id);
+        Ok(archive.clone())
+    })
+    .unwrap()
+    .unwrap();
+    assert_eq!(read_state(temp.path()).unwrap().version, "v0.2.0");
+    assert!(!temp.path().join("current/obsolete.yml").exists());
+    assert!(temp.path().join("current/sigma/demo.yml").is_file());
+    let message = update_message(&state, Some(&outcome));
+    assert!(message.contains("rustinel service restart"));
+    assert!(message.contains("even when hot reload is enabled"));
+}
+
+#[test]
+fn update_rejects_incompatible_missing_or_invalid_versions_before_download() {
+    let temp = tempfile::tempdir().unwrap();
+    let archive = pack_zip(current_os(), "demo-pack");
+    let catalog = catalog_for("demo-pack", current_os(), &archive);
+    install_pack_archive_bytes(&catalog, "demo-pack", temp.path(), &archive).unwrap();
+    let state = load_update_state(temp.path()).unwrap();
+    for case in ["os", "engine", "missing", "version"] {
+        let mut candidate = catalog_for("demo-pack", current_os(), &archive);
+        candidate.packs[0].version = "0.2.0".into();
+        match case {
+            "os" => candidate.packs[0].os = "unsupported".into(),
+            "engine" => candidate.packs[0].requires_rustinel = ">=999.0.0".into(),
+            "missing" => candidate.packs[0].id = "other-pack".into(),
+            "version" => candidate.packs[0].version = "invalid".into(),
+            _ => unreachable!(),
+        }
+        assert!(update_active_pack(&candidate, &state, temp.path(), |_| {
+            panic!("invalid candidate must not download")
+        })
+        .is_err());
+        assert_eq!(read_state(temp.path()).unwrap(), state);
+    }
+}
+
+#[test]
+fn failed_updates_preserve_previous_pack_and_state() {
+    let temp = tempfile::tempdir().unwrap();
+    let archive = pack_zip(current_os(), "demo-pack");
+    let catalog = catalog_for("demo-pack", current_os(), &archive);
+    install_pack_archive_bytes(&catalog, "demo-pack", temp.path(), &archive).unwrap();
+    let state = load_update_state(temp.path()).unwrap();
+    let state_bytes = fs::read(temp.path().join("state.json")).unwrap();
+    let manifest = fs::read(temp.path().join("current/pack.yml")).unwrap();
+    for case in ["download", "checksum", "unsafe", "manifest"] {
+        let candidate_archive = match case {
+            "unsafe" => unsafe_pack_zip(),
+            "manifest" => pack_zip_with_schema(current_os(), "demo-pack", 999),
+            _ => archive.clone(),
+        };
+        let mut candidate = catalog_for("demo-pack", current_os(), &candidate_archive);
+        candidate.packs[0].version = "0.2.0".into();
+        if case == "checksum" {
+            candidate.packs[0].sha256 = "00".repeat(32);
+        }
+        assert!(update_active_pack(&candidate, &state, temp.path(), |_| {
+            if case == "download" {
+                bail!("simulated download failure");
+            }
+            Ok(candidate_archive)
+        })
+        .is_err());
+        assert_eq!(
+            fs::read(temp.path().join("state.json")).unwrap(),
+            state_bytes
+        );
+        assert_eq!(
+            fs::read(temp.path().join("current/pack.yml")).unwrap(),
+            manifest
+        );
+    }
+}
+
+#[test]
+fn update_requires_readable_state_and_installed_pack() {
+    let temp = tempfile::tempdir().unwrap();
+    assert!(load_update_state(temp.path()).is_err());
+    fs::write(temp.path().join("state.json"), b"invalid").unwrap();
+    assert!(load_update_state(temp.path()).is_err());
+    let archive = pack_zip(current_os(), "demo-pack");
+    let catalog = catalog_for("demo-pack", current_os(), &archive);
+    install_pack_archive_bytes(&catalog, "demo-pack", temp.path(), &archive).unwrap();
+    fs::remove_dir_all(temp.path().join("current")).unwrap();
+    assert!(load_update_state(temp.path()).is_err());
+}
+
+#[test]
+fn activation_failures_restore_previous_pack_and_state() {
+    for fail_state in [false, true] {
+        let temp = tempfile::tempdir().unwrap();
+        let archive = pack_zip(current_os(), "demo-pack");
+        let catalog = catalog_for("demo-pack", current_os(), &archive);
+        install_pack_archive_bytes(&catalog, "demo-pack", temp.path(), &archive).unwrap();
+        let previous_state = fs::read(temp.path().join("state.json")).unwrap();
+        let next = temp.path().join("next");
+        if fail_state {
+            fs::create_dir(&next).unwrap();
+        }
+        assert!(atomic_replace_active(
+            temp.path(),
+            &temp.path().join("staging"),
+            &next,
+            &temp.path().join("missing-state"),
+        )
+        .is_err());
+        assert!(temp.path().join("current/sigma/demo.yml").is_file());
+        assert_eq!(
+            fs::read(temp.path().join("state.json")).unwrap(),
+            previous_state
+        );
+    }
+}
+
+#[test]
+fn state_backup_failure_restores_current_directory() {
+    let temp = tempfile::tempdir().unwrap();
+    let archive = pack_zip(current_os(), "demo-pack");
+    let catalog = catalog_for("demo-pack", current_os(), &archive);
+    install_pack_archive_bytes(&catalog, "demo-pack", temp.path(), &archive).unwrap();
+    let previous_state = fs::read(temp.path().join("state.json")).unwrap();
+    // A nonempty directory cannot be removed as a file or replaced by state.json.
+    let blocked = temp.path().join("staging/previous-state.json");
+    fs::create_dir(&blocked).unwrap();
+    fs::write(blocked.join("blocker"), b"blocker").unwrap();
+    assert!(install_pack_archive_bytes(&catalog, "demo-pack", temp.path(), &archive).is_err());
+    assert!(temp.path().join("current/sigma/demo.yml").is_file());
+    assert_eq!(
+        fs::read(temp.path().join("state.json")).unwrap(),
+        previous_state
+    );
+}
+
+#[test]
+fn rules_operations_reject_concurrent_writers_and_stale_update_state() {
+    let temp = tempfile::tempdir().unwrap();
+    let archive = pack_zip(current_os(), "demo-pack");
+    let mut catalog = catalog_for("demo-pack", current_os(), &archive);
+    install_pack_archive_bytes(&catalog, "demo-pack", temp.path(), &archive).unwrap();
+    let state = load_update_state(temp.path()).unwrap();
+    let lock = lock_rules_dir(temp.path()).unwrap();
+    assert!(install_pack_archive_bytes(&catalog, "demo-pack", temp.path(), &archive).is_err());
+    assert!(update_active_pack(&catalog, &state, temp.path(), |_| panic!("locked")).is_err());
+    drop(lock);
+    catalog.packs[0].version = "0.2.0".into();
+    install_pack_archive_bytes(&catalog, "demo-pack", temp.path(), &archive).unwrap();
+    let error = update_active_pack(&catalog, &state, temp.path(), |_| panic!("stale")).unwrap_err();
+    assert!(error.to_string().contains("state changed"), "{error:#}");
+}


### PR DESCRIPTION
Adds `rustinel rules update` to upgrade the pack recorded in `state.json` when the catalog offers a newer version for the current platform and Rustinel version. Equal or older versions are a no-op without downloading an artifact.

Updates reuse the installer's checksum verification, safe ZIP extraction, manifest checks, and staged activation. A rules-directory lock prevents concurrent writers, stale update state is rejected, and a failed state backup now restores the previous rules directory.

Successful updates explicitly require a service restart because replacing watched directories can invalidate watches and detector types reload independently. CLI and operations documentation explain the restart requirement and the stop/update/start production workflow.

Validation:
- `cargo test --locked` passed on macOS, including update selection, no-op output, restart guidance, incompatible versions, download/validation failures, activation rollback, and writer locking.
- `cargo clippy --locked --all-targets -- -D clippy::all` passed.
- `cargo fmt --all -- --check` and `git diff --check` passed.

Closes #111.
