### PR TITLE
fix(nix): refresh the stale release pin and make its drift visible

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -15,7 +15,13 @@ on:
       - flake.lock
       - nix/**
       - .github/workflows/nix.yml
-  workflow_call:
+  # The paths filters above mean a release never triggers this workflow, so a
+  # stale release pin in nix/package.nix cannot fail a push or a PR. The
+  # scheduled run is what actually surfaces that drift; it lands on Mondays
+  # alongside the weekly dependabot run.
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -41,7 +47,35 @@ jobs:
       # builds the native package, fetches + verifies the aarch64 release
       # archive's SRI hash using the local stdenv's fetchurl (no QEMU), and
       # runs a --version smoke test. A single step covers everything; no Rust
-      # change can affect the flake (paths filter scopes this workflow to
-      # flake.* / nix/** / this file).
+      # change can affect the flake (the paths filters scope the push / PR
+      # triggers to flake.* / nix/** / this file).
       - name: Check flake
         run: nix flake check
+
+  release-pin:
+    name: release pin freshness
+    runs-on: ubuntu-latest
+    # Scheduled / manual only. On a PR the pin is legitimately allowed to trail
+    # a tag that has not shipped yet, so gating merges on it would be wrong.
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Compare nix/package.nix against the latest release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          pinned="$(sed -n 's/^  version = "\(.*\)";$/\1/p' nix/package.nix)"
+          if [ -z "$pinned" ]; then
+            echo "::error file=nix/package.nix::could not read the pinned version"
+            exit 1
+          fi
+          latest="$(gh api "repos/$GITHUB_REPOSITORY/releases/latest" --jq '.tag_name')"
+          latest="${latest#v}"
+          echo "nix/package.nix pins $pinned; latest release is $latest"
+          if [ "$pinned" != "$latest" ]; then
+            echo "::error file=nix/package.nix::pins $pinned but the latest release is $latest. Bump version and both SRI hashes as described in the header comment of nix/package.nix."
+            exit 1
+          fi

--- a/deny.toml
+++ b/deny.toml
@@ -2,7 +2,7 @@
 ignore = [
     { id = "RUSTSEC-2023-0071", reason = "rsa is pulled transitively by yara-x. No fixed rsa release is available, and rustinel does not use yara-x for attacker observable private key RSA operations." },
     { id = "RUSTSEC-2025-0141", reason = "bincode is pulled transitively by yara-x. This is tracked as an upstream maintenance advisory until yara-x removes or replaces it." },
-  { id = "RUSTSEC-2026-0222", reason = "yara-x 1.19.0 creates a single Wasmtime engine, so the cross-engine type-index mix-up described by this advisory is not reachable. See https://github.com/VirusTotal/yara-x/issues/726." },
+    { id = "RUSTSEC-2026-0222", reason = "yara-x 1.20.0 still builds its Wasmtime engine as a process-wide singleton (ENGINE.get_or_init in src/wasm/mod.rs), so the cross-engine type-index mix-up described by this advisory is not reachable. See https://github.com/VirusTotal/yara-x/issues/726." },
     { id = "RUSTSEC-2026-0269", reason = "Wasmtime is pulled transitively by yara-x, which uses it only to JIT compiled rule conditions. This advisory is a WASI filesystem sandbox escape and wasmtime-wasi is not in the dependency tree, so it is not reachable. No fixed release is available on the 43.x line that yara-x 1.19 requires (nor 45.x, required by yara-x 1.20)." },
 ]
 

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -49,10 +49,10 @@
 }:
 
 let
-  version = "1.3.0";
+  version = "1.6.0";
   hashes = {
-    x86_64-linux = "sha256-Co3Pn9PyiFn7MDPA8wV2RttdmvvlEFjVHpCZwPBuFV0=";
-    aarch64-linux = "sha256-DhV5OkCSBnHckq2cAeEjC7PwCtJU3+uorVJtHcWPNYM=";
+    x86_64-linux = "sha256-MwzxaMGfpNFflOrSU6u1DZ1Yel+V3YdN6NUhJLdRktA=";
+    aarch64-linux = "sha256-tXawq8vTlfPaL2SBxCoicgpgUfwquYjXuKUnEKqcLXg=";
   };
   archMap = {
     x86_64-linux = "x86_64-unknown-linux-musl";
@@ -107,12 +107,11 @@ stdenv.mkDerivation {
     # future third occurrence would be swept up silently — revisit if the
     # config grows another `directory = "logs"` field.
     #
-    # The `directory = "captures"` substitution uses `--replace` (non-failing):
-    # the [capture] section was added to the repo config after the v1.3.0 tag,
-    # so the v1.3.0 release archive does not contain it. `--replace` no-ops
-    # on archives without the section and rewrites it on releases that ship
-    # it, keeping the package forward-compatible without breaking the current
-    # build.
+    # `directory = "captures"` was added to the bundled config after the v1.3.0
+    # tag and ships in every release the package has pinned since, so it is
+    # `--replace-fail` like the rest: a release that stopped shipping the
+    # [capture] section should break the build rather than silently leave
+    # captures pointing at a relative path inside the read-only store.
     install -Dm644 config.toml $out/share/rustinel/config.toml
     substituteInPlace $out/share/rustinel/config.toml \
       --replace-fail 'sigma_rules_path = "rules/sigma"' \
@@ -129,8 +128,8 @@ stdenv.mkDerivation {
                      'paths_regex_path = "'"$out"'/share/rustinel/rules/ioc/paths_regex.txt"' \
       --replace-fail 'directory = "logs"' \
                      'directory = "'${logDir}'"' \
-      --replace 'directory = "captures"' \
-                'directory = "'${captureDir}'"'
+      --replace-fail 'directory = "captures"' \
+                     'directory = "'${captureDir}'"'
 
     # Unmodified bundled config for reference / customization.
     install -Dm644 config.toml $out/share/rustinel/config.example.toml


### PR DESCRIPTION
Follow-up to an audit of every hash-shaped pin in the repo. The automated
half is healthy; this PR fixes the manual half.

## What was wrong

`nix/package.nix` pinned the **1.3.0** release tarball while the repo shipped
**1.6.0** — three releases and about four weeks behind. Anyone running
`nix run github:Karib0u/rustinel` got a month-old binary.

The reason it drifted silently: `nix.yml`'s `push`/`pull_request` triggers are
filtered to `flake.*` / `nix/**` / itself, so **publishing a release never runs
the workflow**. A stale `version` cannot fail any check, and no bot watches it
either — dependabot has no Nix ecosystem.

## Changes

- **Bump the pin to 1.6.0.** Both SRI hashes were computed from the published
  v1.6.0 archives and cross-checked against
  `rustinel-1.6.0-checksums-sha256.txt` from the same release. The tarball
  layout still matches the derivation, and every `--replace-fail` target still
  occurs in the bundled `config.toml` exactly as documented (`directory =
  "logs"` still matches the intended pair, no third occurrence).
- **Tighten `directory = "captures"` to `--replace-fail`.** It was the one
  non-failing substitution, kept that way only because the v1.3.0 archive
  predates the `[capture]` section. Every release pinned since ships it.
- **Add a Monday schedule + manual dispatch to `nix.yml`,** with a `release-pin`
  job that compares the pinned version against the latest published release and
  fails loudly on divergence. Scheduled/dispatch-only on purpose: on a PR the
  pin is legitimately allowed to trail an unshipped tag, so gating merges on it
  would block unrelated work every time a release lands.
- **Drop the `workflow_call` trigger** from `nix.yml` — it had no caller
  (`release.yml` calls `ci.yml` only).
- **Re-anchor the `RUSTSEC-2026-0222` ignore in `deny.toml`** to yara-x 1.20.0.
  The justification still argued from 1.19.0 after #369 moved the lock; 1.20.0
  still builds the Wasmtime engine as a process-wide singleton
  (`ENGINE.get_or_init` in `src/wasm/mod.rs`), so the advisory stays
  unreachable.

## Verification

- `cargo deny check` → `advisories ok, bans ok, licenses ok, sources ok`.
- Both v1.6.0 tarballs verified with `shasum -a 256 -c` against the release's
  own checksums file before deriving the SRI values.
- `nix.yml` parses; the `sed` used by the new job extracts exactly `1.6.0` from
  `nix/package.nix`.

`nix flake check` itself was **not** run locally — nix is not installed on this
machine. The Nix workflow will exercise it on this PR, since the diff touches
`nix/**`.

## Deliberately not included

- **`RUSTINEL_RULES_REF` repin.** `ci.yml` pins a commit that is not on
  rustinel-rules `main` — it is the head of the open PR
  Karib0u/rustinel-rules#55. If that branch is force-pushed or deleted on merge,
  CI on `main` starts failing at checkout. The fix is to merge #55 (green, but
  `BEHIND`) and repin both `ci.yml` and `release.yml`, which today point at
  *different* rules commits. That needs a merge in the other repo first.
- **`flake.lock` automation.** A scheduled `nix flake update` PR opened with
  `GITHUB_TOKEN` would not trigger the Nix workflow, so a nixpkgs bump would be
  mergeable without ever being built — worse than the status quo. Needs a PAT
  or an explicit decision.
- **The four behind-latest action pins.** All four upstream releases landed
  within the last three days, inside dependabot's 7-day cooldown. Monday's run
  picks them up.
