### PR TITLE
fix(macos-esf): resolve effective UIDs to account names

### DIFF
--- a/benches/ioc_domains.rs
+++ b/benches/ioc_domains.rs
@@ -63,6 +63,7 @@ fn dns_event(query_name: &str) -> NormalizedEvent {
         event_id_string: "22".to_string(),
         opcode: 0,
         fields: EventFields::DnsQuery(DnsQueryFields {
+            user: None,
             query_name: Some(query_name.to_string()),
             query_results: None,
             record_type: None,

--- a/docs/detection.md
+++ b/docs/detection.md
@@ -281,7 +281,10 @@ Per-platform process notes:
   mark `ParentProcessId` as `Derived` and leave parent enrichment absent when
   the cache cannot resolve an unambiguous identity. No late parent path lookup
   occurs. `CommandLine` and `CurrentDirectory` are native ESF fields.
-  `User` uses the effective UID; `RealUserId` preserves the numeric real UID.
+  `User` resolves the effective UID to an account name in the normalizer, marked
+  `Derived`, and retains the numeric UID when lookup fails, as on Linux.
+  `RealUserId` preserves the numeric real UID. Packet-captured macOS network
+  and DNS events have no user identity to resolve.
   `Script` is the native interpreter script path for direct shebang execution
   (message version 2+), absent for scripts passed as interpreter arguments.
   `Signed` is `true` or `false`. `SignatureStatus` is `unsigned`, `valid`, or

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -679,6 +679,7 @@ detection:
             event_id_string: "22".to_string(),
             opcode: 0,
             fields: EventFields::DnsQuery(crate::models::DnsQueryFields {
+                user: None,
                 query_name: Some("example.com".to_string()),
                 query_results: Some("1.1.1.1".to_string()),
                 record_type: Some("A".to_string()),

--- a/src/ioc/mod.rs
+++ b/src/ioc/mod.rs
@@ -293,6 +293,7 @@ mod tests {
             event_id_string: "22".to_string(),
             opcode: 0,
             fields: EventFields::DnsQuery(crate::models::DnsQueryFields {
+                user: None,
                 query_name: Some("foo.example.com".to_string()),
                 query_results: None,
                 record_type: None,
@@ -346,6 +347,7 @@ mod tests {
             event_id_string: "22".to_string(),
             opcode: 0,
             fields: EventFields::DnsQuery(crate::models::DnsQueryFields {
+                user: None,
                 query_name: Some(query_name.to_string()),
                 query_results: None,
                 record_type: None,

--- a/src/models/ecs/mod.rs
+++ b/src/models/ecs/mod.rs
@@ -241,6 +241,7 @@ impl From<&Alert> for EcsAlert {
                 }
             }
             EventFields::DnsQuery(f) => {
+                apply_user_fields(&mut ecs, f.user.as_deref());
                 ecs.dns_query = f.query_name.clone();
                 if let Some(results) = &f.query_results {
                     ecs.dns_answers = Some(vec![DnsAnswer {
@@ -838,6 +839,7 @@ mod tests {
                 event_id_string: "22".to_string(),
                 opcode: 0,
                 fields: EventFields::DnsQuery(DnsQueryFields {
+                    user: None,
                     query_name: Some("example.com".to_string()),
                     query_results: Some("1.1.1.1".to_string()),
                     record_type: Some("A".to_string()),

--- a/src/models/event.rs
+++ b/src/models/event.rs
@@ -308,6 +308,7 @@ impl NormalizedEvent {
                 _ => None,
             },
             EventFields::DnsQuery(f) => match key {
+                "User" => f.user.as_deref(),
                 "query" => f.query_name.as_deref(),
                 "answer" => f.query_results.as_deref(),
                 "record_type" => f.record_type.as_deref(),

--- a/src/models/fields.rs
+++ b/src/models/fields.rs
@@ -321,6 +321,9 @@ pub struct NetworkConnectionFields {
 /// DNS query event fields (Sigma: dns_query)
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DnsQueryFields {
+    #[serde(rename = "User", skip_serializing_if = "Option::is_none")]
+    pub user: Option<String>,
+
     #[serde(rename = "QueryName", skip_serializing_if = "Option::is_none")]
     pub query_name: Option<String>,
 

--- a/src/normalizer/mod.rs
+++ b/src/normalizer/mod.rs
@@ -119,26 +119,12 @@ impl Normalizer {
         }
 
         let mut fields = fields.clone();
-        let measured_user = fields.user.clone();
-        self.resolve_user_field(&mut fields.user);
-        if fields.user != measured_user {
-            provenance.mark_derived("User");
-        }
-        #[cfg(target_os = "linux")]
-        if event.platform == Platform::Linux {
-            if let Some(uid) = fields
-                .linux_identity
-                .effective_user_id
-                .as_deref()
-                .and_then(|id| id.parse::<u32>().ok())
-            {
-                // Account lookup belongs downstream, outside the ring drain.
-                if let Some(name) = crate::utils::lookup_username_by_uid(uid) {
-                    fields.user = Some(name);
-                    provenance.mark_derived("User");
-                }
-            }
-        }
+        self.resolve_actor_user(
+            event.platform,
+            &mut fields.user,
+            fields.linux_identity.effective_user_id.as_deref(),
+            provenance,
+        );
         if fields.process_start_time.is_none() {
             fields.process_start_time = event.process_start_key.map(|key| key.start_time);
             if fields.process_start_time.is_some()
@@ -239,7 +225,7 @@ impl Normalizer {
         mut fields: FileEventFields,
         provenance: &mut Provenance,
     ) -> Option<EventFields> {
-        self.resolve_user_field(&mut fields.user);
+        self.resolve_actor_user(event.platform, &mut fields.user, None, provenance);
         self.enrich_image(event, &mut fields.image, provenance);
 
         Some(EventFields::FileEvent(fields))
@@ -263,7 +249,7 @@ impl Normalizer {
         mut fields: NetworkConnectionFields,
         provenance: &mut Provenance,
     ) -> Option<EventFields> {
-        self.resolve_user_field(&mut fields.user);
+        self.resolve_actor_user(event.platform, &mut fields.user, None, provenance);
         self.enrich_image(event, &mut fields.image, provenance);
 
         if fields.destination_hostname.is_none() {
@@ -285,6 +271,7 @@ impl Normalizer {
         mut fields: DnsQueryFields,
         provenance: &mut Provenance,
     ) -> Option<EventFields> {
+        self.resolve_actor_user(event.platform, &mut fields.user, None, provenance);
         self.enrich_image(event, &mut fields.image, provenance);
 
         if let (Some(query_name), Some(query_results)) = (
@@ -367,6 +354,34 @@ impl Normalizer {
         let key = event.process_start_key?;
         self.process_cache
             .get_metadata_by_key(key.pid, key.start_time)
+    }
+
+    fn resolve_actor_user(
+        &self,
+        platform: Platform,
+        user: &mut Option<String>,
+        effective_uid: Option<&str>,
+        provenance: &mut Provenance,
+    ) {
+        let measured_user = user.clone();
+        self.resolve_user_field(user);
+        if *user != measured_user {
+            provenance.mark_derived("User");
+        }
+
+        // Account lookup stays downstream of the sensor callbacks and ring drain.
+        #[cfg(unix)]
+        if matches!(platform, Platform::Linux | Platform::MacOS) {
+            let uid = effective_uid
+                .or(user.as_deref())
+                .and_then(|value| value.parse::<u32>().ok());
+            if let Some(name) = uid.and_then(crate::utils::lookup_username_by_uid) {
+                *user = Some(name);
+                provenance.mark_derived("User");
+            }
+        }
+        #[cfg(not(unix))]
+        let _ = (platform, effective_uid);
     }
 
     fn resolve_user_field(&self, user: &mut Option<String>) {
@@ -509,6 +524,95 @@ mod tests {
             Arc::new(SidCache::new()),
             Arc::new(DnsCache::new()),
         )
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_actor_users_resolve_consistently_and_match_rules() {
+        for platform in [Platform::Linux, Platform::MacOS] {
+            // Synthetic inputs exercise optional identities independently of
+            // each live collector's required-field contract.
+            let provider = "test";
+            let mut dns = file_event(platform, provider, 4242);
+            dns.payload = SensorPayload::Dns(DnsQueryFields {
+                user: None,
+                query_name: Some("example.test".into()),
+                query_results: None,
+                record_type: Some("A".into()),
+                query_status: None,
+                process_id: None,
+                image: None,
+            });
+            dns.normalization.event_id = 22;
+            for (mut event, category) in [
+                (
+                    process_start_event(platform, provider, 4242),
+                    "process_creation",
+                ),
+                (file_event(platform, provider, 4242), "file_event"),
+                (
+                    network_event(platform, provider, 4242),
+                    "network_connection",
+                ),
+                (dns, "dns_query"),
+            ] {
+                let rules = tempfile::tempdir().unwrap();
+                std::fs::write(rules.path().join("root.yml"), format!(
+                    "title: Root actor\nlogsource:\n  category: {category}\ndetection:\n  selection:\n    User: 'root'\n  condition: selection\n"
+                )).unwrap();
+                let mut engine = crate::engine::Engine::new_for_platform(platform);
+                engine.load_rules(rules.path()).unwrap();
+                for user in [Some("0"), Some("4294967295"), Some("alice"), None] {
+                    match &mut event.payload {
+                        SensorPayload::Process(fields) => {
+                            fields.user = user.map(str::to_string);
+                            fields.linux_identity.effective_user_id = (platform == Platform::Linux)
+                                .then(|| user.map(str::to_string))
+                                .flatten();
+                        }
+                        SensorPayload::File(fields) => fields.user = user.map(str::to_string),
+                        SensorPayload::Network(fields) => fields.user = user.map(str::to_string),
+                        SensorPayload::Dns(fields) => fields.user = user.map(str::to_string),
+                        _ => unreachable!(),
+                    }
+                    let normalized = build_normalizer().normalize(&event).unwrap();
+                    let resolved = user == Some("0");
+                    assert_eq!(
+                        normalized.get_field("User"),
+                        if resolved { Some("root") } else { user }
+                    );
+                    assert_eq!(
+                        normalized
+                            .provenance
+                            .entries()
+                            .iter()
+                            .any(|entry| entry.field == "User"
+                                && entry.fidelity == Fidelity::Derived),
+                        resolved
+                    );
+                    let alerts = engine.evaluate_event(&normalized);
+                    assert_eq!(!alerts.is_empty(), resolved, "{platform:?} {category}");
+                    if resolved {
+                        let ecs = crate::models::ecs::EcsAlert::from(&alerts[0]);
+                        assert_eq!(ecs.user_name.as_deref(), Some("root"));
+                    }
+                    let recorded = serde_json::to_vec(&normalized).unwrap();
+                    let replayed: NormalizedEvent = serde_json::from_slice(&recorded).unwrap();
+                    assert_eq!(replayed.get_field("User"), normalized.get_field("User"));
+                    assert_eq!(replayed.provenance, normalized.provenance);
+                }
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn windows_numeric_user_is_not_resolved_as_unix_uid() {
+        let mut user = Some("0".to_string());
+        let mut provenance = Provenance::default();
+        build_normalizer().resolve_actor_user(Platform::Windows, &mut user, None, &mut provenance);
+        assert_eq!(user.as_deref(), Some("0"));
+        assert!(provenance.is_empty());
     }
 
     #[test]

--- a/src/sensor/linux/ebpf.rs
+++ b/src/sensor/linux/ebpf.rs
@@ -857,6 +857,7 @@ fn build_dns_event(ev: &DnsEvent) -> Option<SensorEvent> {
         process_start_key: process_start_key(ev.pid, ev.process_start_time),
         parent_process_start_key: None,
         payload: SensorPayload::Dns(DnsQueryFields {
+            user: None,
             query_name,
             query_results,
             record_type: Some(record_type),

--- a/src/sensor/linux/events.rs
+++ b/src/sensor/linux/events.rs
@@ -544,6 +544,7 @@ pub mod mapping {
             process_start_key: process_start_key(event.pid, event.process_start_time),
             parent_process_start_key: None,
             payload: SensorPayload::Dns(DnsQueryFields {
+                user: None,
                 query_name: Some(bytes_to_string(&event.query_name)),
                 query_results: Some(bytes_to_string(&event.query_results)),
                 record_type: Some(bytes_to_string(&event.record_type)),

--- a/src/sensor/macos/bpf.rs
+++ b/src/sensor/macos/bpf.rs
@@ -629,6 +629,7 @@ fn build_dns_event(packet: &ParsedPacket, event_time: SystemTime) -> Option<Sens
         process_start_key: None,
         parent_process_start_key: None,
         payload: SensorPayload::Dns(DnsQueryFields {
+            user: None,
             query_name: Some(query_name),
             query_results: None,
             record_type: record_type_name(qtype).map(str::to_string),

--- a/src/sensor/macos/esf.rs
+++ b/src/sensor/macos/esf.rs
@@ -865,7 +865,10 @@ mod tests {
         assert_eq!(normalized.get_field("ParentImage"), Some("/sbin/launchd"));
         assert_eq!(normalized.get_field("PreExecImage"), Some("/bin/bash"));
         assert_eq!(normalized.get_field("Image"), Some("/bin/sh"));
-        assert_eq!(normalized.get_field("User"), Some("0"));
+        assert_eq!(normalized.get_field("User"), Some("root"));
+        assert!(normalized.provenance.entries().iter().any(
+            |entry| entry.field == "User" && entry.fidelity == crate::models::Fidelity::Derived
+        ));
         assert_eq!(normalized.get_field("RealUserId"), Some("501"));
         assert_eq!(normalized.get_field("Script"), Some("/tmp/payload.sh"));
         assert_eq!(normalized.get_field("SignatureStatus"), Some("valid"));

--- a/src/sensor/windows/etw/decode.rs
+++ b/src/sensor/windows/etw/decode.rs
@@ -782,6 +782,7 @@ pub(super) fn decode_network(parser: &Parser, record: &EventRecord) -> Option<De
 pub(super) fn decode_dns(parser: &Parser, record: &EventRecord) -> Option<DecodedEtwEvent> {
     let mappings = field_maps::dns_query_mappings();
     let fields = DnsQueryFields {
+        user: None,
         query_name: try_get_string(parser, mappings.get_etw_field("QueryName")?),
         query_results: try_get_string(parser, mappings.get_etw_field("QueryResults")?),
         record_type: None,

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -31,5 +31,5 @@ pub use process::{query_process_command_line_at_start, query_process_command_lin
 pub use time::now_timestamp_string;
 #[cfg(windows)]
 pub use user::lookup_account_sid;
-#[cfg(target_os = "linux")]
+#[cfg(unix)]
 pub use user::lookup_username_by_uid;

--- a/src/utils/user.rs
+++ b/src/utils/user.rs
@@ -2,7 +2,7 @@
 
 use anyhow::{anyhow, Result};
 
-#[cfg(target_os = "linux")]
+#[cfg(unix)]
 use std::ffi::CStr;
 
 #[cfg(windows)]
@@ -103,7 +103,7 @@ pub fn lookup_account_sid(_sid_str: &str) -> Result<String> {
     Err(anyhow!("SID resolution is only supported on Windows"))
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(unix)]
 pub fn lookup_username_by_uid(uid: u32) -> Option<String> {
     let mut buf_len = match unsafe { libc::sysconf(libc::_SC_GETPW_R_SIZE_MAX) } {
         value if value > 0 => value as usize,
@@ -141,13 +141,13 @@ pub fn lookup_username_by_uid(uid: u32) -> Option<String> {
     None
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(unix))]
 #[allow(dead_code)]
 pub fn lookup_username_by_uid(_uid: u32) -> Option<String> {
     None
 }
 
-#[cfg(all(test, target_os = "linux"))]
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -293,6 +293,7 @@ pub fn dns_query_event(platform: Platform) -> SensorEvent {
         }),
         parent_process_start_key: None,
         payload: SensorPayload::Dns(DnsQueryFields {
+            user: None,
             query_name: Some(TEST_DOMAIN.to_string()),
             query_results: Some(TEST_DESTINATION_IP.to_string()),
             record_type: Some("A".to_string()),

--- a/tests/ecs_contract.rs
+++ b/tests/ecs_contract.rs
@@ -239,6 +239,7 @@ fn ecs_category_coverage_maps_event_contract_fields() {
                 22,
                 0,
                 EventFields::DnsQuery(DnsQueryFields {
+                    user: None,
                     query_name: Some("example.test".to_string()),
                     query_results: Some("198.51.100.10 198.51.100.10".to_string()),
                     record_type: Some("A".to_string()),


### PR DESCRIPTION
## Summary

macOS ESF events currently retain `User: '0'`, so rules selecting `User: 'root'` silently miss them. Resolve effective UIDs through one shared Unix normalizer implementation, retain numeric values when lookup fails, and mark resolved account names as `Derived`. Account lookup stays outside sensor callbacks.

Apply the same resolution to process, file, network, and DNS fields. Add an optional DNS `User` field with rule, recording, and ECS support. Current macOS packet collectors do not supply user identities, so their network and DNS events continue to omit `User`; this differs from the issue's description of those collectors.

Closes #457.

## Type of change

- [x] `bug` - bug fix

## Test plan

- [x] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
- [x] Existing tests pass (`cargo test --locked --quiet`)
- [x] New tests cover Linux and macOS synthetic events matching `User: 'root'`, numeric fallback, missing identities, provenance, recordings, and ECS output
- [x] `cargo clippy --all-targets -- -D clippy::all`
- [x] `cargo fmt --all -- --check`

## Checklist

- [x] Bug label added
- [x] Docs updated
