### PR TITLE
ci: pin rustinel-rules to be877b7 on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ env:
   CARGO_TERM_COLOR: always
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   # Update this commit deliberately when the rules repository's atomic suite changes.
-  RUSTINEL_RULES_REF: 5b8f00181114c6be1d7dbb0b37c6df7101f2c78b
+  RUSTINEL_RULES_REF: be877b7e23bcffcfeeccbb4d0f078987e9253c82
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ env:
   CARGO_TERM_COLOR: always
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   # Update this commit deliberately when the rules repository's atomic suite changes.
-  RUSTINEL_RULES_REF: c1d78b4dec00eef42b5ccb741da6f7e7521dd854
+  RUSTINEL_RULES_REF: be877b7e23bcffcfeeccbb4d0f078987e9253c82
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Point both workflows at the same rustinel-rules commit on `main`.

- `ci.yml` pinned `5b8f001`, a commit on the unmerged `fix/windows-atomic-fixture-lifetime` branch.
- `release.yml` pinned `c1d78b4`, which predates that fix, so release atomics could still hit the Windows YARA fixture deletion race.

The fix is now merged as `be877b7` (Karib0u/rustinel-rules#55). Between `c1d78b4` and `be877b7`, rustinel-rules changed only that fixture fix and a Python dependency bump.

## Validation

- rustinel-rules#55 passed Linux, Windows and macOS atomics and the Detection as Code checks on its updated head before merge.
- This PR's own `Atomic (linux)` and `Atomic (windows)` jobs exercise the new pin against the PR build.

Part of #490 (the macOS atomic leg remains).