### PR TITLE
chore(release): prepare 1.7.0

### DIFF
--- a/.github/release-notes/1.7.0.md
+++ b/.github/release-notes/1.7.0.md
@@ -1,0 +1,15 @@
+## Highlights
+
+- **Update from the CLI.** `rustinel update` downloads and verifies the latest binary while preserving configuration, rules, logs, and recordings. `rustinel rules update` separately validates and atomically replaces the active rule pack, keeping the previous pack if an update fails.
+- **More reliable Windows telemetry.** Improved process metadata and startup file-name attribution give detections better context. Event Log subscriptions persist bookmarks across restarts and expose subscription health and retention loss in `doctor`. Malformed PE version resources no longer prevent startup.
+- **Broader macOS visibility.** Network capture covers all active interfaces discovered at startup, including VPN and loopback traffic, with best-effort DNS process attribution. `doctor` separates Endpoint Security and packet-capture loss from pipeline drops, and effective UIDs resolve to account names.
+- **Stronger Linux file identity.** eBPF captures device and inode identity for supported file operations and carries it into identity-aware scanning and hashing. Existing syscall paths remain authoritative, and missing kernel capabilities degrade identity enrichment independently.
+- **Lower memory use and clearer documentation.** YARA process-memory scans stream regions through a reusable buffer and share a per-process deadline. Large IOC feeds share source paths and repeated comments. Reorganized guides and generated CLI, configuration, and field references make deployment and troubleshooting easier.
+
+## Upgrade notes
+
+- **Upgrading from 1.6.x:** use the installer or replace the release package to reach 1.7.0; `rustinel update` is introduced in this release. Restart the service after replacing the binary, then run `rustinel doctor`. Future binary updates also require an explicit restart.
+- **Rule packs:** keep custom rules outside `rules/current`, which pack updates replace. Restart Rustinel after installing or updating a pack so it loads the new directory.
+- **Windows DNS integrations:** DNS Client events retain native event IDs **3006** and **3008** instead of being emitted as Sysmon event 22. Update downstream queries that rely on the emitted ID. Sigma DNS rules matching `EventID: 22` remain compatible through a matching alias.
+- **Windows Event Log replay:** subscriptions resume from persisted per-channel bookmarks. Without a bookmark, collection starts at the oldest available record; abrupt exits can replay some records. Account for historical or duplicate events in downstream ingestion.
+- **macOS interfaces:** restart after interface changes so new interfaces are discovered. Traffic visible on multiple interfaces can produce duplicate events; process attribution remains best-effort. macOS support remains experimental.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ env:
   CARGO_TERM_COLOR: always
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   # Update this commit deliberately when the rules repository's atomic suite changes.
-  RUSTINEL_RULES_REF: be877b7e23bcffcfeeccbb4d0f078987e9253c82
+  RUSTINEL_RULES_REF: 8732a0f02e88a1a67d011543cd25ed8c464d7d33
 
 permissions:
   contents: read
@@ -253,7 +253,8 @@ jobs:
         working-directory: rustinel-rules
         run: |
           uv sync --frozen
-          uv run python tools/validate.py
+          # Validate a rules commit, not the enclosing engine release tag.
+          uv run python -c "import os, subprocess, sys; os.environ.pop('GITHUB_REF_TYPE', None); sys.exit(subprocess.call([sys.executable, 'tools/validate.py']))"
           uv run python tools/build_packs.py
 
       - name: Check atomic coverage metadata
@@ -387,7 +388,8 @@ jobs:
         working-directory: rustinel-rules
         run: |
           uv sync --frozen
-          uv run python tools/validate.py
+          # Validate a rules commit, not the enclosing engine release tag.
+          uv run python -c "import os, subprocess, sys; os.environ.pop('GITHUB_REF_TYPE', None); sys.exit(subprocess.call([sys.executable, 'tools/validate.py']))"
           uv run python tools/build_packs.py
 
       - name: Check atomic coverage metadata

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ env:
   CARGO_TERM_COLOR: always
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   # Update this commit deliberately when the rules repository's atomic suite changes.
-  RUSTINEL_RULES_REF: be877b7e23bcffcfeeccbb4d0f078987e9253c82
+  RUSTINEL_RULES_REF: 8732a0f02e88a1a67d011543cd25ed8c464d7d33
 
 permissions:
   contents: read
@@ -318,7 +318,8 @@ jobs:
         working-directory: rustinel-rules
         run: |
           uv sync --frozen
-          uv run python tools/validate.py
+          # Validate a rules commit, not the enclosing engine release tag.
+          uv run python -c "import os, subprocess, sys; os.environ.pop('GITHUB_REF_TYPE', None); sys.exit(subprocess.call([sys.executable, 'tools/validate.py']))"
           uv run python tools/build_packs.py
 
       - name: Check atomic coverage metadata

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3167,7 +3167,7 @@ dependencies = [
 
 [[package]]
 name = "rustinel"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustinel"
-version = "1.6.0"
+version = "1.7.0"
 edition = "2021"
 authors = []
 description = "Open-source EDR for Windows, Linux, and macOS with Sigma, YARA, and IOC detection"

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -21,12 +21,6 @@ They never build from source or change system settings.
     curl -fsSL https://rustinel.io/install.sh | sh
     ```
 
-    Pass options after `sh -s --`:
-
-    ```bash
-    curl -fsSL https://rustinel.io/install.sh | sh -s -- --dir /opt/rustinel
-    ```
-
     | Option | Default | Effect |
     | --- | --- | --- |
     | `--dir PATH` | `./rustinel` | Install folder |
@@ -42,18 +36,10 @@ They never build from source or change system settings.
     irm https://rustinel.io/install.ps1 | iex
     ```
 
-    Set options with environment variables before running it:
-
-    ```powershell
-    $env:RUSTINEL_INSTALL_DIR = "C:\Rustinel"
-    irm https://rustinel.io/install.ps1 | iex
-    ```
-
-    Or download it and pass parameters: `.\install.ps1 -InstallDir C:\Rustinel [-Run] [-Force]`.
-
-To pin a release, pass `--version VERSION` on Linux or macOS, or `-Version VERSION` when running the downloaded PowerShell script.
-For the piped PowerShell installer, set `$env:RUSTINEL_VERSION` before running it and remove it afterward with `Remove-Item Env:\RUSTINEL_VERSION`.
-Replace `VERSION` with the desired release tag from [GitHub Releases](https://github.com/Karib0u/rustinel/releases).
+    | Environment variable | Default | Effect |
+    | --- | --- | --- |
+    | `RUSTINEL_INSTALL_DIR` | `./rustinel` | Install folder |
+    | `RUSTINEL_VERSION` | latest | Release to install |
 
 The folder contains the binary, a default `config.toml`, demo rules, and an empty `logs/` folder.
 On macOS the binary is inside a signed `Rustinel.app` with a `rustinel` symlink next to it.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -12,7 +12,7 @@ macOS support is experimental.
 
 ## Install script
 
-The scripts download a published release into a folder.
+The scripts download the latest published release into a folder by default.
 They never build from source or change system settings.
 
 === "Linux and macOS"
@@ -24,7 +24,7 @@ They never build from source or change system settings.
     Pass options after `sh -s --`:
 
     ```bash
-    curl -fsSL https://rustinel.io/install.sh | sh -s -- --dir /opt/rustinel --version 1.7.0
+    curl -fsSL https://rustinel.io/install.sh | sh -s -- --dir /opt/rustinel
     ```
 
     | Option | Default | Effect |
@@ -45,12 +45,15 @@ They never build from source or change system settings.
     Set options with environment variables before running it:
 
     ```powershell
-    $env:RUSTINEL_VERSION = "1.7.0"
     $env:RUSTINEL_INSTALL_DIR = "C:\Rustinel"
     irm https://rustinel.io/install.ps1 | iex
     ```
 
-    Or download it and pass parameters: `.\install.ps1 -InstallDir C:\Rustinel -Version 1.7.0 [-Run] [-Force]`.
+    Or download it and pass parameters: `.\install.ps1 -InstallDir C:\Rustinel [-Run] [-Force]`.
+
+To pin a release, pass `--version VERSION` on Linux or macOS, or `-Version VERSION` when running the downloaded PowerShell script.
+For the piped PowerShell installer, set `$env:RUSTINEL_VERSION` before running it and remove it afterward with `Remove-Item Env:\RUSTINEL_VERSION`.
+Replace `VERSION` with the desired release tag from [GitHub Releases](https://github.com/Karib0u/rustinel/releases).
 
 The folder contains the binary, a default `config.toml`, demo rules, and an empty `logs/` folder.
 On macOS the binary is inside a signed `Rustinel.app` with a `rustinel` symlink next to it.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -24,7 +24,7 @@ They never build from source or change system settings.
     Pass options after `sh -s --`:
 
     ```bash
-    curl -fsSL https://rustinel.io/install.sh | sh -s -- --dir /opt/rustinel --version 1.6.0
+    curl -fsSL https://rustinel.io/install.sh | sh -s -- --dir /opt/rustinel --version 1.7.0
     ```
 
     | Option | Default | Effect |
@@ -45,12 +45,12 @@ They never build from source or change system settings.
     Set options with environment variables before running it:
 
     ```powershell
-    $env:RUSTINEL_VERSION = "1.6.0"
+    $env:RUSTINEL_VERSION = "1.7.0"
     $env:RUSTINEL_INSTALL_DIR = "C:\Rustinel"
     irm https://rustinel.io/install.ps1 | iex
     ```
 
-    Or download it and pass parameters: `.\install.ps1 -InstallDir C:\Rustinel -Version 1.6.0 [-Run] [-Force]`.
+    Or download it and pass parameters: `.\install.ps1 -InstallDir C:\Rustinel -Version 1.7.0 [-Run] [-Force]`.
 
 The folder contains the binary, a default `config.toml`, demo rules, and an empty `logs/` folder.
 On macOS the binary is inside a signed `Rustinel.app` with a `rustinel` symlink next to it.


### PR DESCRIPTION
Prepare Rustinel 1.7.0 with five user-facing highlights and upgrade notes covering initial installation, rule-pack replacement, Windows DNS IDs and Event Log replay, and macOS interface discovery.

Bumps the package and lockfile version and makes installation examples default to the latest release, with version pinning documented separately. The release workflow prepends the reviewed highlights to downloads and the categorized changelog. Performance PRs are labeled for the Performance section.

Validation: `cargo fmt --all -- --check`, `git diff --check`, and `cargo metadata --locked --no-deps` pass. Cross-platform build, tests, and Clippy run in CI before merge; the tag workflow validates and tests release artifacts before publication.

Pins CI and release atomic tests to rustinel-rules `8732a0f02e88a1a67d011543cd25ed8c464d7d33`, including corrected history detections, executable IOC canaries, and expanded macOS coverage. Rules validation clears the enclosing engine tag context inside its Python process because the checked-out rules commit has an independent version.
