### PR TITLE
chore(cleanup): remove stale dead-code allows and unreachable code

### DIFF
--- a/src/doctor/inspect.rs
+++ b/src/doctor/inspect.rs
@@ -1,4 +1,4 @@
-use crate::config::{AppConfig, ConfigLoadOptions, ConfigSource, InstallLayout, InstallPlatform};
+use crate::config::{AppConfig, ConfigLoadOptions, ConfigSource, InstallPlatform};
 use serde::Serialize;
 use std::fmt;
 use std::path::{Path, PathBuf};
@@ -603,12 +603,6 @@ impl ResolvedPaths {
             logs_dir: cfg.logging.directory.clone(),
             alerts_dir: cfg.alerts.directory.clone(),
         }
-    }
-
-    #[allow(dead_code)]
-    fn from_layout(layout: &InstallLayout) -> Self {
-        let cfg = layout.managed_config();
-        Self::from_config(&cfg, Some(layout.config_file.clone()))
     }
 }
 

--- a/src/engine/logsource.rs
+++ b/src/engine/logsource.rs
@@ -124,7 +124,6 @@ pub(crate) enum RuleLoadDecision {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
-#[allow(dead_code)] // Used by companion binaries outside the library crate.
 pub enum LogSourceStatus {
     Supported,
     ProductMismatch,
@@ -133,7 +132,6 @@ pub enum LogSourceStatus {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[allow(dead_code)] // Used by companion binaries outside the library crate.
 pub struct LogSourceClassification {
     pub status: LogSourceStatus,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -415,7 +413,6 @@ impl Engine {
             .unwrap_or(false)
     }
 
-    #[allow(dead_code)] // Used by companion binaries outside the library crate.
     pub fn classify_logsource_key(&self, logsource: &LogSourceKey) -> LogSourceClassification {
         let decision = self.rule_load_decision(logsource);
         let status = match decision {
@@ -435,7 +432,6 @@ impl Engine {
         }
     }
 
-    #[allow(dead_code)] // Used by companion binaries outside the library crate.
     pub fn classify_logsource(&self, logsource: &LogSource) -> LogSourceClassification {
         self.classify_logsource_key(&LogSourceKey::from_logsource(logsource))
     }

--- a/src/engine/stats.rs
+++ b/src/engine/stats.rs
@@ -87,14 +87,10 @@ impl Engine {
 pub struct EngineStats {
     pub total_rules: usize,
     pub rule_files_found: usize,
-    #[allow(dead_code)] // Used by companion binaries outside the library crate.
     pub rules_by_category: HashMap<String, usize>,
     pub rules_by_logsource: HashMap<String, usize>,
-    #[allow(dead_code)] // Used by companion binaries outside the library crate.
     pub deferred_logsource_rules: HashMap<String, usize>,
-    #[allow(dead_code)] // Used by companion binaries outside the library crate.
     pub unknown_logsource_rules: HashMap<String, usize>,
-    #[allow(dead_code)] // Used by validation binaries outside this crate.
     pub failed_rules: Vec<(String, String)>,
     /// Parsed documents dropped because their references do not resolve.
     pub unsupported_rules: Vec<UnsupportedRule>,
@@ -105,7 +101,6 @@ pub struct EngineStats {
     /// Inert rule counts grouped by the telemetry category no collector feeds.
     pub inactive_collector_categories: BTreeMap<String, usize>,
     /// Inert rule counts by full logsource, for detailed diagnostics.
-    #[allow(dead_code)] // Used by companion binaries outside the library crate.
     pub inactive_collector_logsources: BTreeMap<String, usize>,
 }
 

--- a/src/memory/types.rs
+++ b/src/memory/types.rs
@@ -13,7 +13,6 @@ pub struct MemoryScanConfig {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[allow(dead_code)]
 pub enum MemoryRegionKind {
     Private,
     Image,
@@ -22,7 +21,6 @@ pub enum MemoryRegionKind {
 }
 
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub struct MemoryRegion {
     pub base: u64,
     pub size: usize,

--- a/src/normalizer/mod.rs
+++ b/src/normalizer/mod.rs
@@ -873,11 +873,6 @@ mod tests {
     }
 
     #[test]
-    fn test_normalizer_creation() {
-        let _normalizer = build_normalizer();
-    }
-
-    #[test]
     fn process_stop_events_only_maintain_cache() {
         let normalizer = build_normalizer();
 

--- a/src/runtime/linux.rs
+++ b/src/runtime/linux.rs
@@ -61,10 +61,10 @@ async fn run_linux_edr(
         _guards,
     } = RuntimeLogging::start(&cfg, "Linux eBPF");
 
-    // 3. Shared state
+    // Shared state
     let state = SharedState::new(&cfg);
 
-    // 4. Active response engine
+    // Active response engine
     let response_config = Arc::new(ArcSwap::from(Arc::new(cfg.response.clone())));
     let (response_engine, response_worker_handle) = ResponseEngine::new(response_config.clone());
 
@@ -79,7 +79,7 @@ async fn run_linux_edr(
         response_engine.clone(),
     );
 
-    // 13. eBPF sensor
+    // eBPF sensor
     let sensor = Arc::new(EbpfSensor::with_process_cache(process_cache));
 
     info!(
@@ -101,7 +101,7 @@ async fn run_linux_edr(
         return Err(e);
     }
 
-    // 14. Wait for Ctrl+C
+    // Wait for Ctrl+C
     match tokio::signal::ctrl_c().await {
         Ok(()) => info!(target: TARGET_CONSOLE, "Received Ctrl+C, shutting down"),
         Err(e) => error!("Failed to listen for Ctrl+C: {}", e),

--- a/src/runtime/macos.rs
+++ b/src/runtime/macos.rs
@@ -76,10 +76,10 @@ async fn run_macos_edr(
         _guards,
     } = RuntimeLogging::start(&cfg, "macOS ESF");
 
-    // 3. Shared state
+    // Shared state
     let state = SharedState::new(&cfg);
 
-    // 4. Active response engine
+    // Active response engine
     let response_config = Arc::new(ArcSwap::from(Arc::new(cfg.response.clone())));
     let (response_engine, response_worker_handle) = ResponseEngine::new(response_config.clone());
 
@@ -93,7 +93,7 @@ async fn run_macos_edr(
         response_engine.clone(),
     );
 
-    // 13. macOS sensors: Endpoint Security (process/file) and bpf (network/DNS)
+    // macOS sensors: Endpoint Security (process/file) and bpf (network/DNS)
     let esf_sensor = Arc::new(EsfSensor::new());
     let bpf_sensor = Arc::new(BpfSensor::new());
 
@@ -126,7 +126,7 @@ async fn run_macos_edr(
         );
     }
 
-    // 14. Wait for Ctrl+C
+    // Wait for Ctrl+C
     match tokio::signal::ctrl_c().await {
         Ok(()) => info!(target: TARGET_CONSOLE, "Received Ctrl+C, shutting down"),
         Err(e) => error!("Failed to listen for Ctrl+C: {}", e),

--- a/src/runtime/pipeline.rs
+++ b/src/runtime/pipeline.rs
@@ -63,7 +63,7 @@ impl LivePipeline {
             Platform::MacOS => "esf",
             Platform::Windows => "etw",
         };
-        // 5. Sigma engine
+        // Sigma engine
         let mut sigma_engine =
             Engine::new_for_platform_with_match_debug(platform, cfg.alerts.match_debug);
 
@@ -100,7 +100,7 @@ impl LivePipeline {
         }
         let sigma_engine = Arc::new(sigma_engine);
 
-        // 6. YARA scanner
+        // YARA scanner
         let yara_scanner = if cfg.scanner.yara_enabled {
             match scanner::Scanner::new(&cfg.scanner.yara_rules_path)
                 .map(|s| s.with_limits(cfg.scanner.yara_scan_limits()))
@@ -122,7 +122,7 @@ impl LivePipeline {
         let yara_allowlist_paths =
             scanner::normalize_allowlist_paths(&cfg.scanner.yara_allowlist_paths);
 
-        // 7. IOC engine
+        // IOC engine
         let ioc_engine = Arc::new(IocEngine::load(&cfg.ioc));
         if ioc_engine.is_enabled() {
             let stats = ioc_engine.stats();
@@ -142,7 +142,7 @@ impl LivePipeline {
             info!(target: TARGET_CONSOLE, "IOC detection disabled by configuration");
         }
 
-        // 8. Detector store + hot-reload
+        // Detector store + hot-reload
         let detectors = DetectorStore::new(
             Arc::clone(&sigma_engine),
             Arc::clone(&yara_scanner),
@@ -174,7 +174,7 @@ impl LivePipeline {
             reload_tx = Some(tx);
         }
 
-        // 9. YARA background worker
+        // YARA background worker
         let (yara_tx, yara_worker_handle) = if cfg.scanner.yara_enabled {
             let (tx, rx) = mpsc::channel::<crate::scanner::FileScanTarget>(1000);
             let handle = runtime_yara::spawn_yara_file_worker(
@@ -225,7 +225,7 @@ impl LivePipeline {
             None
         };
 
-        // 10. IOC hash background worker
+        // IOC hash background worker
         let (ioc_hash_tx, ioc_hash_worker_handle) = if ioc_engine.is_enabled() {
             let (hash_tx, hash_rx) = mpsc::channel::<crate::scanner::FileScanTarget>(1000);
             let handle = runtime_ioc::spawn_ioc_hash_worker(
@@ -241,14 +241,14 @@ impl LivePipeline {
             (None, None)
         };
 
-        // 11. Normalizer
+        // Normalizer
         let normalizer = Arc::new(Normalizer::new(
             Arc::clone(&state.process_cache),
             Arc::clone(&state.sid_cache),
             Arc::clone(&state.dns_cache),
         ));
 
-        // 12. Detection handlers + router
+        // Detection handlers + router
         let sigma_handler = NormalizedEventHandler::detecting(
             Arc::clone(&normalizer),
             DetectionPipeline {

--- a/src/runtime/windows.rs
+++ b/src/runtime/windows.rs
@@ -278,7 +278,7 @@ async fn run_edr(
         _guards,
     } = RuntimeLogging::start(&cfg, "Windows ETW");
 
-    // 2.1 Initialize Active Response Engine (optional)
+    // Initialize Active Response Engine (optional)
     let response_config = Arc::new(ArcSwap::from(Arc::new(cfg.response.clone())));
     let (response_engine, response_worker_handle) = ResponseEngine::new(response_config.clone());
     info!(
@@ -316,11 +316,6 @@ async fn run_edr(
                 );
             }
         }
-    }
-
-    #[cfg(not(windows))]
-    {
-        info!("Process snapshot not available on non-Windows platforms");
     }
 
     let sensor = Arc::new(

--- a/src/state/dns.rs
+++ b/src/state/dns.rs
@@ -61,7 +61,6 @@ impl DnsCache {
     }
 
     /// Return current cache size (primarily for tests/metrics)
-    #[allow(dead_code)]
     pub fn count(&self) -> usize {
         let cache = self.cache.read().unwrap();
         cache.len()

--- a/src/state/process.rs
+++ b/src/state/process.rs
@@ -14,42 +14,29 @@ fn now_secs() -> u64 {
 #[derive(Debug, Clone)]
 pub struct ProcessMetadata {
     pub image_name: String,
-    #[allow(dead_code)]
     pub command_line: Option<String>,
-    #[allow(dead_code)]
     pub user: Option<String>,
     /// Platform-native process execution identity paired with the PID.
-    #[allow(dead_code)]
     pub creation_time: u64,
     /// Parent process ID
-    #[allow(dead_code)]
     pub parent_pid: Option<u32>,
     /// Parent process image name (enriched at creation time)
-    #[allow(dead_code)]
     pub parent_image: Option<String>,
     /// Parent process command line (enriched at creation time)
-    #[allow(dead_code)]
     pub parent_command_line: Option<String>,
     /// PE metadata: Original filename from version info
-    #[allow(dead_code)]
     pub original_filename: Option<String>,
     /// PE metadata: Product name
-    #[allow(dead_code)]
     pub product: Option<String>,
     /// PE metadata: File description
-    #[allow(dead_code)]
     pub description: Option<String>,
     /// PE metadata: Company name
-    #[allow(dead_code)]
     pub company: Option<String>,
     /// PE metadata: File version
-    #[allow(dead_code)]
     pub file_version: Option<String>,
     /// Process working directory
-    #[allow(dead_code)]
     pub current_directory: Option<String>,
     /// Process integrity level
-    #[allow(dead_code)]
     pub integrity_level: Option<String>,
 }
 
@@ -191,7 +178,6 @@ impl ProcessCache {
 
     /// Get full metadata for a given compound key (PID, CreationTime)
     /// This is the precise lookup method that avoids PID reuse issues
-    #[allow(dead_code)]
     pub fn get_metadata_by_key(&self, pid: u32, creation_time: u64) -> Option<ProcessMetadata> {
         let cache = self.cache.read().unwrap();
         if let Some(meta) = cache.get(&(pid, creation_time)) {
@@ -209,7 +195,6 @@ impl ProcessCache {
     }
 
     /// Get the current count of cached processes
-    #[allow(dead_code)]
     pub fn count(&self) -> usize {
         let cache = self.cache.read().unwrap();
         cache.len()

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,6 +1,7 @@
 //! Utility modules for Rustinel
 //!
-//! Provides helper functions for path normalization and PE parsing.
+//! Path handling, process and user lookup, PE parsing, caching, and
+//! filesystem helpers shared across the sensor, engine, and runtime layers.
 
 pub(crate) mod cache;
 pub(crate) mod file_identity;

--- a/src/utils/user.rs
+++ b/src/utils/user.rs
@@ -98,7 +98,6 @@ pub fn lookup_account_sid(sid_str: &str) -> Result<String> {
 }
 
 #[cfg(not(windows))]
-#[allow(dead_code)]
 pub fn lookup_account_sid(_sid_str: &str) -> Result<String> {
     Err(anyhow!("SID resolution is only supported on Windows"))
 }


### PR DESCRIPTION
Fallout from a structural review of the tree. Every item here is a deletion with no behavior change — 63 lines removed, 20 added (most of those a reworded module doc).

## What was wrong

**Stale `#[allow(dead_code)]` (28 attributes).** Thirteen of the fifteen in `state/process.rs` sat on `ProcessMetadata` fields that are read on every normalized process event at `normalizer/mod.rs:431-445`; the other two covered `ProcessCache` methods with live callers. The suppressions in `engine/stats.rs`, `engine/logsource.rs`, `memory/types.rs`, `state/dns.rs`, and `utils/user.rs` were the same story — including four commented *"used by companion binaries outside the library crate"* that the compiler disagrees with. They read as "this data is unused," which was false, and they suppressed a lint the crate otherwise takes seriously (`warnings = "deny"`).

**One attribute was doing real work.** It hid `ResolvedPaths::from_layout` in `doctor/inspect.rs`, which has no callers anywhere in the tree. Deleted the function rather than the attribute; `InstallLayout` drops out of the imports with it.

**Unreachable block.** `runtime::windows` is declared `#[cfg(windows)]` in `runtime/mod.rs`, so the `#[cfg(not(windows))]` block inside `run_edr` could never compile on any target.

**A test that asserted nothing.** `test_normalizer_creation` built a `Normalizer` and dropped it. The surrounding module already covers construction through tests that check behavior.

**Misleading step numbers.** The `// 3.` through `// 14.` comments in the runtime described a sequence that a previous refactor split across three files — 3-4 in `linux.rs`/`macos.rs`, 5-12 in `pipeline.rs`, 13-14 back in `linux.rs`/`macos.rs`, with 1-2 no longer existing anywhere and Windows using `// 2.1`. Labels kept, numbers dropped.

## Verification

On macOS (aarch64), all clean:

- `cargo check --all-targets` — no warnings, no errors
- `cargo clippy --all-targets` — silent
- `cargo fmt --check` — clean
- `cargo test --all-targets` — 425 unit tests plus every integration suite pass, 0 failures

## Left alone deliberately

Three `#[allow(dead_code)]` attributes sit in files that do not compile on macOS, so I could not prove them stale and did not touch them: `utils/pe.rs`, `sensor/linux/events.rs`, `sensor/windows/field_maps.rs`. Same reasoning for the `#[cfg(not(unix))]` fallback in `utils/user.rs`, which only compiles on Windows — its `#[cfg(not(windows))]` sibling is verified and was removed.

The `run_edr` deletion and the Windows comment change need a Windows build to confirm; both are provably inert, but worth a CI pass before merge.