### PR TITLE
feat(windows-eventlog): add subscription health and retention-loss accounting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ env:
   CARGO_TERM_COLOR: always
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   # Update this commit deliberately when the rules repository's atomic suite changes.
-  RUSTINEL_RULES_REF: c1d78b4dec00eef42b5ccb741da6f7e7521dd854
+  RUSTINEL_RULES_REF: 5b8f00181114c6be1d7dbb0b37c6df7101f2c78b
 
 permissions:
   contents: read
@@ -281,6 +281,11 @@ jobs:
         if: matrix.platform == 'windows'
         working-directory: rustinel-rules
         run: |
+          # Keep fixture executables inside the workspace's Defender exclusion.
+          $atomicTemp = Join-Path $env:GITHUB_WORKSPACE "atomic-temp"
+          New-Item -ItemType Directory -Path $atomicTemp -Force | Out-Null
+          $env:TEMP = $atomicTemp
+          $env:TMP = $atomicTemp
           python tests\atomic\run_atomics.py `
             --platform windows `
             --engine-bin "$env:GITHUB_WORKSPACE\target\release\rustinel.exe" `

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -33,6 +33,36 @@ Before changing config or rules, check these first:
 | Logs mention dropped events or full queues | sensor backpressure, YARA/IOC/response queues saturated |
 | Not sure whether events were lost at all | run `rustinel doctor` and read the `pipeline_telemetry` check |
 
+## Windows Event Log subscription health
+
+`doctor` reports `windows_event_log_System` and `windows_event_log_Security`
+separately from ETW diagnostics and `pipeline_telemetry` queue shedding. The
+`windows_event_log` section in `doctor --json` includes per-channel activity,
+decoded records, the last record ID, subscription errors, live stale signals,
+resume failures, checkpoint errors, and decode failures. These counters cover
+one agent process; use the snapshot timestamp and PID when reading a stopped
+agent's report. A quiet active subscription is healthy, without a silence timeout.
+
+`live_stale` counts `ERROR_EVT_QUERY_RESULT_STALE` notifications. These are
+incidents with an unknown number of missing matching records, not event counts.
+Any callback error stops the sensor and appears in the final telemetry snapshot.
+Check channel access and the named error, then restart the agent.
+
+Bookmarks are saved atomically under `logging.directory/event-log`, separately
+for System and Security, and reused after restart or service recycle. Keep this
+directory when rotating logs. Capture uses `event-log-capture` to keep its cursor
+independent of detection. Checkpoints are flushed every 250 ms and on graceful
+shutdown. An abrupt exit can replay records since the last flush; checkpointing
+marks sensor handling, not durable completion by every downstream detector.
+Unreadable or invalid checkpoints fail startup rather than silently resetting.
+
+The separate `windows_event_log_<channel>_retention` check reports when the
+oldest retained record has passed unprocessed records after the saved bookmark.
+Strict resume also reports a missing bookmark (for example after a channel clear)
+and recovers from the oldest available record. The number of matching records
+lost during downtime is unknown. Live differences between record IDs are never
+counted as loss: System and Security queries intentionally exclude other events.
+
 ## Startup Failures
 
 ### Windows exits without printing output

--- a/src/doctor/telemetry.rs
+++ b/src/doctor/telemetry.rs
@@ -47,6 +47,7 @@ pub(crate) fn telemetry_results(
     results.extend(registry_results(&snapshot));
     results.extend(file_attribution_results(&snapshot));
     results.extend(etw_decode_results(&snapshot));
+    results.extend(event_log_results(&snapshot));
 
     results.extend(process_correlation_results(&snapshot));
     let dropping = snapshot.dropping_channels();
@@ -56,7 +57,7 @@ pub(crate) fn telemetry_results(
             DiagnosticResult::pass(
                 "pipeline_telemetry",
                 format!(
-                    "No telemetry dropped across {} events (snapshot from {})",
+                    "No pipeline queue drops across {} events (snapshot from {})",
                     snapshot.total_accepted(),
                     snapshot.captured_at
                 ),
@@ -88,6 +89,55 @@ pub(crate) fn telemetry_results(
 
     results.insert(0, result);
     (results, Some(snapshot))
+}
+
+fn event_log_results(snapshot: &TelemetrySnapshot) -> Vec<DiagnosticResult> {
+    let mut results = Vec::new();
+    for channel in &snapshot.windows_event_log {
+        let id = format!("windows_event_log_{}", channel.channel);
+        let detail =
+            format!(
+            "active={}, delivered={}, subscription_errors={}, live_stale={}, resume_failures={}, \
+             checkpoint_errors={}, decode_errors={}, last_error={}",
+            channel.active, channel.delivered, channel.subscription_errors, channel.live_stale,
+            channel.resume_failures, channel.checkpoint_errors, channel.decode_errors,
+            channel.last_error.as_deref().unwrap_or("none"),
+        );
+        let degraded = !channel.active
+            || channel.subscription_errors > 0
+            || channel.resume_failures > 0
+            || channel.checkpoint_errors > 0
+            || channel.decode_errors > 0;
+        results.push(if degraded {
+            DiagnosticResult::warn(
+                &id,
+                format!(
+                    "{} Event Log subscription is stopped or degraded",
+                    channel.channel
+                ),
+                detail,
+            )
+        } else {
+            DiagnosticResult::pass(&id, detail)
+        });
+        let retention_id = format!("{id}_retention");
+        results.push(if channel.retention_wraps > 0 {
+            DiagnosticResult::warn(
+                retention_id,
+                format!(
+                    "{} Event Log retention passed the saved bookmark",
+                    channel.channel
+                ),
+                format!(
+                    "{} downtime retention incidents; matching records lost is unknown",
+                    channel.retention_wraps
+                ),
+            )
+        } else {
+            DiagnosticResult::pass(retention_id, "No downtime retention wrap detected")
+        });
+    }
+    results
 }
 
 fn process_correlation_results(snapshot: &TelemetrySnapshot) -> Vec<DiagnosticResult> {
@@ -459,6 +509,45 @@ mod tests {
     };
 
     #[test]
+    fn event_log_health_and_retention_are_separate_from_shedding() {
+        let mut report = snapshot(Vec::new());
+        assert!(event_log_results(&report).is_empty());
+        report
+            .windows_event_log
+            .push(crate::telemetry::event_log::EventLogSnapshot {
+                channel: "Security".into(),
+                active: true,
+                delivered: 2,
+                last_record_id: Some(100_000),
+                ..Default::default()
+            });
+        assert!(event_log_results(&report)
+            .iter()
+            .all(|r| r.status == DiagnosticStatus::Pass));
+        report.windows_event_log[0].subscription_errors = 1;
+        report.windows_event_log[0].live_stale = 1;
+        report.windows_event_log[0].last_error = Some("ERROR_EVT_QUERY_RESULT_STALE".into());
+        let results = event_log_results(&report);
+        assert_eq!(results[0].status, DiagnosticStatus::Warn);
+        assert!(results[0].id.contains("Security"));
+        assert!(results[0]
+            .detail
+            .as_ref()
+            .unwrap()
+            .contains("ERROR_EVT_QUERY_RESULT_STALE"));
+        assert_eq!(results[1].status, DiagnosticStatus::Pass);
+        report.windows_event_log[0].retention_wraps = 1;
+        assert_eq!(event_log_results(&report)[1].status, DiagnosticStatus::Warn);
+        assert_eq!(report.total_dropped(), 0);
+        assert!(report.dropping_channels().is_empty());
+        let json = serde_json::to_string(&report).unwrap();
+        assert_eq!(
+            serde_json::from_str::<TelemetrySnapshot>(&json).unwrap(),
+            report
+        );
+    }
+
+    #[test]
     fn doctor_reports_process_join_outcomes_separately() {
         let mut report = snapshot(Vec::new());
         assert!(process_correlation_results(&report).is_empty());
@@ -488,6 +577,7 @@ mod tests {
             channels,
             sensor_events_by_category: Vec::new(),
             linux_ebpf: None,
+            windows_event_log: Vec::new(),
             windows_process_correlation: Default::default(),
             windows_process_command_line: None,
             registry: None,

--- a/src/runtime/windows.rs
+++ b/src/runtime/windows.rs
@@ -205,6 +205,7 @@ pub fn run_capture(options: CaptureOptions) -> anyhow::Result<()> {
         ensure_administrator_privileges()?;
         let flush_interval_ms = context.config().windows.etw_flush_interval_ms;
         let process_flush_interval_ms = context.config().windows.etw_process_flush_interval_ms;
+        let event_log_directory = context.config().logging.directory.join("event-log-capture");
         let session = context.start_recording(&options, Platform::Windows)?;
 
         // Cold start: seed the process cache so early events resolve parents.
@@ -221,10 +222,10 @@ pub fn run_capture(options: CaptureOptions) -> anyhow::Result<()> {
         }
 
         let (sensor_tx, sensor_worker) = session.sensor_channel();
-        let sensor = Arc::new(EtwSensor::with_flush_intervals(
-            flush_interval_ms,
-            process_flush_interval_ms,
-        ));
+        let sensor = Arc::new(
+            EtwSensor::with_flush_intervals(flush_interval_ms, process_flush_interval_ms)
+                .with_event_log_directory(event_log_directory),
+        );
         let sensor_for_trace = Arc::clone(&sensor);
         let mut trace_handle =
             tokio::task::spawn_blocking(move || sensor_for_trace.start(sensor_tx));
@@ -322,10 +323,13 @@ async fn run_edr(
         info!("Process snapshot not available on non-Windows platforms");
     }
 
-    let sensor = Arc::new(EtwSensor::with_flush_intervals(
-        cfg.windows.etw_flush_interval_ms,
-        cfg.windows.etw_process_flush_interval_ms,
-    ));
+    let sensor = Arc::new(
+        EtwSensor::with_flush_intervals(
+            cfg.windows.etw_flush_interval_ms,
+            cfg.windows.etw_process_flush_interval_ms,
+        )
+        .with_event_log_directory(cfg.logging.directory.join("event-log")),
+    );
 
     let pipeline = LivePipeline::new(
         &cfg,

--- a/src/sensor/windows/etw.rs
+++ b/src/sensor/windows/etw.rs
@@ -38,6 +38,7 @@ pub(super) const PROCESS_TRACE_SESSION_NAME: &str = "rustinel-etw-process";
 /// Windows ETW sensor implementation.
 pub struct EtwSensor {
     shutdown: Arc<AtomicBool>,
+    event_log_directory: std::path::PathBuf,
     loss_counters: Arc<super::loss::LossCounters>,
     flush_interval_ms: u64,
     process_flush_interval_ms: u64,
@@ -56,10 +57,20 @@ impl EtwSensor {
     pub fn with_flush_intervals(flush_interval_ms: u64, process_flush_interval_ms: u64) -> Self {
         Self {
             shutdown: Arc::new(AtomicBool::new(false)),
+            event_log_directory: crate::config::InstallLayout::managed(
+                crate::config::InstallPlatform::Windows,
+            )
+            .logs_dir
+            .join("event-log"),
             loss_counters: Arc::new(super::loss::LossCounters::new()),
             flush_interval_ms,
             process_flush_interval_ms,
         }
+    }
+
+    pub fn with_event_log_directory(mut self, directory: std::path::PathBuf) -> Self {
+        self.event_log_directory = directory;
+        self
     }
 
     pub fn is_shutdown(&self) -> bool {
@@ -84,7 +95,11 @@ impl Sensor for EtwSensor {
 
         self.shutdown.store(false, Ordering::Relaxed);
         self.loss_counters.reset();
-        let event_logs = EventLogSubscriptions::start(tx.clone(), Arc::clone(&self.shutdown))?;
+        let event_logs = EventLogSubscriptions::start(
+            tx.clone(),
+            Arc::clone(&self.shutdown),
+            &self.event_log_directory,
+        )?;
 
         // A session left running by a previous process keeps its old buffer
         // sizing and its old providers, and `start` would then bind to it.

--- a/src/sensor/windows/etw/session.rs
+++ b/src/sensor/windows/etw/session.rs
@@ -418,6 +418,15 @@ impl EtwSensor {
         });
         let flushers = [main_flusher, process_flusher];
 
+        // An Event Log callback can fail while these sessions are starting.
+        // Its stop-by-name may precede session creation, so honor shutdown
+        // again before entering the blocking processor.
+        if self.shutdown.load(Ordering::Relaxed) {
+            for session in [TRACE_SESSION_NAME, PROCESS_TRACE_SESSION_NAME] {
+                let _ = ferrisetw::trace::stop_trace_by_name(session);
+            }
+        }
+
         let main_result = interpret_process_result(
             TRACE_SESSION_NAME,
             main_trace.process(),

--- a/src/sensor/windows/event_log/mod.rs
+++ b/src/sensor/windows/event_log/mod.rs
@@ -218,10 +218,12 @@ fn run_subscription_inner(
         update(source.channel, |health| health.checkpoint_errors += 1);
         anyhow!("invalid {} Event Log bookmark: {err}", source.channel)
     })?;
+    let mut saved_record_id = None;
     if let Some(xml) = &saved {
         let record_id = bookmark_record_id(xml, source.channel).inspect_err(|_| {
             update(source.channel, |health| health.checkpoint_errors += 1);
         })?;
+        saved_record_id = Some(record_id);
         let oldest = oldest_record(source.channel).inspect_err(|_| {
             update(source.channel, |health| health.subscription_errors += 1);
         })?;
@@ -237,8 +239,8 @@ fn run_subscription_inner(
     }
     // Establish a baseline even when no matching record has been delivered yet.
     // Reading the newest unfiltered record does not infer loss from record gaps.
-    let resume = if saved.is_some() {
-        true
+    let resume = if let Some(record_id) = saved_record_id {
+        record_id != 0
     } else {
         seed_bookmark(source.channel, bookmark.0, checkpoint).inspect_err(|_| {
             update(source.channel, |health| health.checkpoint_errors += 1);
@@ -276,7 +278,7 @@ fn run_subscription_inner(
     let origin = if resume {
         EvtSubscribeStartAfterBookmark.0
     } else {
-        EvtSubscribeToFutureEvents.0
+        EvtSubscribeStartAtOldestRecord.0
     };
     let subscription = match subscribe(origin) {
         Ok(handle) => OwnedEvtHandle(handle),
@@ -442,6 +444,7 @@ fn write_checkpoint(path: &Path, xml: &str) -> Result<()> {
 }
 
 fn seed_bookmark(channel: &str, bookmark: EVT_HANDLE, path: &Path) -> Result<bool> {
+    let channel_name = channel;
     let channel = wide_string(channel);
     let query = wide_string("*");
     let result = OwnedEvtHandle(unsafe {
@@ -455,7 +458,21 @@ fn seed_bookmark(channel: &str, bookmark: EVT_HANDLE, path: &Path) -> Result<boo
     let mut events = [0isize; 1];
     let mut returned = 0;
     match unsafe { EvtNext(result.0, &mut events, 0, 0, &mut returned) } {
-        Err(err) if err.code() == ERROR_NO_MORE_ITEMS.to_hresult() => return Ok(false),
+        Err(err) if err.code() == ERROR_NO_MORE_ITEMS.to_hresult() => {
+            // Zero means the channel was empty, not a missing processed record.
+            // Resume it from the oldest record so downtime events are replayed.
+            let escaped = channel_name
+                .replace('&', "&amp;")
+                .replace('"', "&quot;")
+                .replace('<', "&lt;");
+            write_checkpoint(
+                path,
+                &format!(
+                    r#"<BookmarkList><Bookmark Channel="{escaped}" RecordId="0" IsCurrent="true"/></BookmarkList>"#
+                ),
+            )?;
+            return Ok(false);
+        }
         other => other?,
     }
     let event = OwnedEvtHandle(EVT_HANDLE(events[0]));

--- a/src/sensor/windows/event_log/mod.rs
+++ b/src/sensor/windows/event_log/mod.rs
@@ -7,23 +7,22 @@
 mod security;
 mod service;
 
+use std::io::Write;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{mpsc, Arc};
+use std::sync::{mpsc, Arc, Mutex};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
+use crate::telemetry::event_log::update;
 use anyhow::{anyhow, Context, Result};
 use tokio::sync::mpsc::{error::TrySendError, Sender};
 use tracing::{info, trace, warn};
 use windows::core::PCWSTR;
 use windows::Win32::Foundation::{
-    CloseHandle, ERROR_NO_MORE_ITEMS, HANDLE, WAIT_OBJECT_0, WAIT_TIMEOUT,
+    ERROR_EVT_QUERY_RESULT_STALE, ERROR_NOT_FOUND, ERROR_NO_MORE_ITEMS,
 };
-use windows::Win32::System::EventLog::{
-    EvtClose, EvtNext, EvtRender, EvtRenderEventXml, EvtSubscribe, EvtSubscribeToFutureEvents,
-    EVT_HANDLE,
-};
-use windows::Win32::System::Threading::{CreateEventW, ResetEvent, WaitForSingleObject};
+use windows::Win32::System::EventLog::*;
 
 use crate::sensor::SensorEvent;
 
@@ -62,12 +61,21 @@ pub(super) struct EventLogSubscriptions {
 }
 
 impl EventLogSubscriptions {
-    pub(super) fn start(tx: Sender<SensorEvent>, shutdown: Arc<AtomicBool>) -> Result<Self> {
+    pub(super) fn start(
+        tx: Sender<SensorEvent>,
+        shutdown: Arc<AtomicBool>,
+        directory: &Path,
+    ) -> Result<Self> {
         let sources = [service::source(), security::source()];
         let mut workers = Vec::with_capacity(sources.len());
 
         for source in sources {
-            match EventLogSubscription::start(source, tx.clone(), Arc::clone(&shutdown)) {
+            match EventLogSubscription::start(
+                source,
+                tx.clone(),
+                Arc::clone(&shutdown),
+                directory.join(format!("{}.xml", source.channel)),
+            ) {
                 Ok(worker) => workers.push(worker),
                 Err(err) => {
                     shutdown.store(true, Ordering::Relaxed);
@@ -102,11 +110,12 @@ impl EventLogSubscription {
         source: EventLogSource,
         tx: Sender<SensorEvent>,
         shutdown: Arc<AtomicBool>,
+        checkpoint: PathBuf,
     ) -> Result<Self> {
         let (startup_tx, startup_rx) = mpsc::sync_channel(1);
         let worker = thread::Builder::new()
             .name(format!("event-log-{}", source.name))
-            .spawn(move || run_subscription(source, tx, shutdown, startup_tx))
+            .spawn(move || run_subscription(source, tx, shutdown, startup_tx, checkpoint))
             .with_context(|| format!("failed to spawn {} event log worker", source.name))?;
 
         match startup_rx.recv() {
@@ -140,8 +149,19 @@ fn run_subscription(
     tx: Sender<SensorEvent>,
     shutdown: Arc<AtomicBool>,
     startup_tx: mpsc::SyncSender<std::result::Result<(), String>>,
+    checkpoint: PathBuf,
 ) -> Result<()> {
-    let result = run_subscription_inner(source, tx, Arc::clone(&shutdown), &startup_tx);
+    let result =
+        run_subscription_inner(source, tx, Arc::clone(&shutdown), &startup_tx, &checkpoint);
+    update(source.channel, |health| {
+        health.active = false;
+        if let Err(err) = &result {
+            health.last_error = Some(err.to_string());
+        }
+    });
+    if let Err(err) = &result {
+        let _ = startup_tx.try_send(Err(err.to_string()));
+    }
 
     if result.is_err() && !shutdown.swap(true, Ordering::Relaxed) {
         // ETW processing is blocking. Stop it so an event log failure reaches
@@ -156,138 +176,344 @@ fn run_subscription(
     result
 }
 
+// The box remains alive until EvtClose has waited for outstanding callbacks.
+struct CallbackContext {
+    source: EventLogSource,
+    tx: Sender<SensorEvent>,
+    state: Mutex<CallbackState>,
+}
+
+struct CallbackState {
+    bookmark: OwnedEvtHandle,
+    pending: Option<String>,
+    failure: Option<String>,
+}
+
 fn run_subscription_inner(
     source: EventLogSource,
     tx: Sender<SensorEvent>,
     shutdown: Arc<AtomicBool>,
     startup_tx: &mpsc::SyncSender<std::result::Result<(), String>>,
+    checkpoint: &Path,
 ) -> Result<()> {
-    // Pull subscriptions use a manual-reset event. It starts signaled so the
-    // first EvtNext establishes the result-set state, matching Microsoft's
-    // reference consumer.
-    let signal = match unsafe { CreateEventW(None, true, true, None) } {
-        Ok(handle) => OwnedKernelHandle(handle),
+    update(source.channel, |health| health.active = false);
+    let saved = match std::fs::read_to_string(checkpoint) {
+        Ok(xml) => Some(xml),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => None,
         Err(err) => {
-            let message = format!("failed to create {} event log signal: {err}", source.name);
-            let _ = startup_tx.send(Err(message.clone()));
-            return Err(anyhow!(message));
+            update(source.channel, |health| health.checkpoint_errors += 1);
+            return Err(err).context("failed to read Event Log checkpoint");
         }
     };
-
+    let saved_wide = saved.as_deref().map(wide_string);
+    let bookmark = unsafe {
+        EvtCreateBookmark(
+            saved_wide
+                .as_ref()
+                .map_or(PCWSTR::null(), |xml| PCWSTR(xml.as_ptr())),
+        )
+    }
+    .map(OwnedEvtHandle)
+    .map_err(|err| {
+        update(source.channel, |health| health.checkpoint_errors += 1);
+        anyhow!("invalid {} Event Log bookmark: {err}", source.channel)
+    })?;
+    if let Some(xml) = &saved {
+        let record_id = bookmark_record_id(xml, source.channel).inspect_err(|_| {
+            update(source.channel, |health| health.checkpoint_errors += 1);
+        })?;
+        let oldest = oldest_record(source.channel).inspect_err(|_| {
+            update(source.channel, |health| health.subscription_errors += 1);
+        })?;
+        if retention_wrapped(record_id, oldest) {
+            update(source.channel, |health| health.retention_wraps += 1);
+            warn!(
+                channel = source.channel,
+                record_id,
+                oldest,
+                "Event Log downtime retention loss; matching record count unknown"
+            );
+        }
+    }
+    // Establish a baseline even when no matching record has been delivered yet.
+    // Reading the newest unfiltered record does not infer loss from record gaps.
+    let resume = if saved.is_some() {
+        true
+    } else {
+        seed_bookmark(source.channel, bookmark.0, checkpoint).inspect_err(|_| {
+            update(source.channel, |health| health.checkpoint_errors += 1);
+        })?
+    };
+    let context = Box::new(CallbackContext {
+        source,
+        tx,
+        state: Mutex::new(CallbackState {
+            bookmark,
+            pending: None,
+            failure: None,
+        }),
+    });
     let channel = wide_string(source.channel);
     let query = wide_string(source.query);
-    let subscription = match unsafe {
+    let bookmark_handle = context
+        .state
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .bookmark
+        .0;
+    let subscribe = |origin: u32| unsafe {
         EvtSubscribe(
             None,
-            Some(signal.0),
+            None,
             PCWSTR(channel.as_ptr()),
             PCWSTR(query.as_ptr()),
-            None,
-            None,
-            None,
-            EvtSubscribeToFutureEvents.0,
+            (origin == EvtSubscribeStartAfterBookmark.0).then_some(bookmark_handle),
+            Some((&*context as *const CallbackContext).cast()),
+            Some(subscription_callback),
+            origin | EvtSubscribeStrict.0,
         )
-    } {
-        Ok(handle) => OwnedEvtHandle(handle),
-        Err(err) => {
-            let message = format!(
-                "failed to subscribe to {} events in {}: {err}",
-                source.name, source.channel
-            );
-            let _ = startup_tx.send(Err(message.clone()));
-            return Err(anyhow!(message));
-        }
     };
-
-    let _ = startup_tx.send(Ok(()));
-    info!(
-        source = source.name,
-        channel = source.channel,
-        "Event log subscription started"
-    );
-
-    while !shutdown.load(Ordering::Relaxed) {
-        let wait = unsafe { WaitForSingleObject(signal.0, EVENT_LOG_WAIT.as_millis() as u32) };
-        if wait == WAIT_TIMEOUT {
-            continue;
+    let origin = if resume {
+        EvtSubscribeStartAfterBookmark.0
+    } else {
+        EvtSubscribeToFutureEvents.0
+    };
+    let subscription = match subscribe(origin) {
+        Ok(handle) => OwnedEvtHandle(handle),
+        Err(err)
+            if resume
+                && (err.code() == ERROR_NOT_FOUND.to_hresult()
+                    || err.code() == ERROR_EVT_QUERY_RESULT_STALE.to_hresult()) =>
+        {
+            update(source.channel, |health| {
+                health.resume_failures += 1;
+                health.last_error = Some(format!("strict bookmark resume failed: {err}"));
+            });
+            warn!(channel = source.channel, error = %err, "Event Log bookmark missing; resuming at oldest available record");
+            subscribe(EvtSubscribeStartAtOldestRecord.0)
+                .map(OwnedEvtHandle)
+                .map_err(|err| subscription_error(source, err))?
         }
-        if wait != WAIT_OBJECT_0 {
-            return Err(anyhow!(
-                "{} event log wait failed with status {wait:?}",
-                source.name
-            ));
-        }
-
-        drain_events(source, subscription.0, &tx)?;
-        unsafe { ResetEvent(signal.0) }
-            .map_err(|err| anyhow!("failed to reset {} event log signal: {err}", source.name))?;
+        Err(err) => return Err(subscription_error(source, err)),
+    };
+    {
+        let state = context.state.lock().unwrap_or_else(|e| e.into_inner());
+        update(source.channel, |health| {
+            health.active = state.failure.is_none()
+        });
     }
+    let _ = startup_tx.send(Ok(()));
+    info!(channel = source.channel, "Event log subscription started");
+    let result = (|| {
+        while !shutdown.load(Ordering::Relaxed) {
+            persist_pending(&context, checkpoint)?;
+            if let Some(error) = &context
+                .state
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .failure
+            {
+                return Err(anyhow!(error.clone()));
+            }
+            thread::sleep(EVENT_LOG_WAIT);
+        }
+        Ok(())
+    })();
+    // Close before the final checkpoint: no callback may change it afterward.
+    drop(subscription);
+    let final_write = persist_pending(&context, checkpoint);
+    result.and(final_write)
+}
 
-    info!(
-        source = source.name,
-        channel = source.channel,
-        "Event log subscription stopped"
-    );
+fn subscription_error(source: EventLogSource, err: windows::core::Error) -> anyhow::Error {
+    update(source.channel, |health| health.subscription_errors += 1);
+    anyhow!("{} Event Log subscription failed: {err}", source.channel)
+}
+
+unsafe extern "system" fn subscription_callback(
+    action: EVT_SUBSCRIBE_NOTIFY_ACTION,
+    user_context: *const core::ffi::c_void,
+    event: EVT_HANDLE,
+) -> u32 {
+    let context = &*(user_context as *const CallbackContext);
+    // Never unwind through the Windows callback ABI.
+    let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let mut state = context.state.lock().unwrap_or_else(|e| e.into_inner());
+        if action == EvtSubscribeActionError {
+            let code = event.0 as u32;
+            let message = if code == ERROR_EVT_QUERY_RESULT_STALE.0 {
+                format!("ERROR_EVT_QUERY_RESULT_STALE ({code}): subscribed records are missing")
+            } else {
+                format!("Event Log subscription error {code}")
+            };
+            update(context.source.channel, |health| {
+                health.subscription_errors += 1;
+                if code == ERROR_EVT_QUERY_RESULT_STALE.0 {
+                    health.live_stale += 1;
+                }
+                health.active = false;
+                health.last_error = Some(message.clone());
+            });
+            warn!(
+                channel = context.source.channel,
+                code, "Event Log subscription error"
+            );
+            state.failure = Some(message);
+            return;
+        }
+        if action != EvtSubscribeActionDeliver || state.failure.is_some() {
+            return;
+        }
+        let decoded = render_event_xml(event).and_then(|xml| (context.source.decoder)(&xml));
+        match decoded {
+            Ok(decoded) => {
+                update(context.source.channel, |health| {
+                    health.delivered += 1;
+                    // XPath excludes records. Differences are never counted as loss.
+                    health.last_record_id = decoded.source_seq;
+                });
+                if let Err(TrySendError::Closed(_)) =
+                    crate::telemetry::try_send_sensor_event(&context.tx, decoded)
+                {
+                    trace!(channel = context.source.channel, "Sensor channel closed");
+                    return;
+                }
+            }
+            Err(err) => {
+                update(context.source.channel, |health| health.decode_errors += 1);
+                warn!(channel = context.source.channel, error = %err, "Failed to decode event log record");
+            }
+        }
+        // Checkpoint records handled here, including explicitly accounted queue shedding.
+        // Native callback event handles belong to Windows and must not be closed.
+        let checkpoint = EvtUpdateBookmark(state.bookmark.0, event)
+            .map_err(anyhow::Error::from)
+            .and_then(|()| render_xml(state.bookmark.0, EvtRenderBookmark.0));
+        match checkpoint {
+            Ok(xml) => state.pending = Some(xml),
+            Err(err) => {
+                update(context.source.channel, |health| {
+                    health.checkpoint_errors += 1
+                });
+                state.failure = Some(format!("Event Log checkpoint update failed: {err}"));
+            }
+        }
+    }));
+    if outcome.is_err() {
+        update(context.source.channel, |health| {
+            health.subscription_errors += 1
+        });
+        context
+            .state
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .failure = Some("Event Log callback panicked".into());
+    }
+    0
+}
+
+fn persist_pending(context: &CallbackContext, path: &Path) -> Result<()> {
+    let pending = context
+        .state
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .pending
+        .take();
+    if let Some(xml) = pending {
+        write_checkpoint(path, &xml).inspect_err(|_| {
+            update(context.source.channel, |health| {
+                health.checkpoint_errors += 1
+            });
+        })?;
+    }
     Ok(())
 }
 
-fn drain_events(
-    source: EventLogSource,
-    subscription: EVT_HANDLE,
-    tx: &Sender<SensorEvent>,
-) -> Result<()> {
-    loop {
-        let mut raw_events = [0isize; 16];
-        let mut returned = 0u32;
-        let next = unsafe { EvtNext(subscription, &mut raw_events, 0, 0, &mut returned) };
+fn write_checkpoint(path: &Path, xml: &str) -> Result<()> {
+    let directory = path
+        .parent()
+        .context("checkpoint needs a parent directory")?;
+    std::fs::create_dir_all(directory)?;
+    let mut file = tempfile::NamedTempFile::new_in(directory)?;
+    file.write_all(xml.as_bytes())?;
+    file.as_file().sync_all()?;
+    file.persist(path).map_err(|err| err.error)?;
+    Ok(())
+}
 
-        match next {
-            Ok(()) => {}
-            Err(err) if err.code() == ERROR_NO_MORE_ITEMS.to_hresult() => return Ok(()),
-            Err(err) => {
-                return Err(anyhow!(
-                    "failed to read {} event log subscription: {err}",
-                    source.name
-                ))
-            }
-        }
-
-        for raw_event in raw_events.into_iter().take(returned as usize) {
-            let event_handle = EVT_HANDLE(raw_event);
-            let decoded = render_event_xml(event_handle).and_then(|xml| (source.decoder)(&xml));
-            unsafe {
-                let _ = EvtClose(event_handle);
-            }
-
-            match decoded {
-                Ok(event) => {
-                    if let Err(TrySendError::Closed(_)) =
-                        crate::telemetry::try_send_sensor_event(tx, event)
-                    {
-                        trace!(
-                            source = source.name,
-                            "Sensor event channel closed; dropping event"
-                        );
-                    }
-                }
-                Err(err) => warn!(
-                    source = source.name,
-                    error = %err,
-                    "Failed to decode event log record"
-                ),
-            }
-        }
+fn seed_bookmark(channel: &str, bookmark: EVT_HANDLE, path: &Path) -> Result<bool> {
+    let channel = wide_string(channel);
+    let query = wide_string("*");
+    let result = OwnedEvtHandle(unsafe {
+        EvtQuery(
+            None,
+            PCWSTR(channel.as_ptr()),
+            PCWSTR(query.as_ptr()),
+            EvtQueryChannelPath.0 | EvtQueryReverseDirection.0,
+        )
+    }?);
+    let mut events = [0isize; 1];
+    let mut returned = 0;
+    match unsafe { EvtNext(result.0, &mut events, 0, 0, &mut returned) } {
+        Err(err) if err.code() == ERROR_NO_MORE_ITEMS.to_hresult() => return Ok(false),
+        other => other?,
     }
+    let event = OwnedEvtHandle(EVT_HANDLE(events[0]));
+    unsafe { EvtUpdateBookmark(bookmark, event.0) }?;
+    write_checkpoint(path, &render_xml(bookmark, EvtRenderBookmark.0)?)?;
+    Ok(true)
+}
+
+fn retention_wrapped(record_id: u64, oldest: u64) -> bool {
+    // The bookmark itself was already processed. Only records after it matter.
+    oldest > record_id.saturating_add(1)
+}
+
+fn bookmark_record_id(xml: &str, channel: &str) -> Result<u64> {
+    let document = roxmltree::Document::parse(xml)?;
+    document
+        .descendants()
+        .find(|node| node.has_tag_name("Bookmark") && node.attribute("Channel") == Some(channel))
+        .and_then(|node| node.attribute("RecordId"))
+        .context("bookmark has no channel record ID")?
+        .parse()
+        .context("invalid bookmark record ID")
+}
+
+fn oldest_record(channel: &str) -> Result<u64> {
+    let channel = wide_string(channel);
+    let log = OwnedEvtHandle(unsafe {
+        EvtOpenLog(None, PCWSTR(channel.as_ptr()), EvtOpenChannelPath.0)
+    }?);
+    let mut value = EVT_VARIANT::default();
+    let mut used = 0;
+    unsafe {
+        EvtGetLogInfo(
+            log.0,
+            EvtLogOldestRecordNumber,
+            std::mem::size_of_val(&value) as u32,
+            Some(&mut value),
+            &mut used,
+        )
+    }?;
+    if value.Type != EvtVarTypeUInt64.0 as u32 {
+        return Err(anyhow!("unexpected oldest record number type"));
+    }
+    Ok(unsafe { value.Anonymous.UInt64Val })
 }
 
 fn render_event_xml(event: EVT_HANDLE) -> Result<String> {
+    render_xml(event, EvtRenderEventXml.0)
+}
+
+fn render_xml(event: EVT_HANDLE, flags: u32) -> Result<String> {
     let mut bytes_needed = 0u32;
     let mut property_count = 0u32;
     let _ = unsafe {
         EvtRender(
             None,
             event,
-            EvtRenderEventXml.0,
+            flags,
             0,
             None,
             &mut bytes_needed,
@@ -303,7 +529,7 @@ fn render_event_xml(event: EVT_HANDLE) -> Result<String> {
         EvtRender(
             None,
             event,
-            EvtRenderEventXml.0,
+            flags,
             bytes_needed,
             Some(buffer.as_mut_ptr().cast()),
             &mut bytes_needed,
@@ -333,12 +559,5 @@ impl Drop for OwnedEvtHandle {
     }
 }
 
-struct OwnedKernelHandle(HANDLE);
-
-impl Drop for OwnedKernelHandle {
-    fn drop(&mut self) {
-        unsafe {
-            let _ = CloseHandle(self.0);
-        }
-    }
-}
+#[cfg(test)]
+mod tests;

--- a/src/sensor/windows/event_log/tests.rs
+++ b/src/sensor/windows/event_log/tests.rs
@@ -13,7 +13,7 @@ fn retention_only_counts_unavailable_records_after_checkpoint() {
 fn checkpoint_replaces_atomically_and_survives_reopen() {
     let temp = tempfile::tempdir().unwrap();
     let path = temp.path().join("System.xml");
-    for id in [100, 105, 10_000] {
+    for id in [0, 100, 105, 10_000] {
         let xml = format!(
             r#"<BookmarkList><Bookmark Channel="System" RecordId="{id}" IsCurrent="true"/></BookmarkList>"#
         );
@@ -178,7 +178,6 @@ fn native_filtered_subscription_resume_and_retention() {
         }
     }
     let _cleanup = Cleanup;
-    powershell("Write-EventLog -LogName RustinelEventLog429 -Source RustinelEventLog429 -EventId 430 -EntryType Information -Message baseline");
     let temp = tempfile::tempdir().unwrap();
     let path = temp.path().join("checkpoint.xml");
     let source = EventLogSource::new(
@@ -191,7 +190,18 @@ fn native_filtered_subscription_resume_and_retention() {
     let shutdown = Arc::new(AtomicBool::new(false));
     let worker =
         EventLogSubscription::start(source, tx.clone(), shutdown.clone(), path.clone()).unwrap();
-    powershell("Write-EventLog -LogName RustinelEventLog429 -Source RustinelEventLog429 -EventId 429 -EntryType Information -Message first; 1..20 | ForEach-Object { Write-EventLog -LogName RustinelEventLog429 -Source RustinelEventLog429 -EventId 430 -EntryType Information -Message excluded }; Write-EventLog -LogName RustinelEventLog429 -Source RustinelEventLog429 -EventId 429 -EntryType Information -Message second");
+    assert_eq!(
+        bookmark_record_id(&std::fs::read_to_string(&path).unwrap(), channel).unwrap(),
+        0
+    );
+    shutdown.store(true, Ordering::Relaxed);
+    worker.join().unwrap();
+    // Even a previously empty channel must replay its first downtime event.
+    powershell("Write-EventLog -LogName RustinelEventLog429 -Source RustinelEventLog429 -EventId 429 -EntryType Information -Message first");
+    shutdown.store(false, Ordering::Relaxed);
+    let worker =
+        EventLogSubscription::start(source, tx.clone(), shutdown.clone(), path.clone()).unwrap();
+    powershell("1..200 | ForEach-Object { Write-EventLog -LogName RustinelEventLog429 -Source RustinelEventLog429 -EventId 430 -EntryType Information -Message excluded }; Write-EventLog -LogName RustinelEventLog429 -Source RustinelEventLog429 -EventId 429 -EntryType Information -Message second");
     let first = receive(&mut rx).source_seq.unwrap();
     let second = receive(&mut rx).source_seq.unwrap();
     assert!(second > first + 1);

--- a/src/sensor/windows/event_log/tests.rs
+++ b/src/sensor/windows/event_log/tests.rs
@@ -1,0 +1,258 @@
+use super::*;
+use crate::telemetry::event_log::WINDOWS_EVENT_LOG;
+
+#[test]
+fn retention_only_counts_unavailable_records_after_checkpoint() {
+    assert!(!retention_wrapped(100, 100));
+    assert!(!retention_wrapped(100, 101));
+    assert!(retention_wrapped(100, 102));
+    assert!(!retention_wrapped(u64::MAX, 1));
+}
+
+#[test]
+fn checkpoint_replaces_atomically_and_survives_reopen() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("System.xml");
+    for id in [100, 105, 10_000] {
+        let xml = format!(
+            r#"<BookmarkList><Bookmark Channel="System" RecordId="{id}" IsCurrent="true"/></BookmarkList>"#
+        );
+        write_checkpoint(&path, &xml).unwrap();
+        let saved = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(bookmark_record_id(&saved, "System").unwrap(), id);
+        let wide = wide_string(&saved);
+        let bookmark = OwnedEvtHandle(unsafe { EvtCreateBookmark(PCWSTR(wide.as_ptr())) }.unwrap());
+        assert_eq!(
+            bookmark_record_id(
+                &render_xml(bookmark.0, EvtRenderBookmark.0).unwrap(),
+                "System"
+            )
+            .unwrap(),
+            id
+        );
+    }
+    assert!(bookmark_record_id("<BookmarkList/>", "System").is_err());
+}
+
+#[test]
+fn invalid_checkpoint_fails_startup_without_resetting_it() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("checkpoint.xml");
+    std::fs::write(&path, "invalid bookmark").unwrap();
+    let (tx, _rx) = tokio::sync::mpsc::channel(1);
+    let (startup_tx, _startup_rx) = mpsc::sync_channel(1);
+    let source = EventLogSource::new(
+        "test",
+        "invalid-checkpoint-test",
+        "*",
+        service::source().decoder,
+    );
+    assert!(run_subscription_inner(
+        source,
+        tx,
+        Arc::new(AtomicBool::new(false)),
+        &startup_tx,
+        &path
+    )
+    .is_err());
+    assert_eq!(std::fs::read_to_string(path).unwrap(), "invalid bookmark");
+    let health = WINDOWS_EVENT_LOG
+        .lock()
+        .unwrap()
+        .iter()
+        .find(|h| h.channel == source.channel)
+        .unwrap()
+        .clone();
+    assert_eq!(health.checkpoint_errors, 1);
+    assert!(!health.active);
+}
+
+#[test]
+fn callback_errors_are_categorical_and_named() {
+    let (tx, _rx) = tokio::sync::mpsc::channel(1);
+    let source = EventLogSource::new(
+        "test",
+        "callback-error-test",
+        "*",
+        service::source().decoder,
+    );
+    let context = CallbackContext {
+        source,
+        tx,
+        state: Mutex::new(CallbackState {
+            bookmark: OwnedEvtHandle(unsafe { EvtCreateBookmark(PCWSTR::null()) }.unwrap()),
+            pending: None,
+            failure: None,
+        }),
+    };
+    for code in [ERROR_EVT_QUERY_RESULT_STALE.0, 5] {
+        unsafe {
+            subscription_callback(
+                EvtSubscribeActionError,
+                (&context as *const CallbackContext).cast(),
+                EVT_HANDLE(code as isize),
+            );
+        }
+    }
+    let health = WINDOWS_EVENT_LOG
+        .lock()
+        .unwrap()
+        .iter()
+        .find(|h| h.channel == source.channel)
+        .unwrap()
+        .clone();
+    assert_eq!(health.subscription_errors, 2);
+    assert_eq!(health.live_stale, 1);
+    assert_eq!(health.retention_wraps, 0);
+    assert!(health.last_error.unwrap().contains('5'));
+    assert!(!health.active);
+}
+
+fn native_channel() -> &'static str {
+    static CHANNEL: std::sync::LazyLock<String> =
+        std::sync::LazyLock::new(|| format!("R429{}", std::process::id()));
+    CHANNEL.as_str()
+}
+
+fn powershell(script: &str) {
+    let script = script.replace("RustinelEventLog429", native_channel());
+    let output = std::process::Command::new("powershell.exe")
+        .args([
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            &format!("$ErrorActionPreference = 'Stop'; {script}"),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn decode_test_record(xml: &str) -> Result<SensorEvent> {
+    let document = roxmltree::Document::parse(xml)?;
+    let id = document
+        .descendants()
+        .find(|n| n.has_tag_name("EventRecordID"))
+        .and_then(|n| n.text())
+        .context("missing ID")?;
+    // Reuse the production decoder to provide a canonical payload for this transport test.
+    (service::source().decoder)(&format!(
+        r#"<Event><System><Provider Name="Service Control Manager"/><EventID>7045</EventID><EventRecordID>{id}</EventRecordID><TimeCreated SystemTime="2026-09-10T00:00:00Z"/></System><EventData><Data Name="ServiceName">test</Data><Data Name="ImagePath">test.exe</Data></EventData></Event>"#
+    ))
+}
+
+fn receive(rx: &mut tokio::sync::mpsc::Receiver<SensorEvent>) -> SensorEvent {
+    let deadline = std::time::Instant::now() + Duration::from_secs(15);
+    loop {
+        if let Ok(event) = rx.try_recv() {
+            return event;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "timed out waiting for Event Log callback"
+        );
+        thread::sleep(Duration::from_millis(20));
+    }
+}
+
+/// Creates and removes only a dedicated test channel. Requires elevation.
+#[test]
+#[ignore = "requires an elevated Windows lab and creates a temporary Event Log channel"]
+fn native_filtered_subscription_resume_and_retention() {
+    let channel = native_channel();
+    powershell("New-EventLog -LogName RustinelEventLog429 -Source RustinelEventLog429; wevtutil sl RustinelEventLog429 /ms:1048576 /rt:false; if ($LASTEXITCODE -ne 0) { throw 'wevtutil failed' }");
+    struct Cleanup;
+    impl Drop for Cleanup {
+        fn drop(&mut self) {
+            let _ = std::process::Command::new("powershell.exe")
+                .args([
+                    "-NoProfile",
+                    "-Command",
+                    &format!("Remove-EventLog -LogName {}", native_channel()),
+                ])
+                .status();
+        }
+    }
+    let _cleanup = Cleanup;
+    powershell("Write-EventLog -LogName RustinelEventLog429 -Source RustinelEventLog429 -EventId 430 -EntryType Information -Message baseline");
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("checkpoint.xml");
+    let source = EventLogSource::new(
+        "native-test",
+        channel,
+        "*[System[EventID=429]]",
+        decode_test_record,
+    );
+    let (tx, mut rx) = tokio::sync::mpsc::channel(100);
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let worker =
+        EventLogSubscription::start(source, tx.clone(), shutdown.clone(), path.clone()).unwrap();
+    powershell("Write-EventLog -LogName RustinelEventLog429 -Source RustinelEventLog429 -EventId 429 -EntryType Information -Message first; 1..20 | ForEach-Object { Write-EventLog -LogName RustinelEventLog429 -Source RustinelEventLog429 -EventId 430 -EntryType Information -Message excluded }; Write-EventLog -LogName RustinelEventLog429 -Source RustinelEventLog429 -EventId 429 -EntryType Information -Message second");
+    let first = receive(&mut rx).source_seq.unwrap();
+    let second = receive(&mut rx).source_seq.unwrap();
+    assert!(second > first + 1);
+    assert!(rx.try_recv().is_err());
+    shutdown.store(true, Ordering::Relaxed);
+    worker.join().unwrap();
+    assert_eq!(
+        bookmark_record_id(&std::fs::read_to_string(&path).unwrap(), channel).unwrap(),
+        second
+    );
+
+    // A new worker reopens the on-disk bookmark and receives downtime events.
+    powershell("Write-EventLog -LogName RustinelEventLog429 -Source RustinelEventLog429 -EventId 429 -EntryType Information -Message downtime");
+    shutdown.store(false, Ordering::Relaxed);
+    let worker =
+        EventLogSubscription::start(source, tx.clone(), shutdown.clone(), path.clone()).unwrap();
+    let third = receive(&mut rx).source_seq.unwrap();
+    assert!(third > second);
+    shutdown.store(true, Ordering::Relaxed);
+    worker.join().unwrap();
+    let health = WINDOWS_EVENT_LOG
+        .lock()
+        .unwrap()
+        .iter()
+        .find(|h| h.channel == channel)
+        .unwrap()
+        .clone();
+    assert_eq!(health.delivered, 3);
+    assert_eq!(health.subscription_errors, 0);
+    assert_eq!(health.live_stale, 0);
+    assert_eq!(health.resume_failures, 0);
+    assert_eq!(health.retention_wraps, 0);
+
+    // Wrap this isolated channel while the subscriber is stopped.
+    powershell("1..600 | ForEach-Object { Write-EventLog -LogName RustinelEventLog429 -Source RustinelEventLog429 -EventId 430 -EntryType Information -Message ([guid]::NewGuid().ToString() * 64) }; Write-EventLog -LogName RustinelEventLog429 -Source RustinelEventLog429 -EventId 429 -EntryType Information -Message retained");
+    // Event Log metadata can lag Write-EventLog completion while buffers flush.
+    let deadline = std::time::Instant::now() + Duration::from_secs(20);
+    loop {
+        let oldest = oldest_record(channel).unwrap();
+        if retention_wrapped(third, oldest) {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "channel did not wrap: bookmark={third}, oldest={oldest}"
+        );
+        thread::sleep(Duration::from_millis(250));
+    }
+    shutdown.store(false, Ordering::Relaxed);
+    let worker = EventLogSubscription::start(source, tx, shutdown.clone(), path).unwrap();
+    assert!(receive(&mut rx).source_seq.unwrap() > third);
+    shutdown.store(true, Ordering::Relaxed);
+    worker.join().unwrap();
+    let health = WINDOWS_EVENT_LOG
+        .lock()
+        .unwrap()
+        .iter()
+        .find(|h| h.channel == channel)
+        .unwrap()
+        .clone();
+    assert_eq!(health.retention_wraps, 1);
+    assert_eq!(health.resume_failures, 1);
+    assert_eq!(health.live_stale, 0);
+}

--- a/src/telemetry/event_log.rs
+++ b/src/telemetry/event_log.rs
@@ -1,0 +1,36 @@
+//! Event Log loss signals are incidents, never gaps between filtered record IDs.
+use serde::{Deserialize, Serialize};
+use std::sync::Mutex;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EventLogSnapshot {
+    pub channel: String,
+    pub active: bool,
+    pub delivered: u64,
+    pub last_record_id: Option<u64>,
+    pub subscription_errors: u64,
+    pub live_stale: u64,
+    pub resume_failures: u64,
+    pub retention_wraps: u64,
+    pub checkpoint_errors: u64,
+    pub decode_errors: u64,
+    pub last_error: Option<String>,
+}
+
+pub static WINDOWS_EVENT_LOG: Mutex<Vec<EventLogSnapshot>> = Mutex::new(Vec::new());
+
+#[cfg(windows)]
+pub(crate) fn update(channel: &str, change: impl FnOnce(&mut EventLogSnapshot)) {
+    let mut channels = WINDOWS_EVENT_LOG.lock().unwrap_or_else(|e| e.into_inner());
+    let index = channels
+        .iter()
+        .position(|entry| entry.channel == channel)
+        .unwrap_or_else(|| {
+            channels.push(EventLogSnapshot {
+                channel: channel.to_owned(),
+                ..Default::default()
+            });
+            channels.len() - 1
+        });
+    change(&mut channels[index]);
+}

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -12,6 +12,8 @@
 //! writes to a snapshot file. `rustinel doctor` reads that snapshot, so the
 //! answer to "did we lose telemetry?" is a command, not a log search.
 
+pub(crate) mod event_log;
+pub use event_log::EventLogSnapshot;
 mod process_correlation;
 mod snapshot;
 pub use process_correlation::{ProcessCorrelationSnapshot, WINDOWS_PROCESS_CORRELATION};

--- a/src/telemetry/snapshot.rs
+++ b/src/telemetry/snapshot.rs
@@ -473,6 +473,9 @@ pub struct TelemetrySnapshot {
     /// Linux eBPF kernel and userspace reconciliation counters.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub linux_ebpf: Option<LinuxEbpfSnapshot>,
+    /// Per-channel Event Log health, separate from ETW and queue shedding.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub windows_event_log: Vec<super::EventLogSnapshot>,
     /// Classic/manifest source correlation outcomes.
     #[serde(default)]
     pub windows_process_correlation: super::ProcessCorrelationSnapshot,
@@ -507,6 +510,10 @@ impl TelemetrySnapshot {
                 .collect(),
             sensor_events_by_category: super::sensor_event_category_snapshots(),
             linux_ebpf: super::LINUX_EBPF.snapshot(),
+            windows_event_log: super::event_log::WINDOWS_EVENT_LOG
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .clone(),
             windows_process_correlation: crate::telemetry::WINDOWS_PROCESS_CORRELATION.snapshot(),
             windows_process_command_line: super::WINDOWS_PROCESS_COMMAND_LINE.snapshot(),
             registry: super::REGISTRY.snapshot(),
@@ -679,6 +686,7 @@ mod tests {
             channels,
             sensor_events_by_category: Vec::new(),
             linux_ebpf: None,
+            windows_event_log: Vec::new(),
             windows_process_correlation: Default::default(),
             windows_process_command_line: None,
             registry: None,

--- a/tests/telemetry_backpressure.rs
+++ b/tests/telemetry_backpressure.rs
@@ -149,6 +149,7 @@ fn snapshot_with(channels: Vec<ChannelSnapshot>) -> TelemetrySnapshot {
         channels,
         sensor_events_by_category: Vec::new(),
         linux_ebpf: None,
+        windows_event_log: Vec::new(),
         windows_process_correlation: Default::default(),
         windows_process_command_line: None,
         registry: None,
@@ -222,7 +223,7 @@ fn doctor_confirms_when_no_telemetry_was_lost() {
     assert!(check["message"]
         .as_str()
         .expect("message")
-        .contains("No telemetry dropped across 250000 events"));
+        .contains("No pipeline queue drops across 250000 events"));
 }
 
 /// An endpoint where the agent has never run must not look like a failure.


### PR DESCRIPTION
## Summary

Closes #429.

System and Security Event Log subscriptions now use strict callbacks, persist per-channel bookmarks, and resume after restart or service recycle. Missing bookmarks recover from the oldest available record, with downtime retention wrap reported separately from live subscription errors.

`doctor` exposes named per-channel health, checkpoint/decode errors, and categorical loss incidents independently of ETW and pipeline queue shedding. Filtered record ID gaps never become loss counts. Bookmarks flush every 250 ms and on graceful shutdown; abrupt exits can replay records, and checkpoints represent sensor handling rather than durable downstream completion.

The CI rules pin also includes [rules PR #55](https://github.com/Karib0u/rustinel-rules/pull/55), which keeps Windows YARA fixtures available for asynchronous scans and reports fixture setup failures. Windows atomics now use temporary files inside the existing workspace Defender exclusion. This fixes the missing-fixture failures also present on main without relaxing detection checks.

## Type of change

- [x] `enhancement`

## Test plan

- [x] [Latest GitHub CI](https://github.com/Karib0u/rustinel/actions/runs/34514949646): every check passed, including Windows atomics. All three YARA fixtures pass; Windows reports 28/29 detections with the pre-existing allowed EICAR miss unchanged.

- [x] macOS: full `cargo test --locked`, Clippy across all targets, and formatting.
- [x] Windows lab: native filtered subscription (200 excluded records with zero loss), initially empty channel replay, persisted restart/resume, and retention-wrap recovery test.
- [x] Added callback error, invalid checkpoint, atomic checkpoint replacement, retention boundary, and doctor diagnostics tests.
- [x] Windows lab: full `cargo test --locked -j 2` and `cargo clippy --locked --all-targets -j 2 -- -D clippy::all` passed. Used `CARGO_PROFILE_DEV_DEBUG=0`, `CARGO_PROFILE_TEST_DEBUG=0`, and `CARGO_INCREMENTAL=0` to fit available disk space.

## Checklist

- [x] Enhancement label added.
- [x] Troubleshooting documentation updated.


