### PR TITLE
fix(windows-etw): preserve DNS Client event IDs

### DIFF
--- a/compatibility/field-availability.json
+++ b/compatibility/field-availability.json
@@ -1028,7 +1028,7 @@
     {
       "platform": "windows",
       "category": "dns_query",
-      "event_id": 22,
+      "event_id": 3006,
       "action": "query",
       "provider": "etw",
       "source": "Microsoft-Windows-DNS-Client",
@@ -1039,7 +1039,7 @@
     {
       "platform": "windows",
       "category": "dns_query",
-      "event_id": 22,
+      "event_id": 3006,
       "action": "query",
       "provider": "etw",
       "source": "Microsoft-Windows-DNS-Client",
@@ -1050,7 +1050,7 @@
     {
       "platform": "windows",
       "category": "dns_query",
-      "event_id": 22,
+      "event_id": 3006,
       "action": "query",
       "provider": "etw",
       "source": "Microsoft-Windows-DNS-Client",
@@ -1061,7 +1061,7 @@
     {
       "platform": "windows",
       "category": "dns_query",
-      "event_id": 22,
+      "event_id": 3006,
       "action": "query",
       "provider": "etw",
       "source": "Microsoft-Windows-DNS-Client",
@@ -1072,7 +1072,7 @@
     {
       "platform": "windows",
       "category": "dns_query",
-      "event_id": 22,
+      "event_id": 3006,
       "action": "query",
       "provider": "etw",
       "source": "Microsoft-Windows-DNS-Client",
@@ -1083,7 +1083,73 @@
     {
       "platform": "windows",
       "category": "dns_query",
-      "event_id": 22,
+      "event_id": 3006,
+      "action": "query",
+      "provider": "etw",
+      "source": "Microsoft-Windows-DNS-Client",
+      "field": "RecordType",
+      "availability": "never",
+      "reason": "the subscribed DNS Client events do not expose the query record type"
+    },
+    {
+      "platform": "windows",
+      "category": "dns_query",
+      "event_id": 3008,
+      "action": "query",
+      "provider": "etw",
+      "source": "Microsoft-Windows-DNS-Client",
+      "field": "QueryName",
+      "availability": "conditional",
+      "reason": "the DNS Client event template carries a query name"
+    },
+    {
+      "platform": "windows",
+      "category": "dns_query",
+      "event_id": 3008,
+      "action": "query",
+      "provider": "etw",
+      "source": "Microsoft-Windows-DNS-Client",
+      "field": "QueryResults",
+      "availability": "conditional",
+      "reason": "the event is a response carrying decoded answers"
+    },
+    {
+      "platform": "windows",
+      "category": "dns_query",
+      "event_id": 3008,
+      "action": "query",
+      "provider": "etw",
+      "source": "Microsoft-Windows-DNS-Client",
+      "field": "QueryStatus",
+      "availability": "conditional",
+      "reason": "the DNS Client event template carries a status"
+    },
+    {
+      "platform": "windows",
+      "category": "dns_query",
+      "event_id": 3008,
+      "action": "query",
+      "provider": "etw",
+      "source": "Microsoft-Windows-DNS-Client",
+      "field": "ProcessId",
+      "availability": "conditional",
+      "reason": "the DNS Client event template carries process identity"
+    },
+    {
+      "platform": "windows",
+      "category": "dns_query",
+      "event_id": 3008,
+      "action": "query",
+      "provider": "etw",
+      "source": "Microsoft-Windows-DNS-Client",
+      "field": "Image",
+      "availability": "conditional",
+      "reason": "present in the event or derived from the process cache"
+    },
+    {
+      "platform": "windows",
+      "category": "dns_query",
+      "event_id": 3008,
       "action": "query",
       "provider": "etw",
       "source": "Microsoft-Windows-DNS-Client",

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -54,7 +54,7 @@ These count fields, not rules: a rule that references a `Never` field inside an 
 
 | Platform | Always | Conditional | Never |
 | --- | ---: | ---: | ---: |
-| windows | 19 | 184 | 40 |
+| windows | 19 | 189 | 41 |
 | linux | 19 | 40 | 17 |
 | macos | 27 | 24 | 26 |
 

--- a/docs/field-availability.md
+++ b/docs/field-availability.md
@@ -41,7 +41,7 @@ Edit that table and run `cargo run --bin generate-docs`.
 | macos | `process_creation` | `1 / start` | `Endpoint Security exec` | `Product` | PE version resources are Windows-only |
 | macos | `process_creation` | `1 / start` | `Endpoint Security exec` | `TargetImage` | a process-creation event has no target process |
 | windows | `create_remote_thread` | `8` | `none` | `*` | no Rustinel sensor produces remote-thread creation telemetry |
-| windows | `dns_query` | `22 / query` | `Microsoft-Windows-DNS-Client` | `RecordType` | the subscribed DNS Client events do not expose the query record type |
+| windows | `dns_query` | `3006 / query, 3008 / query` | `Microsoft-Windows-DNS-Client` | `RecordType` | the subscribed DNS Client events do not expose the query record type |
 | windows | `file_event` | `create, delete, modify, rename, set` | `Microsoft-Windows-Kernel-File` | `CreationUtcTime` | Kernel-File reports the information class, not the new timestamp |
 | windows | `file_event` | `create, delete, modify, rename, set` | `Microsoft-Windows-Kernel-File` | `PathTruncated` | ETW delivers a complete path or no attributable event |
 | windows | `file_event` | `create, delete, modify, rename, set` | `Microsoft-Windows-Kernel-File` | `PreviousCreationUtcTime` | Kernel-File reports the information class, not the old timestamp |

--- a/src/engine/event.rs
+++ b/src/engine/event.rs
@@ -53,10 +53,33 @@ impl<'a> RsigmaEvent<'a> {
             _ => serde_json::Map::new(),
         }
     }
+
+    /// Event IDs exposed to Sigma for this normalized event.
+    ///
+    /// Windows DNS Client rules use the provider-native IDs (3006/3008),
+    /// while category-based `dns_query` rules conventionally use Sysmon 22.
+    /// Keeping the native ID on the recorded event and presenting 22 as an
+    /// additional match value makes both rule families satisfiable without
+    /// discarding source fidelity.
+    fn event_id_value(&self) -> EventValue<'_> {
+        let native = EventValue::Str(Cow::Borrowed(self.event.event_id_string.as_str()));
+        if self.event.platform == crate::sensor::Platform::Windows
+            && self.event.category == crate::models::EventCategory::Dns
+            && self.event.event_id != 22
+        {
+            EventValue::Array(vec![native, EventValue::Str(Cow::Borrowed("22"))])
+        } else {
+            native
+        }
+    }
 }
 
 impl Event for RsigmaEvent<'_> {
     fn get_field(&self, path: &str) -> Option<EventValue<'_>> {
+        if path == "EventID" {
+            return Some(self.event_id_value());
+        }
+
         if let Some(value) = self.event.get_field(path) {
             return Some(EventValue::Str(Cow::Borrowed(value)));
         }
@@ -85,6 +108,13 @@ impl Event for RsigmaEvent<'_> {
         if !self.event.event_id_string.is_empty() && pred(&self.event.event_id_string) {
             return true;
         }
+        if self.event.platform == crate::sensor::Platform::Windows
+            && self.event.category == crate::models::EventCategory::Dns
+            && self.event.event_id != 22
+            && pred("22")
+        {
+            return true;
+        }
         self.field_map()
             .values()
             .filter_map(Value::as_str)
@@ -98,6 +128,12 @@ impl Event for RsigmaEvent<'_> {
         }
         if !self.event.event_id_string.is_empty() {
             values.push(Cow::Borrowed(self.event.event_id_string.as_str()));
+        }
+        if self.event.platform == crate::sensor::Platform::Windows
+            && self.event.category == crate::models::EventCategory::Dns
+            && self.event.event_id != 22
+        {
+            values.push(Cow::Borrowed("22"));
         }
         for (_key, value) in self.field_map() {
             if let Value::String(text) = value {

--- a/src/field_availability.rs
+++ b/src/field_availability.rs
@@ -900,7 +900,16 @@ pub const FIELD_AVAILABILITY: &[EventFieldContract] = &[
     contract!(
         Windows,
         "dns_query",
-        Some(22),
+        Some(3006),
+        Query,
+        "etw",
+        "Microsoft-Windows-DNS-Client",
+        WINDOWS_DNS
+    ),
+    contract!(
+        Windows,
+        "dns_query",
+        Some(3008),
         Query,
         "etw",
         "Microsoft-Windows-DNS-Client",

--- a/src/models/event.rs
+++ b/src/models/event.rs
@@ -64,7 +64,8 @@ pub struct NormalizedEvent {
     pub provider: String,
     /// Event category (Process, Network, File, Registry, DNS, ImageLoad)
     pub category: EventCategory,
-    /// Sensor-supplied compatibility event ID used by downstream detectors/output.
+    /// Sensor-supplied event ID used by downstream detectors and output.
+    /// Provider-native IDs are retained when rules select them directly.
     pub event_id: u16,
     /// Cached string representation of event_id for zero-copy flatten()
     #[serde(skip)]

--- a/src/sensor/windows/mapper.rs
+++ b/src/sensor/windows/mapper.rs
@@ -94,6 +94,11 @@ fn raw_event_id_for_record(category: EventCategory, action_code: u8, record: &Ev
 }
 
 /// Maps Windows ETW opcodes/event IDs to the existing Sysmon-compatible IDs.
+///
+/// Provider-native event IDs are preserved when the Sigma logsource is keyed
+/// by a Windows service rather than a Sysmon category. In particular, DNS
+/// Client rules select events 3006 and 3008 directly; the engine supplies the
+/// Sysmon 22 compatibility alias when evaluating `dns_query` rules.
 pub fn map_to_sysmon_id(category: EventCategory, action_code: u8, raw_event_id: u16) -> u16 {
     match category {
         EventCategory::Process => match action_code {
@@ -123,8 +128,8 @@ pub fn map_to_sysmon_id(category: EventCategory, action_code: u8, raw_event_id: 
             12 | 15 => 3,
             _ => raw_event_id,
         },
-        EventCategory::Dns => 22,
-        EventCategory::Wmi
+        EventCategory::Dns
+        | EventCategory::Wmi
         | EventCategory::Scripting
         | EventCategory::PowerShellModule
         | EventCategory::Service
@@ -238,6 +243,7 @@ mod tests {
     #[test]
     fn native_provider_event_ids_are_not_relabelled() {
         for (category, raw_event_id) in [
+            (EventCategory::Dns, 3008),
             (EventCategory::Scripting, 4104),
             (EventCategory::PowerShellModule, 4103),
             (EventCategory::Wmi, 23),

--- a/tests/pipeline_sigma.rs
+++ b/tests/pipeline_sigma.rs
@@ -2,12 +2,13 @@
 mod common;
 
 use common::{
-    assert_ecs_field_eq, assert_ecs_field_present, assert_normalized_field_eq, ecs_json,
-    file_create_event, file_delete_event, file_rename_event, image_for, network_connect_event,
-    powershell_module_event, process_start_event, provider_for, renamed_test_file_path,
-    service_installation_event, test_file_path, SigmaFixture, TestNormalizer, TEST_DESTINATION_IP,
-    TEST_DESTINATION_PORT, TEST_PID, TEST_PS_MODULE_CONTEXT, TEST_PS_MODULE_PAYLOAD,
-    TEST_SERVICE_IMAGE_PATH, TEST_SERVICE_NAME, TEST_SERVICE_PROVIDER, TEST_SOURCE_IP, TEST_USER,
+    assert_ecs_field_eq, assert_ecs_field_present, assert_normalized_field_eq, dns_query_event,
+    ecs_json, file_create_event, file_delete_event, file_rename_event, image_for,
+    network_connect_event, powershell_module_event, process_start_event, provider_for,
+    renamed_test_file_path, service_installation_event, test_file_path, SigmaFixture,
+    TestNormalizer, TEST_DESTINATION_IP, TEST_DESTINATION_PORT, TEST_PID, TEST_PS_MODULE_CONTEXT,
+    TEST_PS_MODULE_PAYLOAD, TEST_SERVICE_IMAGE_PATH, TEST_SERVICE_NAME, TEST_SERVICE_PROVIDER,
+    TEST_SOURCE_IP, TEST_USER,
 };
 use rustinel::{
     engine::Engine,
@@ -200,6 +201,83 @@ level: medium
     let ecs = ecs_json(&alert);
     assert_ecs_field_eq(&ecs, "event.dataset", "edr.scripting");
     assert_ecs_field_eq(&ecs, "event.action", "powershell-script");
+}
+
+#[test]
+fn sigma_dns_client_rule_matches_native_event_3008_and_sysmon_alias_22() {
+    // Regression fixture from SigmaHQ's
+    // rules/windows/builtin/dns_client/win_dns_client_mal_cobaltstrike.yml.
+    let fixture = SigmaFixture::new();
+    fixture.write_rule(
+        "win_dns_client_mal_cobaltstrike.yml",
+        r#"title: Suspicious Cobalt Strike DNS Beaconing - DNS Client
+id: 0d18728b-f5bf-4381-9dcf-915539fff6c2
+logsource:
+  product: windows
+  service: dns-client
+detection:
+  selection_eid:
+    EventID: 3008
+  selection_query_1:
+    QueryName|startswith:
+      - 'aaa.stage.'
+      - 'post.1'
+  selection_query_2:
+    QueryName|contains: '.stage.123456.'
+  condition: selection_eid and 1 of selection_query_*
+level: critical
+"#,
+    );
+    let native_engine = load_engine(Platform::Windows, &fixture);
+    let harness = TestNormalizer::new();
+    let mut event = dns_query_event(Platform::Windows);
+    event.normalization.event_id = 3008;
+    match &mut event.payload {
+        SensorPayload::Dns(fields) => {
+            fields.query_name = Some("aaa.stage.example.test".to_string());
+        }
+        other => panic!("unexpected payload: {other:?}"),
+    }
+
+    let normalized = harness
+        .normalizer
+        .normalize(&event)
+        .expect("DNS Client query should normalize");
+    assert_eq!(normalized.event_id, 3008);
+    assert_eq!(normalized.get_field("EventID"), Some("3008"));
+    assert_sigma_alert(
+        &native_engine
+            .check_event(&normalized)
+            .into_iter()
+            .next()
+            .expect("SigmaHQ DNS Client rule should match native event 3008"),
+        "Suspicious Cobalt Strike DNS Beaconing - DNS Client",
+    );
+
+    let sysmon_fixture = SigmaFixture::new();
+    sysmon_fixture.write_rule(
+        "dns_query_sysmon.yml",
+        r#"title: Sysmon DNS Query Compatibility
+logsource:
+  product: windows
+  category: dns_query
+detection:
+  selection:
+    EventID: 22
+    QueryName|startswith: 'aaa.stage.'
+  condition: selection
+level: high
+"#,
+    );
+    let sysmon_engine = load_engine(Platform::Windows, &sysmon_fixture);
+    assert_sigma_alert(
+        &sysmon_engine
+            .check_event(&normalized)
+            .into_iter()
+            .next()
+            .expect("category dns_query rule should still match Sysmon event 22"),
+        "Sysmon DNS Query Compatibility",
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- preserve native Microsoft-Windows-DNS-Client event IDs 3006 and 3008 instead of relabeling every event as Sysmon 22
- expose Sysmon 22 as a Sigma matching alias so existing `category: dns_query` rules remain compatible
- update the field-availability contract and generated artifacts for both subscribed DNS Client event IDs
- add a regression using SigmaHQ's Cobalt Strike DNS Client rule, plus a compatibility assertion for `EventID: 22`

Closes #482.

## Type of change

- [ ] `feat` / `enhancement` - new feature
- [ ] `performance` - performance improvement
- [x] `bug` - bug fix
- [ ] `refactor` - refactoring, no behaviour change
- [ ] `documentation` - docs only
- [ ] `ci` - CI and release changes
- [ ] `dependencies` - dependency update
- [ ] `chore` - other maintenance
- [ ] `breaking-change` - breaking change (takes priority over other categories)
- [ ] `skip-changelog` - release preparation or changes with no release-note value

## Test plan

- [ ] Tested on Windows
- [x] Tested on Linux
- [ ] Existing tests pass (`cargo test`)
- [x] New tests added (if applicable)

Passing checks:

- `RUSTINEL_EBPF_STUB=1 cargo test --test pipeline_sigma sigma_dns_client_rule_matches_native_event_3008_and_sysmon_alias_22`
- `RUSTINEL_EBPF_STUB=1 cargo test --test field_availability`
- `RUSTINEL_EBPF_STUB=1 cargo test --test generated_docs`
- `RUSTINEL_EBPF_STUB=1 cargo clippy --all-targets -- -D clippy::all`
- `cargo fmt --all -- --check`

The full stubbed suite reached 478 passing tests. The eBPF ABI test requires a real built object rather than the documented test stub; two unrelated file-identity timing tests failed in the suite and passed when rerun individually.

## Checklist

- [x] Label added to this PR
- [x] Docs updated (if behaviour changed): current behaviour only, measurements stay in this PR description
- [x] Generated docs refreshed (`cargo run --bin generate-docs`) if CLI flags or config options changed
- [ ] Release highlights and upgrade notes added (release preparation only)
